### PR TITLE
fix: CodeQL code scanning alert no. 58, 59, 60, 62: Unsafe shell command constructed from library input

### DIFF
--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -30,8 +30,9 @@ export async function detectWebView2VersionFromBinary(binaryPath?: string): Prom
   try {
     // Use PowerShell to extract version info from the binary.
     // Pass the binary path as an argument to avoid interpolating it into the script.
-    const { stdout } = await execAsync(
-      `powershell.exe -Command "(Get-Item $args[0]).VersionInfo.FileVersion" "${binaryPath}"`,
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      ['-Command', '(Get-Item $args[0]).VersionInfo.FileVersion', binaryPath],
       {
         encoding: 'utf8',
         timeout: 5000,


### PR DESCRIPTION
Potential fix for [https://github.com/webdriverio/desktop-mobile/security/code-scanning/60](https://github.com/webdriverio/desktop-mobile/security/code-scanning/60)

In general, the safest approach is to avoid constructing a shell command string with untrusted data and instead pass arguments as an array to a function like `child_process.execFile` or `child_process.spawn` with `shell: false`. This ensures that arguments are not interpreted by a shell, and arbitrary shell metacharacters in the input cannot change the meaning of the command.

For this specific code, we can keep the same behavior (running the generated PowerShell script) but invoke `powershell.exe` with arguments passed as an array rather than building a single command string. We already use `node:child_process.exec`, but we can switch to `node:child_process.execFile` (and its promisified form) alongside the existing `execAsync`. To minimize changes, we will:

1. Import `execFile` from `node:child_process`.
2. Create a new promisified helper `execFileAsync = promisify(execFile);`.
3. Replace the `execAsync` call on line 257 with `execFileAsync('powershell.exe', ['-ExecutionPolicy', 'Bypass', '-File', psScriptPath], { encoding: 'utf8', timeout: 60000 })`.

This preserves the functionality (run PowerShell with the same options and script path) while removing the shell interpretation of the path, eliminating the unsafe command construction. All changes will be contained within `packages/tauri-service/src/edgeDriverManager.ts` in the shown regions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
