### PR TITLE
fix(electron): add macOS 26 diagnostics and reproduction matrix entry

### DIFF
--- a/.github/workflows/_ci-e2e.reusable.yml
+++ b/.github/workflows/_ci-e2e.reusable.yml
@@ -220,6 +220,11 @@ jobs:
             }
             return scenarios.map(s => `test:e2e:electron-${s}`).join(' ');
 
+      # Ensure the log directory exists so ChromeDriver's --log-path can write to it
+      - name: 📁 Prepare Log Directory
+        shell: bash
+        run: mkdir -p e2e/logs
+
       # Run the E2E tests using Turbo with the generated test commands
       # Each test builds its own apps with correct environment context
       - name: 🧪 Execute E2E Tests
@@ -227,6 +232,12 @@ jobs:
         env:
           ENABLE_SPLASH_WINDOW: 'true'
           TEST_TASKS: ${{ steps.gen-test.outputs.result }}
+          # Diagnostic logging — captures Electron startup output and a verbose
+          # ChromeDriver log so failures (e.g. macOS 26 session-not-created) are debuggable
+          ELECTRON_ENABLE_LOGGING: '1'
+          ELECTRON_ENABLE_STACK_DUMPING: '1'
+          WDIO_CHROMEDRIVER_VERBOSE: '1'
+          WDIO_CHROMEDRIVER_LOG_PATH: ${{ github.workspace }}/e2e/logs/chromedriver.log
         run: pnpm exec turbo run $TEST_TASKS --only --log-order=stream
 
       # Show logs on failure for debugging
@@ -249,6 +260,30 @@ jobs:
           path: e2e/logs/**/*.log
           retention-days: 90
           if-no-files-found: warn
+
+      # Collect macOS crash reports on failure
+      # macOS writes .ips dumps to ~/Library/Logs/DiagnosticReports/ when a process exits abnormally.
+      # Useful for diagnosing immediate Electron crashes (e.g. macOS 26 sandbox/codesigning failures)
+      # where ChromeDriver only reports "Chrome instance exited" without further detail.
+      - name: 🍎 Collect macOS Crash Reports
+        if: failure() && runner.os == 'macOS'
+        continue-on-error: true
+        shell: bash
+        run: |
+          DEST="${{ github.workspace }}/logs/macos-crash-reports"
+          mkdir -p "$DEST"
+          cp -v ~/Library/Logs/DiagnosticReports/*.ips "$DEST/" 2>/dev/null || echo "No .ips reports found"
+          cp -v /Library/Logs/DiagnosticReports/*.ips "$DEST/" 2>/dev/null || true
+
+      - name: 📦 Upload macOS Crash Reports
+        if: failure() && runner.os == 'macOS'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-crash-reports-${{ inputs.os }}${{ inputs.variant && format('-{0}', inputs.variant) || '' }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.scenario }}
+          path: logs/macos-crash-reports/*.ips
+          retention-days: 90
+          if-no-files-found: ignore
 
       # Provide an interactive debugging session on failure
       # This allows manual investigation of the environment

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -170,6 +170,11 @@ jobs:
              fi
            fi
 
+      # Ensure the log directory exists so ChromeDriver's --log-path can write to it
+      - name: 📁 Prepare Log Directory
+        shell: bash
+        run: mkdir -p logs/package-tests
+
       # Run package tests using test-package.ts script
       # All apps are built in isolated environments (Electron always, Tauri if not skipBuild)
       # Tauri uses skipBuild to copy pre-built binaries from separate build jobs
@@ -180,6 +185,12 @@ jobs:
           RUST_BACKTRACE: '1'
           # Disable AT-SPI accessibility bus warnings (same as E2E)
           NO_AT_BRIDGE: '1'
+          # Diagnostic logging — captures Electron startup output and a verbose
+          # ChromeDriver log so failures (e.g. macOS 26 session-not-created) are debuggable
+          ELECTRON_ENABLE_LOGGING: '1'
+          ELECTRON_ENABLE_STACK_DUMPING: '1'
+          WDIO_CHROMEDRIVER_VERBOSE: '1'
+          WDIO_CHROMEDRIVER_LOG_PATH: ${{ github.workspace }}/logs/package-tests/chromedriver.log
           SERVICE: ${{ inputs.service }}
         run: |
           case "$SERVICE" in
@@ -237,6 +248,30 @@ jobs:
           path: logs/package-tests/*.log
           retention-days: 90
           if-no-files-found: warn
+
+      # Collect macOS crash reports on failure
+      # macOS writes .ips dumps to ~/Library/Logs/DiagnosticReports/ when a process exits abnormally.
+      # Useful for diagnosing immediate Electron crashes (e.g. macOS 26 sandbox/codesigning failures)
+      # where ChromeDriver only reports "Chrome instance exited" without further detail.
+      - name: 🍎 Collect macOS Crash Reports
+        if: failure() && runner.os == 'macOS'
+        continue-on-error: true
+        shell: bash
+        run: |
+          DEST="${{ github.workspace }}/logs/macos-crash-reports"
+          mkdir -p "$DEST"
+          cp -v ~/Library/Logs/DiagnosticReports/*.ips "$DEST/" 2>/dev/null || echo "No .ips reports found"
+          cp -v /Library/Logs/DiagnosticReports/*.ips "$DEST/" 2>/dev/null || true
+
+      - name: 📦 Upload macOS Crash Reports
+        if: failure() && runner.os == 'macOS'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-crash-reports-${{ inputs.os }}-${{ inputs.service }}-${{ inputs.module-type || 'default' }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: logs/macos-crash-reports/*.ips
+          retention-days: 90
+          if-no-files-found: ignore
 
       # Provide an interactive debugging session on failure
       # This allows manual investigation of the environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,12 @@ jobs:
           - os: macos-15-intel
             display-name: macOS-Intel
             module-type: esm
+          # Forward-compat coverage: catches macOS 26 regressions before
+          # `macos-latest` aliases to it. The `check-macos-alias-overlap` job
+          # below auto-fails when this becomes redundant.
+          - os: macos-26
+            display-name: macOS-26
+            module-type: esm
     uses: ./.github/workflows/_ci-package.reusable.yml
     secrets: inherit
     with:
@@ -213,6 +219,60 @@ jobs:
       build_id: ${{ needs.build.outputs.build_id }}
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
+
+  # macOS alias-overlap guard
+  # The `package-electron-matrix` includes a dedicated `macos-26` row to catch
+  # macOS 26 regressions before `macos-latest` aliases to that version. When
+  # GitHub eventually flips the alias, the dedicated row becomes redundant.
+  # These three jobs detect that automatically: each `detect-*` job emits the
+  # major OS version of its runner, and `check-macos-alias-overlap` fails with
+  # a clear remediation message if the majors match.
+  detect-macos-latest-version:
+    name: Detect - macos-latest OS major
+    runs-on: macos-latest
+    outputs:
+      major: ${{ steps.detect.outputs.major }}
+    steps:
+      - name: Detect macOS major version
+        id: detect
+        shell: bash
+        run: |
+          MAJOR=$(sw_vers -productVersion | cut -d. -f1)
+          echo "macos-latest reports macOS $MAJOR.x"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+
+  detect-macos-26-version:
+    name: Detect - macos-26 OS major
+    runs-on: macos-26
+    outputs:
+      major: ${{ steps.detect.outputs.major }}
+    steps:
+      - name: Detect macOS major version
+        id: detect
+        shell: bash
+        run: |
+          MAJOR=$(sw_vers -productVersion | cut -d. -f1)
+          echo "macos-26 reports macOS $MAJOR.x"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+
+  check-macos-alias-overlap:
+    name: Check - macOS alias overlap
+    needs: [detect-macos-latest-version, detect-macos-26-version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify macos-latest does not alias to macos-26
+        shell: bash
+        env:
+          LATEST_MAJOR: ${{ needs.detect-macos-latest-version.outputs.major }}
+          PINNED_MAJOR: ${{ needs.detect-macos-26-version.outputs.major }}
+        run: |
+          echo "macos-latest major: $LATEST_MAJOR"
+          echo "macos-26    major: $PINNED_MAJOR"
+          if [ "$LATEST_MAJOR" = "$PINNED_MAJOR" ]; then
+            echo "::error::macos-latest now aliases to macOS $LATEST_MAJOR — the dedicated macos-26 row in package-electron-matrix is redundant. Remove the macos-26 row from .github/workflows/ci.yml AND remove this alias-overlap guard (detect-macos-latest-version, detect-macos-26-version, check-macos-alias-overlap)."
+            exit 1
+          fi
+          echo "Not redundant — macos-26 row still provides forward-compat coverage."
 
   package-tauri-linux:
     name: Package - Tauri [Linux]

--- a/fixtures/package-tests/electron-builder-app-cjs/test/app.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-cjs/test/app.spec.ts
@@ -85,8 +85,9 @@ describe('Builder App Example', () => {
     expect(result).not.toBeNull();
     expect(result?.width).toBe(900);
     if (process.platform === 'darwin') {
-      // Allow minor variance on macOS due to frame metrics and work area fitting
-      expect(result.height).toBeGreaterThanOrEqual(680);
+      // Allow minor variance on macOS due to frame metrics and work area fitting.
+      // macOS 26 has slightly taller titlebar metrics; lower bound covers ~674px observed there.
+      expect(result.height).toBeGreaterThanOrEqual(670);
       expect(result.height).toBeLessThanOrEqual(720);
     } else {
       expect(result?.height).toBe(700);

--- a/fixtures/package-tests/electron-builder-app-esm/test/app.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/test/app.spec.ts
@@ -85,8 +85,9 @@ describe('Builder App Example', () => {
     expect(result).not.toBeNull();
     expect(result?.width).toBe(900);
     if (process.platform === 'darwin') {
-      // Allow minor variance on macOS due to frame metrics and work area fitting
-      expect(result.height).toBeGreaterThanOrEqual(680);
+      // Allow minor variance on macOS due to frame metrics and work area fitting.
+      // macOS 26 has slightly taller titlebar metrics; lower bound covers ~674px observed there.
+      expect(result.height).toBeGreaterThanOrEqual(670);
       expect(result.height).toBeLessThanOrEqual(720);
     } else {
       expect(result?.height).toBe(700);

--- a/fixtures/package-tests/electron-forge-app-cjs/test/app.spec.ts
+++ b/fixtures/package-tests/electron-forge-app-cjs/test/app.spec.ts
@@ -85,7 +85,7 @@ describe('Forge App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(670);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);

--- a/fixtures/package-tests/electron-forge-app-esm/test/app.spec.ts
+++ b/fixtures/package-tests/electron-forge-app-esm/test/app.spec.ts
@@ -85,7 +85,7 @@ describe('Forge App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(670);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);

--- a/fixtures/package-tests/electron-script-app-cjs/test/app.spec.ts
+++ b/fixtures/package-tests/electron-script-app-cjs/test/app.spec.ts
@@ -100,7 +100,7 @@ describe('Script App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(670);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);

--- a/fixtures/package-tests/electron-script-app-esm/test/app.spec.ts
+++ b/fixtures/package-tests/electron-script-app-esm/test/app.spec.ts
@@ -100,7 +100,7 @@ describe('Script App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(670);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);

--- a/packages/electron-service/src/capabilities.ts
+++ b/packages/electron-service/src/capabilities.ts
@@ -15,7 +15,14 @@ export function getChromeOptions(options: ElectronServiceOptions, cap: Webdriver
 
 export function getChromedriverOptions(cap: WebdriverIO.Capabilities) {
   const existingOptions = cap['wdio:chromedriverOptions'] || {};
-  return existingOptions;
+  if (process.env.WDIO_CHROMEDRIVER_VERBOSE !== '1') {
+    return existingOptions;
+  }
+  return {
+    ...existingOptions,
+    verbose: true,
+    ...(process.env.WDIO_CHROMEDRIVER_LOG_PATH ? { logPath: process.env.WDIO_CHROMEDRIVER_LOG_PATH } : {}),
+  };
 }
 
 const isElectron = (cap: unknown) => (cap as WebdriverIO.Capabilities)?.browserName?.toLowerCase() === 'electron';

--- a/packages/electron-service/test/capabilities.spec.ts
+++ b/packages/electron-service/test/capabilities.spec.ts
@@ -1,5 +1,5 @@
 import type { Capabilities } from '@wdio/types';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   getChromedriverOptions,
   getChromeOptions,
@@ -90,6 +90,46 @@ describe('Capabilities Utilities', () => {
           },
         }),
       ).toStrictEqual({});
+    });
+
+    describe('when WDIO_CHROMEDRIVER_VERBOSE=1', () => {
+      const originalEnv = { ...process.env };
+
+      beforeEach(() => {
+        process.env.WDIO_CHROMEDRIVER_VERBOSE = '1';
+        delete process.env.WDIO_CHROMEDRIVER_LOG_PATH;
+      });
+
+      afterEach(() => {
+        process.env = { ...originalEnv };
+      });
+
+      it('should inject verbose: true', () => {
+        expect(getChromedriverOptions({})).toStrictEqual({
+          verbose: true,
+        });
+      });
+
+      it('should inject logPath when WDIO_CHROMEDRIVER_LOG_PATH is set', () => {
+        process.env.WDIO_CHROMEDRIVER_LOG_PATH = '/tmp/cd.log';
+        expect(getChromedriverOptions({})).toStrictEqual({
+          verbose: true,
+          logPath: '/tmp/cd.log',
+        });
+      });
+
+      it('should preserve existing chromedriverOptions', () => {
+        expect(
+          getChromedriverOptions({
+            'wdio:chromedriverOptions': {
+              binary: '/path/to/chromedriver',
+            },
+          }),
+        ).toStrictEqual({
+          binary: '/path/to/chromedriver',
+          verbose: true,
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds env-var-gated chromedriver verbose logging (`WDIO_CHROMEDRIVER_VERBOSE=1`, optional `WDIO_CHROMEDRIVER_LOG_PATH=...`) plus `ELECTRON_ENABLE_LOGGING=1` / `ELECTRON_ENABLE_STACK_DUMPING=1` and macOS `.ips` crash-report capture in both reusable workflows — turns "session not created / no useful logs" failures into something actionable.
- Adds a single `macos-26 / esm` row to `package-electron-matrix` aimed at reproducing [webdriverio-community/wdio-electron-service#1265](https://github.com/webdriverio-community/wdio-electron-service/issues/1265).
- Adds an alias-overlap guard (three small jobs) that auto-fails the day GitHub flips `macos-latest` to point at macOS 26, with a clear remediation message naming the rows to remove.
- Widens the macOS window-height tolerance in the `electron-builder-app-{cjs,esm}` package tests from 680→670, since macOS 26 has a slightly taller titlebar (observed 674px content height for a 700px request).

## Outcome of the macos-26 reproduction attempt

The `macos-26 / esm` package-test row **did not reproduce** the symptom from the bug report — Electron started successfully, ChromeDriver attached, and the test suite ran to completion (only the pre-existing window-config assertion failed because of the titlebar metrics shift on macOS 26, which is what the tolerance widening fixes).

This is informative: the failure mode in #1265 is almost certainly tied to the reporter's local machine state (codesigning/Gatekeeper, prior user-data-dir, accessibility/screen-recording permissions, etc.) rather than something a fresh CI runner reproduces. Diagnostic plumbing is wired in correctly though — verified by the running tests producing chromedriver/Electron output through the new env vars — so when (a) the reporter shares logs from `WDIO_CHROMEDRIVER_VERBOSE=1` locally, or (b) we find a setup that triggers the failure in CI, we'll have the data we need.

The follow-up steps (open a tracking issue, post a cross-link comment on the legacy issue, work on a fix) are paused until we have that signal.

## Test plan

- [x] `pnpm --filter @wdio/electron-service test` — 453 tests pass (3 new tests cover the env-var-gated chromedriver options)
- [x] `pnpm --filter @wdio/electron-service typecheck` — clean
- [x] `pnpm --filter @wdio/electron-service lint` — clean
- [x] YAML syntax validated for all three workflow files
- [x] CI: `macos-26 / esm` row runs and reaches the test phase, confirming Electron starts and diagnostics flow through
- [ ] CI: `check-macos-alias-overlap` job is green (majors differ today)

## Notes

- Diagnostic plumbing centralized at the service level (`getChromedriverOptions`) rather than duplicated across the seven wdio configs. Env-var gate keeps it CI-only by default; users debugging the same issue locally on macOS 26 can also enable it.
- The `macos-26` matrix row stays in place after this PR as forward-compat coverage; the alias-overlap guard signals when to remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
