### PR TITLE
feat(native-spy): implement interceptor framework for Tauri and Electron

### DIFF
--- a/agent-os/standards/global/mock-architecture.md
+++ b/agent-os/standards/global/mock-architecture.md
@@ -11,6 +11,13 @@ Test Process (WDIO Worker)              App Process (Electron/Tauri)
 │  - .mock.calls (for tests)   │ <── │  - tracks calls internally    │
 └──────────────────────────────┘    └──────────────────────────────┘
           update()                    (one-way sync: inner → outer)
+         ┌──────────────────────────────────────────┐
+         │  Serialization Layer (test-process only) │
+         │  @wdio/native-spy/interceptor             │
+         │  - script-string builders (Tauri/Electron)│
+         │  - parseCallData + safeJson               │
+         │  - IpcContext seeding                     │
+         └──────────────────────────────────────────┘
 ```
 
 ## Key Concepts
@@ -20,6 +27,18 @@ Test Process (WDIO Worker)              App Process (Electron/Tauri)
 - JSON serialization is required due to CDP/WebDriver process boundary
 - Sync is **one-directional**: inner call data → outer mock
 - `mockImplementation`/`mockReturnValue` methods push config from outer → inner
+
+## Serialization Layer (`@wdio/native-spy/interceptor`)
+
+The sub-path export `@wdio/native-spy/interceptor` is **test-process-only** (never bundled into the app).
+It provides a shared `IpcInterceptor` interface for building the script strings injected into the app context.
+
+- **Tauri** uses `createIpcInterceptor('tauri')` — all `build*Script` methods port from `tauri-service/src/mock.ts`
+- **Electron** uses `createIpcInterceptor('electron')` — stub (throws `Not implemented`), filled in by a future browser-mode spec
+- Transport stays in each service (`tauriExecute`, CDP, etc.) — interceptor returns strings only
+
+Error values in `mockRejectedValue`/`mockRejectedValueOnce` are serialized with `safeJson()` as
+`{ __wdioError: true, message }` and reconstructed as `new Error(message)` inside the app script.
 
 ## Mock Methods (all async)
 Every mock method operates on **both** inner and outer:

--- a/packages/bundler/src/cli/executor.ts
+++ b/packages/bundler/src/cli/executor.ts
@@ -100,16 +100,11 @@ export class RollupExecutor {
         const tsconfigPath = resolve(targetCwd, 'tsconfig.json');
         const hasTsconfig = existsSync(tsconfigPath);
 
-        // Only add declaration options if tsconfig.json exists to avoid TypeScript plugin issues
         const compilerOptions: CompilerOptions = {
-          target: 'ES2020',
-          module: 'ESNext',
-          moduleResolution: 'Node',
-          allowSyntheticDefaultImports: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
           noEmitOnError: false,
           outDir: resolve(targetCwd, configSpec.output.dir),
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
         };
 
         if (hasTsconfig) {

--- a/packages/bundler/src/cli/executor.ts
+++ b/packages/bundler/src/cli/executor.ts
@@ -103,8 +103,8 @@ export class RollupExecutor {
         const compilerOptions: CompilerOptions = {
           noEmitOnError: false,
           outDir: resolve(targetCwd, configSpec.output.dir),
-          module: 'NodeNext',
-          moduleResolution: 'NodeNext',
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
         };
 
         if (hasTsconfig) {

--- a/packages/native-spy/package.json
+++ b/packages/native-spy/package.json
@@ -24,11 +24,11 @@
     "./interceptor": [
       {
         "import": {
-          "types": "./dist/esm/interceptor/index.d.ts",
+          "types": "./dist/esm/interceptor.d.ts",
           "default": "./dist/esm/interceptor.js"
         },
         "require": {
-          "types": "./dist/cjs/interceptor/index.d.ts",
+          "types": "./dist/cjs/interceptor.d.ts",
           "default": "./dist/cjs/interceptor.js"
         }
       }
@@ -40,6 +40,7 @@
   "scripts": {
     "clean": "shx rm -rf dist coverage .turbo",
     "build": "tsx ../../scripts/build-package.ts",
+    "postbuild": "echo \"export * from './interceptor/index.js';\" > dist/esm/interceptor.d.ts && echo \"export * from './interceptor/index.js';\" > dist/cjs/interceptor.d.ts",
     "dev": "tsx ../../scripts/build-package.ts --watch",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",

--- a/packages/native-spy/package.json
+++ b/packages/native-spy/package.json
@@ -20,6 +20,18 @@
           "default": "./dist/cjs/index.js"
         }
       }
+    ],
+    "./interceptor": [
+      {
+        "import": {
+          "types": "./dist/esm/interceptor/index.d.ts",
+          "default": "./dist/esm/interceptor.js"
+        },
+        "require": {
+          "types": "./dist/cjs/interceptor/index.d.ts",
+          "default": "./dist/cjs/interceptor.js"
+        }
+      }
     ]
   },
   "engines": {

--- a/packages/native-spy/package.json
+++ b/packages/native-spy/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "clean": "shx rm -rf dist coverage .turbo",
     "build": "tsx ../../scripts/build-package.ts",
-    "postbuild": "echo \"export * from './interceptor/index.js';\" > dist/esm/interceptor.d.ts && echo \"export * from './interceptor/index.js';\" > dist/cjs/interceptor.d.ts",
+    "postbuild": "node scripts/postbuild.js",
     "dev": "tsx ../../scripts/build-package.ts --watch",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",

--- a/packages/native-spy/scripts/postbuild.js
+++ b/packages/native-spy/scripts/postbuild.js
@@ -1,0 +1,5 @@
+import { writeFileSync } from 'node:fs';
+
+const stub = "export * from './interceptor/index.js';\n";
+writeFileSync('dist/esm/interceptor.d.ts', stub);
+writeFileSync('dist/cjs/interceptor.d.ts', stub);

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -1,0 +1,34 @@
+import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
+import type { SerializedHandler } from './serialize.js';
+
+export class ElectronAdapter implements FrameworkAdapter {
+  readonly framework = 'electron' as const;
+
+  buildRegistrationScript(_mockName: string): string {
+    throw new Error('Not implemented');
+  }
+
+  buildSetImplementationScript(_mockName: string, _s: SerializedHandler, _once?: boolean): string {
+    throw new Error('Not implemented');
+  }
+
+  buildInnerInvocationScript(_mockName: string, _method: InnerMockMethod): string {
+    throw new Error('Not implemented');
+  }
+
+  buildInnerSetterScript(_mockName: string, _method: InnerMockSetterMethod, _value: unknown): string {
+    throw new Error('Not implemented');
+  }
+
+  buildCallDataReadScript(_mockName: string): string {
+    throw new Error('Not implemented');
+  }
+
+  buildUnregistrationScript(_mockName: string): string {
+    throw new Error('Not implemented');
+  }
+
+  buildWithImplementationScript(_mockName: string, _implFnSource: string, _callbackFnSource: string): string {
+    throw new Error('Not implemented');
+  }
+}

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -1,6 +1,10 @@
 import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
 import type { SerializedHandler } from './serialize.js';
 
+/**
+ * @internal Placeholder adapter — Electron support is not yet implemented.
+ * All methods throw `'Not implemented'` at runtime. Do not use in production code.
+ */
 export class ElectronAdapter implements FrameworkAdapter {
   readonly framework = 'electron' as const;
 

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -1,4 +1,5 @@
 import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
+import type { IpcContext } from './ipcContext.js';
 import type { SerializedHandler } from './serialize.js';
 
 /**
@@ -33,6 +34,10 @@ export class ElectronAdapter implements FrameworkAdapter {
   }
 
   buildWithImplementationScript(_mockName: string, _implFnSource: string, _callbackFnSource: string): string {
+    throw new Error('Not implemented');
+  }
+
+  buildContextSeedScript(_context: IpcContext): string {
     throw new Error('Not implemented');
   }
 }

--- a/packages/native-spy/src/interceptor/framework.ts
+++ b/packages/native-spy/src/interceptor/framework.ts
@@ -1,0 +1,22 @@
+import type { SerializedHandler } from './serialize.js';
+
+export type Framework = 'tauri' | 'electron';
+export type InnerMockMethod = 'mockClear' | 'mockReset' | 'mockReturnThis';
+export type InnerMockSetterMethod =
+  | 'mockReturnValue'
+  | 'mockReturnValueOnce'
+  | 'mockResolvedValue'
+  | 'mockResolvedValueOnce'
+  | 'mockRejectedValue'
+  | 'mockRejectedValueOnce';
+
+export interface FrameworkAdapter {
+  readonly framework: Framework;
+  buildRegistrationScript(mockName: string): string;
+  buildSetImplementationScript(mockName: string, s: SerializedHandler, once?: boolean): string;
+  buildInnerInvocationScript(mockName: string, method: InnerMockMethod): string;
+  buildInnerSetterScript(mockName: string, method: InnerMockSetterMethod, value: unknown): string;
+  buildCallDataReadScript(mockName: string): string;
+  buildUnregistrationScript(mockName: string): string;
+  buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string;
+}

--- a/packages/native-spy/src/interceptor/framework.ts
+++ b/packages/native-spy/src/interceptor/framework.ts
@@ -1,3 +1,4 @@
+import type { IpcContext } from './ipcContext.js';
 import type { SerializedHandler } from './serialize.js';
 
 export type Framework = 'tauri' | 'electron';
@@ -19,4 +20,5 @@ export interface FrameworkAdapter {
   buildCallDataReadScript(mockName: string): string;
   buildUnregistrationScript(mockName: string): string;
   buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string;
+  buildContextSeedScript(context: IpcContext): string;
 }

--- a/packages/native-spy/src/interceptor/index.ts
+++ b/packages/native-spy/src/interceptor/index.ts
@@ -1,7 +1,6 @@
 import { ElectronAdapter } from './electron.js';
 import type { Framework, FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
 import type { IpcContext } from './ipcContext.js';
-import { buildContextSeedScript } from './ipcContext.js';
 import type { SerializedHandler } from './serialize.js';
 import { serializeHandler } from './serialize.js';
 import type { MockCallData } from './syncProtocol.js';
@@ -15,7 +14,6 @@ export type { MockCallData } from './syncProtocol.js';
 
 export interface InterceptorOptions {
   context?: IpcContext;
-  onDebug?: (msg: string) => void;
 }
 
 export interface IpcInterceptor {
@@ -92,7 +90,7 @@ class IpcInterceptorImpl implements IpcInterceptor {
   }
 
   buildContextSeedScript(context: IpcContext): string {
-    return buildContextSeedScript(context);
+    return this.adapter.buildContextSeedScript(context);
   }
 
   setContext(partial: IpcContext): IpcContext {

--- a/packages/native-spy/src/interceptor/index.ts
+++ b/packages/native-spy/src/interceptor/index.ts
@@ -1,0 +1,111 @@
+import { ElectronAdapter } from './electron.js';
+import type { Framework, FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
+import type { IpcContext } from './ipcContext.js';
+import { buildContextSeedScript } from './ipcContext.js';
+import type { SerializedHandler } from './serialize.js';
+import { serializeHandler } from './serialize.js';
+import type { MockCallData } from './syncProtocol.js';
+import { parseCallData } from './syncProtocol.js';
+import { TauriAdapter } from './tauri.js';
+
+export type { Framework, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
+export type { IpcContext } from './ipcContext.js';
+export type { SerializedHandler } from './serialize.js';
+export type { MockCallData } from './syncProtocol.js';
+
+export interface InterceptorOptions {
+  context?: IpcContext;
+  onDebug?: (msg: string) => void;
+}
+
+export interface IpcInterceptor {
+  readonly framework: Framework;
+  serializeHandler(fn: (...a: unknown[]) => unknown): SerializedHandler;
+  buildRegistrationScript(mockName: string): string;
+  buildSetImplementationScript(mockName: string, s: SerializedHandler, once?: boolean): string;
+  buildInnerInvocationScript(mockName: string, method: InnerMockMethod): string;
+  buildInnerSetterScript(mockName: string, method: InnerMockSetterMethod, value: unknown): string;
+  buildCallDataReadScript(mockName: string): string;
+  buildUnregistrationScript(mockName: string): string;
+  buildWithImplementationScript(
+    mockName: string,
+    implFn: (...a: unknown[]) => unknown,
+    callbackFn: (...a: unknown[]) => unknown,
+  ): string;
+  parseCallData(raw: unknown): MockCallData;
+  buildContextSeedScript(context: IpcContext): string;
+  setContext(partial: IpcContext): IpcContext;
+  getContext(): IpcContext;
+}
+
+class IpcInterceptorImpl implements IpcInterceptor {
+  private _context: IpcContext;
+  private adapter: FrameworkAdapter;
+
+  constructor(adapter: FrameworkAdapter, options: InterceptorOptions = {}) {
+    this.adapter = adapter;
+    this._context = options.context ?? {};
+  }
+
+  get framework(): Framework {
+    return this.adapter.framework;
+  }
+
+  serializeHandler(fn: (...a: unknown[]) => unknown): SerializedHandler {
+    return serializeHandler(fn);
+  }
+
+  buildRegistrationScript(mockName: string): string {
+    return this.adapter.buildRegistrationScript(mockName);
+  }
+
+  buildSetImplementationScript(mockName: string, s: SerializedHandler, once?: boolean): string {
+    return this.adapter.buildSetImplementationScript(mockName, s, once);
+  }
+
+  buildInnerInvocationScript(mockName: string, method: InnerMockMethod): string {
+    return this.adapter.buildInnerInvocationScript(mockName, method);
+  }
+
+  buildInnerSetterScript(mockName: string, method: InnerMockSetterMethod, value: unknown): string {
+    return this.adapter.buildInnerSetterScript(mockName, method, value);
+  }
+
+  buildCallDataReadScript(mockName: string): string {
+    return this.adapter.buildCallDataReadScript(mockName);
+  }
+
+  buildUnregistrationScript(mockName: string): string {
+    return this.adapter.buildUnregistrationScript(mockName);
+  }
+
+  buildWithImplementationScript(
+    mockName: string,
+    implFn: (...a: unknown[]) => unknown,
+    callbackFn: (...a: unknown[]) => unknown,
+  ): string {
+    return this.adapter.buildWithImplementationScript(mockName, implFn.toString(), callbackFn.toString());
+  }
+
+  parseCallData(raw: unknown): MockCallData {
+    return parseCallData(raw);
+  }
+
+  buildContextSeedScript(context: IpcContext): string {
+    return buildContextSeedScript(context);
+  }
+
+  setContext(partial: IpcContext): IpcContext {
+    this._context = { ...this._context, ...partial };
+    return this._context;
+  }
+
+  getContext(): IpcContext {
+    return this._context;
+  }
+}
+
+export function createIpcInterceptor(framework: Framework, options?: InterceptorOptions): IpcInterceptor {
+  const adapter: FrameworkAdapter = framework === 'tauri' ? new TauriAdapter() : new ElectronAdapter();
+  return new IpcInterceptorImpl(adapter, options);
+}

--- a/packages/native-spy/src/interceptor/injection.ts
+++ b/packages/native-spy/src/interceptor/injection.ts
@@ -1,0 +1,7 @@
+export function mockLookupExpr(mockName: string): string {
+  return `window.__wdio_mocks__?.[${JSON.stringify(mockName)}]`;
+}
+
+export function errorReconstructExpr(varName: string): string {
+  return `(${varName} && typeof ${varName} === 'object' && ${varName}.__wdioError ? new Error(${varName}.message) : ${varName})`;
+}

--- a/packages/native-spy/src/interceptor/ipcContext.ts
+++ b/packages/native-spy/src/interceptor/ipcContext.ts
@@ -1,0 +1,5 @@
+export type IpcContext = { [key: string]: unknown };
+
+export function buildContextSeedScript(context: IpcContext): string {
+  return `(_tauri) => { if (!window.__wdio_ipc_context__) { window.__wdio_ipc_context__ = {}; } Object.assign(window.__wdio_ipc_context__, ${JSON.stringify(context)}); }`;
+}

--- a/packages/native-spy/src/interceptor/ipcContext.ts
+++ b/packages/native-spy/src/interceptor/ipcContext.ts
@@ -1,5 +1,6 @@
 export type IpcContext = { [key: string]: unknown };
 
 export function buildContextSeedScript(context: IpcContext): string {
-  return `(_tauri) => { if (!window.__wdio_ipc_context__) { window.__wdio_ipc_context__ = {}; } Object.assign(window.__wdio_ipc_context__, ${JSON.stringify(context)}); }`;
+  const serialized = JSON.stringify(JSON.stringify(context));
+  return `(_tauri) => { if (!window.__wdio_ipc_context__) { window.__wdio_ipc_context__ = {}; } Object.assign(window.__wdio_ipc_context__, JSON.parse(${serialized})); }`;
 }

--- a/packages/native-spy/src/interceptor/ipcContext.ts
+++ b/packages/native-spy/src/interceptor/ipcContext.ts
@@ -1,6 +1,19 @@
 export type IpcContext = { [key: string]: unknown };
 
+const unsafeJsCharMap: Record<string, string> = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  '/': '\\u002F',
+};
+
+function escapeUnsafeJsChars(str: string): string {
+  return str
+    .replace(/[<>/]/g, (ch) => unsafeJsCharMap[ch])
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
 export function buildContextSeedScript(context: IpcContext): string {
-  const serialized = JSON.stringify(JSON.stringify(context));
+  const serialized = escapeUnsafeJsChars(JSON.stringify(JSON.stringify(context)));
   return `(_tauri) => { if (!window.__wdio_ipc_context__) { window.__wdio_ipc_context__ = {}; } Object.assign(window.__wdio_ipc_context__, JSON.parse(${serialized})); }`;
 }

--- a/packages/native-spy/src/interceptor/serialize.ts
+++ b/packages/native-spy/src/interceptor/serialize.ts
@@ -11,5 +11,9 @@ export function safeJson(value: unknown): string {
   if (value instanceof Error) {
     return JSON.stringify({ __wdioError: true, message: value.message });
   }
-  return JSON.stringify(value);
+  try {
+    return JSON.stringify(value) ?? 'undefined';
+  } catch {
+    return '"[unserializable]"';
+  }
 }

--- a/packages/native-spy/src/interceptor/serialize.ts
+++ b/packages/native-spy/src/interceptor/serialize.ts
@@ -1,0 +1,15 @@
+export interface SerializedHandler {
+  source: string;
+  label?: string;
+}
+
+export function serializeHandler(fn: (...args: unknown[]) => unknown): SerializedHandler {
+  return { source: fn.toString() };
+}
+
+export function safeJson(value: unknown): string {
+  if (value instanceof Error) {
+    return JSON.stringify({ __wdioError: true, message: value.message });
+  }
+  return JSON.stringify(value);
+}

--- a/packages/native-spy/src/interceptor/syncProtocol.ts
+++ b/packages/native-spy/src/interceptor/syncProtocol.ts
@@ -1,0 +1,17 @@
+export interface MockCallData {
+  calls: unknown[][];
+  results: Array<{ type: 'return' | 'throw'; value: unknown }>;
+  invocationCallOrder: number[];
+}
+
+const EMPTY: MockCallData = { calls: [], results: [], invocationCallOrder: [] };
+
+export function parseCallData(raw: unknown): MockCallData {
+  if (!raw || typeof raw !== 'object') return EMPTY;
+  const r = raw as Record<string, unknown>;
+  return {
+    calls: Array.isArray(r.calls) ? (r.calls as unknown[][]) : [],
+    results: Array.isArray(r.results) ? (r.results as MockCallData['results']) : [],
+    invocationCallOrder: Array.isArray(r.invocationCallOrder) ? (r.invocationCallOrder as number[]) : [],
+  };
+}

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -1,0 +1,82 @@
+import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
+import { errorReconstructExpr, mockLookupExpr } from './injection.js';
+import type { SerializedHandler } from './serialize.js';
+import { safeJson } from './serialize.js';
+
+export class TauriAdapter implements FrameworkAdapter {
+  readonly framework = 'tauri' as const;
+
+  buildRegistrationScript(mockName: string): string {
+    return `(_tauri) => {
+  const spy = window.__wdio_spy__;
+  if (!spy?.fn) { throw new Error('@wdio/native-spy not available. Make sure @wdio/tauri-plugin is imported and initialized in your app.'); }
+  const mockFn = spy.fn();
+  mockFn.mockName('tauri.${mockName}');
+  if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }
+  window.__wdio_mocks__[${JSON.stringify(mockName)}] = mockFn;
+  mockFn.mockClear();
+}`;
+  }
+
+  buildCallDataReadScript(mockName: string): string {
+    const lookup = mockLookupExpr(mockName);
+    return `(_tauri) => {
+  const mockObj = ${lookup};
+  if (!mockObj?.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
+  const m = mockObj.mock;
+  return {
+    calls: JSON.parse(JSON.stringify(m.calls || [])),
+    results: JSON.parse(JSON.stringify(m.results || [])),
+    invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
+  };
+}`;
+  }
+
+  buildSetImplementationScript(mockName: string, s: SerializedHandler, once = false): string {
+    const lookup = mockLookupExpr(mockName);
+    const method = once ? 'mockImplementationOnce' : 'mockImplementation';
+    return `(_tauri) => {
+  const mockObj = ${lookup};
+  if (mockObj) { mockObj.${method}?.((${s.source})); }
+}`;
+  }
+
+  buildInnerInvocationScript(mockName: string, method: InnerMockMethod): string {
+    const lookup = mockLookupExpr(mockName);
+    return `(_tauri) => {
+  const mockObj = ${lookup};
+  mockObj?.${method}?.();
+}`;
+  }
+
+  buildInnerSetterScript(mockName: string, method: InnerMockSetterMethod, value: unknown): string {
+    const lookup = mockLookupExpr(mockName);
+    const serialized = safeJson(value);
+    const reconstruct = errorReconstructExpr('_v');
+    return `(_tauri) => {
+  const _v = ${serialized};
+  const mockObj = ${lookup};
+  mockObj?.${method}?.(${reconstruct});
+}`;
+  }
+
+  buildUnregistrationScript(mockName: string): string {
+    return `(_tauri) => {
+  if (window.__wdio_mocks__?.[${JSON.stringify(mockName)}]) {
+    delete window.__wdio_mocks__[${JSON.stringify(mockName)}];
+  }
+}`;
+  }
+
+  buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string {
+    const lookup = mockLookupExpr(mockName);
+    return `async (_tauri) => {
+  const impl = (${implFnSource});
+  const callback = (${callbackFnSource});
+  let result;
+  const mockObj = ${lookup};
+  mockObj?.withImplementation?.(impl, () => { result = callback(_tauri); });
+  return result?.then ? await result : result;
+}`;
+  }
+}

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -11,7 +11,7 @@ export class TauriAdapter implements FrameworkAdapter {
   const spy = window.__wdio_spy__;
   if (!spy?.fn) { throw new Error('@wdio/native-spy not available. Make sure @wdio/tauri-plugin is imported and initialized in your app.'); }
   const mockFn = spy.fn();
-  mockFn.mockName('tauri.${mockName}');
+  mockFn.mockName(${JSON.stringify(`tauri.${mockName}`)});
   if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }
   window.__wdio_mocks__[${JSON.stringify(mockName)}] = mockFn;
   mockFn.mockClear();

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -1,5 +1,7 @@
 import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
 import { errorReconstructExpr, mockLookupExpr } from './injection.js';
+import type { IpcContext } from './ipcContext.js';
+import { buildContextSeedScript } from './ipcContext.js';
 import type { SerializedHandler } from './serialize.js';
 import { safeJson } from './serialize.js';
 
@@ -66,6 +68,10 @@ export class TauriAdapter implements FrameworkAdapter {
     delete window.__wdio_mocks__[${JSON.stringify(mockName)}];
   }
 }`;
+  }
+
+  buildContextSeedScript(context: IpcContext): string {
+    return buildContextSeedScript(context);
   }
 
   buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string {

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -75,8 +75,8 @@ export class TauriAdapter implements FrameworkAdapter {
   const callback = (${callbackFnSource});
   let result;
   const mockObj = ${lookup};
-  mockObj?.withImplementation?.(impl, () => { result = callback(_tauri); });
-  return result?.then ? await result : result;
+  await mockObj?.withImplementation?.(impl, async () => { result = await callback(_tauri); });
+  return result;
 }`;
   }
 }

--- a/packages/native-spy/test/interceptor/index.spec.ts
+++ b/packages/native-spy/test/interceptor/index.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { createIpcInterceptor } from '../../src/interceptor/index.js';
+
+describe('createIpcInterceptor', () => {
+  describe('tauri', () => {
+    const interceptor = createIpcInterceptor('tauri');
+
+    it('reports tauri framework', () => {
+      expect(interceptor.framework).toBe('tauri');
+    });
+
+    it('serializeHandler captures function source', () => {
+      const fn = () => 42;
+      const { source } = interceptor.serializeHandler(fn);
+      expect(source).toContain('42');
+    });
+
+    it('buildRegistrationScript delegates to adapter', () => {
+      const script = interceptor.buildRegistrationScript('cmd');
+      expect(script).toContain('__wdio_spy__');
+    });
+
+    it('buildSetImplementationScript accepts SerializedHandler', () => {
+      const s = interceptor.serializeHandler(() => 1);
+      const script = interceptor.buildSetImplementationScript('cmd', s);
+      expect(script).toContain('mockImplementation');
+    });
+
+    it('buildWithImplementationScript takes function objects', () => {
+      const script = interceptor.buildWithImplementationScript(
+        'cmd',
+        () => 1,
+        () => 2,
+      );
+      expect(script).toContain('withImplementation');
+    });
+
+    it('parseCallData returns empty data for null', () => {
+      const data = interceptor.parseCallData(null);
+      expect(data.calls).toEqual([]);
+      expect(data.results).toEqual([]);
+      expect(data.invocationCallOrder).toEqual([]);
+    });
+
+    it('parseCallData parses valid call data', () => {
+      const raw = { calls: [[1, 2]], results: [{ type: 'return', value: 3 }], invocationCallOrder: [0] };
+      const data = interceptor.parseCallData(raw);
+      expect(data.calls).toEqual([[1, 2]]);
+      expect(data.results[0].type).toBe('return');
+    });
+  });
+
+  describe('electron stub', () => {
+    const interceptor = createIpcInterceptor('electron');
+
+    it('reports electron framework', () => {
+      expect(interceptor.framework).toBe('electron');
+    });
+
+    it('throws Not implemented for buildRegistrationScript', () => {
+      expect(() => interceptor.buildRegistrationScript('cmd')).toThrow('Not implemented');
+    });
+  });
+
+  describe('context management', () => {
+    it('starts with empty context', () => {
+      const interceptor = createIpcInterceptor('tauri');
+      expect(interceptor.getContext()).toEqual({});
+    });
+
+    it('initializes with provided context', () => {
+      const interceptor = createIpcInterceptor('tauri', { context: { foo: 'bar' } });
+      expect(interceptor.getContext()).toEqual({ foo: 'bar' });
+    });
+
+    it('setContext merges into existing context', () => {
+      const interceptor = createIpcInterceptor('tauri', { context: { a: 1 } });
+      interceptor.setContext({ b: 2 });
+      expect(interceptor.getContext()).toEqual({ a: 1, b: 2 });
+    });
+
+    it('buildContextSeedScript generates a script with context', () => {
+      const interceptor = createIpcInterceptor('tauri');
+      const script = interceptor.buildContextSeedScript({ x: 99 });
+      expect(script).toContain('__wdio_ipc_context__');
+      expect(script).toContain('99');
+    });
+  });
+});

--- a/packages/native-spy/test/interceptor/integration.spec.ts
+++ b/packages/native-spy/test/interceptor/integration.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { createIpcInterceptor } from '../../src/interceptor/index.js';
+import { fn } from '../../src/mock.js';
+
+type SyntheticWindow = {
+  __wdio_spy__: { fn: typeof fn };
+  __wdio_mocks__: Record<string, ReturnType<typeof fn>>;
+  __wdio_ipc_context__?: Record<string, unknown>;
+};
+
+function makeSyntheticWindow(): SyntheticWindow {
+  return {
+    __wdio_spy__: { fn },
+    __wdio_mocks__: {},
+  };
+}
+
+function evalScript(script: string, win: SyntheticWindow): unknown {
+  const fn = new Function('window', `return (${script})(undefined)`);
+  return fn(win);
+}
+
+describe('TauriAdapter integration (synthetic window)', () => {
+  const interceptor = createIpcInterceptor('tauri');
+
+  it('buildRegistrationScript creates a mock in __wdio_mocks__', () => {
+    const win = makeSyntheticWindow();
+    const script = interceptor.buildRegistrationScript('my_cmd');
+    evalScript(script, win);
+    expect(typeof win.__wdio_mocks__['my_cmd']).toBe('function');
+  });
+
+  it('buildRegistrationScript calls mockClear so calls start empty', () => {
+    const win = makeSyntheticWindow();
+    const script = interceptor.buildRegistrationScript('my_cmd');
+    evalScript(script, win);
+    const mock = win.__wdio_mocks__['my_cmd'];
+    mock('some_arg');
+    evalScript(script, win);
+    expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(0);
+  });
+
+  it('buildCallDataReadScript returns call data', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+    win.__wdio_mocks__['my_cmd']('arg1');
+    win.__wdio_mocks__['my_cmd']('arg2');
+
+    const readScript = interceptor.buildCallDataReadScript('my_cmd');
+    const raw = evalScript(readScript, win);
+    const data = interceptor.parseCallData(raw);
+    expect(data.calls).toHaveLength(2);
+  });
+
+  it('buildSetImplementationScript sets implementation', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+
+    const s = interceptor.serializeHandler(() => 'hello');
+    evalScript(interceptor.buildSetImplementationScript('my_cmd', s), win);
+
+    const result = win.__wdio_mocks__['my_cmd']();
+    expect(result).toBe('hello');
+  });
+
+  it('buildSetImplementationScript once=true uses mockImplementationOnce', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+
+    const s = interceptor.serializeHandler(() => 'once');
+    evalScript(interceptor.buildSetImplementationScript('my_cmd', s, true), win);
+
+    expect(win.__wdio_mocks__['my_cmd']()).toBe('once');
+    expect(win.__wdio_mocks__['my_cmd']()).toBeUndefined();
+  });
+
+  it('buildInnerSetterScript mockReturnValue sets return value', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+    evalScript(interceptor.buildInnerSetterScript('my_cmd', 'mockReturnValue', 42), win);
+    expect(win.__wdio_mocks__['my_cmd']()).toBe(42);
+  });
+
+  it('buildInnerSetterScript mockRejectedValue with Error reconstructs correctly', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+    evalScript(interceptor.buildInnerSetterScript('my_cmd', 'mockRejectedValue', new Error('fail msg')), win);
+
+    expect(() => win.__wdio_mocks__['my_cmd']()).toThrow('fail msg');
+  });
+
+  it('buildInnerInvocationScript mockClear empties call history', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+    win.__wdio_mocks__['my_cmd']('test');
+    expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(1);
+
+    evalScript(interceptor.buildInnerInvocationScript('my_cmd', 'mockClear'), win);
+    expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(0);
+  });
+
+  it('buildUnregistrationScript removes mock from __wdio_mocks__', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+    expect(win.__wdio_mocks__['my_cmd']).toBeDefined();
+
+    evalScript(interceptor.buildUnregistrationScript('my_cmd'), win);
+    expect(win.__wdio_mocks__['my_cmd']).toBeUndefined();
+  });
+
+  it('buildContextSeedScript seeds __wdio_ipc_context__', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildContextSeedScript({ userId: 'abc' }), win);
+    expect(win.__wdio_ipc_context__?.userId).toBe('abc');
+  });
+
+  it('buildContextSeedScript is idempotent (Object.assign merges)', () => {
+    const win = makeSyntheticWindow();
+    evalScript(interceptor.buildContextSeedScript({ a: 1 }), win);
+    evalScript(interceptor.buildContextSeedScript({ b: 2 }), win);
+    expect(win.__wdio_ipc_context__?.a).toBe(1);
+    expect(win.__wdio_ipc_context__?.b).toBe(2);
+  });
+});

--- a/packages/native-spy/test/interceptor/ipcContext.spec.ts
+++ b/packages/native-spy/test/interceptor/ipcContext.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildContextSeedScript } from '../../src/interceptor/ipcContext.js';
 
 describe('buildContextSeedScript', () => {
-  it('returns a function-like string', () => {
+  it('should return a function-like string', () => {
     const script = buildContextSeedScript({ foo: 'bar' });
     expect(script.trim()).toMatch(/^\(_tauri\)/);
   });
@@ -22,8 +22,15 @@ describe('buildContextSeedScript', () => {
     expect(script).toContain('JSON.parse');
   });
 
-  it('handles empty context', () => {
+  it('should handle empty context', () => {
     const script = buildContextSeedScript({});
     expect(script).toContain('{}');
+  });
+
+  it('escapes HTML-unsafe characters in context values', () => {
+    const script = buildContextSeedScript({ tag: '</script>' });
+    expect(script).not.toContain('</script>');
+    expect(script).toContain('\\u003C');
+    expect(script).toContain('\\u003E');
   });
 });

--- a/packages/native-spy/test/interceptor/ipcContext.spec.ts
+++ b/packages/native-spy/test/interceptor/ipcContext.spec.ts
@@ -9,14 +9,17 @@ describe('buildContextSeedScript', () => {
 
   it('includes the serialized context', () => {
     const script = buildContextSeedScript({ count: 3, label: 'test' });
-    expect(script).toContain('"count":3');
-    expect(script).toContain('"label":"test"');
+    expect(script).toContain('count');
+    expect(script).toContain('3');
+    expect(script).toContain('label');
+    expect(script).toContain('test');
   });
 
   it('seeds window.__wdio_ipc_context__ via Object.assign', () => {
     const script = buildContextSeedScript({ x: 1 });
     expect(script).toContain('__wdio_ipc_context__');
     expect(script).toContain('Object.assign');
+    expect(script).toContain('JSON.parse');
   });
 
   it('handles empty context', () => {

--- a/packages/native-spy/test/interceptor/ipcContext.spec.ts
+++ b/packages/native-spy/test/interceptor/ipcContext.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildContextSeedScript } from '../../src/interceptor/ipcContext.js';
+
+describe('buildContextSeedScript', () => {
+  it('returns a function-like string', () => {
+    const script = buildContextSeedScript({ foo: 'bar' });
+    expect(script.trim()).toMatch(/^\(_tauri\)/);
+  });
+
+  it('includes the serialized context', () => {
+    const script = buildContextSeedScript({ count: 3, label: 'test' });
+    expect(script).toContain('"count":3');
+    expect(script).toContain('"label":"test"');
+  });
+
+  it('seeds window.__wdio_ipc_context__ via Object.assign', () => {
+    const script = buildContextSeedScript({ x: 1 });
+    expect(script).toContain('__wdio_ipc_context__');
+    expect(script).toContain('Object.assign');
+  });
+
+  it('handles empty context', () => {
+    const script = buildContextSeedScript({});
+    expect(script).toContain('{}');
+  });
+});

--- a/packages/native-spy/test/interceptor/serialize.spec.ts
+++ b/packages/native-spy/test/interceptor/serialize.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { safeJson, serializeHandler } from '../../src/interceptor/serialize.js';
+
+describe('serializeHandler', () => {
+  it('captures function source', () => {
+    const fn = (x: number) => x * 2;
+    const { source } = serializeHandler(fn);
+    expect(source).toContain('x * 2');
+  });
+
+  it('works for named functions', () => {
+    function myFn() {
+      return 42;
+    }
+    const { source } = serializeHandler(myFn);
+    expect(source).toContain('42');
+  });
+});
+
+describe('safeJson', () => {
+  it('serializes primitives normally', () => {
+    expect(safeJson(42)).toBe('42');
+    expect(safeJson('hello')).toBe('"hello"');
+    expect(safeJson(null)).toBe('null');
+    expect(safeJson(true)).toBe('true');
+  });
+
+  it('serializes plain objects normally', () => {
+    expect(safeJson({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it('serializes Error as wdioError sentinel', () => {
+    const err = new Error('boom');
+    const result = safeJson(err);
+    const parsed = JSON.parse(result) as { __wdioError: boolean; message: string };
+    expect(parsed.__wdioError).toBe(true);
+    expect(parsed.message).toBe('boom');
+  });
+
+  it('preserves Error message through sentinel round-trip', () => {
+    const err = new TypeError('type error message');
+    const result = safeJson(err);
+    const parsed = JSON.parse(result) as { __wdioError: boolean; message: string };
+    expect(parsed.message).toBe('type error message');
+  });
+});

--- a/packages/native-spy/test/interceptor/serialize.spec.ts
+++ b/packages/native-spy/test/interceptor/serialize.spec.ts
@@ -43,4 +43,14 @@ describe('safeJson', () => {
     const parsed = JSON.parse(result) as { __wdioError: boolean; message: string };
     expect(parsed.message).toBe('type error message');
   });
+
+  it('returns the string "undefined" for undefined input', () => {
+    expect(safeJson(undefined)).toBe('undefined');
+  });
+
+  it('returns "[unserializable]" for circular references', () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    expect(safeJson(obj)).toBe('"[unserializable]"');
+  });
 });

--- a/packages/native-spy/test/interceptor/tauri.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { TauriAdapter } from '../../src/interceptor/tauri.js';
+
+describe('TauriAdapter', () => {
+  const adapter = new TauriAdapter();
+
+  describe('framework', () => {
+    it('is tauri', () => {
+      expect(adapter.framework).toBe('tauri');
+    });
+  });
+
+  describe('buildRegistrationScript', () => {
+    it('returns a function-like string', () => {
+      const script = adapter.buildRegistrationScript('my_command');
+      expect(script.trim()).toMatch(/^\(_tauri\)/);
+    });
+
+    it('uses the mock name for __wdio_mocks__ key', () => {
+      const script = adapter.buildRegistrationScript('get_platform');
+      expect(script).toContain('"get_platform"');
+    });
+
+    it('sets mock name as tauri.<command>', () => {
+      const script = adapter.buildRegistrationScript('my_cmd');
+      expect(script).toContain('tauri.my_cmd');
+    });
+
+    it('calls mockClear after registration', () => {
+      const script = adapter.buildRegistrationScript('cmd');
+      expect(script).toContain('mockClear()');
+    });
+
+    it('checks for __wdio_spy__', () => {
+      const script = adapter.buildRegistrationScript('cmd');
+      expect(script).toContain('__wdio_spy__');
+    });
+  });
+
+  describe('buildCallDataReadScript', () => {
+    it('returns function string with mockObj lookup', () => {
+      const script = adapter.buildCallDataReadScript('my_cmd');
+      expect(script).toContain('"my_cmd"');
+      expect(script).toContain('mockObj.mock');
+    });
+
+    it('falls back to empty arrays when mockObj absent', () => {
+      const script = adapter.buildCallDataReadScript('my_cmd');
+      expect(script).toContain('calls: []');
+    });
+  });
+
+  describe('buildSetImplementationScript', () => {
+    it('uses mockImplementation by default', () => {
+      const script = adapter.buildSetImplementationScript('cmd', { source: '() => 42' });
+      expect(script).toContain('mockImplementation');
+      expect(script).not.toContain('mockImplementationOnce');
+    });
+
+    it('uses mockImplementationOnce when once=true', () => {
+      const script = adapter.buildSetImplementationScript('cmd', { source: '() => 42' }, true);
+      expect(script).toContain('mockImplementationOnce');
+    });
+
+    it('embeds the handler source', () => {
+      const script = adapter.buildSetImplementationScript('cmd', { source: '() => "hello"' });
+      expect(script).toContain('"hello"');
+    });
+  });
+
+  describe('buildInnerInvocationScript', () => {
+    it('calls mockClear', () => {
+      const script = adapter.buildInnerInvocationScript('cmd', 'mockClear');
+      expect(script).toContain('mockClear?.()');
+    });
+
+    it('calls mockReset', () => {
+      const script = adapter.buildInnerInvocationScript('cmd', 'mockReset');
+      expect(script).toContain('mockReset?.()');
+    });
+
+    it('calls mockReturnThis', () => {
+      const script = adapter.buildInnerInvocationScript('cmd', 'mockReturnThis');
+      expect(script).toContain('mockReturnThis?.()');
+    });
+  });
+
+  describe('buildInnerSetterScript', () => {
+    it('calls mockReturnValue with the value', () => {
+      const script = adapter.buildInnerSetterScript('cmd', 'mockReturnValue', 42);
+      expect(script).toContain('mockReturnValue');
+      expect(script).toContain('42');
+    });
+
+    it('serializes Error as wdioError sentinel and reconstructs', () => {
+      const script = adapter.buildInnerSetterScript('cmd', 'mockRejectedValue', new Error('boom'));
+      expect(script).toContain('__wdioError');
+      expect(script).toContain('boom');
+      expect(script).toContain('new Error');
+    });
+
+    it('passes plain values without Error reconstruction', () => {
+      const script = adapter.buildInnerSetterScript('cmd', 'mockReturnValue', 'hello');
+      expect(script).toContain('"hello"');
+    });
+
+    it('handles null value', () => {
+      const script = adapter.buildInnerSetterScript('cmd', 'mockReturnValue', null);
+      expect(script).toContain('null');
+    });
+  });
+
+  describe('buildUnregistrationScript', () => {
+    it('deletes the mock from __wdio_mocks__', () => {
+      const script = adapter.buildUnregistrationScript('my_cmd');
+      expect(script).toContain('delete window.__wdio_mocks__');
+      expect(script).toContain('"my_cmd"');
+    });
+  });
+
+  describe('buildWithImplementationScript', () => {
+    it('embeds impl and callback sources', () => {
+      const script = adapter.buildWithImplementationScript('cmd', '() => 99', '() => {}');
+      expect(script).toContain('99');
+      expect(script).toContain('withImplementation');
+    });
+
+    it('is async and awaits result', () => {
+      const script = adapter.buildWithImplementationScript('cmd', '() => {}', '() => {}');
+      expect(script.trim()).toMatch(/^async/);
+      expect(script).toContain('await result');
+    });
+
+    it('passes _tauri to callback', () => {
+      const script = adapter.buildWithImplementationScript('cmd', '() => {}', '() => {}');
+      expect(script).toContain('callback(_tauri)');
+    });
+  });
+});

--- a/packages/native-spy/test/interceptor/tauri.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri.spec.ts
@@ -11,7 +11,7 @@ describe('TauriAdapter', () => {
   });
 
   describe('buildRegistrationScript', () => {
-    it('returns a function-like string', () => {
+    it('should return a function-like string', () => {
       const script = adapter.buildRegistrationScript('my_command');
       expect(script.trim()).toMatch(/^\(_tauri\)/);
     });
@@ -21,12 +21,12 @@ describe('TauriAdapter', () => {
       expect(script).toContain('"get_platform"');
     });
 
-    it('sets mock name as tauri.<command>', () => {
+    it('should set mock name as tauri.<command>', () => {
       const script = adapter.buildRegistrationScript('my_cmd');
       expect(script).toContain('tauri.my_cmd');
     });
 
-    it('calls mockClear after registration', () => {
+    it('should call mockClear after registration', () => {
       const script = adapter.buildRegistrationScript('cmd');
       expect(script).toContain('mockClear()');
     });
@@ -38,7 +38,7 @@ describe('TauriAdapter', () => {
   });
 
   describe('buildCallDataReadScript', () => {
-    it('returns function string with mockObj lookup', () => {
+    it('should return function string with mockObj lookup', () => {
       const script = adapter.buildCallDataReadScript('my_cmd');
       expect(script).toContain('"my_cmd"');
       expect(script).toContain('mockObj.mock');
@@ -69,24 +69,24 @@ describe('TauriAdapter', () => {
   });
 
   describe('buildInnerInvocationScript', () => {
-    it('calls mockClear', () => {
+    it('should call mockClear', () => {
       const script = adapter.buildInnerInvocationScript('cmd', 'mockClear');
       expect(script).toContain('mockClear?.()');
     });
 
-    it('calls mockReset', () => {
+    it('should call mockReset', () => {
       const script = adapter.buildInnerInvocationScript('cmd', 'mockReset');
       expect(script).toContain('mockReset?.()');
     });
 
-    it('calls mockReturnThis', () => {
+    it('should call mockReturnThis', () => {
       const script = adapter.buildInnerInvocationScript('cmd', 'mockReturnThis');
       expect(script).toContain('mockReturnThis?.()');
     });
   });
 
   describe('buildInnerSetterScript', () => {
-    it('calls mockReturnValue with the value', () => {
+    it('should call mockReturnValue with the value', () => {
       const script = adapter.buildInnerSetterScript('cmd', 'mockReturnValue', 42);
       expect(script).toContain('mockReturnValue');
       expect(script).toContain('42');
@@ -104,7 +104,7 @@ describe('TauriAdapter', () => {
       expect(script).toContain('"hello"');
     });
 
-    it('handles null value', () => {
+    it('should handle null value', () => {
       const script = adapter.buildInnerSetterScript('cmd', 'mockReturnValue', null);
       expect(script).toContain('null');
     });
@@ -125,10 +125,12 @@ describe('TauriAdapter', () => {
       expect(script).toContain('withImplementation');
     });
 
-    it('is async and awaits result', () => {
+    it('is async and awaits the callback', () => {
       const script = adapter.buildWithImplementationScript('cmd', '() => {}', '() => {}');
       expect(script.trim()).toMatch(/^async/);
-      expect(script).toContain('await result');
+      expect(script).toContain('await mockObj?.withImplementation');
+      expect(script).toContain('async () =>');
+      expect(script).toContain('await callback(_tauri)');
     });
 
     it('passes _tauri to callback', () => {

--- a/packages/tauri-service/src/mock.ts
+++ b/packages/tauri-service/src/mock.ts
@@ -1,42 +1,12 @@
 import { fn as vitestFn } from '@wdio/native-spy';
+import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import type { AbstractFn, TauriMock } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 import { execute as tauriExecute } from './commands/execute.js';
 import mockStore from './mockStore.js';
 
 const log = createLogger('tauri-service', 'mock');
-
-interface InnerMock {
-  mock?: { calls?: unknown[]; results?: unknown[]; invocationCallOrder?: number[] };
-  mockClear?: () => void;
-  mockReset?: () => void;
-  mockReturnValue?: (val: unknown) => void;
-  mockReturnValueOnce?: (val: unknown) => void;
-  mockResolvedValue?: (val: unknown) => void;
-  mockResolvedValueOnce?: (val: unknown) => void;
-  mockRejectedValue?: (val: unknown) => void;
-  mockRejectedValueOnce?: (val: unknown) => void;
-  mockImplementation?: (fn: unknown) => void;
-  mockImplementationOnce?: (fn: unknown) => void;
-  mockReturnThis?: () => void;
-  withImplementation?: (impl: unknown, cb: unknown) => void;
-}
-
-async function restoreTauriCommand(command: string, browserContext?: WebdriverIO.Browser) {
-  const browserToUse = browserContext || browser;
-
-  await tauriExecute<void, [string]>(
-    browserToUse,
-    (_tauri, cmd) => {
-      // @ts-expect-error - window is available in browser context
-      if (window.__wdio_mocks__?.[cmd]) {
-        // @ts-expect-error - window is available in browser context
-        delete window.__wdio_mocks__[cmd];
-      }
-    },
-    command,
-  );
-}
+const interceptor = createIpcInterceptor('tauri');
 
 export async function createMock(command: string, browserContext?: WebdriverIO.Browser): Promise<TauriMock> {
   log.debug(`[${command}] createMock called - starting mock creation`);
@@ -86,65 +56,13 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   log.debug(`[${command}] Using browser context:`, typeof browserToUse, browserToUse?.constructor?.name);
 
   log.debug(`[${command}] Setting up JavaScript mock`);
-  await tauriExecute<void, [string]>(
-    browserToUse,
-    (_tauri, cmd) => {
-      // @ts-expect-error - window is available in browser context
-      const spy = window.__wdio_spy__;
-      if (!spy?.fn) {
-        throw new Error(
-          '@wdio/native-spy not available. Make sure @wdio/tauri-plugin is imported and initialized in your app.',
-        );
-      }
-
-      const mockFn = spy.fn();
-      mockFn.mockName(`tauri.${cmd}`);
-
-      // @ts-expect-error - window is available in browser context
-      if (!window.__wdio_mocks__) {
-        // @ts-expect-error - window is available in browser context
-        window.__wdio_mocks__ = {};
-      }
-      // @ts-expect-error - window is available in browser context
-      window.__wdio_mocks__[cmd] = mockFn;
-    },
-    command,
-  );
+  await tauriExecute<void>(browserToUse, interceptor.buildRegistrationScript(command));
   log.debug(`[${command}] JavaScript mock setup complete`);
-
-  await tauriExecute<void, [string]>(
-    browserToUse,
-    (_tauri, cmd) => {
-      // @ts-expect-error - window is available in browser context
-      const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-      mockObj?.mockClear?.();
-    },
-    command,
-  );
-  log.debug(`[${command}] Inner mock cleared to ensure clean initial state`);
 
   mock.update = async () => {
     log.debug(`[${command}] Starting mock update`);
-    const syncData = (await tauriExecute<
-      { calls: unknown[][]; results: { type: string; value: unknown }[]; invocationCallOrder: number[] },
-      [string]
-    >(
-      browserToUse,
-      (_tauri, cmd: string) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        if (!mockObj?.mock) {
-          return { calls: [], results: [], invocationCallOrder: [] };
-        }
-        const m = mockObj.mock;
-        return {
-          calls: JSON.parse(JSON.stringify(m.calls || [])),
-          results: JSON.parse(JSON.stringify(m.results || [])),
-          invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
-        };
-      },
-      command,
-    )) || { calls: [], results: [], invocationCallOrder: [] };
+    const raw = await tauriExecute<unknown>(browserToUse, interceptor.buildCallDataReadScript(command));
+    const syncData = interceptor.parseCallData(raw);
 
     const existingCount = originalMock.calls.length;
     log.debug(
@@ -170,175 +88,59 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   };
 
   mock.mockImplementation = async (implFn: AbstractFn) => {
-    const implStr = implFn.toString();
-    await tauriExecute<void, [string]>(
-      browserToUse,
-      `(_tauri, cmd) => { const mockObj = window.__wdio_mocks__?.[cmd]; if (mockObj) { mockObj.mockImplementation?.(${implStr}); } }`,
-      command,
-    );
-
+    const s = interceptor.serializeHandler(implFn);
+    await tauriExecute<void>(browserToUse, interceptor.buildSetImplementationScript(command, s));
     outerMockImplementation(implFn);
-
     return mock;
   };
 
   mock.mockImplementationOnce = async (implFn: AbstractFn) => {
-    const implStr = implFn.toString();
-    await tauriExecute<void, [string]>(
-      browserToUse,
-      `(_tauri, cmd) => { const mockObj = window.__wdio_mocks__?.[cmd]; if (mockObj) { mockObj.mockImplementationOnce?.(${implStr}); } }`,
-      command,
-    );
-
+    const s = interceptor.serializeHandler(implFn);
+    await tauriExecute<void>(browserToUse, interceptor.buildSetImplementationScript(command, s, true));
     outerMockImplementationOnce(implFn);
-
     return mock;
   };
 
   mock.mockReturnValue = async (value: unknown) => {
-    await tauriExecute<void, [string, unknown]>(
-      browserToUse,
-      (_tauri, cmd, returnValue) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.mockReturnValue?.(returnValue);
-      },
-      command,
-      value,
-    );
-
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockReturnValue', value));
     return mock;
   };
 
   mock.mockReturnValueOnce = async (value: unknown) => {
-    await tauriExecute<void, [string, unknown]>(
-      browserToUse,
-      (_tauri, cmd, returnValue) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.mockReturnValueOnce?.(returnValue);
-      },
-      command,
-      value,
-    );
-
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockReturnValueOnce', value));
     return mock;
   };
 
   mock.mockResolvedValue = async (value: unknown) => {
-    await tauriExecute<void, [string, unknown]>(
-      browserToUse,
-      (_tauri, cmd, resolvedValue) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.mockResolvedValue?.(resolvedValue);
-      },
-      command,
-      value,
-    );
-
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockResolvedValue', value));
     return mock;
   };
 
   mock.mockResolvedValueOnce = async (value: unknown) => {
-    await tauriExecute<void, [string, unknown]>(
-      browserToUse,
-      (_tauri, cmd, resolvedValue) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.mockResolvedValueOnce?.(resolvedValue);
-      },
-      command,
-      value,
-    );
-
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockResolvedValueOnce', value));
     return mock;
   };
 
   mock.mockRejectedValue = async (value: unknown) => {
-    if (value instanceof Error) {
-      await tauriExecute<void, [string, string]>(
-        browserToUse,
-        (_tauri, cmd, errMsg) => {
-          // @ts-expect-error - window is available in browser context
-          const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-          mockObj?.mockRejectedValue?.(new Error(errMsg));
-        },
-        command,
-        value.message,
-      );
-    } else {
-      await tauriExecute<void, [string, unknown]>(
-        browserToUse,
-        (_tauri, cmd, rejectedValue) => {
-          // @ts-expect-error - window is available in browser context
-          const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-          mockObj?.mockRejectedValue?.(rejectedValue);
-        },
-        command,
-        value,
-      );
-    }
-
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockRejectedValue', value));
     return mock;
   };
 
   mock.mockRejectedValueOnce = async (value: unknown) => {
-    if (value instanceof Error) {
-      await tauriExecute<void, [string, string]>(
-        browserToUse,
-        (_tauri, cmd, errMsg) => {
-          // @ts-expect-error - window is available in browser context
-          const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-          mockObj?.mockRejectedValueOnce?.(new Error(errMsg));
-        },
-        command,
-        value.message,
-      );
-    } else {
-      await tauriExecute<void, [string, unknown]>(
-        browserToUse,
-        (_tauri, cmd, rejectedValue) => {
-          // @ts-expect-error - window is available in browser context
-          const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-          mockObj?.mockRejectedValueOnce?.(rejectedValue);
-        },
-        command,
-        value,
-      );
-    }
-
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockRejectedValueOnce', value));
     return mock;
   };
 
   mock.mockClear = async () => {
-    await tauriExecute<void, [string]>(
-      browserToUse,
-      (_tauri, cmd) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.mockClear?.();
-      },
-      command,
-    );
-
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockClear'));
     outerMockClear();
-
     return mock;
   };
 
   mock.mockReset = async () => {
     const currentName = outerMock.getMockName();
 
-    await tauriExecute<void, [string]>(
-      browserToUse,
-      (_tauri, cmd) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.mockReset?.();
-      },
-      command,
-    );
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReset'));
 
     // Temporarily restore the sync mockClear so outerMockReset's internal mockFn.mockClear()
     // call doesn't fire the async override, which would defer outerMockClear() and race
@@ -356,46 +158,25 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   };
 
   mock.mockRestore = async () => {
-    await restoreTauriCommand(command, browserToUse);
-
+    await tauriExecute<void>(browserToUse, interceptor.buildUnregistrationScript(command));
     outerMockClear();
     mockStore.deleteMock(`tauri.${command}`);
-
     return mock;
   };
 
   mock.mockReturnThis = async () => {
-    await tauriExecute<void, [string]>(
-      browserToUse,
-      (_tauri, cmd) => {
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.mockReturnThis?.();
-      },
-      command,
-    );
+    await tauriExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReturnThis'));
     return mock;
   };
 
   mock.withImplementation = async (implFn, callbackFn) => {
-    return await tauriExecute<unknown, [string, string, string]>(
+    return await tauriExecute<unknown>(
       browserToUse,
-      async (tauri, cmd, implFnStr, callbackFnStr) => {
-        const callback = new Function(`return ${callbackFnStr}`)();
-        const impl = new Function(`return ${implFnStr}`)();
-        let result: unknown | Promise<unknown>;
-
-        // @ts-expect-error - window is available in browser context
-        const mockObj = window.__wdio_mocks__?.[cmd] as InnerMock | undefined;
-        mockObj?.withImplementation?.(impl, () => {
-          result = callback(tauri);
-        });
-
-        return (result as Promise<unknown>)?.then ? await result : result;
-      },
-      command,
-      implFn.toString(),
-      callbackFn.toString(),
+      interceptor.buildWithImplementationScript(
+        command,
+        implFn as (...a: unknown[]) => unknown,
+        callbackFn as (...a: unknown[]) => unknown,
+      ),
     );
   };
 

--- a/packages/tauri-service/test/commands/execute.spec.ts
+++ b/packages/tauri-service/test/commands/execute.spec.ts
@@ -120,7 +120,7 @@ describe('execute — embedded provider (direct eval)', () => {
   });
 
   describe('window label routing', () => {
-    it('sends window_label when per-call option is provided', async () => {
+    it('should send window_label when per-call option is provided', async () => {
       const mockFn = mockFetch({ value: 1 });
       vi.stubGlobal('fetch', mockFn);
       await execute(browser, '() => 1', { __wdioOptions__: true, windowLabel: 'settings' } as never);
@@ -128,7 +128,7 @@ describe('execute — embedded provider (direct eval)', () => {
       expect(body.window_label).toBe('settings');
     });
 
-    it('omits window_label for default session', async () => {
+    it('should omit window_label for default session', async () => {
       const mockFn = mockFetch({ value: 1 });
       vi.stubGlobal('fetch', mockFn);
       await execute(browser, '() => 1');
@@ -138,7 +138,7 @@ describe('execute — embedded provider (direct eval)', () => {
   });
 
   describe('client caching', () => {
-    it('reuses the same client for the same browser', async () => {
+    it('should reuse the same client for the same browser', async () => {
       const mockFn = mockFetch({ value: 1 });
       vi.stubGlobal('fetch', mockFn);
       await execute(browser, '() => 1');
@@ -147,7 +147,7 @@ describe('execute — embedded provider (direct eval)', () => {
       expect(mockFn.mock.calls[0][0]).toBe(mockFn.mock.calls[1][0]);
     });
 
-    it('creates separate clients for different browsers', async () => {
+    it('should create separate clients for different browsers', async () => {
       const browser2 = createMockBrowser();
       const mockFn = mockFetch({ value: 1 });
       vi.stubGlobal('fetch', mockFn);
@@ -156,7 +156,7 @@ describe('execute — embedded provider (direct eval)', () => {
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
-    it('creates a new client when TAURI_WEBDRIVER_PORT changes between calls', async () => {
+    it('should create a new client when TAURI_WEBDRIVER_PORT changes between calls', async () => {
       const mockFn = mockFetch({ value: 1 });
       vi.stubGlobal('fetch', mockFn);
 

--- a/packages/tauri-service/test/driverManager.spec.ts
+++ b/packages/tauri-service/test/driverManager.spec.ts
@@ -143,12 +143,12 @@ describe('isCargoAvailable', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns true when cargo --version succeeds', () => {
+  it('should return true when cargo --version succeeds', () => {
     vi.mocked(execSync).mockReturnValue('cargo 1.75.0');
     expect(isCargoAvailable()).toBe(true);
   });
 
-  it('returns false when cargo --version throws', () => {
+  it('should return false when cargo --version throws', () => {
     vi.mocked(execSync).mockImplementation(() => {
       throw new Error('command not found');
     });
@@ -164,7 +164,7 @@ describe('findTauriDriver', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   });
 
-  it('returns path when which command finds tauri-driver on Unix', () => {
+  it('should return path when which command finds tauri-driver on Unix', () => {
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
     vi.mocked(execSync).mockReturnValue('/usr/local/bin/tauri-driver\n');
     vi.mocked(existsSync).mockReturnValue(true);
@@ -172,7 +172,7 @@ describe('findTauriDriver', () => {
     expect(findTauriDriver()).toBe('/usr/local/bin/tauri-driver');
   });
 
-  it('returns path when where command finds tauri-driver on Windows', () => {
+  it('should return path when where command finds tauri-driver on Windows', () => {
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
     vi.mocked(execSync).mockReturnValue('C:\\Users\\user\\.cargo\\bin\\tauri-driver.exe\n');
     vi.mocked(existsSync).mockReturnValue(true);
@@ -180,7 +180,7 @@ describe('findTauriDriver', () => {
     expect(findTauriDriver()).toBe('C:\\Users\\user\\.cargo\\bin\\tauri-driver.exe');
   });
 
-  it('returns undefined when command throws and no common paths exist', () => {
+  it('should return undefined when command throws and no common paths exist', () => {
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
     vi.mocked(execSync).mockImplementation(() => {
       throw new Error('not found');
@@ -190,7 +190,7 @@ describe('findTauriDriver', () => {
     expect(findTauriDriver()).toBeUndefined();
   });
 
-  it('falls back to common paths when command fails', () => {
+  it('should fall back to common paths when command fails', () => {
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
     vi.mocked(execSync).mockImplementation(() => {
       throw new Error('not found');
@@ -208,7 +208,7 @@ describe('installTauriDriver', () => {
     vi.restoreAllMocks();
   });
 
-  it('resolves with driver path on successful install', async () => {
+  it('should resolve with driver path on successful install', async () => {
     const mockProc = new EventEmitter() as any;
     mockProc.stdout = new EventEmitter();
     mockProc.stderr = new EventEmitter();
@@ -228,7 +228,7 @@ describe('installTauriDriver', () => {
     expect(result).toContain('tauri-driver');
   });
 
-  it('rejects when cargo install fails with non-zero exit code', async () => {
+  it('should reject when cargo install fails with non-zero exit code', async () => {
     const mockProc = new EventEmitter() as any;
     mockProc.stdout = new EventEmitter();
     mockProc.stderr = new EventEmitter();
@@ -246,7 +246,7 @@ describe('installTauriDriver', () => {
     await expect(promise).rejects.toThrow('cargo install failed with code 1');
   });
 
-  it('rejects when binary not found after successful install', async () => {
+  it('should reject when binary not found after successful install', async () => {
     const mockProc = new EventEmitter() as any;
     mockProc.stdout = new EventEmitter();
     mockProc.stderr = new EventEmitter();
@@ -265,7 +265,7 @@ describe('installTauriDriver', () => {
     await expect(promise).rejects.toThrow('binary not found');
   });
 
-  it('rejects on spawn error', async () => {
+  it('should reject on spawn error', async () => {
     const mockProc = new EventEmitter() as any;
     mockProc.stdout = new EventEmitter();
     mockProc.stderr = new EventEmitter();
@@ -297,7 +297,7 @@ describe('ensureTauriDriver', () => {
   });
 
   describe('crabnebula provider', () => {
-    it('returns Ok with custom path when crabnebulaDriverPath exists', async () => {
+    it('should return Ok with custom path when crabnebulaDriverPath exists', async () => {
       vi.mocked(existsSync).mockReturnValue(true);
 
       const result = await ensureTauriDriver({
@@ -310,7 +310,7 @@ describe('ensureTauriDriver', () => {
       expect(result.value.method).toBe('found');
     });
 
-    it('returns Err when custom crabnebulaDriverPath does not exist', async () => {
+    it('should return Err when custom crabnebulaDriverPath does not exist', async () => {
       vi.mocked(existsSync).mockReturnValue(false);
 
       const result = await ensureTauriDriver({
@@ -322,7 +322,7 @@ describe('ensureTauriDriver', () => {
       expect(result.error.message).toContain('CrabNebula driver not found');
     });
 
-    it('returns Err when no crabnebula driver detected in node_modules', async () => {
+    it('should return Err when no crabnebula driver detected in node_modules', async () => {
       vi.mocked(existsSync).mockReturnValue(false);
 
       const result = await ensureTauriDriver({ driverProvider: 'crabnebula' });
@@ -333,7 +333,7 @@ describe('ensureTauriDriver', () => {
   });
 
   describe('official provider', () => {
-    it('returns Ok with custom tauriDriverPath when it exists', async () => {
+    it('should return Ok with custom tauriDriverPath when it exists', async () => {
       vi.mocked(existsSync).mockReturnValue(true);
 
       const result = await ensureTauriDriver({
@@ -345,7 +345,7 @@ describe('ensureTauriDriver', () => {
       expect(result.value.method).toBe('found');
     });
 
-    it('returns Err when custom tauriDriverPath does not exist', async () => {
+    it('should return Err when custom tauriDriverPath does not exist', async () => {
       vi.mocked(existsSync).mockReturnValue(false);
 
       const result = await ensureTauriDriver({
@@ -356,7 +356,7 @@ describe('ensureTauriDriver', () => {
       expect(result.error.message).toContain('tauri-driver not found at provided path');
     });
 
-    it('returns Ok when findTauriDriver finds existing driver', async () => {
+    it('should return Ok when findTauriDriver finds existing driver', async () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
       vi.mocked(execSync).mockReturnValue('/usr/local/bin/tauri-driver\n');
       vi.mocked(existsSync).mockReturnValue(true);
@@ -367,7 +367,7 @@ describe('ensureTauriDriver', () => {
       expect(result.value.method).toBe('found');
     });
 
-    it('auto-installs when enabled and driver not found', async () => {
+    it('should auto-install when enabled and driver not found', async () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
       vi.mocked(execSync).mockImplementation((cmd: string) => {
@@ -395,7 +395,7 @@ describe('ensureTauriDriver', () => {
       expect(result.value.method).toBe('installed');
     });
 
-    it('returns Err when auto-install is enabled but cargo is unavailable', async () => {
+    it('should return Err when auto-install is enabled but cargo is unavailable', async () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
       vi.mocked(execSync).mockImplementation(() => {
@@ -409,7 +409,7 @@ describe('ensureTauriDriver', () => {
       expect(result.error.message).toContain('Rust toolchain (cargo) not found');
     });
 
-    it('returns Err when auto-install fails', async () => {
+    it('should return Err when auto-install fails', async () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
       vi.mocked(execSync).mockImplementation((cmd: string) => {
@@ -436,7 +436,7 @@ describe('ensureTauriDriver', () => {
       expect(result.error.message).toContain('cargo install failed');
     });
 
-    it('returns Err with install instructions when driver not found and no auto-install', async () => {
+    it('should return Err with install instructions when driver not found and no auto-install', async () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
       vi.mocked(execSync).mockImplementation(() => {

--- a/packages/tauri-service/test/embeddedProvider.spec.ts
+++ b/packages/tauri-service/test/embeddedProvider.spec.ts
@@ -26,7 +26,7 @@ describe('checkEmbeddedServerAlive', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('returns true when the status endpoint responds ok', async () => {
+  it('should return true when the status endpoint responds ok', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
     expect(await checkEmbeddedServerAlive(4445)).toBe(true);
     expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -35,23 +35,23 @@ describe('checkEmbeddedServerAlive', () => {
     );
   });
 
-  it('uses the given port in the URL', async () => {
+  it('should use the given port in the URL', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
     await checkEmbeddedServerAlive(9999);
     expect(globalThis.fetch).toHaveBeenCalledWith('http://127.0.0.1:9999/status', expect.anything());
   });
 
-  it('returns false when fetch throws (connection refused)', async () => {
+  it('should return false when fetch throws (connection refused)', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
     expect(await checkEmbeddedServerAlive(4445)).toBe(false);
   });
 
-  it('returns false when response.ok is false', async () => {
+  it('should return false when response.ok is false', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false });
     expect(await checkEmbeddedServerAlive(4445)).toBe(false);
   });
 
-  it('returns false when fetch times out (AbortError)', async () => {
+  it('should return false when fetch times out (AbortError)', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new DOMException('The operation was aborted', 'AbortError'));
     expect(await checkEmbeddedServerAlive(4445)).toBe(false);
   });
@@ -66,35 +66,35 @@ describe('isEmbeddedProvider', () => {
   });
 
   describe('explicit driverProvider — always takes priority', () => {
-    it('returns true for "embedded"', () => {
+    it('should return true for "embedded"', () => {
       expect(isEmbeddedProvider({ driverProvider: 'embedded' })).toBe(true);
     });
 
-    it('returns false for "official"', () => {
+    it('should return false for "official"', () => {
       expect(isEmbeddedProvider({ driverProvider: 'official' })).toBe(false);
     });
 
-    it('returns false for "crabnebula"', () => {
+    it('should return false for "crabnebula"', () => {
       expect(isEmbeddedProvider({ driverProvider: 'crabnebula' })).toBe(false);
     });
   });
 
   describe('default behavior (no explicit driverProvider)', () => {
-    it('returns true when no driverProvider is set', () => {
+    it('should return true when no driverProvider is set', () => {
       expect(isEmbeddedProvider({})).toBe(true);
     });
 
-    it('returns true on macOS with no driverProvider', () => {
+    it('should return true on macOS with no driverProvider', () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       expect(isEmbeddedProvider({})).toBe(true);
     });
 
-    it('returns true on Windows with no driverProvider', () => {
+    it('should return true on Windows with no driverProvider', () => {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       expect(isEmbeddedProvider({})).toBe(true);
     });
 
-    it('returns true on Linux with no driverProvider', () => {
+    it('should return true on Linux with no driverProvider', () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
       expect(isEmbeddedProvider({})).toBe(true);
     });
@@ -116,30 +116,30 @@ describe('getEmbeddedPort', () => {
     process.env = originalEnv;
   });
 
-  it('returns explicit embeddedPort option when set', () => {
+  it('should return explicit embeddedPort option when set', () => {
     expect(getEmbeddedPort({ embeddedPort: 9999 })).toBe(9999);
   });
 
-  it('prefers embeddedPort option over env var', () => {
+  it('should prefer embeddedPort option over env var', () => {
     process.env.TAURI_WEBDRIVER_PORT = '8888';
     expect(getEmbeddedPort({ embeddedPort: 9999 })).toBe(9999);
   });
 
-  it('falls back to TAURI_WEBDRIVER_PORT env var when no option', () => {
+  it('should fall back to TAURI_WEBDRIVER_PORT env var when no option', () => {
     process.env.TAURI_WEBDRIVER_PORT = '7777';
     expect(getEmbeddedPort({})).toBe(7777);
   });
 
-  it('returns default 4445 when neither option nor env var is set', () => {
+  it('should return default 4445 when neither option nor env var is set', () => {
     expect(getEmbeddedPort({})).toBe(4445);
   });
 
-  it('ignores NaN env var and returns default', () => {
+  it('should ignore NaN env var and returns default', () => {
     process.env.TAURI_WEBDRIVER_PORT = 'not-a-number';
     expect(getEmbeddedPort({})).toBe(4445);
   });
 
-  it('parses numeric string env var correctly', () => {
+  it('should parse numeric string env var correctly', () => {
     process.env.TAURI_WEBDRIVER_PORT = '5555';
     expect(getEmbeddedPort({})).toBe(5555);
   });
@@ -183,7 +183,7 @@ describe('startEmbeddedDriver', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   });
 
-  it('spawns app and resolves when poll succeeds', async () => {
+  it('should spawn app and resolves when poll succeeds', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ value: { ready: true } }),
@@ -208,7 +208,7 @@ describe('startEmbeddedDriver', () => {
     expect(result.logHandlers).toBeDefined();
   });
 
-  it('rejects on spawn error', async () => {
+  it('should reject on spawn error', async () => {
     globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}));
 
     const promise = startEmbeddedDriver('/path/to/nonexistent', 4445, {});
@@ -220,7 +220,7 @@ describe('startEmbeddedDriver', () => {
     await expect(promise).rejects.toThrow('Failed to spawn Tauri app');
   });
 
-  it('cleans up on poll timeout failure', async () => {
+  it('should clean up on poll timeout failure', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('Connection refused'));
 
     const options: TauriServiceOptions = { startTimeout: 500 };
@@ -244,7 +244,7 @@ describe('stopEmbeddedDriver', () => {
     vi.useRealTimers();
   });
 
-  it('sends SIGTERM and resolves when process exits gracefully', async () => {
+  it('should send SIGTERM and resolves when process exits gracefully', async () => {
     const mockChild = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
     Object.defineProperty(mockChild, 'pid', { value: 111, configurable: true });
     Object.defineProperty(mockChild, 'exitCode', { value: null, writable: true, configurable: true });
@@ -261,7 +261,7 @@ describe('stopEmbeddedDriver', () => {
     expect(handler.close).toHaveBeenCalled();
   });
 
-  it('sends SIGKILL after graceful timeout expires', async () => {
+  it('should send SIGKILL after graceful timeout expires', async () => {
     const mockChild = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
     Object.defineProperty(mockChild, 'pid', { value: 222, configurable: true });
     Object.defineProperty(mockChild, 'exitCode', { value: null, writable: true, configurable: true });
@@ -284,7 +284,7 @@ describe('stopEmbeddedDriver', () => {
     expect(killCalls).toContain('SIGKILL');
   });
 
-  it('returns early when no PID is available', async () => {
+  it('should return early when no PID is available', async () => {
     const mockChild = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
     Object.defineProperty(mockChild, 'pid', { value: undefined, configurable: true });
     mockChild.kill = vi.fn();
@@ -296,7 +296,7 @@ describe('stopEmbeddedDriver', () => {
     expect(handler.close).toHaveBeenCalled();
   });
 
-  it('ignores errors when closing log handlers', async () => {
+  it('should ignore errors when closing log handlers', async () => {
     const mockChild = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
     Object.defineProperty(mockChild, 'pid', { value: undefined, configurable: true });
     mockChild.kill = vi.fn();

--- a/packages/tauri-service/test/integration/launcher.multiremote.integration.spec.ts
+++ b/packages/tauri-service/test/integration/launcher.multiremote.integration.spec.ts
@@ -365,7 +365,7 @@ describe('Multiremote Mode - Integration', () => {
   });
 
   describe('provider configuration', () => {
-    it('defaults to embedded provider when no driverProvider is set', async () => {
+    it('should default to embedded provider when no driverProvider is set', async () => {
       launcher = new TauriLaunchService(
         { startTimeout: 5000 },
         { browserName: 'tauri', 'tauri:options': { application: '/app' } },
@@ -384,7 +384,7 @@ describe('Multiremote Mode - Integration', () => {
       await expect((launcher as any).onPrepare({}, capabilities)).rejects.toThrow();
     });
 
-    it('uses official provider when explicitly set', async () => {
+    it('should use official provider when explicitly set', async () => {
       vi.mocked(ensureTauriDriver).mockResolvedValue({
         ok: true,
         value: { path: mockSuccessPath, method: 'found' },

--- a/packages/tauri-service/test/mock.spec.ts
+++ b/packages/tauri-service/test/mock.spec.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../src/mockStore.js', () => ({
+  default: {
+    deleteMock: vi.fn(),
+    getMock: vi.fn(),
+    setMock: vi.fn(),
+  },
+}));
+
+vi.mock('../src/commands/execute.js', () => ({
+  execute: vi.fn(),
+}));
+
+import { execute as tauriExecute } from '../src/commands/execute.js';
+import { createMock } from '../src/mock.js';
+import mockStore from '../src/mockStore.js';
+
+const mockExecute = vi.mocked(tauriExecute);
+
+function makeBrowser(): WebdriverIO.Browser {
+  return { isMultiremote: false } as unknown as WebdriverIO.Browser;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExecute.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createMock', () => {
+  it('calls tauriExecute once for registration (registration + initial mockClear are combined)', async () => {
+    const browser = makeBrowser();
+    await createMock('my_cmd', browser);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a TauriMock with __isTauriMock', async () => {
+    const browser = makeBrowser();
+    const mock = await createMock('my_cmd', browser);
+    expect(mock.__isTauriMock).toBe(true);
+  });
+
+  it('mock name is set to tauri.<command>', async () => {
+    const browser = makeBrowser();
+    const mock = await createMock('platform_info', browser);
+    expect(mock.getMockName()).toBe('tauri.platform_info');
+  });
+
+  describe('update()', () => {
+    it('populates calls from parsed call data', async () => {
+      const browser = makeBrowser();
+      mockExecute.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+        calls: [['arg1'], ['arg2']],
+        results: [
+          { type: 'return', value: 'a' },
+          { type: 'return', value: 'b' },
+        ],
+        invocationCallOrder: [0, 1],
+      });
+
+      const mock = await createMock('my_cmd', browser);
+      await mock.update();
+
+      expect(mock.mock.calls).toHaveLength(2);
+      expect(mock.mock.calls[0]).toEqual(['arg1']);
+      expect(mock.mock.calls[1]).toEqual(['arg2']);
+    });
+
+    it('does not duplicate existing calls on a second update', async () => {
+      const browser = makeBrowser();
+      const syncPayload = {
+        calls: [['arg1']],
+        results: [{ type: 'return', value: 'x' }],
+        invocationCallOrder: [0],
+      };
+      mockExecute
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(syncPayload)
+        .mockResolvedValueOnce(syncPayload);
+
+      const mock = await createMock('my_cmd', browser);
+      await mock.update();
+      await mock.update();
+
+      expect(mock.mock.calls).toHaveLength(1);
+    });
+
+    it('uses fallback result when syncData.results entry is missing', async () => {
+      const browser = makeBrowser();
+      mockExecute.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+        calls: [['arg1']],
+        results: [],
+        invocationCallOrder: [],
+      });
+
+      const mock = await createMock('my_cmd', browser);
+      await mock.update();
+
+      expect(mock.mock.results[0]).toEqual({ type: 'return', value: undefined });
+    });
+
+    it('returns a mock object for chaining', async () => {
+      const browser = makeBrowser();
+      mockExecute
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ calls: [], results: [], invocationCallOrder: [] });
+
+      const mock = await createMock('my_cmd', browser);
+      const result = await mock.update();
+      expect(typeof result).toBe('function');
+      expect((result as { __isTauriMock?: boolean }).__isTauriMock).toBe(true);
+    });
+  });
+
+  describe('mockReset() race-condition hack', () => {
+    it('preserves mock name after mockReset', async () => {
+      const browser = makeBrowser();
+      const mock = await createMock('my_cmd', browser);
+      const nameBefore = mock.getMockName();
+
+      mockExecute.mockResolvedValueOnce(undefined);
+      await mock.mockReset();
+
+      expect(mock.getMockName()).toBe(nameBefore);
+    });
+
+    it('restores async mockClear (not the sync outerMockClear) after mockReset completes', async () => {
+      const browser = makeBrowser();
+      const mock = await createMock('my_cmd', browser);
+
+      mockExecute.mockResolvedValueOnce(undefined);
+      await mock.mockReset();
+
+      // After mockReset, calling mockClear should again go through tauriExecute (async path)
+      // If the sync outerMockClear was accidentally left in place, mockExecute wouldn't be called
+      mockExecute.mockResolvedValueOnce(undefined);
+      await mock.mockClear();
+      expect(mockExecute).toHaveBeenCalled();
+    });
+
+    it('clears calls after mockReset', async () => {
+      const browser = makeBrowser();
+      const syncPayload = { calls: [['arg']], results: [{ type: 'return', value: 1 }], invocationCallOrder: [0] };
+      mockExecute.mockResolvedValueOnce(undefined).mockResolvedValueOnce(syncPayload).mockResolvedValueOnce(undefined);
+
+      const mock = await createMock('my_cmd', browser);
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(1);
+
+      await mock.mockReset();
+      expect(mock.mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('mockRestore()', () => {
+    it('calls mockStore.deleteMock with the tauri-prefixed name', async () => {
+      const browser = makeBrowser();
+      const mock = await createMock('my_cmd', browser);
+
+      mockExecute.mockResolvedValueOnce(undefined);
+      await mock.mockRestore();
+
+      expect(mockStore.deleteMock).toHaveBeenCalledWith('tauri.my_cmd');
+    });
+  });
+
+  describe('wrapperMock', () => {
+    it('wrapperMock.mock returns the outer mock state', async () => {
+      const browser = makeBrowser();
+      const wrapper = await createMock('my_cmd', browser);
+      expect(wrapper.mock).toBeDefined();
+      expect(Array.isArray(wrapper.mock.calls)).toBe(true);
+    });
+
+    it('wrapperMock.update is bound and functional', async () => {
+      const browser = makeBrowser();
+      const wrapper = await createMock('my_cmd', browser);
+
+      mockExecute.mockResolvedValueOnce({ calls: [], results: [], invocationCallOrder: [] });
+      const result = await wrapper.update();
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/packages/tauri-service/test/wrapForDirectEval.spec.ts
+++ b/packages/tauri-service/test/wrapForDirectEval.spec.ts
@@ -3,7 +3,7 @@ import { wrapScriptForDirectEval } from '../src/wrapForDirectEval.js';
 
 describe('wrapScriptForDirectEval', () => {
   describe('function-like scripts', () => {
-    it('wraps an arrow function', () => {
+    it('should wrap an arrow function', () => {
       const result = wrapScriptForDirectEval('(tauri, x) => x * 2', '[21]');
       expect(result).toContain('var __cb = arguments[arguments.length - 1]');
       expect(result).toContain('__wdio_args = [21]');
@@ -13,46 +13,46 @@ describe('wrapScriptForDirectEval', () => {
       expect(result).toContain('__cb({ ok: false,');
     });
 
-    it('wraps a named function expression', () => {
+    it('should wrap a named function expression', () => {
       const result = wrapScriptForDirectEval('function myFn(tauri) { return 1; }', '[]');
       expect(result).toContain('var __cb = arguments[arguments.length - 1]');
       expect(result).toContain('await (function myFn(tauri) { return 1; })(__wdio_tauri, ...__wdio_args)');
     });
 
-    it('wraps an async function', () => {
+    it('should wrap an async function', () => {
       const result = wrapScriptForDirectEval('async function fn(tauri) { return await fetch(); }', '[]');
       expect(result).toContain('await (async function fn(tauri) { return await fetch(); })(__wdio_tauri');
     });
 
-    it('wraps an async arrow function', () => {
+    it('should wrap an async arrow function', () => {
       const result = wrapScriptForDirectEval('async (tauri) => 42', '[]');
       expect(result).toContain('await (async (tauri) => 42)(__wdio_tauri');
     });
 
-    it('wraps a bare identifier arrow function', () => {
+    it('should wrap a bare identifier arrow function', () => {
       const result = wrapScriptForDirectEval('x => x + 1', '[5]');
       expect(result).toContain('await (x => x + 1)(__wdio_tauri');
     });
 
-    it('includes mock-routing invoke block', () => {
+    it('should include mock-routing invoke block', () => {
       const result = wrapScriptForDirectEval('(tauri) => 1', '[]');
       expect(result).toContain('window.__wdio_mocks__');
       expect(result).toContain('mocks[cmd]');
       expect(result).toContain('__wdio_invoke_real');
     });
 
-    it('includes __wdio_original_core__ wait loop', () => {
+    it('should include __wdio_original_core__ wait loop', () => {
       const result = wrapScriptForDirectEval('(tauri) => 1', '[]');
       expect(result).toContain('window.__wdio_original_core__');
       expect(result).toContain('5s timeout');
     });
 
-    it('embeds args JSON correctly', () => {
+    it('should embed args JSON correctly', () => {
       const result = wrapScriptForDirectEval('(tauri, a, b) => a + b', '[1,"hello"]');
       expect(result).toContain('__wdio_args = [1,"hello"]');
     });
 
-    it('passes undef=true for undefined results', () => {
+    it('should pass undef=true for undefined results', () => {
       const result = wrapScriptForDirectEval('(tauri) => 1', '[]');
       expect(result).toContain('undef: __result === undefined');
       expect(result).toContain('value: __result === undefined ? null : __result');
@@ -60,51 +60,51 @@ describe('wrapScriptForDirectEval', () => {
   });
 
   describe('string expression scripts', () => {
-    it('wraps a simple expression', () => {
+    it('should wrap a simple expression', () => {
       const result = wrapScriptForDirectEval('1 + 2', '[]');
       expect(result).toContain('var __cb = arguments[arguments.length - 1]');
       expect(result).toContain('(async function() { return 1 + 2; }).apply(null, __wdio_args)');
       expect(result).toContain('__cb({ ok: true,');
     });
 
-    it('wraps a property access expression', () => {
+    it('should wrap a property access expression', () => {
       const result = wrapScriptForDirectEval('document.title', '[]');
       expect(result).toContain('(async function() { return document.title; }).apply(null, __wdio_args)');
     });
 
-    it('embeds args JSON', () => {
+    it('should embed args JSON', () => {
       const result = wrapScriptForDirectEval('arguments[0] * 2', '[21]');
       expect(result).toContain('__wdio_args = [21]');
     });
   });
 
   describe('string statement scripts', () => {
-    it('wraps a const declaration', () => {
+    it('should wrap a const declaration', () => {
       const result = wrapScriptForDirectEval('const x = 1; return x;', '[]');
       expect(result).toContain('(async function() { const x = 1; return x; }).apply(null, __wdio_args)');
     });
 
-    it('wraps a let declaration', () => {
+    it('should wrap a let declaration', () => {
       const result = wrapScriptForDirectEval('let x = 2; return x;', '[]');
       expect(result).toContain('(async function() { let x = 2; return x; }).apply(null, __wdio_args)');
     });
 
-    it('wraps an if statement', () => {
+    it('should wrap an if statement', () => {
       const result = wrapScriptForDirectEval('if (true) { return 1; }', '[]');
       expect(result).toContain('(async function() { if (true) { return 1; } }).apply(null, __wdio_args)');
     });
 
-    it('wraps a script with semicolons as statement', () => {
+    it('should wrap a script with semicolons as statement', () => {
       const result = wrapScriptForDirectEval('var x = 1; var y = 2; return x + y;', '[]');
       expect(result).toContain('(async function() { var x = 1; var y = 2; return x + y; }).apply(null, __wdio_args)');
     });
 
-    it('wraps a return statement', () => {
+    it('should wrap a return statement', () => {
       const result = wrapScriptForDirectEval('return document.title', '[]');
       expect(result).toContain('(async function() { return document.title }).apply(null, __wdio_args)');
     });
 
-    it('does NOT wrap return statement as expression', () => {
+    it('should NOT wrap return statement as expression', () => {
       const result = wrapScriptForDirectEval('return 42', '[]');
       expect(result).not.toContain('return return 42');
       expect(result).toContain('(async function() { return 42 }).apply(null');
@@ -112,21 +112,21 @@ describe('wrapScriptForDirectEval', () => {
   });
 
   describe('callback contract', () => {
-    it('always sets up the __cb callback', () => {
+    it('should always set up the __cb callback', () => {
       for (const script of ['(tauri) => 1', '1 + 1', 'return 1']) {
         const result = wrapScriptForDirectEval(script, '[]');
         expect(result).toContain('var __cb = arguments[arguments.length - 1]');
       }
     });
 
-    it('always calls __cb on success', () => {
+    it('should always call __cb on success', () => {
       for (const script of ['(tauri) => 1', '1 + 1', 'return 1']) {
         const result = wrapScriptForDirectEval(script, '[]');
         expect(result).toContain('__cb({ ok: true,');
       }
     });
 
-    it('always calls __cb on error', () => {
+    it('should always call __cb on error', () => {
       for (const script of ['(tauri) => 1', '1 + 1', 'return 1']) {
         const result = wrapScriptForDirectEval(script, '[]');
         expect(result).toContain('__cb({ ok: false,');

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -89,8 +89,13 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'both' = 'bot
   log(`Building and packing services and dependencies (service: ${service})...`);
 
   try {
-    // Build all packages
-    execCommand('pnpm build', rootDir, 'Building all packages');
+    // Build only the packages required for the requested service
+    const buildFilters: Record<'electron' | 'tauri' | 'both', string> = {
+      electron: '--filter=@wdio/electron-service --filter=@wdio/native-spy',
+      tauri: '--filter=@wdio/tauri-service',
+      both: '--filter=./packages/*',
+    };
+    execCommand(`pnpm turbo run build ${buildFilters[service]}`, rootDir, `Building packages for ${service}`);
 
     // Pack native-utils (required for both services)
     const utilsDir = normalize(join(rootDir, 'packages', 'native-utils'));


### PR DESCRIPTION
- Added support for Tauri and Electron frameworks in the native-spy package, introducing the `FrameworkAdapter` interface and specific implementations for both platforms.
- Implemented the `ElectronAdapter` and `TauriAdapter` classes, providing methods for building registration, invocation, and setter scripts tailored to each framework.
- Created utility functions for handling IPC context and serialization of handler functions, enhancing the flexibility of script execution.
- Introduced comprehensive tests for the interceptor functionality, ensuring robust behavior across both frameworks and validating the correct generation of scripts.
- Updated package.json to include new entry points for the interceptor module, facilitating easier integration and usage in applications.