### PR TITLE
feat: enhance package.json emission with bundled package filtering

### DIFF
--- a/packages/bundler/src/cli/analyzer.ts
+++ b/packages/bundler/src/cli/analyzer.ts
@@ -58,6 +58,7 @@ export class PackageAnalyzer {
       input,
       outDir,
       dependencies,
+      dependenciesObj: packageJson.dependencies || {},
       devDependencies,
       peerDependencies: Object.keys(packageJson.peerDependencies || {}),
     };
@@ -136,18 +137,43 @@ export class PackageAnalyzer {
   /**
    * Create emit package.json inline plugin
    */
-  createEmitPackageJsonPlugin(_packageName: string, format: 'esm' | 'cjs'): InlinePluginSpec {
-    const packageContent = format === 'esm' ? '{ "type": "module" }' : '{ "type": "commonjs" }';
+  createEmitPackageJsonPlugin(
+    _packageName: string,
+    format: 'esm' | 'cjs',
+    bundledPackages: string[] = [],
+    originalDependencies: Record<string, string> = {},
+  ): InlinePluginSpec {
+    // Pass options to runtime so they can be evaluated when generateBundle is called
+    const optionsJson = JSON.stringify({ bundledPackages, originalDependencies });
+    const formatStr = format;
 
     return {
       name: 'emit-package-json',
       code: `{
   name: 'emit-package-json',
-  generateBundle() {
+  generateBundle(options, bundle) {
+    const opts = ${optionsJson};
+    const deps = opts.originalDependencies || {};
+    const bundled = opts.bundledPackages || [];
+    
+    // Filter out bundled packages
+    const filtered = {};
+    for (const [key, val] of Object.entries(deps)) {
+      if (!bundled.includes(key)) {
+        filtered[key] = val;
+      }
+    }
+    
+    const source = {
+      name: 'emit-package-json-${formatStr}',
+      type: '${formatStr === 'esm' ? 'module' : 'commonjs'}',
+      ...(Object.keys(filtered).length > 0 ? { dependencies: filtered } : {})
+    };
+    
     this.emitFile({
       type: 'asset',
       fileName: 'package.json',
-      source: ${JSON.stringify(packageContent)}
+      source: JSON.stringify(source)
     });
   }
 }`,

--- a/packages/bundler/src/cli/executor.ts
+++ b/packages/bundler/src/cli/executor.ts
@@ -166,21 +166,41 @@ export class RollupExecutor {
         exports: 'named', // Always use named exports to avoid mixed export warnings
         dynamicImportInCjs: configSpec.output.dynamicImportInCjs,
         plugins:
-          configSpec.output.plugins?.map((plugin) => ({
-            name: plugin.name,
-            generateBundle() {
-              (this as { emitFile: (options: { type: 'asset'; fileName: string; source: string }) => void }).emitFile({
-                type: 'asset' as const,
-                fileName: 'package.json',
-                source:
-                  plugin.name === 'emit-package-json'
-                    ? configSpec.output.format === 'esm'
-                      ? '{ "type": "module" }'
-                      : '{ "type": "commonjs" }'
-                    : '',
-              });
-            },
-          })) || [],
+          configSpec.output.plugins?.map((plugin) => {
+            if (plugin.name === 'emit-package-json' && plugin.code) {
+              const createPlugin = new Function(`return ${plugin.code}`)();
+              return createPlugin;
+            } else if (plugin.name === 'emit-package-json') {
+              return {
+                name: 'emit-package-json',
+                generateBundle: () => {
+                  (
+                    this as unknown as {
+                      emitFile: (options: { type: 'asset'; fileName: string; source: string }) => void;
+                    }
+                  ).emitFile({
+                    type: 'asset' as const,
+                    fileName: 'package.json',
+                    source: configSpec.output.format === 'esm' ? '{ "type": "module" }' : '{ "type": "commonjs" }',
+                  });
+                },
+              };
+            }
+            return {
+              name: plugin.name,
+              generateBundle() {
+                (
+                  this as unknown as {
+                    emitFile: (options: { type: 'asset'; fileName: string; source: string }) => void;
+                  }
+                ).emitFile({
+                  type: 'asset' as const,
+                  fileName: 'package.json',
+                  source: '',
+                });
+              },
+            };
+          }) || [],
       },
       plugins: plugins as RollupOptions['plugins'],
     };

--- a/packages/bundler/src/cli/generator.ts
+++ b/packages/bundler/src/cli/generator.ts
@@ -64,8 +64,11 @@ export class ConfigGenerator {
     // Build plugins for this format
     const plugins = this.packageAnalyzer.buildPluginSpecs(config, packageInfo, packagePath, format);
 
+    // Extract bundled packages from transformations
+    const bundledPackages = this.extractBundledPackages(config);
+
     // Build output configuration
-    const output = this.buildOutput(packageInfo, format);
+    const output = this.buildOutput(packageInfo, format, bundledPackages);
 
     return {
       input: packageInfo.input,
@@ -76,11 +79,48 @@ export class ConfigGenerator {
   }
 
   /**
+   * Extract package names that are being bundled from transformations
+   */
+  private extractBundledPackages(config: BundlerConfig): string[] {
+    const bundled: string[] = [];
+
+    if (config.transformations) {
+      for (const transformation of config.transformations) {
+        if (transformation.type === 'injectDependency' && transformation.options) {
+          const pkgName = transformation.options.packageName as string;
+          if (pkgName && !bundled.includes(pkgName)) {
+            bundled.push(pkgName);
+          }
+        }
+      }
+    }
+
+    // Also check for bundle lists in format configs
+    if (config.cjs && typeof config.cjs === 'object' && 'bundle' in config.cjs) {
+      const cjsBundle = (config.cjs as { bundle?: string[] }).bundle;
+      if (cjsBundle) {
+        for (const pkg of cjsBundle) {
+          if (!bundled.includes(pkg)) {
+            bundled.push(pkg);
+          }
+        }
+      }
+    }
+
+    return bundled;
+  }
+
+  /**
    * Build output configuration for a format
    */
-  private buildOutput(packageInfo: PackageInfo, format: 'esm' | 'cjs'): OutputSpec {
-    // Create emit package.json plugin
-    const emitPlugin = this.packageAnalyzer.createEmitPackageJsonPlugin(packageInfo.name, format);
+  private buildOutput(packageInfo: PackageInfo, format: 'esm' | 'cjs', bundledPackages: string[]): OutputSpec {
+    // Create emit package.json plugin with bundled packages info
+    const emitPlugin = this.packageAnalyzer.createEmitPackageJsonPlugin(
+      packageInfo.name,
+      format,
+      bundledPackages,
+      packageInfo.dependenciesObj,
+    );
 
     return {
       format,

--- a/packages/bundler/src/cli/types.ts
+++ b/packages/bundler/src/cli/types.ts
@@ -59,6 +59,7 @@ export interface PackageInfo {
     cjs: string;
   };
   dependencies: string[];
+  dependenciesObj: Record<string, string>;
   devDependencies: string[];
   peerDependencies: string[];
 }

--- a/packages/bundler/src/plugins.ts
+++ b/packages/bundler/src/plugins.ts
@@ -28,8 +28,35 @@ export const getPackageJsonSource = (name: NormalizedPackageJson['name'], type: 
   private: true,
 });
 
-export const emitPackageJsonPlugin = (name: NormalizedPackageJson['name'], type: SourceCodeType): Plugin => {
-  const source = JSON.stringify(getPackageJsonSource(name, type), null, '  ');
+export const emitPackageJsonPlugin = (
+  name: NormalizedPackageJson['name'],
+  type: SourceCodeType,
+  options?: {
+    bundledPackages?: string[];
+    originalDependencies?: Record<string, string>;
+  },
+): Plugin => {
+  let source: string;
+
+  if (options?.bundledPackages && options.bundledPackages.length > 0 && options.originalDependencies) {
+    // Filter out bundled packages from dependencies
+    const filteredDeps: Record<string, string> = {};
+    for (const [key, value] of Object.entries(options.originalDependencies)) {
+      if (!options.bundledPackages.includes(key)) {
+        filteredDeps[key] = value;
+      }
+    }
+
+    const packageJson = {
+      name: `${name}-${type}`,
+      type: getTypeValue(type),
+      private: true,
+      ...(Object.keys(filteredDeps).length > 0 ? { dependencies: filteredDeps } : {}),
+    };
+    source = JSON.stringify(packageJson, null, '  ');
+  } else {
+    source = JSON.stringify(getPackageJsonSource(name, type), null, '  ');
+  }
 
   return {
     name: 'rollup-wdio-emit-package-json',

--- a/packages/bundler/test/helpers/fixture-utils.ts
+++ b/packages/bundler/test/helpers/fixture-utils.ts
@@ -34,3 +34,12 @@ export function getBundlerFixturePath(moduleType: 'cjs' | 'esm', fixtureName: st
 export function getFixturePackagePath(fixtureType: string, fixtureName: string): string {
   return getFixturePath(fixtureType, fixtureName, 'package.json');
 }
+
+/**
+ * Get path to a package in the monorepo
+ * @param packageName - The package name (e.g., 'electron-service')
+ * @returns Path to the package directory
+ */
+export function getMonorepoPackagePath(packageName: string): string {
+  return path.resolve(__dirname, '..', '..', '..', '..', 'packages', packageName);
+}

--- a/packages/bundler/test/integration/cli-workflows.spec.ts
+++ b/packages/bundler/test/integration/cli-workflows.spec.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { runBundlerBuild } from '../helpers/cli-runner.js';
-import { getBundlerFixturePath } from '../helpers/fixture-utils.js';
+import { getBundlerFixturePath, getMonorepoPackagePath } from '../helpers/fixture-utils.js';
 
 describe('CLI Workflows Integration', () => {
   let tempDir: string;
@@ -148,5 +148,50 @@ describe('CLI Workflows Integration', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Build failed');
     });
+  });
+
+  describe('package.json emission', () => {
+    it('should emit package.json with correct type for ESM', async () => {
+      const fixturePath = getBundlerFixturePath('esm', 'simple-ts-config');
+
+      const result = await runBundlerBuild(fixturePath);
+
+      expect(result.exitCode).toBe(0);
+
+      const pkgJsonPath = path.join(fixturePath, 'dist', 'esm', 'package.json');
+      const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, 'utf-8'));
+
+      expect(pkgJson.type).toBe('module');
+    }, 30000);
+
+    it('should emit package.json with correct type for CJS', async () => {
+      const fixturePath = getBundlerFixturePath('cjs', 'simple-ts-config');
+
+      const result = await runBundlerBuild(fixturePath);
+
+      expect(result.exitCode).toBe(0);
+
+      const pkgJsonPath = path.join(fixturePath, 'dist', 'cjs', 'package.json');
+      const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, 'utf-8'));
+
+      expect(pkgJson.type).toBe('commonjs');
+    }, 30000);
+
+    it('should filter out bundled packages from output package.json', async () => {
+      const packagePath = getMonorepoPackagePath('electron-service');
+
+      const result = await runBundlerBuild(packagePath);
+
+      expect(result.exitCode).toBe(0);
+
+      const esmPkgJsonPath = path.join(packagePath, 'dist', 'esm', 'package.json');
+      const esmPkgJson = JSON.parse(await fs.readFile(esmPkgJsonPath, 'utf-8'));
+
+      expect(esmPkgJson).toHaveProperty('type', 'module');
+      expect(esmPkgJson).toHaveProperty('dependencies');
+      expect(esmPkgJson.dependencies).not.toHaveProperty('fast-copy');
+      expect(esmPkgJson.dependencies).not.toHaveProperty('@wdio/native-spy');
+      expect(esmPkgJson.dependencies).toHaveProperty('debug');
+    }, 60000);
   });
 });

--- a/packages/bundler/test/unit/cli/analyzer.spec.ts
+++ b/packages/bundler/test/unit/cli/analyzer.spec.ts
@@ -79,6 +79,7 @@ describe('PackageAnalyzer', () => {
         dependencies: ['dep1'],
         devDependencies: ['dev-dep1'],
         peerDependencies: ['peer-dep1'],
+        dependenciesObj: { dep1: '^1.0.0' },
       });
     });
 
@@ -377,18 +378,33 @@ describe('PackageAnalyzer', () => {
   });
 
   describe('createEmitPackageJsonPlugin', () => {
-    it('should create ESM package.json plugin', () => {
+    it('should create ESM package.json plugin with dynamic type detection', () => {
       const plugin = analyzer.createEmitPackageJsonPlugin('@test/package', 'esm');
 
       expect(plugin.name).toBe('emit-package-json');
-      expect(plugin.code).toContain('"{ \\"type\\": \\"module\\" }"');
+      expect(plugin.code).toContain("type: 'module'");
+      expect(plugin.code).toContain('generateBundle');
     });
 
-    it('should create CJS package.json plugin', () => {
+    it('should create CJS package.json plugin with dynamic type detection', () => {
       const plugin = analyzer.createEmitPackageJsonPlugin('@test/package', 'cjs');
 
       expect(plugin.name).toBe('emit-package-json');
-      expect(plugin.code).toContain('"{ \\"type\\": \\"commonjs\\" }"');
+      expect(plugin.code).toContain("type: 'commonjs'");
+      expect(plugin.code).toContain('generateBundle');
+    });
+
+    it('should filter out bundled packages from dependencies', () => {
+      const plugin = analyzer.createEmitPackageJsonPlugin('@test/package', 'esm', ['fast-copy', '@wdio/native-spy'], {
+        'fast-copy': '^2.0.0',
+        '@wdio/native-spy': '^1.0.0',
+        debug: '^4.0.0',
+      });
+
+      expect(plugin.name).toBe('emit-package-json');
+      expect(plugin.code).toContain('bundledPackages');
+      expect(plugin.code).toContain('filtered');
+      expect(plugin.code).toContain('debug');
     });
   });
 });

--- a/packages/bundler/test/unit/cli/executor.spec.ts
+++ b/packages/bundler/test/unit/cli/executor.spec.ts
@@ -311,5 +311,50 @@ describe('RollupExecutor', () => {
         source: '',
       });
     });
+
+    it('should use plugin code when emit-package-json has code property', async () => {
+      const mockConfig = {
+        configs: [
+          {
+            format: 'esm',
+            input: { index: 'src/index.ts' },
+            output: {
+              format: 'esm',
+              dir: 'dist/esm',
+              sourcemap: true,
+              plugins: [
+                {
+                  name: 'emit-package-json',
+                  code: `{
+  name: 'emit-package-json',
+  generateBundle(options, bundle) {
+    const source = { type: 'module', dependencies: { foo: '^1.0.0' } };
+    this.emitFile({ type: 'asset', fileName: 'package.json', source: JSON.stringify(source) });
+  }
+}`,
+                },
+              ],
+            },
+            plugins: [{ name: 'typescript' }],
+          },
+        ],
+      };
+
+      await executor.executeBuild(mockConfig as any, '/test/package', false);
+
+      const rollupCall = mockRollup.mock.calls[0][0];
+      const outputPlugins = (rollupCall.output as any).plugins;
+      expect(outputPlugins[0].name).toBe('emit-package-json');
+
+      const mockThis = {
+        emitFile: vi.fn(),
+      };
+      outputPlugins[0].generateBundle.call(mockThis);
+      expect(mockThis.emitFile).toHaveBeenCalledWith({
+        type: 'asset',
+        fileName: 'package.json',
+        source: JSON.stringify({ type: 'module', dependencies: { foo: '^1.0.0' } }),
+      });
+    });
   });
 });


### PR DESCRIPTION
- Updated the `emitPackageJsonPlugin` to accept options for bundled packages and original dependencies, allowing for dynamic filtering of dependencies in the emitted package.json.
- Modified the `createEmitPackageJsonPlugin` method to pass bundled packages and dependencies to the plugin.
- Implemented a new method in `ConfigGenerator` to extract bundled packages from transformations, improving the accuracy of emitted package.json files.
- Added tests to verify the correct emission of package.json with filtered dependencies for both ESM and CJS formats.
