### PR TITLE
feat(tauri): implement browser mode in TauriLaunchService 

### DIFF
--- a/packages/bundler/src/cli/executor.ts
+++ b/packages/bundler/src/cli/executor.ts
@@ -105,6 +105,8 @@ export class RollupExecutor {
           outDir: resolve(targetCwd, configSpec.output.dir),
           module: 'ESNext',
           moduleResolution: 'Bundler',
+          skipLibCheck: true,
+          target: 'ES2022',
         };
 
         if (hasTsconfig) {

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -40,4 +40,8 @@ export class ElectronAdapter implements FrameworkAdapter {
   buildContextSeedScript(_context: IpcContext): string {
     throw new Error('Not implemented');
   }
+
+  buildBrowserIpcInjectionScript(): string {
+    throw new Error('Not implemented');
+  }
 }

--- a/packages/native-spy/src/interceptor/framework.ts
+++ b/packages/native-spy/src/interceptor/framework.ts
@@ -21,4 +21,6 @@ export interface FrameworkAdapter {
   buildUnregistrationScript(mockName: string): string;
   buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string;
   buildContextSeedScript(context: IpcContext): string;
+  /** One-shot browser-context init script: sets up window.__wdio_spy__, window.__wdio_mocks__, and patches the framework IPC bridge. */
+  buildBrowserIpcInjectionScript(): string;
 }

--- a/packages/native-spy/src/interceptor/index.ts
+++ b/packages/native-spy/src/interceptor/index.ts
@@ -32,6 +32,7 @@ export interface IpcInterceptor {
   ): string;
   parseCallData(raw: unknown): MockCallData;
   buildContextSeedScript(context: IpcContext): string;
+  buildBrowserIpcInjectionScript(): string;
   setContext(partial: IpcContext): IpcContext;
   getContext(): IpcContext;
 }
@@ -91,6 +92,10 @@ class IpcInterceptorImpl implements IpcInterceptor {
 
   buildContextSeedScript(context: IpcContext): string {
     return this.adapter.buildContextSeedScript(context);
+  }
+
+  buildBrowserIpcInjectionScript(): string {
+    return this.adapter.buildBrowserIpcInjectionScript();
   }
 
   setContext(partial: IpcContext): IpcContext {

--- a/packages/native-spy/src/interceptor/injection.ts
+++ b/packages/native-spy/src/interceptor/injection.ts
@@ -3,5 +3,5 @@ export function mockLookupExpr(mockName: string): string {
 }
 
 export function errorReconstructExpr(varName: string): string {
-  return `(${varName} && typeof ${varName} === 'object' && ${varName}.__wdioError ? new Error(${varName}.message) : ${varName})`;
+  return `(${varName} && typeof ${varName} === 'object' && ${varName}.__wdioError === true ? new Error(${varName}.message) : ${varName})`;
 }

--- a/packages/native-spy/src/interceptor/syncProtocol.ts
+++ b/packages/native-spy/src/interceptor/syncProtocol.ts
@@ -4,10 +4,8 @@ export interface MockCallData {
   invocationCallOrder: number[];
 }
 
-const EMPTY: MockCallData = { calls: [], results: [], invocationCallOrder: [] };
-
 export function parseCallData(raw: unknown): MockCallData {
-  if (!raw || typeof raw !== 'object') return EMPTY;
+  if (!raw || typeof raw !== 'object') return { calls: [], results: [], invocationCallOrder: [] };
   const r = raw as Record<string, unknown>;
   return {
     calls: Array.isArray(r.calls) ? (r.calls as unknown[][]) : [],

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -152,11 +152,12 @@ export class TauriAdapter implements FrameworkAdapter {
       _implQueue.push(function() { return Promise.reject(val); }); return mockFn;
     };
     mockFn.mockClear = function() {
-      _calls = []; _results = []; _invocationCallOrder = []; _implQueue = [];
+      _calls = []; _results = []; _invocationCallOrder = [];
       return mockFn;
     };
     mockFn.mockReset = function() {
       mockFn.mockClear();
+      _implQueue = [];
       _defaultImpl = undefined; _defaultReturnValue = undefined;
       _defaultResolvedValue = undefined; _defaultRejectedValue = undefined; _returnThis = false;
       return mockFn;

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -77,13 +77,14 @@ export class TauriAdapter implements FrameworkAdapter {
   buildBrowserIpcInjectionScript(): string {
     return `(function() {
   window.__wdio_call_id__ = window.__wdio_call_id__ || 0;
+  var NOT_SET = {};
   function createMockFn() {
     var _name = 'spy';
     var _defaultImpl;
     var _implQueue = [];
-    var _defaultReturnValue;
-    var _defaultResolvedValue;
-    var _defaultRejectedValue;
+    var _defaultReturnValue = NOT_SET;
+    var _defaultResolvedValue = NOT_SET;
+    var _defaultRejectedValue = NOT_SET;
     var _returnThis = false;
     var _calls = [];
     var _results = [];
@@ -102,19 +103,19 @@ export class TauriAdapter implements FrameworkAdapter {
           _results.push({ type: 'throw', value: e });
           throw e;
         }
-      } else if (_defaultRejectedValue !== undefined) {
+      } else if (_defaultRejectedValue !== NOT_SET) {
         var rv = _defaultRejectedValue;
         var rejectedPromise = Promise.reject(rv);
         _results.push({ type: 'return', value: rejectedPromise });
         return rejectedPromise;
-      } else if (_defaultResolvedValue !== undefined) {
+      } else if (_defaultResolvedValue !== NOT_SET) {
         var p = Promise.resolve(_defaultResolvedValue);
         _results.push({ type: 'return', value: p });
         return p;
       } else if (_returnThis) {
         _results.push({ type: 'return', value: this });
         return this;
-      } else if (_defaultReturnValue !== undefined) {
+      } else if (_defaultReturnValue !== NOT_SET) {
         _results.push({ type: 'return', value: _defaultReturnValue });
         return _defaultReturnValue;
       } else {
@@ -133,20 +134,20 @@ export class TauriAdapter implements FrameworkAdapter {
     mockFn.mockImplementation = function(fn) { _defaultImpl = fn; _returnThis = false; return mockFn; };
     mockFn.mockImplementationOnce = function(fn) { _implQueue.push(fn); return mockFn; };
     mockFn.mockReturnValue = function(val) {
-      _defaultImpl = undefined; _defaultReturnValue = val; _defaultResolvedValue = undefined;
-      _defaultRejectedValue = undefined; _returnThis = false; return mockFn;
+      _defaultImpl = undefined; _defaultReturnValue = val; _defaultResolvedValue = NOT_SET;
+      _defaultRejectedValue = NOT_SET; _returnThis = false; return mockFn;
     };
     mockFn.mockReturnValueOnce = function(val) { _implQueue.push(function() { return val; }); return mockFn; };
     mockFn.mockResolvedValue = function(val) {
-      _defaultImpl = undefined; _defaultResolvedValue = val; _defaultReturnValue = undefined;
-      _defaultRejectedValue = undefined; _returnThis = false; return mockFn;
+      _defaultImpl = undefined; _defaultResolvedValue = val; _defaultReturnValue = NOT_SET;
+      _defaultRejectedValue = NOT_SET; _returnThis = false; return mockFn;
     };
     mockFn.mockResolvedValueOnce = function(val) {
       _implQueue.push(function() { return Promise.resolve(val); }); return mockFn;
     };
     mockFn.mockRejectedValue = function(val) {
-      _defaultImpl = undefined; _defaultRejectedValue = val; _defaultReturnValue = undefined;
-      _defaultResolvedValue = undefined; _returnThis = false; return mockFn;
+      _defaultImpl = undefined; _defaultRejectedValue = val; _defaultReturnValue = NOT_SET;
+      _defaultResolvedValue = NOT_SET; _returnThis = false; return mockFn;
     };
     mockFn.mockRejectedValueOnce = function(val) {
       _implQueue.push(function() { return Promise.reject(val); }); return mockFn;
@@ -158,13 +159,13 @@ export class TauriAdapter implements FrameworkAdapter {
     mockFn.mockReset = function() {
       mockFn.mockClear();
       _implQueue = [];
-      _defaultImpl = undefined; _defaultReturnValue = undefined;
-      _defaultResolvedValue = undefined; _defaultRejectedValue = undefined; _returnThis = false;
+      _defaultImpl = undefined; _defaultReturnValue = NOT_SET;
+      _defaultResolvedValue = NOT_SET; _defaultRejectedValue = NOT_SET; _returnThis = false;
       return mockFn;
     };
     mockFn.mockReturnThis = function() {
-      _returnThis = true; _defaultReturnValue = undefined; _defaultResolvedValue = undefined;
-      _defaultRejectedValue = undefined; return mockFn;
+      _returnThis = true; _defaultReturnValue = NOT_SET; _defaultResolvedValue = NOT_SET;
+      _defaultRejectedValue = NOT_SET; return mockFn;
     };
     mockFn.withImplementation = function(fn, callback) {
       var prevImpl = _defaultImpl, prevQueue = _implQueue.slice(), prevReturnThis = _returnThis;

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -74,6 +74,125 @@ export class TauriAdapter implements FrameworkAdapter {
     return buildContextSeedScript(context);
   }
 
+  buildBrowserIpcInjectionScript(): string {
+    return `(function() {
+  window.__wdio_call_id__ = window.__wdio_call_id__ || 0;
+  function createMockFn() {
+    var _name = 'spy';
+    var _defaultImpl;
+    var _implQueue = [];
+    var _defaultReturnValue;
+    var _defaultResolvedValue;
+    var _defaultRejectedValue;
+    var _returnThis = false;
+    var _calls = [];
+    var _results = [];
+    var _invocationCallOrder = [];
+    function mockFn() {
+      var args = Array.prototype.slice.call(arguments);
+      _calls.push(args);
+      _invocationCallOrder.push(window.__wdio_call_id__++);
+      var impl = _implQueue.length > 0 ? _implQueue.shift() : _defaultImpl;
+      if (impl !== undefined) {
+        try {
+          var val = impl.apply(this, args);
+          _results.push({ type: 'return', value: val });
+          return val;
+        } catch (e) {
+          _results.push({ type: 'throw', value: e });
+          throw e;
+        }
+      } else if (_defaultRejectedValue !== undefined) {
+        var rv = _defaultRejectedValue;
+        _results.push({ type: 'throw', value: rv });
+        throw rv;
+      } else if (_defaultResolvedValue !== undefined) {
+        var p = Promise.resolve(_defaultResolvedValue);
+        _results.push({ type: 'return', value: p });
+        return p;
+      } else if (_returnThis) {
+        _results.push({ type: 'return', value: this });
+        return this;
+      } else if (_defaultReturnValue !== undefined) {
+        _results.push({ type: 'return', value: _defaultReturnValue });
+        return _defaultReturnValue;
+      } else {
+        _results.push({ type: 'return', value: undefined });
+        return undefined;
+      }
+    }
+    mockFn._isMockFunction = true;
+    Object.defineProperty(mockFn, 'mock', {
+      get: function() { return { calls: _calls, results: _results, invocationCallOrder: _invocationCallOrder }; },
+      enumerable: true, configurable: true
+    });
+    mockFn.mockName = function(n) { _name = n; return mockFn; };
+    mockFn.getMockName = function() { return _name; };
+    mockFn.getMockImplementation = function() { return _defaultImpl; };
+    mockFn.mockImplementation = function(fn) { _defaultImpl = fn; _returnThis = false; return mockFn; };
+    mockFn.mockImplementationOnce = function(fn) { _implQueue.push(fn); return mockFn; };
+    mockFn.mockReturnValue = function(val) {
+      _defaultImpl = undefined; _defaultReturnValue = val; _defaultResolvedValue = undefined;
+      _defaultRejectedValue = undefined; _returnThis = false; return mockFn;
+    };
+    mockFn.mockReturnValueOnce = function(val) { _implQueue.push(function() { return val; }); return mockFn; };
+    mockFn.mockResolvedValue = function(val) {
+      _defaultImpl = undefined; _defaultResolvedValue = val; _defaultReturnValue = undefined;
+      _defaultRejectedValue = undefined; _returnThis = false; return mockFn;
+    };
+    mockFn.mockResolvedValueOnce = function(val) {
+      _implQueue.push(function() { return Promise.resolve(val); }); return mockFn;
+    };
+    mockFn.mockRejectedValue = function(val) {
+      _defaultImpl = undefined; _defaultRejectedValue = val; _defaultReturnValue = undefined;
+      _defaultResolvedValue = undefined; _returnThis = false; return mockFn;
+    };
+    mockFn.mockRejectedValueOnce = function(val) {
+      _implQueue.push(function() { throw val; }); return mockFn;
+    };
+    mockFn.mockClear = function() {
+      _calls = []; _results = []; _invocationCallOrder = []; _implQueue = [];
+      return mockFn;
+    };
+    mockFn.mockReset = function() {
+      mockFn.mockClear();
+      _defaultImpl = undefined; _defaultReturnValue = undefined;
+      _defaultResolvedValue = undefined; _defaultRejectedValue = undefined; _returnThis = false;
+      return mockFn;
+    };
+    mockFn.mockReturnThis = function() {
+      _returnThis = true; _defaultReturnValue = undefined; _defaultResolvedValue = undefined;
+      _defaultRejectedValue = undefined; return mockFn;
+    };
+    mockFn.withImplementation = function(fn, callback) {
+      var prevImpl = _defaultImpl, prevQueue = _implQueue.slice(), prevReturnThis = _returnThis;
+      _defaultImpl = fn; _implQueue = []; _returnThis = false;
+      var result = callback();
+      if (result && typeof result.then === 'function') {
+        return result.then(function(r) {
+          _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis; return r;
+        }, function(e) {
+          _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis; throw e;
+        });
+      }
+      _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis;
+      return result;
+    };
+    return mockFn;
+  }
+  window.__wdio_spy__ = { fn: createMockFn };
+  if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }
+  if (!window.__TAURI_INTERNALS__) { window.__TAURI_INTERNALS__ = {}; }
+  window.__TAURI_INTERNALS__.invoke = function(cmd, args) {
+    var mock = window.__wdio_mocks__ && window.__wdio_mocks__[cmd];
+    if (mock && typeof mock === 'function') {
+      return Promise.resolve().then(function() { return mock(args); });
+    }
+    return Promise.reject(new Error('unmocked Tauri command in browser mode: ' + cmd));
+  };
+})()`;
+  }
+
   buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string {
     const lookup = mockLookupExpr(mockName);
     return `async (_tauri) => {

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -186,10 +186,10 @@ export class TauriAdapter implements FrameworkAdapter {
   window.__wdio_spy__ = { fn: createMockFn };
   if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }
   if (!window.__TAURI_INTERNALS__) { window.__TAURI_INTERNALS__ = {}; }
-  window.__TAURI_INTERNALS__.invoke = function(cmd, args) {
+  window.__TAURI_INTERNALS__.invoke = function(cmd, args, options) {
     var mock = window.__wdio_mocks__ && window.__wdio_mocks__[cmd];
     if (mock && typeof mock === 'function') {
-      return Promise.resolve().then(function() { return mock(args); });
+      return Promise.resolve().then(function() { return mock(args, options); });
     }
     return Promise.reject(new Error('unmocked Tauri command in browser mode: ' + cmd));
   };

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -104,8 +104,9 @@ export class TauriAdapter implements FrameworkAdapter {
         }
       } else if (_defaultRejectedValue !== undefined) {
         var rv = _defaultRejectedValue;
-        _results.push({ type: 'throw', value: rv });
-        throw rv;
+        var rejectedPromise = Promise.reject(rv);
+        _results.push({ type: 'return', value: rejectedPromise });
+        return rejectedPromise;
       } else if (_defaultResolvedValue !== undefined) {
         var p = Promise.resolve(_defaultResolvedValue);
         _results.push({ type: 'return', value: p });
@@ -148,7 +149,7 @@ export class TauriAdapter implements FrameworkAdapter {
       _defaultResolvedValue = undefined; _returnThis = false; return mockFn;
     };
     mockFn.mockRejectedValueOnce = function(val) {
-      _implQueue.push(function() { throw val; }); return mockFn;
+      _implQueue.push(function() { return Promise.reject(val); }); return mockFn;
     };
     mockFn.mockClear = function() {
       _calls = []; _results = []; _invocationCallOrder = []; _implQueue = [];
@@ -200,7 +201,7 @@ export class TauriAdapter implements FrameworkAdapter {
   const callback = (${callbackFnSource});
   let result;
   const mockObj = ${lookup};
-  await mockObj?.withImplementation?.(impl, async () => { result = await callback(_tauri); });
+  await mockObj?.withImplementation?.(impl, async () => { result = await (_tauri !== undefined ? callback(_tauri) : callback()); });
   return result;
 }`;
   }

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -117,7 +117,7 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
       expect(result).toBe(10);
     });
 
-    it('fn() mockResolvedValue(undefined) returns Promise.resolve(undefined)', async () => {
+    it('should return Promise.resolve(undefined) for mockResolvedValue(undefined)', async () => {
       const script = adapter.buildBrowserIpcInjectionScript();
       const window = runInBrowserContext(script);
       const spy = window.__wdio_spy__ as Record<string, unknown>;
@@ -128,7 +128,7 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
       await expect(result as Promise<unknown>).resolves.toBeUndefined();
     });
 
-    it('fn() mockRejectedValue(undefined) returns Promise.reject(undefined)', async () => {
+    it('should return Promise.reject(undefined) for mockRejectedValue(undefined)', async () => {
       const script = adapter.buildBrowserIpcInjectionScript();
       const window = runInBrowserContext(script);
       const spy = window.__wdio_spy__ as Record<string, unknown>;
@@ -139,7 +139,7 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
       await expect(result as Promise<unknown>).rejects.toBeUndefined();
     });
 
-    it('fn() mockClear preserves queued once-implementations', () => {
+    it('should preserve queued once-implementations across mockClear', () => {
       const script = adapter.buildBrowserIpcInjectionScript();
       const window = runInBrowserContext(script);
       const spy = window.__wdio_spy__ as Record<string, unknown>;
@@ -150,7 +150,7 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
       expect(result).toBe(99);
     });
 
-    it('fn() mockReset drains queued once-implementations', () => {
+    it('should drain queued once-implementations on mockReset', () => {
       const script = adapter.buildBrowserIpcInjectionScript();
       const window = runInBrowserContext(script);
       const spy = window.__wdio_spy__ as Record<string, unknown>;

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -117,6 +117,28 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
       expect(result).toBe(10);
     });
 
+    it('fn() mockClear preserves queued once-implementations', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockReturnValueOnce as (v: unknown) => void)(99);
+      (mockFn.mockClear as () => void)();
+      const result = (mockFn as unknown as () => unknown)();
+      expect(result).toBe(99);
+    });
+
+    it('fn() mockReset drains queued once-implementations', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockReturnValueOnce as (v: unknown) => void)(99);
+      (mockFn.mockReset as () => void)();
+      const result = (mockFn as unknown as () => unknown)();
+      expect(result).toBeUndefined();
+    });
+
     it('should return a rejected Promise for mockRejectedValue', async () => {
       const script = adapter.buildBrowserIpcInjectionScript();
       const window = runInBrowserContext(script);

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -60,8 +60,22 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
     const window = runInBrowserContext(script);
     (window.__wdio_mocks__ as Record<string, unknown>).greet = (_args: unknown) => 'hello';
     const internals = window.__TAURI_INTERNALS__ as Record<string, unknown>;
-    const invoke = internals.invoke as (cmd: string, args: unknown) => Promise<unknown>;
+    const invoke = internals.invoke as (cmd: string, args: unknown, options?: unknown) => Promise<unknown>;
     await expect(invoke('greet', { name: 'world' })).resolves.toBe('hello');
+  });
+
+  it('should pass InvokeOptions as second argument to the registered mock', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    let capturedOptions: unknown;
+    (window.__wdio_mocks__ as Record<string, unknown>).greet = (_args: unknown, opts: unknown) => {
+      capturedOptions = opts;
+      return 'hello';
+    };
+    const internals = window.__TAURI_INTERNALS__ as Record<string, unknown>;
+    const invoke = internals.invoke as (cmd: string, args: unknown, options: unknown) => Promise<unknown>;
+    await invoke('greet', { name: 'world' }, { headers: { 'x-test': '1' } });
+    expect(capturedOptions).toEqual({ headers: { 'x-test': '1' } });
   });
 
   describe('fn()', () => {

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -117,6 +117,28 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
       expect(result).toBe(10);
     });
 
+    it('fn() mockResolvedValue(undefined) returns Promise.resolve(undefined)', async () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockResolvedValue as (v: unknown) => void)(undefined);
+      const result = (mockFn as unknown as () => unknown)();
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result as Promise<unknown>).resolves.toBeUndefined();
+    });
+
+    it('fn() mockRejectedValue(undefined) returns Promise.reject(undefined)', async () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockRejectedValue as (v: unknown) => void)(undefined);
+      const result = (mockFn as unknown as () => unknown)();
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result as Promise<unknown>).rejects.toBeUndefined();
+    });
+
     it('fn() mockClear preserves queued once-implementations', () => {
       const script = adapter.buildBrowserIpcInjectionScript();
       const window = runInBrowserContext(script);

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -13,7 +13,7 @@ function runInBrowserContext(script: string, windowProps: Record<string, unknown
 describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
   const adapter = new TauriAdapter();
 
-  it('sets window.__wdio_spy__ with a fn factory', () => {
+  it('should set window.__wdio_spy__ with a fn factory', () => {
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script);
     expect(typeof (window.__wdio_spy__ as Record<string, unknown>)?.fn).toBe('function');
@@ -114,6 +114,28 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
     (mockFn.mockImplementation as (fn: (x: number) => number) => void)((x: number) => x * 2);
     const result = (mockFn as unknown as (x: number) => number)(5);
     expect(result).toBe(10);
+  });
+
+  it('fn() mockRejectedValue returns a rejected Promise, not a synchronous throw', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = window.__wdio_spy__ as Record<string, unknown>;
+    const mockFn = (spy.fn as () => Record<string, unknown>)();
+    (mockFn.mockRejectedValue as (v: unknown) => void)(new Error('oops'));
+    const result = (mockFn as unknown as () => Promise<unknown>)();
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow('oops');
+  });
+
+  it('fn() mockRejectedValueOnce returns a rejected Promise, not a synchronous throw', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = window.__wdio_spy__ as Record<string, unknown>;
+    const mockFn = (spy.fn as () => Record<string, unknown>)();
+    (mockFn.mockRejectedValueOnce as (v: unknown) => void)(new Error('once'));
+    const result = (mockFn as unknown as () => Promise<unknown>)();
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow('once');
   });
 });
 

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -1,0 +1,127 @@
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+import { createIpcInterceptor } from '../../src/interceptor/index.js';
+import { TauriAdapter } from '../../src/interceptor/tauri.js';
+
+function runInBrowserContext(script: string, windowProps: Record<string, unknown> = {}) {
+  const window: Record<string, unknown> = { ...windowProps };
+  const ctx = vm.createContext({ window, Promise });
+  vm.runInContext(script, ctx);
+  return window;
+}
+
+describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
+  const adapter = new TauriAdapter();
+
+  it('sets window.__wdio_spy__ with a fn factory', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    expect(typeof (window.__wdio_spy__ as Record<string, unknown>)?.fn).toBe('function');
+  });
+
+  it('creates window.__wdio_mocks__ if absent', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    expect(window.__wdio_mocks__).toEqual({});
+  });
+
+  it('does not overwrite existing window.__wdio_mocks__', () => {
+    const existing = { greet: () => {} };
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script, { __wdio_mocks__: existing });
+    expect(window.__wdio_mocks__).toBe(existing);
+  });
+
+  it('creates window.__TAURI_INTERNALS__ if absent', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    expect(typeof (window.__TAURI_INTERNALS__ as Record<string, unknown>)?.invoke).toBe('function');
+  });
+
+  it('preserves existing __TAURI_INTERNALS__ object and only patches invoke', () => {
+    const existingInternal = { other: 'value' };
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script, { __TAURI_INTERNALS__: existingInternal });
+    const internals = window.__TAURI_INTERNALS__ as Record<string, unknown>;
+    expect(internals.other).toBe('value');
+    expect(typeof internals.invoke).toBe('function');
+  });
+
+  it('invoke rejects with error for unmocked commands', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const internals = window.__TAURI_INTERNALS__ as Record<string, unknown>;
+    const invoke = internals.invoke as (cmd: string, args: unknown) => Promise<unknown>;
+    await expect(invoke('unknown_cmd', {})).rejects.toThrow('unmocked Tauri command in browser mode: unknown_cmd');
+  });
+
+  it('invoke routes to window.__wdio_mocks__[cmd] when registered', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    (window.__wdio_mocks__ as Record<string, unknown>).greet = (_args: unknown) => 'hello';
+    const internals = window.__TAURI_INTERNALS__ as Record<string, unknown>;
+    const invoke = internals.invoke as (cmd: string, args: unknown) => Promise<unknown>;
+    await expect(invoke('greet', { name: 'world' })).resolves.toBe('hello');
+  });
+
+  it('fn() creates a mock with empty call history', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = window.__wdio_spy__ as Record<string, unknown>;
+    const mockFn = (spy.fn as () => Record<string, unknown>)();
+    const mock = mockFn.mock as Record<string, unknown>;
+    expect(mock.calls).toEqual([]);
+    expect(mock.results).toEqual([]);
+    expect(mock.invocationCallOrder).toEqual([]);
+  });
+
+  it('fn() records calls and results', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = window.__wdio_spy__ as Record<string, unknown>;
+    const mockFn = (spy.fn as () => (...a: unknown[]) => unknown)();
+    mockFn('arg1', 'arg2');
+    const mock = (mockFn as unknown as Record<string, unknown>).mock as Record<string, unknown[][]>;
+    expect(mock.calls).toEqual([['arg1', 'arg2']]);
+  });
+
+  it('fn() supports mockReturnValue', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = window.__wdio_spy__ as Record<string, unknown>;
+    const mockFn = (spy.fn as () => Record<string, unknown>)();
+    (mockFn.mockReturnValue as (v: unknown) => void)(42);
+    expect((mockFn as unknown as (...a: unknown[]) => unknown)()).toBe(42);
+  });
+
+  it('fn() supports mockClear', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = window.__wdio_spy__ as Record<string, unknown>;
+    const mockFn = (spy.fn as () => Record<string, unknown>)();
+    (mockFn as unknown as (...a: unknown[]) => unknown)('x');
+    (mockFn.mockClear as () => void)();
+    const mock = mockFn.mock as Record<string, unknown[]>;
+    expect(mock.calls).toEqual([]);
+    expect(mock.results).toEqual([]);
+  });
+
+  it('fn() supports mockImplementation', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = window.__wdio_spy__ as Record<string, unknown>;
+    const mockFn = (spy.fn as () => Record<string, unknown>)();
+    (mockFn.mockImplementation as (fn: (x: number) => number) => void)((x: number) => x * 2);
+    const result = (mockFn as unknown as (x: number) => number)(5);
+    expect(result).toBe(10);
+  });
+});
+
+describe('createIpcInterceptor buildBrowserIpcInjectionScript delegation', () => {
+  it('delegates to the TauriAdapter', () => {
+    const interceptor = createIpcInterceptor('tauri');
+    const script = interceptor.buildBrowserIpcInjectionScript();
+    expect(script).toContain('window.__wdio_spy__');
+    expect(script).toContain('window.__TAURI_INTERNALS__');
+  });
+});

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -19,26 +19,26 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
     expect(typeof (window.__wdio_spy__ as Record<string, unknown>)?.fn).toBe('function');
   });
 
-  it('creates window.__wdio_mocks__ if absent', () => {
+  it('should create window.__wdio_mocks__ if absent', () => {
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script);
     expect(window.__wdio_mocks__).toEqual({});
   });
 
-  it('does not overwrite existing window.__wdio_mocks__', () => {
+  it('should not overwrite existing window.__wdio_mocks__', () => {
     const existing = { greet: () => {} };
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script, { __wdio_mocks__: existing });
     expect(window.__wdio_mocks__).toBe(existing);
   });
 
-  it('creates window.__TAURI_INTERNALS__ if absent', () => {
+  it('should create window.__TAURI_INTERNALS__ if absent', () => {
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script);
     expect(typeof (window.__TAURI_INTERNALS__ as Record<string, unknown>)?.invoke).toBe('function');
   });
 
-  it('preserves existing __TAURI_INTERNALS__ object and only patches invoke', () => {
+  it('should preserve existing __TAURI_INTERNALS__ object and only patch invoke', () => {
     const existingInternal = { other: 'value' };
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script, { __TAURI_INTERNALS__: existingInternal });
@@ -47,7 +47,7 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
     expect(typeof internals.invoke).toBe('function');
   });
 
-  it('invoke rejects with error for unmocked commands', async () => {
+  it('should invoke reject with error for unmocked commands', async () => {
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script);
     const internals = window.__TAURI_INTERNALS__ as Record<string, unknown>;
@@ -55,7 +55,7 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
     await expect(invoke('unknown_cmd', {})).rejects.toThrow('unmocked Tauri command in browser mode: unknown_cmd');
   });
 
-  it('invoke routes to window.__wdio_mocks__[cmd] when registered', async () => {
+  it('should invoke route to window.__wdio_mocks__[cmd] when registered', async () => {
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script);
     (window.__wdio_mocks__ as Record<string, unknown>).greet = (_args: unknown) => 'hello';
@@ -64,83 +64,85 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
     await expect(invoke('greet', { name: 'world' })).resolves.toBe('hello');
   });
 
-  it('fn() creates a mock with empty call history', () => {
-    const script = adapter.buildBrowserIpcInjectionScript();
-    const window = runInBrowserContext(script);
-    const spy = window.__wdio_spy__ as Record<string, unknown>;
-    const mockFn = (spy.fn as () => Record<string, unknown>)();
-    const mock = mockFn.mock as Record<string, unknown>;
-    expect(mock.calls).toEqual([]);
-    expect(mock.results).toEqual([]);
-    expect(mock.invocationCallOrder).toEqual([]);
-  });
+  describe('fn()', () => {
+    it('should create a mock with empty call history', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      const mock = mockFn.mock as Record<string, unknown>;
+      expect(mock.calls).toEqual([]);
+      expect(mock.results).toEqual([]);
+      expect(mock.invocationCallOrder).toEqual([]);
+    });
 
-  it('fn() records calls and results', () => {
-    const script = adapter.buildBrowserIpcInjectionScript();
-    const window = runInBrowserContext(script);
-    const spy = window.__wdio_spy__ as Record<string, unknown>;
-    const mockFn = (spy.fn as () => (...a: unknown[]) => unknown)();
-    mockFn('arg1', 'arg2');
-    const mock = (mockFn as unknown as Record<string, unknown>).mock as Record<string, unknown[][]>;
-    expect(mock.calls).toEqual([['arg1', 'arg2']]);
-  });
+    it('should record calls and results', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => (...a: unknown[]) => unknown)();
+      mockFn('arg1', 'arg2');
+      const mock = (mockFn as unknown as Record<string, unknown>).mock as Record<string, unknown[][]>;
+      expect(mock.calls).toEqual([['arg1', 'arg2']]);
+    });
 
-  it('fn() supports mockReturnValue', () => {
-    const script = adapter.buildBrowserIpcInjectionScript();
-    const window = runInBrowserContext(script);
-    const spy = window.__wdio_spy__ as Record<string, unknown>;
-    const mockFn = (spy.fn as () => Record<string, unknown>)();
-    (mockFn.mockReturnValue as (v: unknown) => void)(42);
-    expect((mockFn as unknown as (...a: unknown[]) => unknown)()).toBe(42);
-  });
+    it('should support mockReturnValue', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockReturnValue as (v: unknown) => void)(42);
+      expect((mockFn as unknown as (...a: unknown[]) => unknown)()).toBe(42);
+    });
 
-  it('fn() supports mockClear', () => {
-    const script = adapter.buildBrowserIpcInjectionScript();
-    const window = runInBrowserContext(script);
-    const spy = window.__wdio_spy__ as Record<string, unknown>;
-    const mockFn = (spy.fn as () => Record<string, unknown>)();
-    (mockFn as unknown as (...a: unknown[]) => unknown)('x');
-    (mockFn.mockClear as () => void)();
-    const mock = mockFn.mock as Record<string, unknown[]>;
-    expect(mock.calls).toEqual([]);
-    expect(mock.results).toEqual([]);
-  });
+    it('should support mockClear', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn as unknown as (...a: unknown[]) => unknown)('x');
+      (mockFn.mockClear as () => void)();
+      const mock = mockFn.mock as Record<string, unknown[]>;
+      expect(mock.calls).toEqual([]);
+      expect(mock.results).toEqual([]);
+    });
 
-  it('fn() supports mockImplementation', () => {
-    const script = adapter.buildBrowserIpcInjectionScript();
-    const window = runInBrowserContext(script);
-    const spy = window.__wdio_spy__ as Record<string, unknown>;
-    const mockFn = (spy.fn as () => Record<string, unknown>)();
-    (mockFn.mockImplementation as (fn: (x: number) => number) => void)((x: number) => x * 2);
-    const result = (mockFn as unknown as (x: number) => number)(5);
-    expect(result).toBe(10);
-  });
+    it('should support mockImplementation', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockImplementation as (fn: (x: number) => number) => void)((x: number) => x * 2);
+      const result = (mockFn as unknown as (x: number) => number)(5);
+      expect(result).toBe(10);
+    });
 
-  it('fn() mockRejectedValue returns a rejected Promise, not a synchronous throw', async () => {
-    const script = adapter.buildBrowserIpcInjectionScript();
-    const window = runInBrowserContext(script);
-    const spy = window.__wdio_spy__ as Record<string, unknown>;
-    const mockFn = (spy.fn as () => Record<string, unknown>)();
-    (mockFn.mockRejectedValue as (v: unknown) => void)(new Error('oops'));
-    const result = (mockFn as unknown as () => Promise<unknown>)();
-    expect(result).toBeInstanceOf(Promise);
-    await expect(result).rejects.toThrow('oops');
-  });
+    it('should return a rejected Promise for mockRejectedValue', async () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockRejectedValue as (v: unknown) => void)(new Error('oops'));
+      const result = (mockFn as unknown as () => Promise<unknown>)();
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result).rejects.toThrow('oops');
+    });
 
-  it('fn() mockRejectedValueOnce returns a rejected Promise, not a synchronous throw', async () => {
-    const script = adapter.buildBrowserIpcInjectionScript();
-    const window = runInBrowserContext(script);
-    const spy = window.__wdio_spy__ as Record<string, unknown>;
-    const mockFn = (spy.fn as () => Record<string, unknown>)();
-    (mockFn.mockRejectedValueOnce as (v: unknown) => void)(new Error('once'));
-    const result = (mockFn as unknown as () => Promise<unknown>)();
-    expect(result).toBeInstanceOf(Promise);
-    await expect(result).rejects.toThrow('once');
+    it('should return a rejected Promise for mockRejectedValueOnce', async () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockRejectedValueOnce as (v: unknown) => void)(new Error('once'));
+      const result = (mockFn as unknown as () => Promise<unknown>)();
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result).rejects.toThrow('once');
+    });
   });
 });
 
 describe('createIpcInterceptor buildBrowserIpcInjectionScript delegation', () => {
-  it('delegates to the TauriAdapter', () => {
+  it('should delegate to the TauriAdapter', () => {
     const interceptor = createIpcInterceptor('tauri');
     const script = interceptor.buildBrowserIpcInjectionScript();
     expect(script).toContain('window.__wdio_spy__');

--- a/packages/native-spy/test/interceptor/tauri.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri.spec.ts
@@ -130,12 +130,12 @@ describe('TauriAdapter', () => {
       expect(script.trim()).toMatch(/^async/);
       expect(script).toContain('await mockObj?.withImplementation');
       expect(script).toContain('async () =>');
-      expect(script).toContain('await callback(_tauri)');
+      expect(script).toContain('callback');
     });
 
-    it('passes _tauri to callback', () => {
+    it('passes _tauri to callback only when defined (browser mode compat)', () => {
       const script = adapter.buildWithImplementationScript('cmd', '() => {}', '() => {}');
-      expect(script).toContain('callback(_tauri)');
+      expect(script).toContain('_tauri !== undefined ? callback(_tauri) : callback()');
     });
   });
 });

--- a/packages/native-types/src/tauri.ts
+++ b/packages/native-types/src/tauri.ts
@@ -268,6 +268,18 @@ export interface TauriServiceAPI {
  */
 export interface TauriServiceOptions extends BaseServiceOptions, DriverProviderConfig {
   /**
+   * Run mode for the Tauri service.
+   * - 'native': default; requires a built Tauri binary and tauri-driver.
+   * - 'browser': runs the frontend in plain Chrome against a Vite dev server with Tauri IPC intercepted at the JS boundary. No binary or native driver required.
+   * @default 'native'
+   */
+  mode?: 'native' | 'browser';
+  /**
+   * URL of the Vite dev server to navigate to when mode is 'browser'.
+   * Required when mode === 'browser'. e.g. 'http://localhost:1420'
+   */
+  devServerUrl?: string;
+  /**
    * The port for tauri-driver to listen on.
    */
   tauriDriverPort?: number;
@@ -311,6 +323,8 @@ export interface TauriServiceOptions extends BaseServiceOptions, DriverProviderC
  * Extends base global options with Tauri-specific configuration
  */
 export interface TauriServiceGlobalOptions extends BaseServiceGlobalOptions, DriverProviderConfig {
+  mode?: 'native' | 'browser';
+  devServerUrl?: string;
   logLevel?: LogLevel;
   tauriDriverPort?: number;
   nativeDriverPath?: string;

--- a/packages/tauri-service/src/launcher.ts
+++ b/packages/tauri-service/src/launcher.ts
@@ -73,6 +73,7 @@ export default class TauriLaunchService {
   private portManager: PortManager;
   private backendPortManager: PortManager;
   private driverPool: DriverPool;
+  private browserMode: boolean = false;
   private embeddedProcesses: Map<string, EmbeddedDriverInfo> = new Map();
   private embeddedConfigs: Map<string, { appBinaryPath: string; port: number; options: TauriServiceOptions }> =
     new Map();
@@ -134,6 +135,26 @@ export default class TauriLaunchService {
     const capsList = Array.isArray(capabilities)
       ? capabilities
       : Object.values(capabilities).map((multiremoteOption) => multiremoteOption.capabilities);
+
+    // Browser mode: skip all driver/binary setup — worker navigates to a Vite dev server
+    if (mergedOptions.mode === 'browser') {
+      const devServerUrl = mergedOptions.devServerUrl;
+      if (!devServerUrl) {
+        throw new SevereServiceError('devServerUrl is required when mode is "browser"');
+      }
+      try {
+        new URL(devServerUrl);
+      } catch {
+        throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+      }
+      this.browserMode = true;
+      for (const cap of capsList) {
+        (cap as { browserName?: string }).browserName = 'chrome';
+        delete (cap as { 'tauri:options'?: unknown })['tauri:options'];
+      }
+      log.info('Browser mode enabled — skipping driver/binary setup');
+      return;
+    }
 
     // Validate capabilities
     for (const cap of capsList) {
@@ -575,6 +596,11 @@ export default class TauriLaunchService {
   ): Promise<void> {
     log.debug(`Starting Tauri worker session: ${cid}`);
 
+    if (this.browserMode) {
+      log.debug(`Worker ${cid}: browser mode — skipping driver setup`);
+      return;
+    }
+
     if (!caps) {
       log.warn('onWorkerStart: No capabilities provided, skipping setup');
       return;
@@ -855,6 +881,10 @@ export default class TauriLaunchService {
    */
   async onWorkerEnd(cid: string): Promise<void> {
     log.debug(`Ending Tauri worker session: ${cid}`);
+
+    if (this.browserMode) {
+      return;
+    }
 
     // Stop worker's test-runner-backend if spawned (CrabNebula per-worker mode)
     const workerBackend = this.workerBackends.get(cid);

--- a/packages/tauri-service/src/mock.ts
+++ b/packages/tauri-service/src/mock.ts
@@ -80,7 +80,21 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
       `[${command}] Retrieved ${syncData.calls.length} calls from inner mock, outer mock has ${existingCount} calls`,
     );
 
-    if (existingCount < syncData.calls.length) {
+    if (syncData.calls.length < existingCount) {
+      log.debug(`[${command}] Inner mock shrank (cleared after reload or reset); replacing outer data`);
+      (originalMock.calls as unknown[][]).length = 0;
+      (originalMock.results as { type: string; value: unknown }[]).length = 0;
+      (originalMock.invocationCallOrder as number[]).length = 0;
+      for (let i = 0; i < syncData.calls.length; i++) {
+        (originalMock.calls as unknown[][]).push(syncData.calls[i]);
+        (originalMock.results as { type: string; value: unknown }[]).push(
+          syncData.results[i] ?? { type: 'return', value: undefined },
+        );
+        (originalMock.invocationCallOrder as number[]).push(
+          syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+        );
+      }
+    } else if (existingCount < syncData.calls.length) {
       log.debug(`[${command}] Applying ${syncData.calls.length - existingCount} new calls to outer mock`);
       for (let i = existingCount; i < syncData.calls.length; i++) {
         (originalMock.calls as unknown[][]).push(syncData.calls[i]);
@@ -237,7 +251,20 @@ async function createBrowserModeMock(command: string, browser: WebdriverIO.Brows
     const syncData = interceptor.parseCallData(raw);
 
     const existingCount = originalMock.calls.length;
-    if (existingCount < syncData.calls.length) {
+    if (syncData.calls.length < existingCount) {
+      (originalMock.calls as unknown[][]).length = 0;
+      (originalMock.results as { type: string; value: unknown }[]).length = 0;
+      (originalMock.invocationCallOrder as number[]).length = 0;
+      for (let i = 0; i < syncData.calls.length; i++) {
+        (originalMock.calls as unknown[][]).push(syncData.calls[i]);
+        (originalMock.results as { type: string; value: unknown }[]).push(
+          syncData.results[i] ?? { type: 'return', value: undefined },
+        );
+        (originalMock.invocationCallOrder as number[]).push(
+          syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+        );
+      }
+    } else if (existingCount < syncData.calls.length) {
       for (let i = existingCount; i < syncData.calls.length; i++) {
         (originalMock.calls as unknown[][]).push(syncData.calls[i]);
         (originalMock.results as { type: string; value: unknown }[]).push(

--- a/packages/tauri-service/src/mock.ts
+++ b/packages/tauri-service/src/mock.ts
@@ -335,14 +335,18 @@ async function createBrowserModeMock(command: string, browser: WebdriverIO.Brows
   };
 
   mock.withImplementation = async (implFn, callbackFn) => {
-    return await runInterceptorScript<unknown>(
-      browser,
-      interceptor.buildWithImplementationScript(
-        command,
-        implFn as (...a: unknown[]) => unknown,
-        callbackFn as (...a: unknown[]) => unknown,
-      ),
+    const script = interceptor.buildWithImplementationScript(
+      command,
+      implFn as (...a: unknown[]) => unknown,
+      callbackFn as (...a: unknown[]) => unknown,
     );
+    return browser.executeAsync((s: string, done: (v: unknown) => void) => {
+      // eslint-disable-next-line no-new-func
+      const fn = new Function('return (' + s + ')')() as () => Promise<unknown>;
+      Promise.resolve(fn()).then(done, (err: unknown) => {
+        done({ __wdioAsyncErr__: err instanceof Error ? err.message : String(err) });
+      });
+    }, script);
   };
 
   log.debug(`[${command}] Browser-mode mock created successfully`);

--- a/packages/tauri-service/src/mock.ts
+++ b/packages/tauri-service/src/mock.ts
@@ -340,13 +340,17 @@ async function createBrowserModeMock(command: string, browser: WebdriverIO.Brows
       implFn as (...a: unknown[]) => unknown,
       callbackFn as (...a: unknown[]) => unknown,
     );
-    return browser.executeAsync((s: string, done: (v: unknown) => void) => {
+    const result = await browser.executeAsync((s: string, done: (v: unknown) => void) => {
       // eslint-disable-next-line no-new-func
       const fn = new Function('return (' + s + ')')() as () => Promise<unknown>;
       Promise.resolve(fn()).then(done, (err: unknown) => {
         done({ __wdioAsyncErr__: err instanceof Error ? err.message : String(err) });
       });
     }, script);
+    if (result && typeof result === 'object' && '__wdioAsyncErr__' in result) {
+      throw new Error((result as { __wdioAsyncErr__: string }).__wdioAsyncErr__);
+    }
+    return result;
   };
 
   log.debug(`[${command}] Browser-mode mock created successfully`);

--- a/packages/tauri-service/src/mock.ts
+++ b/packages/tauri-service/src/mock.ts
@@ -8,8 +8,21 @@ import mockStore from './mockStore.js';
 const log = createLogger('tauri-service', 'mock');
 const interceptor = createIpcInterceptor('tauri');
 
+function isBrowserMode(browser: WebdriverIO.Browser): boolean {
+  return !!(browser as unknown as Record<string, unknown>).__wdioBrowserMode__;
+}
+
+async function runInterceptorScript<T>(browser: WebdriverIO.Browser, script: string): Promise<T> {
+  return browser.execute(`return (${script})()`) as Promise<T>;
+}
+
 export async function createMock(command: string, browserContext?: WebdriverIO.Browser): Promise<TauriMock> {
   log.debug(`[${command}] createMock called - starting mock creation`);
+
+  const browserToUse = (browserContext || browser) as WebdriverIO.Browser;
+  if (isBrowserMode(browserToUse)) {
+    return createBrowserModeMock(command, browserToUse);
+  }
 
   const outerMock = vitestFn();
   const outerMockImplementation = outerMock.mockImplementation;
@@ -50,8 +63,6 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
       return originalMock;
     },
   });
-
-  const browserToUse: WebdriverIO.Browser = (browserContext || browser) as WebdriverIO.Browser;
 
   log.debug(`[${command}] Using browser context:`, typeof browserToUse, browserToUse?.constructor?.name);
 
@@ -201,4 +212,139 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   log.debug(`[${command}] Auto-updating mock wrapper created successfully`);
 
   return wrapperMock;
+}
+
+async function createBrowserModeMock(command: string, browser: WebdriverIO.Browser): Promise<TauriMock> {
+  log.debug(`[${command}] createBrowserModeMock called`);
+
+  const outerMock = vitestFn();
+  const outerMockImplementation = outerMock.mockImplementation;
+  const outerMockImplementationOnce = outerMock.mockImplementationOnce;
+  const outerMockClear = outerMock.mockClear;
+  const outerMockReset = outerMock.mockReset;
+
+  outerMock.mockName(`tauri.${command}`);
+
+  const mock = outerMock as unknown as TauriMock;
+  mock.__isTauriMock = true;
+
+  const originalMock = outerMock.mock;
+
+  await runInterceptorScript<void>(browser, interceptor.buildRegistrationScript(command));
+
+  mock.update = async () => {
+    const raw = await runInterceptorScript<unknown>(browser, interceptor.buildCallDataReadScript(command));
+    const syncData = interceptor.parseCallData(raw);
+
+    const existingCount = originalMock.calls.length;
+    if (existingCount < syncData.calls.length) {
+      for (let i = existingCount; i < syncData.calls.length; i++) {
+        (originalMock.calls as unknown[][]).push(syncData.calls[i]);
+        (originalMock.results as { type: string; value: unknown }[]).push(
+          syncData.results[i] ?? { type: 'return', value: undefined },
+        );
+        (originalMock.invocationCallOrder as number[]).push(
+          syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+        );
+      }
+    }
+    return mock;
+  };
+
+  mock.mockImplementation = async (implFn: AbstractFn) => {
+    const s = interceptor.serializeHandler(implFn);
+    await runInterceptorScript<void>(browser, interceptor.buildSetImplementationScript(command, s));
+    outerMockImplementation(implFn);
+    return mock;
+  };
+
+  mock.mockImplementationOnce = async (implFn: AbstractFn) => {
+    const s = interceptor.serializeHandler(implFn);
+    await runInterceptorScript<void>(browser, interceptor.buildSetImplementationScript(command, s, true));
+    outerMockImplementationOnce(implFn);
+    return mock;
+  };
+
+  mock.mockReturnValue = async (value: unknown) => {
+    await runInterceptorScript<void>(browser, interceptor.buildInnerSetterScript(command, 'mockReturnValue', value));
+    return mock;
+  };
+
+  mock.mockReturnValueOnce = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      interceptor.buildInnerSetterScript(command, 'mockReturnValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockResolvedValue = async (value: unknown) => {
+    await runInterceptorScript<void>(browser, interceptor.buildInnerSetterScript(command, 'mockResolvedValue', value));
+    return mock;
+  };
+
+  mock.mockResolvedValueOnce = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      interceptor.buildInnerSetterScript(command, 'mockResolvedValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockRejectedValue = async (value: unknown) => {
+    await runInterceptorScript<void>(browser, interceptor.buildInnerSetterScript(command, 'mockRejectedValue', value));
+    return mock;
+  };
+
+  mock.mockRejectedValueOnce = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      interceptor.buildInnerSetterScript(command, 'mockRejectedValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockClear = async () => {
+    await runInterceptorScript<void>(browser, interceptor.buildInnerInvocationScript(command, 'mockClear'));
+    outerMockClear();
+    return mock;
+  };
+
+  mock.mockReset = async () => {
+    const currentName = outerMock.getMockName();
+    await runInterceptorScript<void>(browser, interceptor.buildInnerInvocationScript(command, 'mockReset'));
+    const asyncMockClearFn = mock.mockClear;
+    (mock as unknown as { mockClear: () => void }).mockClear = outerMockClear;
+    outerMockClear();
+    outerMockReset();
+    mock.mockClear = asyncMockClearFn;
+    outerMock.mockName(currentName);
+    return mock;
+  };
+
+  mock.mockRestore = async () => {
+    await runInterceptorScript<void>(browser, interceptor.buildUnregistrationScript(command));
+    outerMockClear();
+    mockStore.deleteMock(`tauri.${command}`);
+    return mock;
+  };
+
+  mock.mockReturnThis = async () => {
+    await runInterceptorScript<void>(browser, interceptor.buildInnerInvocationScript(command, 'mockReturnThis'));
+    return mock;
+  };
+
+  mock.withImplementation = async (implFn, callbackFn) => {
+    return await runInterceptorScript<unknown>(
+      browser,
+      interceptor.buildWithImplementationScript(
+        command,
+        implFn as (...a: unknown[]) => unknown,
+        callbackFn as (...a: unknown[]) => unknown,
+      ),
+    );
+  };
+
+  log.debug(`[${command}] Browser-mode mock created successfully`);
+  return mock;
 }

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -281,6 +281,12 @@ export default class TauriWorkerService {
     await browser.url(this.devServerUrl);
     await browser.execute(browserInterceptor.buildBrowserIpcInjectionScript());
     (browser as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
+    if ((browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
+      const mrBrowser = browser as unknown as WebdriverIO.MultiRemoteBrowser;
+      for (const instanceName of mrBrowser.instances) {
+        (mrBrowser.getInstance(instanceName) as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
+      }
+    }
     this.addTauriApi(browser, true);
     this.installCommandOverrides();
     log.debug('Browser-only mode initialized');

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -1,3 +1,4 @@
+import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import type { TauriAPIs, TauriServiceAPI } from '@wdio/native-types';
 import { createLogger, hasSemicolonOutsideQuotes, waitUntilWindowAvailable } from '@wdio/native-utils';
 import { execute } from './commands/execute.js';
@@ -20,6 +21,7 @@ import {
 const log = createLogger('tauri-service', 'service');
 
 const EXECUTE_PATCHED = Symbol('wdio-tauri-execute-patched');
+const browserInterceptor = createIpcInterceptor('tauri');
 
 /**
  * Tauri worker service
@@ -36,6 +38,8 @@ export default class TauriWorkerService {
   private restoreMocksPrefix?: string;
   private driverProvider?: 'official' | 'crabnebula' | 'embedded';
   private windowLabel: string;
+  private mode?: string;
+  private devServerUrl?: string;
 
   constructor(options: TauriServiceOptions & TauriServiceGlobalOptions, _capabilities: TauriCapabilities) {
     this.clearMocks = options.clearMocks ?? false;
@@ -46,6 +50,8 @@ export default class TauriWorkerService {
     this.restoreMocksPrefix = options.restoreMocksPrefix;
     this.driverProvider = options.driverProvider;
     this.windowLabel = options.windowLabel || getDefaultWindowLabel();
+    this.mode = options.mode;
+    this.devServerUrl = options.devServerUrl;
     log.debug('TauriWorkerService initialized');
   }
 
@@ -59,6 +65,11 @@ export default class TauriWorkerService {
   ): Promise<void> {
     log.debug('Initializing Tauri worker service');
     this.browser = browser;
+
+    if (this.mode === 'browser') {
+      await this.initBrowserMode(browser as WebdriverIO.Browser);
+      return;
+    }
 
     if (browser.isMultiremote) {
       const mrBrowser = browser as WebdriverIO.MultiRemoteBrowser;
@@ -260,23 +271,41 @@ export default class TauriWorkerService {
   }
 
   /**
+   * Initialize browser-only mode: navigate to dev server, inject IPC layer, expose API
+   */
+  private async initBrowserMode(browser: WebdriverIO.Browser): Promise<void> {
+    log.debug('Initializing browser-only mode');
+    await browser.url(this.devServerUrl!);
+    await browser.execute(browserInterceptor.buildBrowserIpcInjectionScript());
+    (browser as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
+    this.addTauriApi(browser, true);
+    this.installCommandOverrides();
+    log.debug('Browser-only mode initialized');
+  }
+
+  /**
    * Add Tauri API to browser object
    * Matches the Electron service API surface exactly
    */
-  private addTauriApi(browser: WebdriverIO.Browser): void {
-    (browser as WebdriverIO.Browser & { tauri: TauriServiceAPI }).tauri = this.getTauriAPI(browser);
+  private addTauriApi(browser: WebdriverIO.Browser, browserMode = false): void {
+    (browser as WebdriverIO.Browser & { tauri: TauriServiceAPI }).tauri = this.getTauriAPI(browser, browserMode);
   }
 
   /**
    * Get Tauri API object for a browser instance
    * Handles both standard and multiremote browsers
    */
-  private getTauriAPI(browser: WebdriverIO.Browser): TauriServiceAPI {
+  private getTauriAPI(browser: WebdriverIO.Browser, browserMode = false): TauriServiceAPI {
     return {
       execute: async <ReturnValue, InnerArguments extends unknown[]>(
         script: string | ((tauri: TauriAPIs, ...innerArgs: InnerArguments) => ReturnValue),
         ...args: InnerArguments
       ): Promise<ReturnValue> => {
+        if (browserMode) {
+          throw new Error(
+            'browser.tauri.execute() is not supported in browser mode. Use browser.execute() for frontend code or browser.tauri.mock() to intercept Tauri commands.',
+          );
+        }
         const result = await execute<ReturnValue, InnerArguments>(browser, script, ...args);
         await updateAllMocks();
         return result;
@@ -311,14 +340,27 @@ export default class TauriWorkerService {
       },
 
       triggerDeeplink: async (url: string): Promise<void> => {
+        if (browserMode) {
+          throw new Error('browser.tauri.triggerDeeplink() is not supported in browser mode.');
+        }
         return triggerDeeplink.call({ browser }, url);
       },
 
       switchWindow: async (label: string): Promise<void> => {
+        if (browserMode) {
+          throw new Error(
+            'browser.tauri.switchWindow() is not supported in browser mode. Multi-window is unavailable in browser mode.',
+          );
+        }
         await switchWindowByLabel(browser, label);
       },
 
       listWindows: async (): Promise<string[]> => {
+        if (browserMode) {
+          throw new Error(
+            'browser.tauri.listWindows() is not supported in browser mode. Multi-window is unavailable in browser mode.',
+          );
+        }
         return listWindowLabels(browser);
       },
     };

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -297,6 +297,7 @@ export default class TauriWorkerService {
         const instance = mrBrowser.getInstance(instanceName);
         (instance as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
         this.addTauriApi(instance, true);
+        this.patchBrowserUrl(instance, injectionScript);
       }
     }
     this.addTauriApi(browser, true);

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -284,7 +284,9 @@ export default class TauriWorkerService {
     if ((browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
       const mrBrowser = browser as unknown as WebdriverIO.MultiRemoteBrowser;
       for (const instanceName of mrBrowser.instances) {
-        (mrBrowser.getInstance(instanceName) as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
+        const instance = mrBrowser.getInstance(instanceName);
+        (instance as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
+        this.addTauriApi(instance, true);
       }
     }
     this.addTauriApi(browser, true);

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -271,7 +271,16 @@ export default class TauriWorkerService {
   }
 
   /**
-   * Initialize browser-only mode: navigate to dev server, inject IPC layer, expose API
+   * Initialize browser-only mode: navigate to dev server, inject IPC layer, expose API.
+   *
+   * Timing note: the IPC interceptor is injected after browser.url() resolves
+   * (i.e. after readyState === "complete"). Any invoke() calls the app makes
+   * during module init, DOMContentLoaded, or onload handlers will therefore
+   * run against the real (unpatched) __TAURI_INTERNALS__ and be missed by mocks.
+   * In practice this is only a problem for apps that call invoke() on startup
+   * before any user interaction. If your app does this, structure tests so that
+   * all mocks are created before the first navigation, or use a Vite plugin to
+   * import the injection script as a top-level module in your dev build.
    */
   private async initBrowserMode(browser: WebdriverIO.Browser): Promise<void> {
     log.debug('Initializing browser-only mode');

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -275,7 +275,10 @@ export default class TauriWorkerService {
    */
   private async initBrowserMode(browser: WebdriverIO.Browser): Promise<void> {
     log.debug('Initializing browser-only mode');
-    await browser.url(this.devServerUrl!);
+    if (!this.devServerUrl) {
+      throw new Error('devServerUrl is required for browser mode but was not set');
+    }
+    await browser.url(this.devServerUrl);
     await browser.execute(browserInterceptor.buildBrowserIpcInjectionScript());
     (browser as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
     this.addTauriApi(browser, true);

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -287,8 +287,9 @@ export default class TauriWorkerService {
     if (!this.devServerUrl) {
       throw new Error('devServerUrl is required for browser mode but was not set');
     }
+    const injectionScript = browserInterceptor.buildBrowserIpcInjectionScript();
     await browser.url(this.devServerUrl);
-    await browser.execute(browserInterceptor.buildBrowserIpcInjectionScript());
+    await browser.execute(injectionScript);
     (browser as unknown as Record<string, boolean>).__wdioBrowserMode__ = true;
     if ((browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
       const mrBrowser = browser as unknown as WebdriverIO.MultiRemoteBrowser;
@@ -299,8 +300,31 @@ export default class TauriWorkerService {
       }
     }
     this.addTauriApi(browser, true);
+    this.patchBrowserUrl(browser, injectionScript);
     this.installCommandOverrides();
     log.debug('Browser-only mode initialized');
+  }
+
+  /**
+   * Patch browser.url() so the IPC injection script is re-applied after every
+   * navigation. A page load wipes window state, so without this any browser.url()
+   * call inside a test would silently remove __TAURI_INTERNALS__ patching and
+   * __wdio_mocks__, breaking all mocks registered for that test.
+   */
+  private patchBrowserUrl(browser: WebdriverIO.Browser, injectionScript: string): void {
+    type UrlFn = (href?: string) => Promise<string | void>;
+    const originalUrl = (browser.url as unknown as UrlFn).bind(browser);
+    (browser as unknown as { url: UrlFn }).url = async (href?: string): Promise<string | void> => {
+      const result = await originalUrl(href);
+      if (href !== undefined) {
+        try {
+          await browser.execute(injectionScript);
+        } catch (error) {
+          log.warn('Failed to re-inject IPC script after navigation:', error);
+        }
+      }
+      return result;
+    };
   }
 
   /**

--- a/packages/tauri-service/test/launcher.browser.spec.ts
+++ b/packages/tauri-service/test/launcher.browser.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/embeddedProvider.js', () => ({
+  checkEmbeddedServerAlive: vi.fn(),
+  startEmbeddedDriver: vi.fn(),
+  stopEmbeddedDriver: vi.fn(),
+  getEmbeddedPort: vi.fn().mockReturnValue(4445),
+  isEmbeddedProvider: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../src/diagnostics.js', () => ({
+  diagnoseTauriEnvironment: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@wdio/native-utils', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  formatDiagnosticResults: vi.fn(),
+  isErr: vi.fn().mockReturnValue(false),
+  isOk: vi.fn().mockReturnValue(true),
+  Ok: (v: unknown) => ({ ok: true, value: v }),
+  Err: (e: unknown) => ({ ok: false, error: e }),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../src/driverPool.js', () => ({
+  DriverPool: class MockDriverPool {
+    startDriver = vi.fn();
+    stopDriver = vi.fn().mockResolvedValue(undefined);
+    stopAll = vi.fn().mockResolvedValue(undefined);
+    getStatus = vi.fn().mockReturnValue({ count: 0, running: false });
+    getRunningPids = vi.fn().mockReturnValue([]);
+  },
+}));
+
+vi.mock('../src/portManager.js', () => ({
+  PortManager: class MockPortManager {
+    allocatePortPair = vi.fn().mockResolvedValue({ port: 4444, nativePort: 4445 });
+    allocatePorts = vi.fn().mockResolvedValue([{ port: 4444, nativePort: 4445 }]);
+    allocatePort = vi.fn().mockResolvedValue(4444);
+    clear = vi.fn();
+  },
+}));
+
+vi.mock('../src/pathResolver.js', () => ({
+  getTauriAppInfo: vi.fn().mockResolvedValue({ version: '1.0.0' }),
+  getTauriBinaryPath: vi.fn().mockResolvedValue('/app/my-app'),
+  getWebKitWebDriverPath: vi.fn().mockReturnValue('/usr/bin/WebKitWebDriver'),
+}));
+
+vi.mock('../src/driverManager.js', () => ({
+  ensureTauriDriver: vi.fn().mockResolvedValue({ ok: true, value: { path: '/tauri-driver', method: 'found' } }),
+  findTestRunnerBackend: vi.fn(),
+}));
+
+vi.mock('../src/edgeDriverManager.js', () => ({
+  ensureMsEdgeDriver: vi.fn().mockResolvedValue({ ok: true, value: { method: 'found', driverVersion: '120' } }),
+}));
+
+vi.mock('../src/commands/triggerDeeplink.js', () => ({
+  setEmbeddedModeInfo: vi.fn(),
+  setCrabnebulaModeInfo: vi.fn(),
+}));
+
+vi.mock('../src/crabnebulaBackend.js', () => ({
+  startTestRunnerBackend: vi.fn(),
+  stopTestRunnerBackend: vi.fn().mockResolvedValue(undefined),
+  waitTestRunnerBackendReady: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ensureTauriDriver } from '../src/driverManager.js';
+import TauriLaunchService from '../src/launcher.js';
+
+const DEV_SERVER = 'http://localhost:1420';
+
+function createLauncher(globalOpts: Record<string, unknown> = {}): TauriLaunchService {
+  return new TauriLaunchService(globalOpts as any, {} as any, { maxInstances: 1 } as any);
+}
+
+describe('TauriLaunchService — browser mode', () => {
+  describe('onPrepare', () => {
+    it('mutates browserName to "chrome" and removes tauri:options', async () => {
+      const launcher = createLauncher();
+      const caps: any[] = [
+        {
+          'tauri:options': { application: '/app/my-app' },
+          'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+        },
+      ];
+      await launcher.onPrepare({} as any, caps);
+      expect(caps[0].browserName).toBe('chrome');
+      expect(caps[0]['tauri:options']).toBeUndefined();
+    });
+
+    it('does not spawn tauri-driver in browser mode', async () => {
+      const launcher = createLauncher();
+      const caps: any[] = [{ 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } }];
+      await launcher.onPrepare({} as any, caps);
+      expect(ensureTauriDriver).not.toHaveBeenCalled();
+    });
+
+    it('throws SevereServiceError when devServerUrl is missing', async () => {
+      const launcher = createLauncher();
+      const caps: any[] = [{ 'wdio:tauriServiceOptions': { mode: 'browser' } }];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('devServerUrl is required');
+    });
+
+    it('throws SevereServiceError when devServerUrl is not a valid URL', async () => {
+      const launcher = createLauncher();
+      const caps: any[] = [{ 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: 'not-a-url' } }];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('not a valid URL');
+    });
+
+    it('accepts devServerUrl via global options', async () => {
+      const launcher = createLauncher({ mode: 'browser', devServerUrl: DEV_SERVER });
+      const caps: any[] = [{}];
+      await launcher.onPrepare({} as any, caps);
+      expect(caps[0].browserName).toBe('chrome');
+    });
+  });
+
+  describe('onWorkerStart', () => {
+    it('returns immediately without setting up drivers', async () => {
+      const launcher = createLauncher();
+      const caps: any[] = [{ 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } }];
+      await launcher.onPrepare({} as any, caps);
+      await expect(launcher.onWorkerStart('0-0', caps as any)).resolves.toBeUndefined();
+      expect(ensureTauriDriver).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onWorkerEnd', () => {
+    it('returns immediately in browser mode', async () => {
+      const launcher = createLauncher();
+      const caps: any[] = [{ 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } }];
+      await launcher.onPrepare({} as any, caps);
+      await expect(launcher.onWorkerEnd('0-0')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/tauri-service/test/mock.spec.ts
+++ b/packages/tauri-service/test/mock.spec.ts
@@ -102,6 +102,32 @@ describe('createMock', () => {
       expect(mock.mock.calls).toHaveLength(1);
     });
 
+    it('replaces outer data when inner call count shrinks (page reload or in-browser clear)', async () => {
+      const browser = makeBrowser();
+      const twoCallsPayload = {
+        calls: [['a'], ['b']],
+        results: [
+          { type: 'return', value: 1 },
+          { type: 'return', value: 2 },
+        ],
+        invocationCallOrder: [0, 1],
+      };
+      const zeroCallsPayload = { calls: [], results: [], invocationCallOrder: [] };
+      mockExecute
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(twoCallsPayload)
+        .mockResolvedValueOnce(zeroCallsPayload);
+
+      const mock = await createMock('my_cmd', browser);
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(2);
+
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(0);
+      expect(mock.mock.results).toHaveLength(0);
+      expect(mock.mock.invocationCallOrder).toHaveLength(0);
+    });
+
     it('uses fallback result when syncData.results entry is missing', async () => {
       const browser = makeBrowser();
       mockExecute.mockResolvedValueOnce(undefined).mockResolvedValueOnce({

--- a/packages/tauri-service/test/mock.spec.ts
+++ b/packages/tauri-service/test/mock.spec.ts
@@ -45,26 +45,26 @@ afterEach(() => {
 });
 
 describe('createMock', () => {
-  it('calls tauriExecute once for registration (registration + initial mockClear are combined)', async () => {
+  it('should call tauriExecute once for registration', async () => {
     const browser = makeBrowser();
     await createMock('my_cmd', browser);
     expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 
-  it('returns a TauriMock with __isTauriMock', async () => {
+  it('should return a TauriMock with __isTauriMock', async () => {
     const browser = makeBrowser();
     const mock = await createMock('my_cmd', browser);
     expect(mock.__isTauriMock).toBe(true);
   });
 
-  it('mock name is set to tauri.<command>', async () => {
+  it('should set mock name to tauri.<command>', async () => {
     const browser = makeBrowser();
     const mock = await createMock('platform_info', browser);
     expect(mock.getMockName()).toBe('tauri.platform_info');
   });
 
   describe('update()', () => {
-    it('populates calls from parsed call data', async () => {
+    it('should populate calls from parsed call data', async () => {
       const browser = makeBrowser();
       mockExecute.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
         calls: [['arg1'], ['arg2']],
@@ -83,7 +83,7 @@ describe('createMock', () => {
       expect(mock.mock.calls[1]).toEqual(['arg2']);
     });
 
-    it('does not duplicate existing calls on a second update', async () => {
+    it('should not duplicate existing calls on a second update', async () => {
       const browser = makeBrowser();
       const syncPayload = {
         calls: [['arg1']],
@@ -102,7 +102,7 @@ describe('createMock', () => {
       expect(mock.mock.calls).toHaveLength(1);
     });
 
-    it('replaces outer data when inner call count shrinks (page reload or in-browser clear)', async () => {
+    it('should replace outer data when inner call count shrinks', async () => {
       const browser = makeBrowser();
       const twoCallsPayload = {
         calls: [['a'], ['b']],
@@ -128,7 +128,7 @@ describe('createMock', () => {
       expect(mock.mock.invocationCallOrder).toHaveLength(0);
     });
 
-    it('uses fallback result when syncData.results entry is missing', async () => {
+    it('should use fallback result when syncData.results entry is missing', async () => {
       const browser = makeBrowser();
       mockExecute.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
         calls: [['arg1']],
@@ -142,7 +142,7 @@ describe('createMock', () => {
       expect(mock.mock.results[0]).toEqual({ type: 'return', value: undefined });
     });
 
-    it('returns a mock object for chaining', async () => {
+    it('should return a mock object for chaining', async () => {
       const browser = makeBrowser();
       mockExecute
         .mockResolvedValueOnce(undefined)
@@ -156,7 +156,7 @@ describe('createMock', () => {
   });
 
   describe('mockReset() race-condition hack', () => {
-    it('preserves mock name after mockReset', async () => {
+    it('should preserve mock name after mockReset', async () => {
       const browser = makeBrowser();
       const mock = await createMock('my_cmd', browser);
       const nameBefore = mock.getMockName();
@@ -167,7 +167,7 @@ describe('createMock', () => {
       expect(mock.getMockName()).toBe(nameBefore);
     });
 
-    it('restores async mockClear (not the sync outerMockClear) after mockReset completes', async () => {
+    it('should restore async mockClear after mockReset completes', async () => {
       const browser = makeBrowser();
       const mock = await createMock('my_cmd', browser);
 
@@ -181,7 +181,7 @@ describe('createMock', () => {
       expect(mockExecute).toHaveBeenCalled();
     });
 
-    it('clears calls after mockReset', async () => {
+    it('should clear calls after mockReset', async () => {
       const browser = makeBrowser();
       const syncPayload = { calls: [['arg']], results: [{ type: 'return', value: 1 }], invocationCallOrder: [0] };
       mockExecute.mockResolvedValueOnce(undefined).mockResolvedValueOnce(syncPayload).mockResolvedValueOnce(undefined);
@@ -196,7 +196,7 @@ describe('createMock', () => {
   });
 
   describe('mockRestore()', () => {
-    it('calls mockStore.deleteMock with the tauri-prefixed name', async () => {
+    it('should call mockStore.deleteMock with the tauri-prefixed name', async () => {
       const browser = makeBrowser();
       const mock = await createMock('my_cmd', browser);
 
@@ -208,14 +208,14 @@ describe('createMock', () => {
   });
 
   describe('wrapperMock', () => {
-    it('wrapperMock.mock returns the outer mock state', async () => {
+    it('should return the outer mock state', async () => {
       const browser = makeBrowser();
       const wrapper = await createMock('my_cmd', browser);
       expect(wrapper.mock).toBeDefined();
       expect(Array.isArray(wrapper.mock.calls)).toBe(true);
     });
 
-    it('wrapperMock.update is bound and functional', async () => {
+    it('should have bound and functional wrapperMock.update', async () => {
       const browser = makeBrowser();
       const wrapper = await createMock('my_cmd', browser);
 


### PR DESCRIPTION
- Implemented the `buildBrowserIpcInjectionScript` method in both `TauriAdapter` and `ElectronAdapter`, providing a mechanism for injecting IPC scripts into the browser context.
- Updated the `FrameworkAdapter` interface to include the new method, ensuring consistent API across adapters.
- Added comprehensive tests for the `buildBrowserIpcInjectionScript` functionality in the Tauri adapter, validating the correct setup of mock functions and internal structures in the browser environment.