### PR TITLE
fix: CodeQL code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_ci-build-tauri-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-package-app.reusable.yml
@@ -1,6 +1,9 @@
 name: Build Tauri Package Test App
 description: 'Builds Tauri package test application and creates shareable artifacts'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/webdriverio/desktop-mobile/security/code-scanning/18](https://github.com/webdriverio/desktop-mobile/security/code-scanning/18)

In general, the fix is to explicitly declare a `permissions:` block that restricts the `GITHUB_TOKEN` to the least privileges required. For a build workflow that only checks out code, runs commands, and uploads artifacts (without pushing commits, creating releases, or modifying issues/PRs), `contents: read` is typically sufficient. If in the future some step needs to write to the repo or interact with issues/PRs, the relevant fine-grained scopes can be added.

The single best fix here is to add a workflow-level `permissions` block near the top of `.github/workflows/_ci-build-tauri-package-app.reusable.yml`, after the `description` (or before `on:`), setting `contents: read`. This applies to all jobs in the workflow that do not override `permissions`, including the `build-tauri-package-app` job highlighted by CodeQL. No behavior of existing steps changes, because none currently require write access to repository contents or other elevated scopes. No additional imports or methods are needed; it is purely a YAML configuration change in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
