### PR TITLE
fix: codeQL scanning alert no. 59: Unsafe shell command constructed from library input

### DIFF
--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -164,8 +164,7 @@ async function getDriverVersionForEdge(edgeVersion: string): Promise<string> {
 
   try {
     // Try to get the latest stable release for this major version
-    const response = await execAsync(
-      `powershell.exe -Command "
+    const psCommand = `
       $ProgressPreference = 'SilentlyContinue'
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       try {
@@ -174,9 +173,12 @@ async function getDriverVersionForEdge(edgeVersion: string): Promise<string> {
       } catch {
         Write-Output ''
       }
-    "`,
-      { encoding: 'utf8', timeout: 15000 },
-    );
+    `;
+
+    const response = await execFileAsync('powershell.exe', ['-Command', psCommand], {
+      encoding: 'utf8',
+      timeout: 15000,
+    });
 
     const latestForMajor = response.stdout.trim();
     if (latestForMajor?.startsWith(safeMajorVersion)) {


### PR DESCRIPTION
Potential fix for [https://github.com/webdriverio/desktop-mobile/security/code-scanning/59](https://github.com/webdriverio/desktop-mobile/security/code-scanning/59)

In general, to fix this kind of issue, avoid passing dynamically constructed strings into `child_process.exec`, because they are interpreted by a shell. Instead, use `execFile` (or `spawn`) with an argument array, so arguments are not parsed by a shell. If you truly must use a shell, you should carefully escape dynamic segments (for example with `shell-quote`) before embedding them, and restrict inputs as much as possible.

In this specific case, we can preserve existing functionality while removing the vulnerable pattern by switching from `execAsync` (a promisified `exec`) to `execFileAsync` (a promisified `execFile`) to run `powershell.exe`. Rather than passing the entire `-Command "..."` script as a single string to a shell, we call `powershell.exe` directly, with `-Command` and the script as separate arguments. The script contents remain the same; the only dynamic piece, `${safeMajorVersion}`, is still used to build the URL but now as part of the script string passed as an argument rather than being interpolated into a shell command line. This prevents any shell from reparsing the command line, eliminating the injection vector. Concretely, in `getDriverVersionForEdge` we will:

- Replace the `execAsync` call with `execFileAsync`.
- Pass `"powershell.exe"` as the program, and the arguments array `['-Command', '...script with safeMajorVersion...']`.
- Keep the existing options `{ encoding: 'utf8', timeout: 15000 }`.

No new imports are needed; `execFileAsync` is already created at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
