### PR TITLE
feat: implement browser-only test mode (Phase 2)

### DIFF
--- a/fixtures/package-tests/tauri-app/docker/arch.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/arch.dockerfile
@@ -2,7 +2,12 @@ FROM archlinux:latest
 
 ENV CI=true
 
-# Update package database and install basic requirements
+# Update package database and install basic requirements.
+# Note: Node.js is NOT installed from pacman — Arch's `nodejs` package tracks
+# the latest release (currently Node 26) whose stricter undici validation
+# trips WDIO's session POST (UND_ERR_INVALID_ARG). We install Node 20 LTS
+# from official binaries below to match Ubuntu/Debian (which pin via
+# setup_20.x) and keep builds repeatable.
 RUN pacman -Syu --noconfirm && \
     pacman -S --noconfirm \
         curl \
@@ -10,12 +15,18 @@ RUN pacman -Syu --noconfirm && \
         sudo \
         git \
         base-devel \
-        nodejs \
-        npm \
         openssl \
         python \
         xorg-server-xvfb && \
     pacman -Scc --noconfirm
+
+# Install Node.js 20 LTS from official binaries (pinned for repeatable builds)
+RUN NODE_VERSION="20.18.1" && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+        -o /tmp/node.tar.xz && \
+    tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 && \
+    rm /tmp/node.tar.xz && \
+    node --version && npm --version
 
 # Install pnpm globally
 RUN npm install -g pnpm

--- a/packages/electron-service/README.md
+++ b/packages/electron-service/README.md
@@ -10,7 +10,7 @@ Enables cross-platform E2E testing of Electron apps via the extensive WebdriverI
 
 Spiritual successor to [Spectron](https://github.com/electron-userland/spectron) ([RIP](https://github.com/electron-userland/spectron/issues/1045)).
 
-> **v10 highlights** — the package is now scoped as `@wdio/electron-service`. v10 adds class mocking (`browser.electron.mock('Tray')`), main- and renderer-process console log capture, deeplink testing (`browser.electron.triggerDeeplink()`), and an `electronBuilderConfig` option for projects with multiple build configs. See the [v10.0.0 release notes](./docs/release-notes/v10.0.0.md) for the full list, or the [v9 → v10 migration guide](./docs/migration/v9-to-v10.md) if you're upgrading.
+> **v10 highlights** — the package is now scoped as `@wdio/electron-service`. v10 adds class mocking (`browser.electron.mock('Tray')`), main- and renderer-process console log capture, deeplink testing (`browser.electron.triggerDeeplink()`), an `electronBuilderConfig` option for projects with multiple build configs, and a `mode: 'browser'` option for testing the renderer in plain Chrome against a Vite dev server without an Electron binary. See the [v10.0.0 release notes](./docs/release-notes/v10.0.0.md) for the full list, or the [v9 → v10 migration guide](./docs/migration/v9-to-v10.md) if you're upgrading.
 
 ### Features
 
@@ -128,6 +128,7 @@ This is because WDIO uses Chrome for Testing to download Chromedriver, which onl
 - **[Window Management](./docs/window-management.md)** — automatic window focus behaviour
 
 ### Operations
+- **[Browser Mode](./docs/browser-mode.md)** — test the renderer in Chrome against a Vite dev server, no Electron binary required
 - **[Deeplink Testing](./docs/deeplink-testing.md)** — protocol handler tests across platforms
 - **[Standalone Mode](./docs/standalone-mode.md)** — using the service without the WDIO test runner
 - **[Debugging](./docs/debugging.md)** — log capture, debug namespaces, troubleshooting

--- a/packages/electron-service/docs/api-reference.md
+++ b/packages/electron-service/docs/api-reference.md
@@ -284,6 +284,8 @@ const fileIcon = await browser.electron.execute(async (electron) => {
 });
 ```
 
+**Browser Mode:** Not available. `browser.electron.execute()` requires a live main process and CDP bridge. In browser mode, use `browser.execute()` to run code in the renderer or `browser.electron.mock()` to intercept IPC channels.
+
 **See Also:**
 - [Electron APIs Guide](./electron-apis.md)
 
@@ -351,6 +353,8 @@ it('should handle deeplinks', async () => {
 - **macOS**: Works with both packaged binaries and script-based apps. No URL modification.
 - **Linux**: Cannot use `appEntryPoint` (must use packaged binary). Automatically appends `userData` parameter to URL.
 
+**Browser Mode:** Not available. There is no Electron process to receive the deeplink in browser mode.
+
 **See Also:**
 - [Deeplink Testing Guide](./deeplink-testing.md)
 
@@ -416,8 +420,23 @@ await browser.electron.execute((electron) => {
 expect(mockTray.setTitle).toHaveBeenCalledWith('My App');
 ```
 
+**Browser Mode:** The signature changes in browser mode. Pass a single IPC channel name — the string your renderer sends via `ipcRenderer.invoke(channel)`. The two-argument form `mock(apiName, funcName)` throws in browser mode.
+
+```ts
+// Browser mode — mock by IPC channel name
+const mockGetUser = await browser.electron.mock('get-user-data');
+await mockGetUser.mockResolvedValue({ id: 1, name: 'Alice' });
+
+// Trigger the IPC call in your app, then assert
+await mockGetUser.update();
+expect(mockGetUser).toHaveBeenCalledTimes(1);
+```
+
+See the [Browser Mode Guide](./browser-mode.md) for a full usage walkthrough.
+
 **See Also:**
 - [Electron APIs Guide](./electron-apis.md#mocking-electron-apis)
+- [Browser Mode Guide](./browser-mode.md)
 
 ---
 
@@ -447,6 +466,8 @@ const { showOpenDialog, showMessageBox } = await browser.electron.mockAll('dialo
 await showOpenDialog.mockReturnValue('I opened a dialog!');
 await showMessageBox.mockReturnValue('I opened a message box!');
 ```
+
+**Browser Mode:** Not available. Use `browser.electron.mock(channel)` to mock individual IPC channels instead.
 
 **See Also:**
 - [Electron APIs Guide](./electron-apis.md#mocking-electron-apis)

--- a/packages/electron-service/docs/browser-mode.md
+++ b/packages/electron-service/docs/browser-mode.md
@@ -1,0 +1,286 @@
+# Browser Mode
+
+Browser mode lets you test your Electron renderer UI in plain Chrome against a running Vite (or webpack) dev server — no Electron binary, no Chromedriver, no CDP bridge. IPC calls are intercepted at the `window.electron.ipcRenderer` JavaScript boundary in the renderer, so you can mock individual channels and assert on call arguments just like in native mode.
+
+## Overview
+
+### What Is It?
+
+In normal (`native`) mode the service launches your compiled Electron app, drives it via Chromedriver, and communicates with the main process through a CDP bridge. Browser mode replaces all of that with a standard Chrome session: it sets `browserName` to `'chrome'`, navigates to your dev server URL, and injects a lightweight script that patches `ipcRenderer.invoke`, `send`, and `sendSync` so your IPC calls can be intercepted in tests.
+
+### Why Use It?
+
+- **No build step needed** — point the service at `vite dev` and start testing immediately.
+- **Fast feedback** — no Electron startup, no binary detection, no port negotiation.
+- **Standard browser devtools** — Chrome DevTools and HMR work as normal during development.
+
+### When to Use It
+
+Browser mode is the right choice when your tests are renderer-focused: asserting UI state, verifying that components call the correct IPC channels with the right arguments, or checking that the renderer handles mock responses correctly.
+
+It is **not** suitable when your tests need to:
+
+- Call `browser.electron.execute()` to run code in the main process
+- Test window management, native menus, or system tray behaviour
+- Use `browser.electron.triggerDeeplink()`
+- Assert on real IPC round-trips to a running Node.js main process
+
+For those scenarios use native mode (the default).
+
+## Setup
+
+### 1. Start Your Dev Server
+
+Browser mode requires a running dev server. Start it before running your tests:
+
+```bash
+vite dev
+# or
+webpack serve
+```
+
+### 2. Configure the Service
+
+Set `mode: 'browser'` and provide `devServerUrl` in your WDIO configuration. No `appBinaryPath` or `appEntryPoint` is needed.
+
+_`wdio.conf.ts`_
+
+```ts
+export const config = {
+  services: ['electron'],
+  capabilities: [
+    {
+      browserName: 'electron',
+      'wdio:electronServiceOptions': {
+        mode: 'browser',
+        devServerUrl: 'http://localhost:5173',
+      },
+    },
+  ],
+};
+```
+
+You can also set `mode` and `devServerUrl` at the global service level so all capabilities inherit them:
+
+```ts
+export const config = {
+  services: [
+    [
+      'electron',
+      {
+        mode: 'browser',
+        devServerUrl: 'http://localhost:5173',
+      },
+    ],
+  ],
+  capabilities: [
+    { browserName: 'electron' },
+  ],
+};
+```
+
+Capability-level options take precedence over service-level ones. All capabilities in a session must use the same mode; mixing `'native'` and `'browser'` across capabilities throws a `SevereServiceError` at startup.
+
+## IPC Mocking
+
+### How It Works
+
+When the session starts, the service injects a script into the page that:
+
+1. Creates `window.__wdio_mocks__` — a registry of per-channel mock functions.
+2. Patches `window.electron.ipcRenderer.invoke` to look up `window.__wdio_mocks__[channel]` and call it; throws if the channel has no registered mock.
+3. Patches `send` and `sendSync` to throw immediately for unmocked channels.
+4. Stubs `on`, `once`, `removeListener`, and `removeAllListeners` as no-ops (event listeners are not supported in browser mode).
+
+The injection script runs again after every `browser.url()` navigation because a page load wipes `window` state.
+
+### Mocking a Channel
+
+```ts
+// In your test
+const mockGetUser = await browser.electron.mock('get-user-data');
+await mockGetUser.mockResolvedValue({ id: 42, name: 'Alice' });
+```
+
+The channel name must match the string your renderer passes to `ipcRenderer.invoke`:
+
+```ts
+// In your renderer code
+const user = await window.electron.ipcRenderer.invoke('get-user-data');
+```
+
+### Asserting on Calls
+
+After triggering the relevant UI action, call `update()` to sync call data from the browser-side spy to the outer mock object, then assert:
+
+```ts
+await $('button#load-user').click(); // triggers ipcRenderer.invoke('get-user-data')
+
+await mockGetUser.update();
+expect(mockGetUser).toHaveBeenCalledTimes(1);
+expect(mockGetUser.mock.calls[0]).toEqual([]);
+```
+
+Element commands (`click`, `doubleClick`, `setValue`, `clearValue`) trigger `update()` automatically on all active mocks, so you often don't need to call it explicitly after those interactions.
+
+### Setting Implementations
+
+All standard mock methods are available:
+
+```ts
+// Return a fixed value
+await mockGetUser.mockReturnValue({ id: 1, name: 'Alice' });
+
+// Resolve a promise (for async IPC handlers)
+await mockGetUser.mockResolvedValue({ id: 1, name: 'Alice' });
+
+// Use a function for dynamic responses
+await mockGetUser.mockImplementation((userId: string) => {
+  return { id: userId, name: 'Dynamic User' };
+});
+
+// Respond differently on the first call, then fall back
+await mockGetUser.mockResolvedValueOnce({ id: 1, name: 'First' });
+await mockGetUser.mockResolvedValue({ id: 0, name: 'Default' });
+```
+
+### Restoring a Mock
+
+`mockRestore()` deregisters the channel from `window.__wdio_mocks__`. After restoring, any `ipcRenderer.invoke` call to that channel will throw the "unmocked channel" error.
+
+```ts
+await mockGetUser.mockRestore();
+```
+
+## Mock Lifecycle Across Tests
+
+### `mock(channel)` Is Idempotent
+
+Calling `browser.electron.mock(channel)` multiple times for the same channel is safe. The service returns the existing mock if the browser-side entry is still live, or silently re-registers it (without resetting call history or implementation) if a navigation wiped `window.__wdio_mocks__`.
+
+This means it is safe to call `mock(channel)` in both `beforeAll` and `beforeEach`:
+
+```ts
+describe('User panel', () => {
+  let mockGetUser: ElectronFunctionMock;
+
+  beforeAll(async () => {
+    mockGetUser = await browser.electron.mock('get-user-data');
+    await mockGetUser.mockResolvedValue({ id: 1, name: 'Alice' });
+  });
+
+  beforeEach(async () => {
+    // Safe to call again — returns the same mock, implementation is preserved
+    mockGetUser = await browser.electron.mock('get-user-data');
+    await mockGetUser.mockClear(); // Reset call history only
+  });
+
+  it('displays the user name', async () => {
+    await $('button#load-user').click();
+    await mockGetUser.update();
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+### Clearing vs Resetting
+
+| Method | Effect |
+|--------|--------|
+| `mockClear()` | Clears `.mock.calls`, `.mock.results`, `.mock.invocationCallOrder`. Implementation unchanged. |
+| `mockReset()` | Clears history **and** removes the implementation (returns `undefined` on next call). |
+| `mockRestore()` | Removes the mock entirely from `window.__wdio_mocks__`. |
+
+Use `mockClear()` in `beforeEach` when you want a clean call history but want to keep the implementation set up in `beforeAll`.
+
+## Navigation
+
+`browser.url()` is patched by the service to re-run the IPC injection script after every navigation. This re-creates `window.__wdio_mocks__` (as an empty object) and patches `ipcRenderer` again, so existing mock handles remain valid — calling `mock(channel)` after navigation re-registers the browser-side entry on demand.
+
+```ts
+it('preserves mock handles across navigation', async () => {
+  const mockGetConfig = await browser.electron.mock('get-config');
+  await mockGetConfig.mockResolvedValue({ theme: 'dark' });
+
+  // Navigate to another route
+  await browser.url('http://localhost:5173/settings');
+
+  // Re-register and use — same outer mock object, fresh browser-side spy
+  await browser.electron.mock('get-config');
+  await mockGetConfig.mockResolvedValue({ theme: 'dark' }); // Re-set implementation
+  await $('button#load-config').click();
+  await mockGetConfig.update();
+  expect(mockGetConfig).toHaveBeenCalledTimes(1);
+});
+```
+
+### Timing Caveat
+
+The injection script runs after `browser.url()` resolves (document `readyState` is `complete`). Any `ipcRenderer.invoke` calls your app makes during module-level initialization — before the first `DOMContentLoaded` — happen before the script is injected and will not be intercepted.
+
+**Workaround:** Create a Vite plugin that imports the injection script as a top-level module in your dev build, so it runs before any app code.
+
+## Limitations
+
+| Feature | Browser Mode |
+|---------|-------------|
+| `browser.electron.execute()` | Throws — no main process |
+| `browser.electron.mockAll()` | Throws — mock channels individually |
+| `browser.electron.triggerDeeplink()` | Throws — no Electron process |
+| `browser.electron.mock(apiName, funcName)` | Throws — use `mock(channel)` instead |
+| `browser.electron.windowHandle` | Not meaningful — standard Chrome window handle |
+| Automatic window focus management | Disabled — standard browser window switching applies |
+| `ipcRenderer.on` / `once` / `removeListener` | No-ops — event listeners not intercepted |
+
+## Multiremote
+
+Each named multiremote instance gets its own isolated mock registry. Mocking the same channel on two instances is safe; they do not share `window.__wdio_mocks__`.
+
+_`wdio.conf.ts`_
+
+```ts
+export const config = {
+  services: [['electron', { mode: 'browser' }]],
+  capabilities: {
+    app1: {
+      capabilities: {
+        browserName: 'electron',
+        'wdio:electronServiceOptions': { devServerUrl: 'http://localhost:5173' },
+      },
+    },
+    app2: {
+      capabilities: {
+        browserName: 'electron',
+        'wdio:electronServiceOptions': { devServerUrl: 'http://localhost:5173' },
+      },
+    },
+  },
+};
+```
+
+```ts
+// In tests — each instance mocks independently
+const mock1 = await browser.getInstance('app1').electron.mock('get-user-data');
+const mock2 = await browser.getInstance('app2').electron.mock('get-user-data');
+
+await mock1.mockResolvedValue({ id: 1 });
+await mock2.mockResolvedValue({ id: 2 });
+```
+
+## Troubleshooting
+
+### `"unmocked Electron IPC channel in browser mode: <channel>"`
+
+Your renderer called `ipcRenderer.invoke(channel)` (or `send`/`sendSync`) before a mock was registered for that channel. Call `browser.electron.mock(channel)` before the code path that triggers the IPC call.
+
+### Mock returns `undefined` after navigation
+
+The browser-side mock was wiped by the navigation. Call `browser.electron.mock(channel)` again to re-register it and re-apply any implementation you need.
+
+### App IPC during startup is not intercepted
+
+The injection script runs after page load. If your app invokes IPC during module initialization, those calls happen before the script is active. See the [timing caveat](#timing-caveat) above.
+
+### Dev server not running
+
+The service throws a `SevereServiceError` if `devServerUrl` is missing or not a valid URL. A connection-refused error from Chrome means the dev server is not running — start it before launching the test suite.

--- a/packages/electron-service/docs/browser-mode.md
+++ b/packages/electron-service/docs/browser-mode.md
@@ -231,6 +231,30 @@ The injection script runs after `browser.url()` resolves (document `readyState` 
 | `browser.electron.windowHandle` | Not meaningful — standard Chrome window handle |
 | Automatic window focus management | Disabled — standard browser window switching applies |
 | `ipcRenderer.on` / `once` / `removeListener` | No-ops — event listeners not intercepted |
+| `mock.withImplementation()` | Serialised to browser page — see below |
+
+### `withImplementation` in browser mode
+
+`mock.withImplementation(implFn, callbackFn)` serialises **both** functions via `.toString()` and executes them inside the browser page using `executeAsync`. This means:
+
+- The `callbackFn` runs in the browser page, **not** in the Node.js test-runner process.
+- It cannot close over test-runner variables, call WebdriverIO commands (`browser.$()`, `browser.click()`, etc.), or use Node.js APIs (`fs`, `path`, etc.) — those symbols do not exist in the page context.
+- Only use `withImplementation` when both functions are fully self-contained browser-side snippets.
+
+For the common pattern of "use a temporary implementation while performing a UI action", use `mockImplementation` + `mockRestore` instead:
+
+```ts
+const mock = await browser.electron.mock('get-user-data');
+await mock.mockImplementation(() => ({ id: 99, name: 'Temporary' }));
+
+// Perform your UI action using standard WebdriverIO commands
+await $('button#load-user').click();
+await mock.update();
+expect(mock).toHaveBeenCalledTimes(1);
+
+// Restore the original implementation
+await mock.mockRestore();
+```
 
 ## Multiremote
 

--- a/packages/electron-service/docs/browser-mode.md
+++ b/packages/electron-service/docs/browser-mode.md
@@ -292,6 +292,16 @@ await mock1.mockResolvedValue({ id: 1 });
 await mock2.mockResolvedValue({ id: 2 });
 ```
 
+### Navigation in multiremote
+
+Per-instance `devServerUrl` is used for the initial navigation only. Once tests are running, `browser.url(href)` on the root navigates all instances to the same `href`. To navigate one instance to a different URL, call `url()` on the instance directly:
+
+```ts
+await browser.getInstance('app1').url('http://localhost:5173/admin');
+```
+
+`browser.electron.mock()` is unsupported on the root multiremote browser — call it on a specific instance instead. The service throws a clear error if you do otherwise.
+
 ## Troubleshooting
 
 ### `"unmocked Electron IPC channel in browser mode: <channel>"`

--- a/packages/electron-service/docs/browser-mode.md
+++ b/packages/electron-service/docs/browser-mode.md
@@ -156,7 +156,7 @@ await mockGetUser.mockRestore();
 
 ### `mock(channel)` Is Idempotent
 
-Calling `browser.electron.mock(channel)` multiple times for the same channel is safe. The service returns the existing mock if the browser-side entry is still live, or silently re-registers it (without resetting call history or implementation) if a navigation wiped `window.__wdio_mocks__`.
+Calling `browser.electron.mock(channel)` multiple times for the same channel is safe. The service returns the existing mock unchanged if the browser-side entry is still live. If a navigation wiped `window.__wdio_mocks__`, it silently re-registers the entry and replays any previously-set implementation, but clears call history (via an internal `mockClear()`). Calls accumulated before the navigation will not appear in `mock.mock.calls` after re-registration.
 
 This means it is safe to call `mock(channel)` in both `beforeAll` and `beforeEach`:
 

--- a/packages/electron-service/docs/browser-mode.md
+++ b/packages/electron-service/docs/browser-mode.md
@@ -229,6 +229,7 @@ The injection script runs after `browser.url()` resolves (document `readyState` 
 | `browser.electron.triggerDeeplink()` | Throws — no Electron process |
 | `browser.electron.mock(apiName, funcName)` | Throws — use `mock(channel)` instead |
 | `browser.electron.windowHandle` | Not meaningful — standard Chrome window handle |
+| `nodeIntegration: true` preloads (no contextBridge) | Unsupported — the browser page has no `require()`. The injection creates a synthetic `window.electron.ipcRenderer` that won't match a preload that exposes a custom API shape via `nodeIntegration`. Use `contextBridge.exposeInMainWorld()` instead. |
 | Automatic window focus management | Disabled — standard browser window switching applies |
 | `ipcRenderer.on` / `once` / `removeListener` | No-ops — event listeners not intercepted |
 | `mock.withImplementation()` | Serialised to browser page — see below |
@@ -304,6 +305,10 @@ The browser-side mock was wiped by the navigation. Call `browser.electron.mock(c
 ### App IPC during startup is not intercepted
 
 The injection script runs after page load. If your app invokes IPC during module initialization, those calls happen before the script is active. See the [timing caveat](#timing-caveat) above.
+
+### Mock never fires / `window.electron` is the wrong shape
+
+If your preload uses `nodeIntegration: true` without `contextBridge.exposeInMainWorld()`, browser mode cannot intercept IPC. The injection assumes a contextBridge-shaped `window.electron.ipcRenderer`. Migrate to contextBridge (see [Electron Context Isolation](https://www.electronjs.org/docs/latest/tutorial/context-isolation)) or use native mode for this test suite.
 
 ### Dev server not running
 

--- a/packages/electron-service/docs/configuration.md
+++ b/packages/electron-service/docs/configuration.md
@@ -122,6 +122,35 @@ When this option is provided, the service will load this specific configuration 
 Type: `string`
 Example: `'config/electron-builder-staging.config.js'`
 
+### `devServerUrl`:
+
+The URL of the Vite (or webpack) dev server to navigate to when `mode` is `'browser'`. Must be a valid URL; the service throws a `SevereServiceError` at startup if the value is missing or malformed.
+
+Type: `string`
+
+Required when: `mode: 'browser'`
+
+Example: `'http://localhost:5173'`
+
+See the [Browser Mode Guide](./browser-mode.md) for full setup instructions.
+
+### `mode`:
+
+Controls which test execution mode the service uses.
+
+Type: `'native' | 'browser'`
+
+Default: `'native'`
+
+- **`'native'`** (default) — launches your packaged Electron app via Chromedriver, establishes a CDP bridge to the main process, and provides the full `browser.electron.*` API surface.
+- **`'browser'`** — skips binary detection, Chromedriver setup, and the CDP bridge entirely. The service sets `browserName` to `'chrome'` and navigates to `devServerUrl`. IPC calls are intercepted at the `window.electron.ipcRenderer` JavaScript boundary, making it suitable for fast renderer-only tests against a running dev server.
+
+All capabilities in a session must use the same mode; mixing modes across capabilities throws a `SevereServiceError`.
+
+Can be set at the global service level or overridden per capability via `wdio:electronServiceOptions`.
+
+See the [Browser Mode Guide](./browser-mode.md) for a complete walkthrough.
+
 ### `clearMocks`:
 
 Calls .mockClear() on all mocked APIs before each test. This will clear mock history, but not reset its implementation.

--- a/packages/electron-service/package.json
+++ b/packages/electron-service/package.json
@@ -34,6 +34,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --coverage",
     "test:unit": "vitest run --coverage",
+    "test:integration": "vitest run -c vitest.integration.config.ts",
     "test:dev": "vitest --coverage",
     "lint": "biome check ."
   },

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -114,9 +114,11 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
           (multiremoteOption) => (multiremoteOption as Capabilities.WithRequestedCapabilities).capabilities,
         );
 
+    // Extract all Electron capabilities once — handles both standard and W3C alwaysMatch format
+    const caps = capsList.flatMap((cap) => getElectronCapabilities(cap) as WebdriverIO.Capabilities);
+
     // Determine and validate run mode across all Electron capabilities
-    const electronCapsList = capsList.filter((cap) => (cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME]);
-    const modes = electronCapsList.map((cap) => {
+    const modes = caps.map((cap) => {
       const capOpts = ((cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME] ?? {}) as ElectronServiceGlobalOptions;
       return capOpts.mode ?? this.#globalOptions.mode ?? 'native';
     });
@@ -130,7 +132,7 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
     const mode = modes[0] ?? 'native';
 
     if (mode === 'browser') {
-      for (const cap of electronCapsList) {
+      for (const cap of caps) {
         const capOpts = ((cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME] ??
           {}) as ElectronServiceGlobalOptions;
         const devServerUrl = capOpts.devServerUrl ?? this.#globalOptions.devServerUrl;
@@ -142,19 +144,14 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
         } catch {
           throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
         }
-      }
-      this.#browserMode = true;
-      const electronCaps = capsList.flatMap((cap) => getElectronCapabilities(cap) as WebdriverIO.Capabilities);
-      for (const cap of electronCaps) {
         cap.browserName = 'chrome';
         delete (cap as Record<string, unknown>)['goog:chromeOptions'];
         delete (cap as Record<string, unknown>)['wdio:enforceWebDriverClassic'];
       }
+      this.#browserMode = true;
       log.info('Browser mode enabled — skipping Electron binary and CDP bridge setup');
       return;
     }
-
-    const caps = capsList.flatMap((cap) => getElectronCapabilities(cap) as WebdriverIO.Capabilities);
     const pkg =
       (await readPackageUp({ cwd: this.#projectRoot })) ||
       ({ packageJson: { dependencies: {}, devDependencies: {} }, path: '' } as NormalizedReadResult);

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -129,19 +129,19 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
     }
     const mode = modes[0] ?? 'native';
 
-    const firstElectronCap = electronCapsList[0];
-    const firstCapOptions = ((firstElectronCap as Record<string, unknown>)?.[CUSTOM_CAPABILITY_NAME] ??
-      {}) as ElectronServiceGlobalOptions;
-    const devServerUrl = firstCapOptions.devServerUrl ?? this.#globalOptions.devServerUrl;
-
     if (mode === 'browser') {
-      if (!devServerUrl) {
-        throw new SevereServiceError('devServerUrl is required when mode is "browser"');
-      }
-      try {
-        new URL(devServerUrl);
-      } catch {
-        throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+      for (const cap of electronCapsList) {
+        const capOpts = ((cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME] ??
+          {}) as ElectronServiceGlobalOptions;
+        const devServerUrl = capOpts.devServerUrl ?? this.#globalOptions.devServerUrl;
+        if (!devServerUrl) {
+          throw new SevereServiceError('devServerUrl is required when mode is "browser"');
+        }
+        try {
+          new URL(devServerUrl);
+        } catch {
+          throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+        }
       }
       this.#browserMode = true;
       const electronCaps = capsList.flatMap((cap) => getElectronCapabilities(cap) as WebdriverIO.Capabilities);

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -114,11 +114,24 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
           (multiremoteOption) => (multiremoteOption as Capabilities.WithRequestedCapabilities).capabilities,
         );
 
-    // Browser mode: skip all Electron binary/CDP setup — worker navigates to a dev server
-    const firstElectronCap = capsList.find((cap) => (cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME]);
+    // Determine and validate run mode across all Electron capabilities
+    const electronCapsList = capsList.filter((cap) => (cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME]);
+    const modes = electronCapsList.map((cap) => {
+      const capOpts = ((cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME] ?? {}) as ElectronServiceGlobalOptions;
+      return capOpts.mode ?? this.#globalOptions.mode ?? 'native';
+    });
+    const uniqueModes = new Set(modes);
+    if (uniqueModes.size > 1) {
+      throw new SevereServiceError(
+        `All Electron capabilities must use the same mode, but found mixed modes: ${[...uniqueModes].join(', ')}. ` +
+          "Set mode consistently across all 'wdio:electronServiceOptions' entries.",
+      );
+    }
+    const mode = modes[0] ?? 'native';
+
+    const firstElectronCap = electronCapsList[0];
     const firstCapOptions = ((firstElectronCap as Record<string, unknown>)?.[CUSTOM_CAPABILITY_NAME] ??
       {}) as ElectronServiceGlobalOptions;
-    const mode = firstCapOptions.mode ?? this.#globalOptions.mode;
     const devServerUrl = firstCapOptions.devServerUrl ?? this.#globalOptions.devServerUrl;
 
     if (mode === 'browser') {

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -100,6 +100,7 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
   #globalOptions: ElectronServiceGlobalOptions;
   #projectRoot: string;
   #usedPorts = new Set<number>();
+  #browserMode = false;
 
   constructor(globalOptions: ElectronServiceGlobalOptions, _caps: unknown, config: Options.Testrunner) {
     this.#globalOptions = globalOptions;
@@ -112,6 +113,33 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
       : Object.values(capabilities as Capabilities.RequestedMultiremoteCapabilities).map(
           (multiremoteOption) => (multiremoteOption as Capabilities.WithRequestedCapabilities).capabilities,
         );
+
+    // Browser mode: skip all Electron binary/CDP setup — worker navigates to a dev server
+    const firstElectronCap = capsList.find((cap) => (cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME]);
+    const firstCapOptions = ((firstElectronCap as Record<string, unknown>)?.[CUSTOM_CAPABILITY_NAME] ??
+      {}) as ElectronServiceGlobalOptions;
+    const mode = firstCapOptions.mode ?? this.#globalOptions.mode;
+    const devServerUrl = firstCapOptions.devServerUrl ?? this.#globalOptions.devServerUrl;
+
+    if (mode === 'browser') {
+      if (!devServerUrl) {
+        throw new SevereServiceError('devServerUrl is required when mode is "browser"');
+      }
+      try {
+        new URL(devServerUrl);
+      } catch {
+        throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+      }
+      this.#browserMode = true;
+      const electronCaps = capsList.flatMap((cap) => getElectronCapabilities(cap) as WebdriverIO.Capabilities);
+      for (const cap of electronCaps) {
+        cap.browserName = 'chrome';
+        delete (cap as Record<string, unknown>)['goog:chromeOptions'];
+        delete (cap as Record<string, unknown>)['wdio:enforceWebDriverClassic'];
+      }
+      log.info('Browser mode enabled — skipping Electron binary and CDP bridge setup');
+      return;
+    }
 
     const caps = capsList.flatMap((cap) => getElectronCapabilities(cap) as WebdriverIO.Capabilities);
     const pkg =
@@ -288,6 +316,9 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
    * This allows for reliable parallel debugging of multiple Electron instances.
    */
   async onWorkerStart(_cid: string, capabilities: WebdriverIO.Capabilities) {
+    if (this.#browserMode) {
+      return;
+    }
     try {
       const capsList = Array.isArray(capabilities) ? (capabilities as WebdriverIO.Capabilities[]) : [capabilities];
       const caps = capsList.flatMap((cap) => getConvertedElectronCapabilities(cap) as WebdriverIO.Capabilities);

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -145,7 +145,15 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
           throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
         }
         cap.browserName = 'chrome';
-        delete (cap as Record<string, unknown>)['goog:chromeOptions'];
+        // Preserve user-supplied goog:chromeOptions (args, extensions, prefs, etc.)
+        // but strip `binary` — in browser mode we want system Chrome, not the
+        // Electron binary that may have been passed in for native mode.
+        const chromeOpts = (cap as Record<string, unknown>)['goog:chromeOptions'] as
+          | Record<string, unknown>
+          | undefined;
+        if (chromeOpts && 'binary' in chromeOpts) {
+          delete chromeOpts.binary;
+        }
         delete (cap as Record<string, unknown>)['wdio:enforceWebDriverClassic'];
       }
       this.#browserMode = true;

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -313,11 +313,8 @@ export async function createElectronBrowserModeMock(
     implState = null;
     const currentName = outerMock.getMockName();
     await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockReset'));
-    const asyncMockClearFn = mock.mockClear;
-    (mock as unknown as { mockClear: () => void }).mockClear = outerMockClear;
     outerMockClear();
     outerMockReset();
-    mock.mockClear = asyncMockClearFn;
     outerMock.mockName(currentName);
     return mock;
   };
@@ -330,11 +327,8 @@ export async function createElectronBrowserModeMock(
     // Behave like mockReset: clear history and implementation but keep the channel alive.
     const currentName = outerMock.getMockName();
     await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockReset'));
-    const asyncMockClearFn = mock.mockClear;
-    (mock as unknown as { mockClear: () => void }).mockClear = outerMockClear;
     outerMockClear();
     outerMockReset();
-    mock.mockClear = asyncMockClearFn;
     outerMock.mockName(currentName);
     return mock;
   };

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -359,6 +359,7 @@ export async function createElectronBrowserModeMock(
     if (result && typeof result === 'object' && '__wdioAsyncErr__' in result) {
       throw new Error((result as { __wdioAsyncErr__: string }).__wdioAsyncErr__);
     }
+    await mock.update();
     return result;
   };
 

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -10,7 +10,6 @@ import type {
 } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 import { buildMockMethods } from './mockFactory.js';
-import mockStore from './mockStore.js';
 
 const log = createLogger('electron-service', 'mock');
 const browserInterceptor = createIpcInterceptor('electron');

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -312,9 +312,18 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockRestore = async () => {
-    await runInterceptorScript<void>(browser, browserInterceptor.buildUnregistrationScript(channel));
+    // There is no original Electron API to restore in browser mode — the IPC interceptor
+    // is always synthetic. Deregistering the channel would make future ipcRenderer.invoke
+    // calls throw "unmocked channel", breaking restoreMocks: true across tests.
+    // Behave like mockReset: clear history and implementation but keep the channel alive.
+    const currentName = outerMock.getMockName();
+    await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockReset'));
+    const asyncMockClearFn = mock.mockClear;
+    (mock as unknown as { mockClear: () => void }).mockClear = outerMockClear;
     outerMockClear();
-    mockStore.deleteMockByRef(mock);
+    outerMockReset();
+    mock.mockClear = asyncMockClearFn;
+    outerMock.mockName(currentName);
     return mock;
   };
 

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -314,7 +314,7 @@ export async function createElectronBrowserModeMock(
   mock.mockRestore = async () => {
     await runInterceptorScript<void>(browser, browserInterceptor.buildUnregistrationScript(channel));
     outerMockClear();
-    mockStore.deleteMock(`electron.${channel}`);
+    mockStore.deleteMockByRef(mock);
     return mock;
   };
 

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -216,31 +216,17 @@ export async function createElectronBrowserModeMock(
     const raw = await runInterceptorScript<unknown>(browser, browserInterceptor.buildCallDataReadScript(channel));
     const syncData = browserInterceptor.parseCallData(raw);
 
-    const existingCount = originalMock.calls.length;
-
-    if (syncData.calls.length < existingCount) {
-      (originalMock.calls as unknown[][]).length = 0;
-      (originalMock.results as { type: string; value: unknown }[]).length = 0;
-      (originalMock.invocationCallOrder as number[]).length = 0;
-      for (let i = 0; i < syncData.calls.length; i++) {
-        (originalMock.calls as unknown[][]).push(syncData.calls[i]);
-        (originalMock.results as { type: string; value: unknown }[]).push(
-          syncData.results[i] ?? { type: 'return', value: undefined },
-        );
-        (originalMock.invocationCallOrder as number[]).push(
-          syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
-        );
-      }
-    } else if (existingCount < syncData.calls.length) {
-      for (let i = existingCount; i < syncData.calls.length; i++) {
-        (originalMock.calls as unknown[][]).push(syncData.calls[i]);
-        (originalMock.results as { type: string; value: unknown }[]).push(
-          syncData.results[i] ?? { type: 'return', value: undefined },
-        );
-        (originalMock.invocationCallOrder as number[]).push(
-          syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
-        );
-      }
+    (originalMock.calls as unknown[][]).length = 0;
+    (originalMock.results as { type: string; value: unknown }[]).length = 0;
+    (originalMock.invocationCallOrder as number[]).length = 0;
+    for (let i = 0; i < syncData.calls.length; i++) {
+      (originalMock.calls as unknown[][]).push(syncData.calls[i]);
+      (originalMock.results as { type: string; value: unknown }[]).push(
+        syncData.results[i] ?? { type: 'return', value: undefined },
+      );
+      (originalMock.invocationCallOrder as number[]).push(
+        syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+      );
     }
     return mock;
   };

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -209,6 +209,12 @@ export async function createElectronBrowserModeMock(
 
   const originalMock = outerMock.mock;
 
+  type ImplState =
+    | { kind: 'returnValue' | 'resolvedValue' | 'rejectedValue'; value: unknown }
+    | { kind: 'implementation'; fn: AbstractFn }
+    | null;
+  let implState: ImplState = null;
+
   await runInterceptorScript<void>(browser, browserInterceptor.buildRegistrationScript(channel));
 
   mock.update = async () => {
@@ -231,6 +237,7 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockImplementation = async (implFn: AbstractFn) => {
+    implState = { kind: 'implementation', fn: implFn };
     const s = browserInterceptor.serializeHandler(implFn);
     await runInterceptorScript<void>(browser, browserInterceptor.buildSetImplementationScript(channel, s));
     outerMockImplementation(implFn);
@@ -245,6 +252,7 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockReturnValue = async (value: unknown) => {
+    implState = { kind: 'returnValue', value };
     await runInterceptorScript<void>(
       browser,
       browserInterceptor.buildInnerSetterScript(channel, 'mockReturnValue', value),
@@ -261,6 +269,7 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockResolvedValue = async (value: unknown) => {
+    implState = { kind: 'resolvedValue', value };
     await runInterceptorScript<void>(
       browser,
       browserInterceptor.buildInnerSetterScript(channel, 'mockResolvedValue', value),
@@ -277,6 +286,7 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockRejectedValue = async (value: unknown) => {
+    implState = { kind: 'rejectedValue', value };
     await runInterceptorScript<void>(
       browser,
       browserInterceptor.buildInnerSetterScript(channel, 'mockRejectedValue', value),
@@ -299,6 +309,7 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockReset = async () => {
+    implState = null;
     const currentName = outerMock.getMockName();
     await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockReset'));
     const asyncMockClearFn = mock.mockClear;
@@ -311,6 +322,7 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockRestore = async () => {
+    implState = null;
     // There is no original Electron API to restore in browser mode — the IPC interceptor
     // is always synthetic. Deregistering the channel would make future ipcRenderer.invoke
     // calls throw "unmocked channel", breaking restoreMocks: true across tests.
@@ -348,6 +360,28 @@ export async function createElectronBrowserModeMock(
       throw new Error((result as { __wdioAsyncErr__: string }).__wdioAsyncErr__);
     }
     return result;
+  };
+
+  // Used by the re-registration path in service.ts to replay persistent implementation
+  // after a navigation wipes window.__wdio_mocks__. "Once" variants are intentionally
+  // excluded — they were consumed before the navigation.
+  (mock as unknown as Record<string, unknown>).__replayBrowserImpl = async (): Promise<void> => {
+    if (!implState) return;
+    if (implState.kind === 'implementation') {
+      const s = browserInterceptor.serializeHandler(implState.fn);
+      await runInterceptorScript<void>(browser, browserInterceptor.buildSetImplementationScript(channel, s));
+    } else {
+      const method =
+        implState.kind === 'returnValue'
+          ? 'mockReturnValue'
+          : implState.kind === 'resolvedValue'
+            ? 'mockResolvedValue'
+            : 'mockRejectedValue';
+      await runInterceptorScript<void>(
+        browser,
+        browserInterceptor.buildInnerSetterScript(channel, method, implState.value),
+      );
+    }
   };
 
   log.debug(`[${channel}] Electron browser-mode mock created successfully`);

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -1,5 +1,7 @@
 import { fn as vitestFn } from '@wdio/native-spy';
+import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import type {
+  AbstractFn,
   ElectronApiFn,
   ElectronFunctionMock,
   ElectronInterface,
@@ -8,8 +10,10 @@ import type {
 } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 import { buildMockMethods } from './mockFactory.js';
+import mockStore from './mockStore.js';
 
 const log = createLogger('electron-service', 'mock');
+const browserInterceptor = createIpcInterceptor('electron');
 
 export { createClassMock } from './classMock.js';
 
@@ -181,4 +185,177 @@ export async function createMock(
   log.debug(`[${apiName}.${funcName}] Auto-updating mock wrapper created successfully`);
 
   return wrapperMock;
+}
+
+async function runInterceptorScript<T>(browser: WebdriverIO.Browser, script: string): Promise<T> {
+  return browser.execute(`return (${script})()`) as Promise<T>;
+}
+
+export async function createElectronBrowserModeMock(
+  channel: string,
+  browser: WebdriverIO.Browser,
+): Promise<ElectronFunctionMock> {
+  log.debug(`[${channel}] createElectronBrowserModeMock called`);
+
+  const outerMock = vitestFn();
+  const outerMockImplementation = outerMock.mockImplementation;
+  const outerMockImplementationOnce = outerMock.mockImplementationOnce;
+  const outerMockClear = outerMock.mockClear;
+  const outerMockReset = outerMock.mockReset;
+
+  outerMock.mockName(`electron.${channel}`);
+
+  const mock = outerMock as unknown as ElectronFunctionMock;
+  mock.__isElectronMock = true;
+
+  const originalMock = outerMock.mock;
+
+  await runInterceptorScript<void>(browser, browserInterceptor.buildRegistrationScript(channel));
+
+  mock.update = async () => {
+    const raw = await runInterceptorScript<unknown>(browser, browserInterceptor.buildCallDataReadScript(channel));
+    const syncData = browserInterceptor.parseCallData(raw);
+
+    const existingCount = originalMock.calls.length;
+
+    if (syncData.calls.length < existingCount) {
+      (originalMock.calls as unknown[][]).length = 0;
+      (originalMock.results as { type: string; value: unknown }[]).length = 0;
+      (originalMock.invocationCallOrder as number[]).length = 0;
+      for (let i = 0; i < syncData.calls.length; i++) {
+        (originalMock.calls as unknown[][]).push(syncData.calls[i]);
+        (originalMock.results as { type: string; value: unknown }[]).push(
+          syncData.results[i] ?? { type: 'return', value: undefined },
+        );
+        (originalMock.invocationCallOrder as number[]).push(
+          syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+        );
+      }
+    } else if (existingCount < syncData.calls.length) {
+      for (let i = existingCount; i < syncData.calls.length; i++) {
+        (originalMock.calls as unknown[][]).push(syncData.calls[i]);
+        (originalMock.results as { type: string; value: unknown }[]).push(
+          syncData.results[i] ?? { type: 'return', value: undefined },
+        );
+        (originalMock.invocationCallOrder as number[]).push(
+          syncData.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+        );
+      }
+    }
+    return mock;
+  };
+
+  mock.mockImplementation = async (implFn: AbstractFn) => {
+    const s = browserInterceptor.serializeHandler(implFn);
+    await runInterceptorScript<void>(browser, browserInterceptor.buildSetImplementationScript(channel, s));
+    outerMockImplementation(implFn);
+    return mock;
+  };
+
+  mock.mockImplementationOnce = async (implFn: AbstractFn) => {
+    const s = browserInterceptor.serializeHandler(implFn);
+    await runInterceptorScript<void>(browser, browserInterceptor.buildSetImplementationScript(channel, s, true));
+    outerMockImplementationOnce(implFn);
+    return mock;
+  };
+
+  mock.mockReturnValue = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      browserInterceptor.buildInnerSetterScript(channel, 'mockReturnValue', value),
+    );
+    return mock;
+  };
+
+  mock.mockReturnValueOnce = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      browserInterceptor.buildInnerSetterScript(channel, 'mockReturnValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockResolvedValue = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      browserInterceptor.buildInnerSetterScript(channel, 'mockResolvedValue', value),
+    );
+    return mock;
+  };
+
+  mock.mockResolvedValueOnce = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      browserInterceptor.buildInnerSetterScript(channel, 'mockResolvedValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockRejectedValue = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      browserInterceptor.buildInnerSetterScript(channel, 'mockRejectedValue', value),
+    );
+    return mock;
+  };
+
+  mock.mockRejectedValueOnce = async (value: unknown) => {
+    await runInterceptorScript<void>(
+      browser,
+      browserInterceptor.buildInnerSetterScript(channel, 'mockRejectedValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockClear = async () => {
+    await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockClear'));
+    outerMockClear();
+    return mock;
+  };
+
+  mock.mockReset = async () => {
+    const currentName = outerMock.getMockName();
+    await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockReset'));
+    const asyncMockClearFn = mock.mockClear;
+    (mock as unknown as { mockClear: () => void }).mockClear = outerMockClear;
+    outerMockClear();
+    outerMockReset();
+    mock.mockClear = asyncMockClearFn;
+    outerMock.mockName(currentName);
+    return mock;
+  };
+
+  mock.mockRestore = async () => {
+    await runInterceptorScript<void>(browser, browserInterceptor.buildUnregistrationScript(channel));
+    outerMockClear();
+    mockStore.deleteMock(`electron.${channel}`);
+    return mock;
+  };
+
+  mock.mockReturnThis = async () => {
+    await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockReturnThis'));
+    return mock;
+  };
+
+  mock.withImplementation = async (implFn, callbackFn) => {
+    const script = browserInterceptor.buildWithImplementationScript(
+      channel,
+      implFn as (...a: unknown[]) => unknown,
+      callbackFn as (...a: unknown[]) => unknown,
+    );
+    const result = await browser.executeAsync((s: string, done: (v: unknown) => void) => {
+      // eslint-disable-next-line no-new-func
+      const fn = new Function('return (' + s + ')')() as () => Promise<unknown>;
+      Promise.resolve(fn()).then(done, (err: unknown) => {
+        done({ __wdioAsyncErr__: err instanceof Error ? err.message : String(err) });
+      });
+    }, script);
+    if (result && typeof result === 'object' && '__wdioAsyncErr__' in result) {
+      throw new Error((result as { __wdioAsyncErr__: string }).__wdioAsyncErr__);
+    }
+    return result;
+  };
+
+  log.debug(`[${channel}] Electron browser-mode mock created successfully`);
+  return mock;
 }

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -212,6 +212,7 @@ export async function createElectronBrowserModeMock(
   type ImplState =
     | { kind: 'returnValue' | 'resolvedValue' | 'rejectedValue'; value: unknown }
     | { kind: 'implementation'; fn: AbstractFn }
+    | { kind: 'returnThis' }
     | null;
   let implState: ImplState = null;
 
@@ -339,6 +340,7 @@ export async function createElectronBrowserModeMock(
   };
 
   mock.mockReturnThis = async () => {
+    implState = { kind: 'returnThis' };
     await runInterceptorScript<void>(browser, browserInterceptor.buildInnerInvocationScript(channel, 'mockReturnThis'));
     return mock;
   };
@@ -371,6 +373,11 @@ export async function createElectronBrowserModeMock(
     if (implState.kind === 'implementation') {
       const s = browserInterceptor.serializeHandler(implState.fn);
       await runInterceptorScript<void>(browser, browserInterceptor.buildSetImplementationScript(channel, s));
+    } else if (implState.kind === 'returnThis') {
+      await runInterceptorScript<void>(
+        browser,
+        browserInterceptor.buildInnerInvocationScript(channel, 'mockReturnThis'),
+      );
     } else {
       const method =
         implState.kind === 'returnValue'

--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -197,10 +197,10 @@ export async function createElectronBrowserModeMock(
   log.debug(`[${channel}] createElectronBrowserModeMock called`);
 
   const outerMock = vitestFn();
-  const outerMockImplementation = outerMock.mockImplementation;
-  const outerMockImplementationOnce = outerMock.mockImplementationOnce;
-  const outerMockClear = outerMock.mockClear;
-  const outerMockReset = outerMock.mockReset;
+  const outerMockImplementation = outerMock.mockImplementation.bind(outerMock);
+  const outerMockImplementationOnce = outerMock.mockImplementationOnce.bind(outerMock);
+  const outerMockClear = outerMock.mockClear.bind(outerMock);
+  const outerMockReset = outerMock.mockReset.bind(outerMock);
 
   outerMock.mockName(`electron.${channel}`);
 

--- a/packages/electron-service/src/mockFactory.ts
+++ b/packages/electron-service/src/mockFactory.ts
@@ -322,18 +322,18 @@ export async function buildMockMethods(mock: ElectronFunctionMock, opts: BuildMo
   mock.mockClear = async () => {
     await browserToUse.electron.execute<void, [MockAccessor, ExecuteOpts]>(
       (electron, accessor) => {
-        let innerMock: Mock;
+        let innerMock: Mock | undefined;
         if (accessor.kind === 'api') {
-          innerMock = (electron[accessor.apiName as keyof typeof electron] as unknown as Record<string, Mock>)[
+          innerMock = (electron[accessor.apiName as keyof typeof electron] as unknown as Record<string, Mock>)?.[
             accessor.funcName
           ];
         } else {
-          const cls = electron[accessor.className as keyof typeof electron] as unknown as {
-            prototype: Record<string, Mock>;
-          };
-          innerMock = cls.prototype[accessor.methodName];
+          const cls = electron[accessor.className as keyof typeof electron] as unknown as
+            | { prototype: Record<string, Mock> }
+            | undefined;
+          innerMock = cls?.prototype?.[accessor.methodName];
         }
-        innerMock.mockClear();
+        innerMock?.mockClear?.();
       },
       accessor,
       { internal: true },
@@ -346,18 +346,18 @@ export async function buildMockMethods(mock: ElectronFunctionMock, opts: BuildMo
     const currentName = outerMock.getMockName();
     await browserToUse.electron.execute<void, [MockAccessor, ExecuteOpts]>(
       (electron, accessor) => {
-        let innerMock: Mock;
+        let innerMock: Mock | undefined;
         if (accessor.kind === 'api') {
-          innerMock = (electron[accessor.apiName as keyof typeof electron] as unknown as Record<string, Mock>)[
+          innerMock = (electron[accessor.apiName as keyof typeof electron] as unknown as Record<string, Mock>)?.[
             accessor.funcName
           ];
         } else {
-          const cls = electron[accessor.className as keyof typeof electron] as unknown as {
-            prototype: Record<string, Mock>;
-          };
-          innerMock = cls.prototype[accessor.methodName];
+          const cls = electron[accessor.className as keyof typeof electron] as unknown as
+            | { prototype: Record<string, Mock> }
+            | undefined;
+          innerMock = cls?.prototype?.[accessor.methodName];
         }
-        innerMock.mockReset();
+        innerMock?.mockReset?.();
       },
       accessor,
       { internal: true },

--- a/packages/electron-service/src/mockStore.ts
+++ b/packages/electron-service/src/mockStore.ts
@@ -13,6 +13,11 @@ export class ElectronServiceMockStore {
     return mock;
   }
 
+  setMockWithKey(key: string, mock: ElectronMock): ElectronMock {
+    this.#mockFns.set(key, mock);
+    return mock;
+  }
+
   getMock(mockId: string): ElectronMock {
     const mock = this.#mockFns.get(mockId);
     if (!mock) {
@@ -28,6 +33,15 @@ export class ElectronServiceMockStore {
 
   deleteMock(mockId: string): boolean {
     return this.#mockFns.delete(mockId);
+  }
+
+  deleteMockByRef(mock: ElectronMock): boolean {
+    for (const [key, m] of this.#mockFns) {
+      if (m === mock) {
+        return this.#mockFns.delete(key);
+      }
+    }
+    return false;
   }
 
   clear(): void {

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -216,6 +216,8 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
       const mrBrowser = browser as unknown as WebdriverIO.MultiRemoteBrowser;
       (browser as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
 
+      const electronInstances: WebdriverIO.Browser[] = [];
+
       for (const instanceName of mrBrowser.instances) {
         const instance = mrBrowser.getInstance(instanceName);
         const caps =
@@ -239,11 +241,14 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         (instance as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
         instance.electron = this.getElectronBrowserModeAPI(instance);
         this.patchBrowserUrl(instance, injectionScript);
-        this.installCommandOverrides(instance);
+        electronInstances.push(instance);
       }
 
+      // Root-level element commands (mrBrowser.$('btn').click()) dispatch through the root's
+      // override chain — independent from per-instance chains. Installing overrides only on the
+      // root covers both root and per-instance interactions without double-wrapping.
       browser.electron = this.getElectronBrowserModeAPI(browser);
-      this.patchBrowserUrl(browser, injectionScript);
+      this.patchBrowserUrl(browser, injectionScript, electronInstances);
       this.installCommandOverrides(browser as unknown as WebdriverIO.Browser);
     } else {
       const devServerUrl = this.globalOptions.devServerUrl;
@@ -264,15 +269,27 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
    * Patch browser.url() so the IPC injection script is re-applied after every
    * navigation. A page load wipes window state, losing __wdio_mocks__ and the
    * ipcRenderer patch.
+   *
+   * When called for the root multiremote browser, `electronInstances` must be
+   * provided so re-injection targets only those browsers — root `execute()` would
+   * otherwise broadcast to every session, including non-Electron ones.
    */
-  private patchBrowserUrl(browser: WebdriverIO.Browser, injectionScript: string): void {
+  private patchBrowserUrl(
+    browser: WebdriverIO.Browser,
+    injectionScript: string,
+    electronInstances?: WebdriverIO.Browser[],
+  ): void {
     type UrlFn = (href?: string) => Promise<string | void>;
     const originalUrl = (browser.url as unknown as UrlFn).bind(browser);
     (browser as unknown as { url: UrlFn }).url = async (href?: string): Promise<string | void> => {
       const result = await originalUrl(href);
       if (href !== undefined) {
         try {
-          await browser.execute(injectionScript);
+          if (electronInstances) {
+            await Promise.all(electronInstances.map((inst) => inst.execute(injectionScript)));
+          } else {
+            await browser.execute(injectionScript);
+          }
         } catch (error) {
           log.warn('Failed to re-inject IPC script after navigation:', error);
           throw error;

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -220,7 +220,9 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
       }
     }
     browser.electron = this.getElectronBrowserModeAPI(browser);
-    this.patchBrowserUrl(browser, injectionScript);
+    if (!(browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
+      this.patchBrowserUrl(browser, injectionScript);
+    }
     this.installCommandOverrides();
     log.debug('Electron browser mode initialised');
   }

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -11,6 +11,7 @@ import type {
 } from '@wdio/native-types';
 import { createLogger, waitUntilWindowAvailable } from '@wdio/native-utils';
 import type { Capabilities, Services } from '@wdio/types';
+import { SevereServiceError } from 'webdriverio';
 import { ElectronCdpBridge, getDebuggerEndpoint } from './bridge.js';
 import { clearAllMocks } from './commands/clearAllMocks.js';
 import { execute } from './commands/executeCdp.js';
@@ -30,6 +31,7 @@ import { isInternalCommand } from './utils.js';
 import { clearPuppeteerSessions, ensureActiveWindowFocus, getActiveWindowHandle, getPuppeteer } from './window.js';
 
 const browserInterceptor = createIpcInterceptor('electron');
+const browserModeMockOwner = new WeakMap<ElectronFunctionMock, WebdriverIO.Browser>();
 
 const log = createLogger('electron-service', 'service');
 
@@ -202,7 +204,7 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
     log.debug('Initialising Electron browser mode');
     const devServerUrl = this.globalOptions.devServerUrl;
     if (!devServerUrl) {
-      throw new Error('devServerUrl is required for browser mode but was not set');
+      throw new SevereServiceError('devServerUrl is required for browser mode but was not set');
     }
     const injectionScript = browserInterceptor.buildBrowserIpcInjectionScript();
     await browser.url(devServerUrl);
@@ -258,16 +260,22 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
               `Use browser.electron.mock('${channel}') to mock the IPC channel directly.`,
           );
         }
-        let existing: ElectronFunctionMock;
+        let existing: ElectronFunctionMock | undefined;
         try {
-          existing = mockStore.getMock(`electron.${channel}`) as ElectronFunctionMock;
-        } catch (e) {
-          if (e instanceof Error && e.message.startsWith('No mock registered for')) {
-            const newMock = await createElectronBrowserModeMock(channel, browser);
-            mockStore.setMock(newMock);
-            return newMock;
+          const found = mockStore.getMock(`electron.${channel}`) as ElectronFunctionMock;
+          if (browserModeMockOwner.get(found) === browser) {
+            existing = found;
           }
-          throw e;
+        } catch (e) {
+          if (!(e instanceof Error && e.message.startsWith('No mock registered for'))) {
+            throw e;
+          }
+        }
+        if (!existing) {
+          const newMock = await createElectronBrowserModeMock(channel, browser);
+          browserModeMockOwner.set(newMock, browser);
+          mockStore.setMock(newMock);
+          return newMock;
         }
         // Re-register browser-side entry — navigation wipes window.__wdio_mocks__
         await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -255,15 +255,21 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
               `Use browser.electron.mock('${channel}') to mock the IPC channel directly.`,
           );
         }
+        let existing: ElectronFunctionMock;
         try {
-          const existing = mockStore.getMock(`electron.${channel}`) as ElectronFunctionMock;
-          await existing.mockReset();
-          return existing;
-        } catch {
-          const newMock = await createElectronBrowserModeMock(channel, browser);
-          mockStore.setMock(newMock);
-          return newMock;
+          existing = mockStore.getMock(`electron.${channel}`) as ElectronFunctionMock;
+        } catch (e) {
+          if (e instanceof Error && e.message.startsWith('No mock registered for')) {
+            const newMock = await createElectronBrowserModeMock(channel, browser);
+            mockStore.setMock(newMock);
+            return newMock;
+          }
+          throw e;
         }
+        // Re-register browser-side entry — navigation wipes window.__wdio_mocks__
+        await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);
+        await existing.mockReset();
+        return existing;
       },
       mockAll: async () => {
         throw new Error(

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -221,6 +221,11 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         const caps =
           (instance.requestedCapabilities as Capabilities.W3CCapabilities).alwaysMatch ||
           (instance.requestedCapabilities as WebdriverIO.Capabilities);
+
+        if (!caps[CUSTOM_CAPABILITY_NAME]) {
+          continue;
+        }
+
         const instanceOptions = caps[CUSTOM_CAPABILITY_NAME] as ElectronServiceGlobalOptions | undefined;
         const instanceDevServerUrl = instanceOptions?.devServerUrl ?? this.globalOptions.devServerUrl;
 

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -234,6 +234,7 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
 
       browser.electron = this.getElectronBrowserModeAPI(browser);
       this.patchBrowserUrl(browser, injectionScript);
+      this.installCommandOverrides(browser as unknown as WebdriverIO.Browser);
     } else {
       const devServerUrl = this.globalOptions.devServerUrl;
       if (!devServerUrl) {
@@ -312,6 +313,7 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         )) as boolean;
         if (!isBrowserSideLive) {
           await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);
+          await existing.mockClear();
         }
         return existing;
       },

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -264,6 +264,7 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
           await browser.execute(injectionScript);
         } catch (error) {
           log.warn('Failed to re-inject IPC script after navigation:', error);
+          throw error;
         }
       }
       return result;

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -169,6 +169,9 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
   }
 
   async beforeCommand(commandName: string, args: unknown[]) {
+    if (this.globalOptions.mode === 'browser') {
+      return;
+    }
     const excludeCommands = ['getWindowHandle', 'getWindowHandles', 'switchToWindow', 'execute'];
     if (!this.browser || excludeCommands.includes(commandName) || isInternalCommand(args)) {
       return;

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -210,27 +210,40 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
    */
   private async initBrowserMode(browser: WebdriverIO.Browser): Promise<void> {
     log.debug('Initialising Electron browser mode');
-    const devServerUrl = this.globalOptions.devServerUrl;
-    if (!devServerUrl) {
-      throw new SevereServiceError('devServerUrl is required for browser mode but was not set');
-    }
     const injectionScript = browserInterceptor.buildBrowserIpcInjectionScript();
-    await browser.url(devServerUrl);
-    await browser.execute(injectionScript);
-    (browser as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
+
     if ((browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
       const mrBrowser = browser as unknown as WebdriverIO.MultiRemoteBrowser;
+      (browser as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
+
       for (const instanceName of mrBrowser.instances) {
         const instance = mrBrowser.getInstance(instanceName);
+        const caps =
+          (instance.requestedCapabilities as Capabilities.W3CCapabilities).alwaysMatch ||
+          (instance.requestedCapabilities as WebdriverIO.Capabilities);
+        const instanceOptions = caps[CUSTOM_CAPABILITY_NAME] as ElectronServiceGlobalOptions | undefined;
+        const instanceDevServerUrl = instanceOptions?.devServerUrl ?? this.globalOptions.devServerUrl;
+
+        await instance.url(instanceDevServerUrl!);
+        await instance.execute(injectionScript);
         (instance as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
         instance.electron = this.getElectronBrowserModeAPI(instance);
         this.patchBrowserUrl(instance, injectionScript);
         this.installCommandOverrides(instance);
       }
-    }
-    browser.electron = this.getElectronBrowserModeAPI(browser);
-    this.patchBrowserUrl(browser, injectionScript);
-    if (!(browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
+
+      browser.electron = this.getElectronBrowserModeAPI(browser);
+      this.patchBrowserUrl(browser, injectionScript);
+    } else {
+      const devServerUrl = this.globalOptions.devServerUrl;
+      if (!devServerUrl) {
+        throw new SevereServiceError('devServerUrl is required for browser mode but was not set');
+      }
+      await browser.url(devServerUrl);
+      await browser.execute(injectionScript);
+      (browser as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
+      browser.electron = this.getElectronBrowserModeAPI(browser);
+      this.patchBrowserUrl(browser, injectionScript);
       this.installCommandOverrides();
     }
     log.debug('Electron browser mode initialised');

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -1,7 +1,9 @@
 import type { CdpBridgeOptions } from '@wdio/electron-cdp-bridge';
+import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import type {
   AbstractFn,
   BrowserExtension,
+  ElectronFunctionMock,
   ElectronInterface,
   ElectronServiceGlobalOptions,
   ElectronType,
@@ -21,10 +23,13 @@ import { triggerDeeplink } from './commands/triggerDeeplink.js';
 import { CUSTOM_CAPABILITY_NAME } from './constants.js';
 import { checkInspectFuse } from './fuses.js';
 import { LogCaptureManager, type LogCaptureOptions } from './logCapture.js';
+import { createElectronBrowserModeMock } from './mock.js';
 import mockStore from './mockStore.js';
 import { ServiceConfig } from './serviceConfig.js';
 import { isInternalCommand } from './utils.js';
 import { clearPuppeteerSessions, ensureActiveWindowFocus, getActiveWindowHandle, getPuppeteer } from './window.js';
+
+const browserInterceptor = createIpcInterceptor('electron');
 
 const log = createLogger('electron-service', 'service');
 
@@ -46,9 +51,15 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
     _specs: string[],
     instance: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
   ): Promise<void> {
+    this.browser = instance as WebdriverIO.Browser;
+
+    if (this.globalOptions.mode === 'browser') {
+      await this.initBrowserMode(instance as WebdriverIO.Browser);
+      return;
+    }
+
     log.debug('Initialising CDP bridge...');
 
-    this.browser = instance as WebdriverIO.Browser;
     const cdpBridge = this.browser.isMultiremote ? undefined : await initCdpBridge(this.cdpOptions, capabilities);
 
     // Initialize log capture if enabled
@@ -173,6 +184,107 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
   async afterSession() {
     await restoreAllMocks();
     mockStore.clear();
+  }
+
+  /**
+   * Initialize browser-only mode: navigate to dev server, inject IPC layer, expose API.
+   *
+   * Timing note: the IPC interceptor is injected after browser.url() resolves
+   * (i.e. after readyState === "complete"). Any ipcRenderer.invoke() calls the app
+   * makes during module init or onload handlers will run against the real surface and
+   * be missed by mocks. If your app does this, use a Vite plugin to import the
+   * injection script as a top-level module in your dev build.
+   */
+  private async initBrowserMode(browser: WebdriverIO.Browser): Promise<void> {
+    log.debug('Initialising Electron browser mode');
+    const devServerUrl = this.globalOptions.devServerUrl;
+    if (!devServerUrl) {
+      throw new Error('devServerUrl is required for browser mode but was not set');
+    }
+    const injectionScript = browserInterceptor.buildBrowserIpcInjectionScript();
+    await browser.url(devServerUrl);
+    await browser.execute(injectionScript);
+    (browser as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
+    if ((browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
+      const mrBrowser = browser as unknown as WebdriverIO.MultiRemoteBrowser;
+      for (const instanceName of mrBrowser.instances) {
+        const instance = mrBrowser.getInstance(instanceName);
+        (instance as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
+        instance.electron = this.getElectronBrowserModeAPI(instance);
+        this.patchBrowserUrl(instance, injectionScript);
+      }
+    }
+    browser.electron = this.getElectronBrowserModeAPI(browser);
+    this.patchBrowserUrl(browser, injectionScript);
+    this.installCommandOverrides();
+    log.debug('Electron browser mode initialised');
+  }
+
+  /**
+   * Patch browser.url() so the IPC injection script is re-applied after every
+   * navigation. A page load wipes window state, losing __wdio_mocks__ and the
+   * ipcRenderer patch.
+   */
+  private patchBrowserUrl(browser: WebdriverIO.Browser, injectionScript: string): void {
+    type UrlFn = (href?: string) => Promise<string | void>;
+    const originalUrl = (browser.url as unknown as UrlFn).bind(browser);
+    (browser as unknown as { url: UrlFn }).url = async (href?: string): Promise<string | void> => {
+      const result = await originalUrl(href);
+      if (href !== undefined) {
+        try {
+          await browser.execute(injectionScript);
+        } catch (error) {
+          log.warn('Failed to re-inject IPC script after navigation:', error);
+        }
+      }
+      return result;
+    };
+  }
+
+  /**
+   * Build the browser.electron API surface for browser mode.
+   * execute(), mockAll(), and triggerDeeplink() throw — they require the Electron
+   * main process which does not exist in browser mode.
+   */
+  private getElectronBrowserModeAPI(browser: WebdriverIO.Browser): BrowserExtension['electron'] {
+    return {
+      mock: async (channel: string, funcName?: string): Promise<ElectronFunctionMock> => {
+        if (funcName !== undefined) {
+          throw new Error(
+            'browser.electron.mock(apiName, funcName) is not supported in browser mode. ' +
+              `Use browser.electron.mock('${channel}') to mock the IPC channel directly.`,
+          );
+        }
+        try {
+          const existing = mockStore.getMock(`electron.${channel}`) as ElectronFunctionMock;
+          await existing.mockReset();
+          return existing;
+        } catch {
+          const newMock = await createElectronBrowserModeMock(channel, browser);
+          mockStore.setMock(newMock);
+          return newMock;
+        }
+      },
+      mockAll: async () => {
+        throw new Error(
+          'browser.electron.mockAll() is not supported in browser mode. ' +
+            "Use browser.electron.mock('channel') to mock individual IPC channels.",
+        );
+      },
+      execute: async () => {
+        throw new Error(
+          'browser.electron.execute() is not supported in browser mode. ' +
+            'Use browser.execute() for renderer code or browser.electron.mock() to intercept IPC.',
+        );
+      },
+      clearAllMocks: async (commandPrefix?: string) => clearAllMocks.call(this, commandPrefix),
+      resetAllMocks: async (commandPrefix?: string) => resetAllMocks.call(this, commandPrefix),
+      restoreAllMocks: async (commandPrefix?: string) => restoreAllMocks.call(this, commandPrefix),
+      isMockFunction: (fn: unknown) => isMockFunction.call(this, fn),
+      triggerDeeplink: async () => {
+        throw new Error('browser.electron.triggerDeeplink() is not supported in browser mode.');
+      },
+    } as unknown as BrowserExtension['electron'];
   }
 
   /**

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -277,8 +277,15 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
    * main process which does not exist in browser mode.
    */
   private getElectronBrowserModeAPI(browser: WebdriverIO.Browser): BrowserExtension['electron'] {
+    const isRootMultiremote = (browser as unknown as { isMultiremote?: boolean }).isMultiremote === true;
     return {
       mock: async (channel: string, funcName?: string): Promise<ElectronFunctionMock> => {
+        if (isRootMultiremote) {
+          throw new Error(
+            'browser.electron.mock() on the root multiremote browser is not supported in browser mode. ' +
+              `Call it on a specific instance instead: mrBrowser.getInstance('name').electron.mock('${channel}')`,
+          );
+        }
         if (funcName !== undefined) {
           throw new Error(
             'browser.electron.mock(apiName, funcName) is not supported in browser mode. ' +

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -244,9 +244,11 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         electronInstances.push(instance);
       }
 
-      // Root-level element commands (mrBrowser.$('btn').click()) dispatch through the root's
-      // override chain — independent from per-instance chains. Installing overrides only on the
-      // root covers both root and per-instance interactions without double-wrapping.
+      // WDIO's multiremote overwriteCommand wrapper forwards the call to origOverwriteCommand
+      // with all per-instance browsers as the `instances` argument. The underlying implementation
+      // then registers the override on every instance's __elementOverrides__ directly, so both
+      // mrBrowser.$('btn').click() and mrBrowser.getInstance('a').$('btn').click() go through
+      // the override. Calling it on each instance separately would double-wrap element commands.
       browser.electron = this.getElectronBrowserModeAPI(browser);
       this.patchBrowserUrl(browser, injectionScript, electronInstances);
       this.installCommandOverrides(browser as unknown as WebdriverIO.Browser);

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -228,8 +228,13 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
 
         const instanceOptions = caps[CUSTOM_CAPABILITY_NAME] as ElectronServiceGlobalOptions | undefined;
         const instanceDevServerUrl = instanceOptions?.devServerUrl ?? this.globalOptions.devServerUrl;
+        if (!instanceDevServerUrl) {
+          throw new SevereServiceError(
+            `devServerUrl is required for browser mode but was not set for multiremote instance "${instanceName}"`,
+          );
+        }
 
-        await instance.url(instanceDevServerUrl!);
+        await instance.url(instanceDevServerUrl);
         await instance.execute(injectionScript);
         (instance as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
         instance.electron = this.getElectronBrowserModeAPI(instance);

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -217,13 +217,14 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         (instance as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
         instance.electron = this.getElectronBrowserModeAPI(instance);
         this.patchBrowserUrl(instance, injectionScript);
+        this.installCommandOverrides(instance);
       }
     }
     browser.electron = this.getElectronBrowserModeAPI(browser);
+    this.patchBrowserUrl(browser, injectionScript);
     if (!(browser as unknown as { isMultiremote?: boolean }).isMultiremote) {
-      this.patchBrowserUrl(browser, injectionScript);
+      this.installCommandOverrides();
     }
-    this.installCommandOverrides();
     log.debug('Electron browser mode initialised');
   }
 
@@ -279,9 +280,13 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
           mockStore.setMock(newMock);
           return newMock;
         }
-        // Re-register browser-side entry — navigation wipes window.__wdio_mocks__
-        await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);
-        await existing.mockReset();
+        // Re-register browser-side entry only if navigation wiped window.__wdio_mocks__
+        const isBrowserSideLive = (await browser.execute(
+          `return !!(window.__wdio_mocks__ && typeof window.__wdio_mocks__[${JSON.stringify(channel)}] === 'function')`,
+        )) as boolean;
+        if (!isBrowserSideLive) {
+          await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);
+        }
         return existing;
       },
       mockAll: async () => {
@@ -309,18 +314,18 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
   /**
    * Install command overrides to trigger mock updates after DOM interactions
    */
-  private installCommandOverrides() {
+  private installCommandOverrides(targetBrowser?: WebdriverIO.Browser) {
     const commandsToOverride = ['click', 'doubleClick', 'setValue', 'clearValue'];
     commandsToOverride.forEach((commandName) => {
-      this.overrideElementCommand(commandName as ElementCommands);
+      this.overrideElementCommand(commandName as ElementCommands, targetBrowser);
     });
   }
 
   /**
    * Override an element-level command to add mock update after execution
    */
-  private overrideElementCommand(commandName: ElementCommands) {
-    const browser = this.browser as WebdriverIO.Browser;
+  private overrideElementCommand(commandName: ElementCommands, targetBrowser?: WebdriverIO.Browser) {
+    const browser = (targetBrowser ?? this.browser) as WebdriverIO.Browser;
     try {
       const testOverride = async function (
         this: WebdriverIO.Element,

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -313,6 +313,10 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         )) as boolean;
         if (!isBrowserSideLive) {
           await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);
+          const replayImpl = (existing as unknown as Record<string, unknown>).__replayBrowserImpl;
+          if (typeof replayImpl === 'function') {
+            await (replayImpl as () => Promise<void>)();
+          }
           await existing.mockClear();
         }
         return existing;

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -31,7 +31,15 @@ import { isInternalCommand } from './utils.js';
 import { clearPuppeteerSessions, ensureActiveWindowFocus, getActiveWindowHandle, getPuppeteer } from './window.js';
 
 const browserInterceptor = createIpcInterceptor('electron');
-const browserModeMockOwner = new WeakMap<ElectronFunctionMock, WebdriverIO.Browser>();
+const browserModeInstanceIds = new WeakMap<WebdriverIO.Browser, number>();
+let browserModeInstanceCount = 0;
+
+function browserModeStoreKey(browser: WebdriverIO.Browser, channel: string): string {
+  if (!browserModeInstanceIds.has(browser)) {
+    browserModeInstanceIds.set(browser, browserModeInstanceCount++);
+  }
+  return `electron.${channel}\x00${browserModeInstanceIds.get(browser)}`;
+}
 
 const log = createLogger('electron-service', 'service');
 
@@ -263,12 +271,10 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
               `Use browser.electron.mock('${channel}') to mock the IPC channel directly.`,
           );
         }
+        const storeKey = browserModeStoreKey(browser, channel);
         let existing: ElectronFunctionMock | undefined;
         try {
-          const found = mockStore.getMock(`electron.${channel}`) as ElectronFunctionMock;
-          if (browserModeMockOwner.get(found) === browser) {
-            existing = found;
-          }
+          existing = mockStore.getMock(storeKey) as ElectronFunctionMock;
         } catch (e) {
           if (!(e instanceof Error && e.message.startsWith('No mock registered for'))) {
             throw e;
@@ -276,8 +282,7 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         }
         if (!existing) {
           const newMock = await createElectronBrowserModeMock(channel, browser);
-          browserModeMockOwner.set(newMock, browser);
-          mockStore.setMock(newMock);
+          mockStore.setMockWithKey(storeKey, newMock);
           return newMock;
         }
         // Re-register browser-side entry only if navigation wiped window.__wdio_mocks__

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -61,22 +61,36 @@ class MockUpdateScheduler {
 
   schedule(): Promise<void> {
     if (!this.#running) {
-      const p = this.#runOnce().finally(() => {
-        if (this.#running === p) this.#running = null;
-      });
+      const p = this.#wrapRun(this.#runOnce());
       this.#running = p;
       return p;
     }
     if (!this.#queued) {
-      const q = this.#running
-        .catch(() => undefined)
-        .then(() => this.#runOnce())
-        .finally(() => {
-          if (this.#queued === q) this.#queued = null;
-        });
-      this.#queued = q;
+      this.#queued = this.#running.catch(() => undefined).then(() => this.#runOnce());
     }
     return this.#queued;
+  }
+
+  /**
+   * Wrap a batch with an end-of-batch hook that atomically promotes any queued
+   * follow-up into the running slot before clearing it. Without this hop, a
+   * schedule() call arriving between the original batch settling and the
+   * queued chain's #runOnce starting would observe #running=null and spawn a
+   * third batch in parallel with the queued one.
+   */
+  #wrapRun(run: Promise<void>): Promise<void> {
+    let wrapped!: Promise<void>;
+    wrapped = run.finally(() => {
+      if (this.#running !== wrapped) return;
+      if (this.#queued) {
+        const promoted = this.#queued;
+        this.#queued = null;
+        this.#running = this.#wrapRun(promoted);
+      } else {
+        this.#running = null;
+      }
+    });
+    return wrapped;
   }
 
   async #runOnce(): Promise<void> {
@@ -487,7 +501,12 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         // Use Reflect.apply to safely call the original command with the correct 'this' context
         // This avoids TypeScript's strict function signature checking while maintaining runtime safety
         const result = await Reflect.apply(originalCommand, this, args as unknown[]);
-        await getMockUpdateScheduler(browser).schedule();
+        // In multiremote, the override is registered on the root but fires per
+        // instance — this.browser is the per-instance owning session. Route
+        // through that browser's scheduler so per-instance mock keys match;
+        // otherwise the root scheduler filters everything out.
+        const ownerBrowser = (this as { browser?: WebdriverIO.Browser }).browser ?? browser;
+        await getMockUpdateScheduler(ownerBrowser).schedule();
         return result;
       } as Parameters<typeof browser.overwriteCommand>[1];
 

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -48,6 +48,7 @@ export function browserModeStoreKey(browser: WebdriverIO.Browser, channel: strin
 }
 
 const mockUpdateSchedulers = new WeakMap<WebdriverIO.Browser, MockUpdateScheduler>();
+const pendingRegistrations = new WeakMap<WebdriverIO.Browser, Map<string, Promise<void>>>();
 
 class MockUpdateScheduler {
   #running: Promise<void> | null = null;
@@ -409,18 +410,35 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
           mockStore.setMockWithKey(storeKey, newMock);
           return newMock;
         }
-        // Re-register browser-side entry only if navigation wiped window.__wdio_mocks__
-        const isBrowserSideLive = (await browser.execute(
-          `return !!(window.__wdio_mocks__ && typeof window.__wdio_mocks__[${JSON.stringify(channel)}] === 'function')`,
-        )) as boolean;
-        if (!isBrowserSideLive) {
-          await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);
-          const replayImpl = (existing as unknown as Record<string, unknown>).__replayBrowserImpl;
-          if (typeof replayImpl === 'function') {
-            await (replayImpl as () => Promise<void>)();
-          }
-          await existing.mockClear();
+        // Concurrent mock(channel) callers after navigation must share a single
+        // re-registration: the liveness check, registration script, impl replay,
+        // and mockClear all happen exactly once inside this gate.
+        let inflight = pendingRegistrations.get(browser);
+        if (!inflight) {
+          inflight = new Map();
+          pendingRegistrations.set(browser, inflight);
         }
+        let registration = inflight.get(channel);
+        if (!registration) {
+          const target = existing;
+          const run = (async () => {
+            const isLive = (await browser.execute(
+              `return !!(window.__wdio_mocks__ && typeof window.__wdio_mocks__[${JSON.stringify(channel)}] === 'function')`,
+            )) as boolean;
+            if (isLive) return;
+            await browser.execute(`return (${browserInterceptor.buildRegistrationScript(channel)})()`);
+            const replayImpl = (target as unknown as Record<string, unknown>).__replayBrowserImpl;
+            if (typeof replayImpl === 'function') {
+              await (replayImpl as () => Promise<void>)();
+            }
+            await target.mockClear();
+          })();
+          registration = run.finally(() => {
+            if (inflight.get(channel) === registration) inflight.delete(channel);
+          });
+          inflight.set(channel, registration);
+        }
+        await registration;
         return existing;
       },
       mockAll: async () => {

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -89,6 +89,11 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
 
     const hasElectronApi = isElectronApiAvailable(this.browser, cdpBridge);
 
+    // Install command overrides if the electron API is available
+    if (hasElectronApi) {
+      this.installCommandOverrides();
+    }
+
     if (isMultiremote(instance)) {
       const mrBrowser = instance;
 

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -34,11 +34,84 @@ const browserInterceptor = createIpcInterceptor('electron');
 const browserModeInstanceIds = new WeakMap<WebdriverIO.Browser, number>();
 let browserModeInstanceCount = 0;
 
-function browserModeStoreKey(browser: WebdriverIO.Browser, channel: string): string {
-  if (!browserModeInstanceIds.has(browser)) {
-    browserModeInstanceIds.set(browser, browserModeInstanceCount++);
+function browserModeInstanceId(browser: WebdriverIO.Browser): number {
+  let id = browserModeInstanceIds.get(browser);
+  if (id === undefined) {
+    id = browserModeInstanceCount++;
+    browserModeInstanceIds.set(browser, id);
   }
-  return `electron.${channel}\x00${browserModeInstanceIds.get(browser)}`;
+  return id;
+}
+
+export function browserModeStoreKey(browser: WebdriverIO.Browser, channel: string): string {
+  return `electron.${channel}\x00${browserModeInstanceId(browser)}`;
+}
+
+const mockUpdateSchedulers = new WeakMap<WebdriverIO.Browser, MockUpdateScheduler>();
+
+class MockUpdateScheduler {
+  #running: Promise<void> | null = null;
+  #queued: Promise<void> | null = null;
+  readonly #browser: WebdriverIO.Browser;
+
+  constructor(browser: WebdriverIO.Browser) {
+    this.#browser = browser;
+  }
+
+  schedule(): Promise<void> {
+    if (!this.#running) {
+      const p = this.#runOnce().finally(() => {
+        if (this.#running === p) this.#running = null;
+      });
+      this.#running = p;
+      return p;
+    }
+    if (!this.#queued) {
+      const q = this.#running
+        .catch(() => undefined)
+        .then(() => this.#runOnce())
+        .finally(() => {
+          if (this.#queued === q) this.#queued = null;
+        });
+      this.#queued = q;
+    }
+    return this.#queued;
+  }
+
+  async #runOnce(): Promise<void> {
+    log.debug('updateAllMocks batch start');
+    // Native-mode mocks (key has no \x00) belong to every scheduler in the
+    // process; browser-mode mocks (key ends with \x00<id>) are owned by a
+    // single browser instance and must only be updated by that browser's
+    // scheduler, otherwise mock.update() runs browser.execute() on the wrong
+    // app context.
+    const suffix = `\x00${browserModeInstanceId(this.#browser)}`;
+    const mocks = mockStore.getMocks().filter(([key]) => !key.includes('\x00') || key.endsWith(suffix));
+    log.debug(`Found ${mocks.length} mocks to update`);
+    if (mocks.length === 0) return;
+
+    try {
+      await Promise.all(
+        mocks.map(async ([mockId, mock]) => {
+          log.debug(`Updating mock: ${mockId}`);
+          await mock.update();
+          log.debug(`Mock update completed: ${mockId}`);
+        }),
+      );
+      log.debug('All mock updates completed successfully');
+    } catch (error) {
+      log.warn('Mock update batch failed:', error);
+    }
+  }
+}
+
+function getMockUpdateScheduler(browser: WebdriverIO.Browser): MockUpdateScheduler {
+  let scheduler = mockUpdateSchedulers.get(browser);
+  if (!scheduler) {
+    scheduler = new MockUpdateScheduler(browser);
+    mockUpdateSchedulers.set(browser, scheduler);
+  }
+  return scheduler;
 }
 
 const log = createLogger('electron-service', 'service');
@@ -396,7 +469,7 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         // Use Reflect.apply to safely call the original command with the correct 'this' context
         // This avoids TypeScript's strict function signature checking while maintaining runtime safety
         const result = await Reflect.apply(originalCommand, this, args as unknown[]);
-        await updateAllMocks();
+        await getMockUpdateScheduler(browser).schedule();
         return result;
       } as Parameters<typeof browser.overwriteCommand>[1];
 
@@ -462,49 +535,6 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
       log.warn('Failed to initialize log capture:', error);
     }
   }
-}
-
-let mockUpdatePending = false;
-let mockUpdatePromise: Promise<void> | null = null;
-
-/**
- * Update all existing mocks with debouncing to prevent redundant updates.
- * Multiple rapid calls will coalesce into a single update.
- */
-async function updateAllMocks() {
-  if (mockUpdatePending && mockUpdatePromise) {
-    return mockUpdatePromise;
-  }
-
-  mockUpdatePending = true;
-  mockUpdatePromise = (async () => {
-    log.debug('updateAllMocks called');
-    const mocks = mockStore.getMocks();
-    log.debug(`Found ${mocks.length} mocks to update`);
-
-    if (mocks.length === 0) {
-      log.debug('No mocks to update, returning');
-      return;
-    }
-
-    try {
-      log.debug('Starting mock update batch');
-      await Promise.all(
-        mocks.map(async ([mockId, mock]) => {
-          log.debug(`Updating mock: ${mockId}`);
-          await mock.update();
-          log.debug(`Mock update completed: ${mockId}`);
-        }),
-      );
-      log.debug('All mock updates completed successfully');
-    } catch (error) {
-      log.warn('Mock update batch failed:', error);
-    } finally {
-      mockUpdatePending = false;
-    }
-  })();
-
-  return mockUpdatePromise;
 }
 
 function isMultiremote(

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -89,11 +89,6 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
 
     const hasElectronApi = isElectronApiAvailable(this.browser, cdpBridge);
 
-    // Install command overrides if the electron API is available
-    if (hasElectronApi) {
-      this.installCommandOverrides();
-    }
-
     if (isMultiremote(instance)) {
       const mrBrowser = instance;
 

--- a/packages/electron-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/electron-service/test/integration/browser-mode.integration.spec.ts
@@ -1,3 +1,4 @@
+import type { ElectronMock } from '@wdio/native-types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import mockStore from '../../src/mockStore.js';
 import ElectronWorkerService, { browserModeStoreKey } from '../../src/service.js';
@@ -110,5 +111,128 @@ describe('browser mode — MockUpdateScheduler', () => {
 
   it('should be a no-op when the mock store is empty', async () => {
     await expect(browser.triggerCommand('click')).resolves.not.toThrow();
+  });
+});
+
+describe('browser mode — registration gate', () => {
+  let service: ElectronWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+    browser = createFakeBrowser();
+    await service.before({}, [], browser as unknown as WebdriverIO.Browser);
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  function seedExistingMock(channel: string) {
+    const mockClear = vi.fn().mockResolvedValue(undefined);
+    const replayBrowserImpl = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      __isElectronMock: true,
+      __replayBrowserImpl: replayBrowserImpl,
+      mockClear,
+      getMockName: () => `electron.${channel}`,
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    const key = browserModeStoreKey(browser as unknown as WebdriverIO.Browser, channel);
+    mockStore.setMockWithKey(key, existing as unknown as ElectronMock);
+    return { existing, mockClear, replayBrowserImpl };
+  }
+
+  function isLivenessScript(arg: unknown): boolean {
+    return typeof arg === 'string' && arg.startsWith('return !!(window.__wdio_mocks__');
+  }
+
+  function isRegistrationScript(arg: unknown, channel: string): boolean {
+    return (
+      typeof arg === 'string' && arg.includes(`__wdio_mocks__[${JSON.stringify(channel)}]`) && !isLivenessScript(arg)
+    );
+  }
+
+  it('should register exactly once when two concurrent mock() calls race after navigation', async () => {
+    const { mockClear, replayBrowserImpl } = seedExistingMock('appInfo:get');
+    browser.execute.mockResolvedValue(false);
+
+    const api = (browser.electron as { mock: (c: string) => Promise<unknown> }).mock;
+    await Promise.all([api('appInfo:get'), api('appInfo:get')]);
+
+    const livenessCalls = browser.execute.mock.calls.filter((c) => isLivenessScript(c[0]));
+    const registrationCalls = browser.execute.mock.calls.filter((c) => isRegistrationScript(c[0], 'appInfo:get'));
+    expect(livenessCalls).toHaveLength(1);
+    expect(registrationCalls).toHaveLength(1);
+    expect(replayBrowserImpl).toHaveBeenCalledTimes(1);
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not serialize concurrent mock() calls on different channels', async () => {
+    seedExistingMock('chan1');
+    seedExistingMock('chan2');
+
+    const chan1Registration = defer<unknown>();
+    browser.execute.mockImplementation(async (arg: unknown) => {
+      if (isLivenessScript(arg)) return false;
+      if (isRegistrationScript(arg, 'chan1')) return chan1Registration.promise;
+      return undefined;
+    });
+
+    const api = (browser.electron as { mock: (c: string) => Promise<unknown> }).mock;
+    const p1 = api('chan1');
+    const p2 = api('chan2');
+
+    await p2;
+    let p1Settled = false;
+    p1.finally(() => {
+      p1Settled = true;
+    });
+    await flushMicrotasks();
+    expect(p1Settled).toBe(false);
+
+    chan1Registration.resolve(undefined);
+    await p1;
+  });
+
+  it('should skip re-registration when the browser side is already live', async () => {
+    const { mockClear, replayBrowserImpl } = seedExistingMock('appInfo:get');
+    browser.execute.mockResolvedValue(true);
+
+    const api = (browser.electron as { mock: (c: string) => Promise<unknown> }).mock;
+    await api('appInfo:get');
+
+    const registrationCalls = browser.execute.mock.calls.filter((c) => isRegistrationScript(c[0], 'appInfo:get'));
+    expect(registrationCalls).toHaveLength(0);
+    expect(replayBrowserImpl).not.toHaveBeenCalled();
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it('should allow a later mock() call to retry after a registration failure', async () => {
+    const { mockClear, replayBrowserImpl } = seedExistingMock('appInfo:get');
+    let livenessCalls = 0;
+    let registrationCalls = 0;
+    browser.execute.mockImplementation(async (arg: unknown) => {
+      if (isLivenessScript(arg)) {
+        livenessCalls++;
+        return false;
+      }
+      if (isRegistrationScript(arg, 'appInfo:get')) {
+        registrationCalls++;
+        if (registrationCalls === 1) throw new Error('registration failed');
+        return undefined;
+      }
+      return undefined;
+    });
+
+    const api = (browser.electron as { mock: (c: string) => Promise<unknown> }).mock;
+    await expect(api('appInfo:get')).rejects.toThrow('registration failed');
+
+    await api('appInfo:get');
+    expect(livenessCalls).toBe(2);
+    expect(registrationCalls).toBe(2);
+    expect(replayBrowserImpl).toHaveBeenCalledTimes(1);
+    expect(mockClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/electron-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/electron-service/test/integration/browser-mode.integration.spec.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import mockStore from '../../src/mockStore.js';
+import ElectronWorkerService, { browserModeStoreKey } from '../../src/service.js';
+import {
+  createFakeBrowser,
+  createFakeMock,
+  defer,
+  type FakeBrowser,
+  type FakeMock,
+  flushMicrotasks,
+} from './helpers.js';
+
+vi.mock('@wdio/native-utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+  waitUntilWindowAvailable: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('browser mode — MockUpdateScheduler', () => {
+  let service: ElectronWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+    browser = createFakeBrowser();
+    await service.before({}, [], browser as unknown as WebdriverIO.Browser);
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  function seedMock(channel: string): FakeMock {
+    const fake = createFakeMock(`electron.${channel}`);
+    const key = browserModeStoreKey(browser as unknown as WebdriverIO.Browser, channel);
+    mockStore.setMockWithKey(key, fake.mock);
+    return fake;
+  }
+
+  it('should trigger two update batches when two concurrent clicks fire', async () => {
+    const fake = seedMock('appInfo:get');
+
+    const c1 = browser.triggerCommand('click');
+    const c2 = browser.triggerCommand('click');
+    await Promise.all([c1, c2]);
+
+    expect(fake.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('should coalesce three rapid clicks into exactly two batches', async () => {
+    const fake = seedMock('appInfo:get');
+
+    const c1 = browser.triggerCommand('click');
+    const c2 = browser.triggerCommand('click');
+    const c3 = browser.triggerCommand('click');
+    await Promise.all([c1, c2, c3]);
+
+    expect(fake.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not poison the next batch when a previous batch rejects', async () => {
+    const fake = seedMock('appInfo:get');
+    fake.update.mockRejectedValueOnce(new Error('boom'));
+
+    await browser.triggerCommand('click');
+    expect(fake.update).toHaveBeenCalledTimes(1);
+
+    await browser.triggerCommand('click');
+    expect(fake.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('should run two browser instances independently without cross-blocking', async () => {
+    const browserB = createFakeBrowser();
+    const serviceB = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5174' }, {});
+    await serviceB.before({}, [], browserB as unknown as WebdriverIO.Browser);
+
+    const keyA = browserModeStoreKey(browser as unknown as WebdriverIO.Browser, 'a');
+    const keyB = browserModeStoreKey(browserB as unknown as WebdriverIO.Browser, 'b');
+    const fakeA = createFakeMock('electron.a');
+    const fakeB = createFakeMock('electron.b');
+    mockStore.setMockWithKey(keyA, fakeA.mock);
+    mockStore.setMockWithKey(keyB, fakeB.mock);
+
+    const aHeld = defer<void>();
+    fakeA.update.mockImplementationOnce(() => aHeld.promise);
+
+    const clickA = browser.triggerCommand('click');
+    const clickB = browserB.triggerCommand('click');
+
+    await clickB;
+    expect(fakeB.update).toHaveBeenCalledTimes(1);
+
+    let aSettled = false;
+    clickA.finally(() => {
+      aSettled = true;
+    });
+    await flushMicrotasks();
+    expect(aSettled).toBe(false);
+
+    aHeld.resolve();
+    await clickA;
+    expect(fakeA.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be a no-op when the mock store is empty', async () => {
+    await expect(browser.triggerCommand('click')).resolves.not.toThrow();
+  });
+});

--- a/packages/electron-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/electron-service/test/integration/browser-mode.integration.spec.ts
@@ -112,6 +112,54 @@ describe('browser mode — MockUpdateScheduler', () => {
   it('should be a no-op when the mock store is empty', async () => {
     await expect(browser.triggerCommand('click')).resolves.not.toThrow();
   });
+
+  it('should not run a parallel batch when a click arrives between running and queued', async () => {
+    const fake = seedMock('appInfo:get');
+
+    // Block the first batch's update so the queued batch is set up.
+    const firstHeld = defer<void>();
+    fake.update.mockImplementationOnce(() => firstHeld.promise);
+    // Block the second (queued) batch as well, so a third click can race in
+    // between the first batch settling and the queued's #runOnce starting.
+    const secondHeld = defer<void>();
+    fake.update.mockImplementationOnce(() => secondHeld.promise);
+
+    const c1 = browser.triggerCommand('click');
+    const c2 = browser.triggerCommand('click');
+
+    // Settle the first batch — between this and the queued batch's #runOnce,
+    // a third schedule() must NOT spawn a parallel #runOnce.
+    firstHeld.resolve();
+    await flushMicrotasks();
+    const c3 = browser.triggerCommand('click');
+    await flushMicrotasks();
+
+    // Only the queued batch should have started (update call count = 2),
+    // not a third concurrent batch.
+    expect(fake.update).toHaveBeenCalledTimes(2);
+
+    secondHeld.resolve();
+    await Promise.all([c1, c2, c3]);
+    // After all settle, click 3's batch ran exactly once.
+    expect(fake.update).toHaveBeenCalledTimes(3);
+  });
+
+  it('should route updates to the per-instance scheduler when the override fires with this.browser set', async () => {
+    // Simulate the multiremote case: the override is registered on `browser`
+    // (the "root"), but a click fires with `this.browser` = a per-instance
+    // session that owns its own mocks.
+    const instanceBrowser = createFakeBrowser();
+    const fake = createFakeMock('electron.instance-channel');
+    const key = browserModeStoreKey(instanceBrowser as unknown as WebdriverIO.Browser, 'instance-channel');
+    mockStore.setMockWithKey(key, fake.mock);
+
+    // Trigger the override registered on `browser` but pass instanceBrowser as
+    // the per-instance owner — the override should route through the
+    // instance's scheduler so the per-instance mock key matches.
+    await browser.triggerCommand('click', instanceBrowser as unknown as WebdriverIO.Browser);
+
+    expect(fake.update).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('browser mode — registration gate', () => {

--- a/packages/electron-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/electron-service/test/integration/browser-mode.integration.spec.ts
@@ -236,3 +236,124 @@ describe('browser mode — registration gate', () => {
     expect(mockClear).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('browser mode — navigation lifecycle', () => {
+  let service: ElectronWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+    browser = createFakeBrowser();
+    await service.before({}, [], browser as unknown as WebdriverIO.Browser);
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  function isLivenessScript(arg: unknown): boolean {
+    return typeof arg === 'string' && arg.startsWith('return !!(window.__wdio_mocks__');
+  }
+
+  function isRegistrationScript(arg: unknown, channel: string): boolean {
+    return (
+      typeof arg === 'string' && arg.includes(`__wdio_mocks__[${JSON.stringify(channel)}]`) && !isLivenessScript(arg)
+    );
+  }
+
+  function isInjectionScript(arg: unknown): boolean {
+    // The full IPC injection script references __wdio_mocks__ but is neither
+    // a liveness probe nor a single-channel registration call.
+    return (
+      typeof arg === 'string' && arg.includes('__wdio_mocks__') && !isLivenessScript(arg) && !arg.startsWith('return (')
+    );
+  }
+
+  it('should re-inject IPC and re-register the mock through a full navigation cycle', async () => {
+    const mockClear = vi.fn().mockResolvedValue(undefined);
+    const replayBrowserImpl = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      __isElectronMock: true,
+      __replayBrowserImpl: replayBrowserImpl,
+      mockClear,
+      getMockName: () => 'electron.appInfo:get',
+      update,
+    };
+    const key = browserModeStoreKey(browser as unknown as WebdriverIO.Browser, 'appInfo:get');
+    mockStore.setMockWithKey(key, existing as unknown as ElectronMock);
+
+    await browser.triggerCommand('click');
+    expect(update).toHaveBeenCalledTimes(1);
+
+    browser.execute.mockClear();
+    await browser.url('http://localhost:5173/page2');
+    const injectionAfterNav = browser.execute.mock.calls.filter((c) => isInjectionScript(c[0]));
+    expect(injectionAfterNav.length).toBeGreaterThan(0);
+
+    browser.execute.mockImplementation(async (arg: unknown) => {
+      if (isLivenessScript(arg)) return false;
+      return undefined;
+    });
+
+    const api = (browser.electron as { mock: (c: string) => Promise<unknown> }).mock;
+    const returned = await api('appInfo:get');
+    expect(returned).toBe(existing);
+    expect(replayBrowserImpl).toHaveBeenCalledTimes(1);
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(browser.execute.mock.calls.filter((c) => isRegistrationScript(c[0], 'appInfo:get'))).toHaveLength(1);
+
+    browser.execute.mockResolvedValue(undefined);
+    await browser.triggerCommand('click');
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call mockClear exactly once when several consumers race to recover after navigation', async () => {
+    const mockClear = vi.fn().mockResolvedValue(undefined);
+    const replayBrowserImpl = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      __isElectronMock: true,
+      __replayBrowserImpl: replayBrowserImpl,
+      mockClear,
+      getMockName: () => 'electron.appInfo:get',
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    const key = browserModeStoreKey(browser as unknown as WebdriverIO.Browser, 'appInfo:get');
+    mockStore.setMockWithKey(key, existing as unknown as ElectronMock);
+    browser.execute.mockResolvedValue(false);
+
+    const api = (browser.electron as { mock: (c: string) => Promise<unknown> }).mock;
+    await Promise.all([api('appInfo:get'), api('appInfo:get'), api('appInfo:get'), api('appInfo:get')]);
+
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(replayBrowserImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit unhandled rejections when in-flight work completes after browser drop', async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', onRejection);
+
+    try {
+      const fake = createFakeMock('electron.appInfo:get');
+      const held = defer<void>();
+      fake.update.mockImplementationOnce(() => held.promise);
+      const key = browserModeStoreKey(browser as unknown as WebdriverIO.Browser, 'appInfo:get');
+      mockStore.setMockWithKey(key, fake.mock);
+
+      const click = browser.triggerCommand('click');
+
+      mockStore.clear();
+      await flushMicrotasks();
+
+      held.resolve();
+      await click;
+      await flushMicrotasks();
+
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onRejection);
+    }
+  });
+});

--- a/packages/electron-service/test/integration/helpers.ts
+++ b/packages/electron-service/test/integration/helpers.ts
@@ -29,7 +29,13 @@ export interface FakeBrowser {
   overwriteCommand: ReturnType<typeof vi.fn>;
   electron: Record<string, unknown>;
   overrides: Map<string, OverrideFn>;
-  triggerCommand: (name: string) => Promise<unknown>;
+  /**
+   * Invoke a registered command override. The optional `ownerBrowser` is set
+   * as `this.browser` inside the override — use this to simulate WDIO's
+   * multiremote behaviour where the override fires on a root-installed
+   * registration but `this.browser` is the per-instance owning session.
+   */
+  triggerCommand: (name: string, ownerBrowser?: WebdriverIO.Browser) => Promise<unknown>;
 }
 
 export function createFakeBrowser(): FakeBrowser {
@@ -42,13 +48,14 @@ export function createFakeBrowser(): FakeBrowser {
     }),
     electron: {} as Record<string, unknown>,
     overrides,
-    triggerCommand: (name: string) => {
+    triggerCommand: (name: string, ownerBrowser?: WebdriverIO.Browser) => {
       const fn = overrides.get(name);
       if (!fn) {
         throw new Error(`No override registered for command "${name}"`);
       }
       const originalCommand = vi.fn().mockResolvedValue(undefined);
-      return fn.call({}, originalCommand);
+      const ctx = ownerBrowser ? { browser: ownerBrowser } : {};
+      return fn.call(ctx, originalCommand);
     },
   };
   return browser;

--- a/packages/electron-service/test/integration/helpers.ts
+++ b/packages/electron-service/test/integration/helpers.ts
@@ -1,0 +1,82 @@
+import type { ElectronMock } from '@wdio/native-types';
+import { vi } from 'vitest';
+
+export type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+export function defer<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export type OverrideFn = (
+  this: unknown,
+  originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
+  ...args: readonly unknown[]
+) => Promise<unknown>;
+
+export interface FakeBrowser {
+  url: ReturnType<typeof vi.fn>;
+  execute: ReturnType<typeof vi.fn>;
+  overwriteCommand: ReturnType<typeof vi.fn>;
+  electron: Record<string, unknown>;
+  overrides: Map<string, OverrideFn>;
+  triggerCommand: (name: string) => Promise<unknown>;
+}
+
+export function createFakeBrowser(): FakeBrowser {
+  const overrides = new Map<string, OverrideFn>();
+  const browser = {
+    url: vi.fn().mockResolvedValue(undefined),
+    execute: vi.fn().mockResolvedValue(undefined),
+    overwriteCommand: vi.fn((name: string, fn: OverrideFn, _isElement?: boolean) => {
+      overrides.set(name, fn);
+    }),
+    electron: {} as Record<string, unknown>,
+    overrides,
+    triggerCommand: (name: string) => {
+      const fn = overrides.get(name);
+      if (!fn) {
+        throw new Error(`No override registered for command "${name}"`);
+      }
+      const originalCommand = vi.fn().mockResolvedValue(undefined);
+      return fn.call({}, originalCommand);
+    },
+  };
+  return browser;
+}
+
+export interface FakeMock {
+  mock: ElectronMock;
+  update: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Create a fake mock whose `update()` resolves immediately by default. Tests
+ * that need controllable timing can override via `.mockImplementationOnce`,
+ * `.mockResolvedValueOnce`, or `.mockRejectedValueOnce`.
+ */
+export function createFakeMock(name: string): FakeMock {
+  const update = vi.fn(async () => undefined);
+  const mock = {
+    getMockName: () => name,
+    update,
+  } as unknown as ElectronMock;
+  return { mock, update };
+}
+
+/**
+ * Flush the microtask queue. Two `setImmediate` flushes cover .then().then() chains.
+ */
+export async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/packages/electron-service/test/launcher.browser.spec.ts
+++ b/packages/electron-service/test/launcher.browser.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wdio/native-utils', async () => {
+  const actual = await vi.importActual('@wdio/native-utils');
+  return {
+    ...actual,
+    readPackageUp: vi.fn(),
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+    })),
+    formatDiagnosticResults: vi.fn(),
+  };
+});
+
+vi.mock('../src/appBuildInfo.js', () => ({ getAppBuildInfo: vi.fn() }));
+vi.mock('../src/binaryPath.js', () => ({ getBinaryPath: vi.fn() }));
+vi.mock('../src/electronVersion.js', () => ({ getElectronVersion: vi.fn() }));
+vi.mock('../src/diagnostics.js', () => ({ diagnoseElectronEnvironment: vi.fn().mockResolvedValue([]) }));
+vi.mock('../src/apparmor.js', () => ({ applyApparmorWorkaround: vi.fn() }));
+
+vi.mock('get-port', () => ({ default: vi.fn().mockResolvedValue(9229) }));
+
+import ElectronLaunchService from '../src/launcher.js';
+
+const DEV_SERVER = 'http://localhost:5173';
+
+function makeLauncher(globalOpts: Record<string, unknown> = {}): ElectronLaunchService {
+  return new ElectronLaunchService(globalOpts as any, {} as any, {} as any);
+}
+
+describe('ElectronLaunchService — browser mode', () => {
+  describe('onPrepare', () => {
+    it('sets browserName to "chrome" and removes goog:chromeOptions', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        {
+          browserName: 'electron',
+          'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+        },
+      ];
+      await launcher.onPrepare({} as any, caps);
+      expect(caps[0].browserName).toBe('chrome');
+      expect(caps[0]['goog:chromeOptions']).toBeUndefined();
+      expect(caps[0]['wdio:enforceWebDriverClassic']).toBeUndefined();
+    });
+
+    it('throws SevereServiceError when devServerUrl is missing', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [{ browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser' } }];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('devServerUrl is required');
+    });
+
+    it('throws SevereServiceError when devServerUrl is not a valid URL', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: 'not-a-url' } },
+      ];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('not a valid URL');
+    });
+
+    it('accepts mode and devServerUrl from global options', async () => {
+      const launcher = makeLauncher({ mode: 'browser', devServerUrl: DEV_SERVER });
+      const caps: any[] = [{ browserName: 'electron', 'wdio:electronServiceOptions': {} }];
+      await launcher.onPrepare({} as any, caps);
+      expect(caps[0].browserName).toBe('chrome');
+    });
+  });
+
+  describe('onWorkerStart', () => {
+    it('returns immediately without allocating debug ports', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+      ];
+      await launcher.onPrepare({} as any, caps);
+      const getPort = (await import('get-port')).default as ReturnType<typeof vi.fn>;
+      getPort.mockClear();
+      await expect(launcher.onWorkerStart('0-0', caps[0])).resolves.toBeUndefined();
+      expect(getPort).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/electron-service/test/launcher.browser.spec.ts
+++ b/packages/electron-service/test/launcher.browser.spec.ts
@@ -87,6 +87,19 @@ describe('ElectronLaunchService — browser mode', () => {
       await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('devServerUrl is required');
     });
 
+    it('validates devServerUrl for W3C alwaysMatch-wrapped capabilities', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        {
+          alwaysMatch: {
+            browserName: 'electron',
+            'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: 'not-a-url' },
+          },
+        },
+      ];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('not a valid URL');
+    });
+
     it('throws SevereServiceError when capabilities have mixed modes', async () => {
       const launcher = makeLauncher();
       const caps: any[] = [

--- a/packages/electron-service/test/launcher.browser.spec.ts
+++ b/packages/electron-service/test/launcher.browser.spec.ts
@@ -68,6 +68,26 @@ describe('ElectronLaunchService — browser mode', () => {
       await launcher.onPrepare({} as any, caps);
       expect(caps[0].browserName).toBe('chrome');
     });
+
+    it('throws SevereServiceError when capabilities have mixed modes', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'native' } },
+      ];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('mixed modes');
+    });
+
+    it('applies browser mode to all capabilities when all agree', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+      ];
+      await launcher.onPrepare({} as any, caps);
+      expect(caps[0].browserName).toBe('chrome');
+      expect(caps[1].browserName).toBe('chrome');
+    });
   });
 
   describe('onWorkerStart', () => {

--- a/packages/electron-service/test/launcher.browser.spec.ts
+++ b/packages/electron-service/test/launcher.browser.spec.ts
@@ -69,6 +69,24 @@ describe('ElectronLaunchService — browser mode', () => {
       expect(caps[0].browserName).toBe('chrome');
     });
 
+    it('throws SevereServiceError when a per-capability devServerUrl is invalid', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: 'bad-url' } },
+      ];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('not a valid URL');
+    });
+
+    it('throws SevereServiceError when a per-capability devServerUrl is missing', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser' } },
+      ];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('devServerUrl is required');
+    });
+
     it('throws SevereServiceError when capabilities have mixed modes', async () => {
       const launcher = makeLauncher();
       const caps: any[] = [

--- a/packages/electron-service/test/launcher.browser.spec.ts
+++ b/packages/electron-service/test/launcher.browser.spec.ts
@@ -34,7 +34,7 @@ function makeLauncher(globalOpts: Record<string, unknown> = {}): ElectronLaunchS
 
 describe('ElectronLaunchService — browser mode', () => {
   describe('onPrepare', () => {
-    it('sets browserName to "chrome" and removes goog:chromeOptions', async () => {
+    it('should set browserName to "chrome" and strip Electron-specific capability bits', async () => {
       const launcher = makeLauncher();
       const caps: any[] = [
         {
@@ -46,6 +46,26 @@ describe('ElectronLaunchService — browser mode', () => {
       expect(caps[0].browserName).toBe('chrome');
       expect(caps[0]['goog:chromeOptions']).toBeUndefined();
       expect(caps[0]['wdio:enforceWebDriverClassic']).toBeUndefined();
+    });
+
+    it('should preserve user-supplied goog:chromeOptions and strip only the Electron binary', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        {
+          browserName: 'electron',
+          'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+          'goog:chromeOptions': {
+            binary: '/path/to/Electron.app/Contents/MacOS/Electron',
+            args: ['--disable-features=IsolateOrigins', '--no-sandbox'],
+            prefs: { 'profile.default_content_setting_values.notifications': 2 },
+          },
+        },
+      ];
+      await launcher.onPrepare({} as any, caps);
+      expect(caps[0]['goog:chromeOptions']).toEqual({
+        args: ['--disable-features=IsolateOrigins', '--no-sandbox'],
+        prefs: { 'profile.default_content_setting_values.notifications': 2 },
+      });
     });
 
     it('throws SevereServiceError when devServerUrl is missing', async () => {

--- a/packages/electron-service/test/mock.spec.ts
+++ b/packages/electron-service/test/mock.spec.ts
@@ -617,6 +617,37 @@ describe('createElectronBrowserModeMock()', () => {
     });
   });
 
+  describe('withImplementation()', () => {
+    it('calls mock.update() after the browser callback so call data is synced to the outer mock', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+
+      mockBrowser.executeAsync.mockResolvedValueOnce('callback-result');
+      mockBrowser.execute.mockResolvedValueOnce(
+        makeCallData([['arg']], [{ type: 'return', value: 'callback-result' }], [1]),
+      );
+
+      await mock.withImplementation(
+        () => 'impl',
+        () => undefined,
+      );
+
+      expect(mock.mock.calls).toStrictEqual([['arg']]);
+    });
+
+    it('throws when the browser-side callback fails', async () => {
+      const mock = await createElectronBrowserModeMock('err-channel', mockBrowser as unknown as WebdriverIO.Browser);
+
+      mockBrowser.executeAsync.mockResolvedValueOnce({ __wdioAsyncErr__: 'boom' });
+
+      await expect(
+        mock.withImplementation(
+          () => undefined,
+          () => undefined,
+        ),
+      ).rejects.toThrow('boom');
+    });
+  });
+
   describe('mockRestore()', () => {
     it('should keep the mock in the store — channel must remain registered for restoreMocks: true to be safe across tests', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);

--- a/packages/electron-service/test/mock.spec.ts
+++ b/packages/electron-service/test/mock.spec.ts
@@ -519,6 +519,104 @@ describe('createElectronBrowserModeMock()', () => {
     });
   });
 
+  describe('__replayBrowserImpl()', () => {
+    it('does nothing and makes no execute call when no impl has been set', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore);
+    });
+
+    it('re-applies mockReturnValue after navigation by running the inner setter script', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockReturnValue('initial');
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore + 1);
+      const replayScript = mockBrowser.execute.mock.calls[callsBefore][0] as string;
+      expect(replayScript).toContain('mockReturnValue');
+    });
+
+    it('re-applies mockResolvedValue after navigation', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockResolvedValue('resolved');
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      const replayScript = mockBrowser.execute.mock.calls[callsBefore][0] as string;
+      expect(replayScript).toContain('mockResolvedValue');
+    });
+
+    it('re-applies mockRejectedValue after navigation', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockRejectedValue(new Error('boom'));
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      const replayScript = mockBrowser.execute.mock.calls[callsBefore][0] as string;
+      expect(replayScript).toContain('mockRejectedValue');
+    });
+
+    it('re-applies mockImplementation after navigation', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockImplementation(() => 'test-impl');
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore + 1);
+    });
+
+    it('replays the latest setter when multiple have been called (last one wins)', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockReturnValue('first');
+      await mock.mockResolvedValue('last');
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      const replayScript = mockBrowser.execute.mock.calls[callsBefore][0] as string;
+      expect(replayScript).toContain('mockResolvedValue');
+      expect(replayScript).not.toContain('mockReturnValue');
+    });
+
+    it('does nothing after mockReset() clears the impl state', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockReturnValue('value');
+      await mock.mockReset();
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore);
+    });
+
+    it('does nothing after mockRestore() clears the impl state', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockResolvedValue('value');
+      await mock.mockRestore();
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
   describe('mockRestore()', () => {
     it('should keep the mock in the store — channel must remain registered for restoreMocks: true to be safe across tests', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);

--- a/packages/electron-service/test/mock.spec.ts
+++ b/packages/electron-service/test/mock.spec.ts
@@ -520,16 +520,14 @@ describe('createElectronBrowserModeMock()', () => {
   });
 
   describe('mockRestore()', () => {
-    it('should remove the mock from the store by reference', async () => {
+    it('should keep the mock in the store — channel must remain registered for restoreMocks: true to be safe across tests', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
-      mockStore.setMockWithKey(
-        'electron.my-channel\x000',
-        mock as unknown as Parameters<typeof mockStore.setMockWithKey>[1],
-      );
+      const storeKey = 'electron.my-channel\x000';
+      mockStore.setMockWithKey(storeKey, mock as unknown as Parameters<typeof mockStore.setMockWithKey>[1]);
 
       await mock.mockRestore();
 
-      expect(() => mockStore.getMock('electron.my-channel\x000')).toThrow('No mock registered');
+      expect(mockStore.getMock(storeKey)).toBe(mock);
     });
 
     it('should clear the outer mock call history on restore', async () => {
@@ -541,6 +539,14 @@ describe('createElectronBrowserModeMock()', () => {
       await mock.mockRestore();
 
       expect(mock.mock.calls).toHaveLength(0);
+    });
+
+    it('should preserve the mock name across restore', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+
+      await mock.mockRestore();
+
+      expect(mock.getMockName()).toBe('electron.my-channel');
     });
   });
 });

--- a/packages/electron-service/test/mock.spec.ts
+++ b/packages/electron-service/test/mock.spec.ts
@@ -1,8 +1,9 @@
 import { isAsyncFunction } from 'node:util/types';
 import type { ElectronInterface, ElectronType } from '@wdio/native-types';
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
-import { createMock } from '../src/mock.js';
+import { createElectronBrowserModeMock, createMock } from '../src/mock.js';
+import mockStore from '../src/mockStore.js';
 
 let mockFn: Mock;
 let mockExecute: Mock;
@@ -380,6 +381,166 @@ describe('Mock API', () => {
 
         expect(executeResults).toStrictEqual(['temporary name']);
       });
+    });
+  });
+});
+
+describe('createElectronBrowserModeMock()', () => {
+  let mockBrowser: { execute: Mock; executeAsync: Mock };
+
+  beforeEach(() => {
+    mockBrowser = {
+      execute: vi.fn().mockResolvedValue(undefined),
+      executeAsync: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  function makeCallData(
+    calls: unknown[][] = [],
+    results: { type: string; value: unknown }[] = [],
+    invocationCallOrder: number[] = [],
+  ) {
+    return { calls, results, invocationCallOrder };
+  }
+
+  it('should create a mock with the expected name', async () => {
+    const mock = await createElectronBrowserModeMock('get-user-data', mockBrowser as unknown as WebdriverIO.Browser);
+    expect(mock.getMockName()).toBe('electron.get-user-data');
+  });
+
+  it('should set __isElectronMock to true', async () => {
+    const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+    expect(mock.__isElectronMock).toBe(true);
+  });
+
+  it('should call browser.execute once during construction to register the channel', async () => {
+    await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+    expect(mockBrowser.execute).toHaveBeenCalledTimes(1);
+  });
+
+  describe('update()', () => {
+    it('should populate mock.calls from browser-side call data', async () => {
+      const mock = await createElectronBrowserModeMock('get-user', mockBrowser as unknown as WebdriverIO.Browser);
+      mockBrowser.execute.mockResolvedValueOnce(
+        makeCallData(
+          [['alice'], ['bob']],
+          [
+            { type: 'return', value: 1 },
+            { type: 'return', value: 2 },
+          ],
+          [1, 2],
+        ),
+      );
+
+      await mock.update();
+
+      expect(mock.mock.calls).toStrictEqual([['alice'], ['bob']]);
+      expect(mock.mock.results).toStrictEqual([
+        { type: 'return', value: 1 },
+        { type: 'return', value: 2 },
+      ]);
+      expect(mock.mock.invocationCallOrder).toStrictEqual([1, 2]);
+    });
+
+    it('should fully replace existing calls — reset+same-count does not silently skip', async () => {
+      const mock = await createElectronBrowserModeMock('get-user', mockBrowser as unknown as WebdriverIO.Browser);
+
+      // First sync: 2 calls with old arguments
+      mockBrowser.execute.mockResolvedValueOnce(
+        makeCallData(
+          [['old-a'], ['old-b']],
+          [
+            { type: 'return', value: 'old1' },
+            { type: 'return', value: 'old2' },
+          ],
+          [1, 2],
+        ),
+      );
+      await mock.update();
+      expect(mock.mock.calls).toStrictEqual([['old-a'], ['old-b']]);
+
+      // Browser was cleared and re-invoked the same number of times with different args
+      mockBrowser.execute.mockResolvedValueOnce(
+        makeCallData(
+          [['new-a'], ['new-b']],
+          [
+            { type: 'return', value: 'new1' },
+            { type: 'return', value: 'new2' },
+          ],
+          [3, 4],
+        ),
+      );
+      await mock.update();
+
+      // Must replace, not keep stale calls
+      expect(mock.mock.calls).toStrictEqual([['new-a'], ['new-b']]);
+      expect(mock.mock.invocationCallOrder).toStrictEqual([3, 4]);
+    });
+
+    it('should clear outer mock when browser reports zero calls', async () => {
+      const mock = await createElectronBrowserModeMock('get-user', mockBrowser as unknown as WebdriverIO.Browser);
+
+      mockBrowser.execute.mockResolvedValueOnce(makeCallData([['arg']], [{ type: 'return', value: 'v' }], [1]));
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(1);
+
+      mockBrowser.execute.mockResolvedValueOnce(makeCallData());
+      await mock.update();
+
+      expect(mock.mock.calls).toHaveLength(0);
+      expect(mock.mock.results).toHaveLength(0);
+      expect(mock.mock.invocationCallOrder).toHaveLength(0);
+    });
+
+    it('should handle missing results gracefully by substituting a default result', async () => {
+      const mock = await createElectronBrowserModeMock('get-user', mockBrowser as unknown as WebdriverIO.Browser);
+      mockBrowser.execute.mockResolvedValueOnce({ calls: [['arg']], results: [], invocationCallOrder: [1] });
+
+      await mock.update();
+
+      expect(mock.mock.results).toStrictEqual([{ type: 'return', value: undefined }]);
+    });
+  });
+
+  describe('mockClear()', () => {
+    it('should clear call history on both browser-side and outer mock', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      mockBrowser.execute.mockResolvedValueOnce(makeCallData([['arg']], [{ type: 'return', value: 1 }], [1]));
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(1);
+
+      await mock.mockClear();
+
+      expect(mock.mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('mockRestore()', () => {
+    it('should remove the mock from the store by reference', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      mockStore.setMockWithKey(
+        'electron.my-channel\x000',
+        mock as unknown as Parameters<typeof mockStore.setMockWithKey>[1],
+      );
+
+      await mock.mockRestore();
+
+      expect(() => mockStore.getMock('electron.my-channel\x000')).toThrow('No mock registered');
+    });
+
+    it('should clear the outer mock call history on restore', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      mockBrowser.execute.mockResolvedValueOnce(makeCallData([['arg']], [{ type: 'return', value: 1 }], [1]));
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(1);
+
+      await mock.mockRestore();
+
+      expect(mock.mock.calls).toHaveLength(0);
     });
   });
 });

--- a/packages/electron-service/test/mock.spec.ts
+++ b/packages/electron-service/test/mock.spec.ts
@@ -520,7 +520,7 @@ describe('createElectronBrowserModeMock()', () => {
   });
 
   describe('__replayBrowserImpl()', () => {
-    it('does nothing and makes no execute call when no impl has been set', async () => {
+    it('should do nothing and make no execute call when no impl has been set', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       const callsBefore = mockBrowser.execute.mock.calls.length;
 
@@ -530,7 +530,7 @@ describe('createElectronBrowserModeMock()', () => {
       expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore);
     });
 
-    it('re-applies mockReturnValue after navigation by running the inner setter script', async () => {
+    it('should re-apply mockReturnValue after navigation by running the inner setter script', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       await mock.mockReturnValue('initial');
       const callsBefore = mockBrowser.execute.mock.calls.length;
@@ -543,7 +543,7 @@ describe('createElectronBrowserModeMock()', () => {
       expect(replayScript).toContain('mockReturnValue');
     });
 
-    it('re-applies mockResolvedValue after navigation', async () => {
+    it('should re-apply mockResolvedValue after navigation', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       await mock.mockResolvedValue('resolved');
       const callsBefore = mockBrowser.execute.mock.calls.length;
@@ -555,7 +555,7 @@ describe('createElectronBrowserModeMock()', () => {
       expect(replayScript).toContain('mockResolvedValue');
     });
 
-    it('re-applies mockRejectedValue after navigation', async () => {
+    it('should re-apply mockRejectedValue after navigation', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       await mock.mockRejectedValue(new Error('boom'));
       const callsBefore = mockBrowser.execute.mock.calls.length;
@@ -567,7 +567,7 @@ describe('createElectronBrowserModeMock()', () => {
       expect(replayScript).toContain('mockRejectedValue');
     });
 
-    it('re-applies mockImplementation after navigation', async () => {
+    it('should re-apply mockImplementation after navigation', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       await mock.mockImplementation(() => 'test-impl');
       const callsBefore = mockBrowser.execute.mock.calls.length;
@@ -578,7 +578,20 @@ describe('createElectronBrowserModeMock()', () => {
       expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore + 1);
     });
 
-    it('replays the latest setter when multiple have been called (last one wins)', async () => {
+    it('should re-apply mockReturnThis after navigation', async () => {
+      const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
+      await mock.mockReturnThis();
+      const callsBefore = mockBrowser.execute.mock.calls.length;
+
+      const replay = (mock as unknown as Record<string, () => Promise<void>>).__replayBrowserImpl;
+      await replay();
+
+      expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore + 1);
+      const replayScript = mockBrowser.execute.mock.calls[callsBefore][0] as string;
+      expect(replayScript).toContain('mockReturnThis');
+    });
+
+    it('should replay the latest setter when multiple have been called (last one wins)', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       await mock.mockReturnValue('first');
       await mock.mockResolvedValue('last');
@@ -592,7 +605,7 @@ describe('createElectronBrowserModeMock()', () => {
       expect(replayScript).not.toContain('mockReturnValue');
     });
 
-    it('does nothing after mockReset() clears the impl state', async () => {
+    it('should do nothing after mockReset() clears the impl state', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       await mock.mockReturnValue('value');
       await mock.mockReset();
@@ -604,7 +617,7 @@ describe('createElectronBrowserModeMock()', () => {
       expect(mockBrowser.execute.mock.calls.length).toBe(callsBefore);
     });
 
-    it('does nothing after mockRestore() clears the impl state', async () => {
+    it('should do nothing after mockRestore() clears the impl state', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
       await mock.mockResolvedValue('value');
       await mock.mockRestore();
@@ -618,7 +631,7 @@ describe('createElectronBrowserModeMock()', () => {
   });
 
   describe('withImplementation()', () => {
-    it('calls mock.update() after the browser callback so call data is synced to the outer mock', async () => {
+    it('should call mock.update() after the browser callback so call data is synced to the outer mock', async () => {
       const mock = await createElectronBrowserModeMock('my-channel', mockBrowser as unknown as WebdriverIO.Browser);
 
       mockBrowser.executeAsync.mockResolvedValueOnce('callback-result');

--- a/packages/electron-service/test/mockStore.spec.ts
+++ b/packages/electron-service/test/mockStore.spec.ts
@@ -73,3 +73,74 @@ describe('clear', () => {
     expect(mockStore.getMocks()).toStrictEqual([]);
   });
 });
+
+describe('setMockWithKey', () => {
+  it('should store the mock under the explicit key, not the mock name', () => {
+    const testMock = { getMockName: () => 'mock name' } as unknown as ElectronMock;
+    mockStore.setMockWithKey('custom-key', testMock);
+    expect(mockStore.getMock('custom-key')).toBe(testMock);
+  });
+
+  it('should allow the same mock to be stored under multiple different keys', () => {
+    const testMock = { getMockName: () => 'shared mock' } as unknown as ElectronMock;
+    mockStore.setMockWithKey('key-a', testMock);
+    mockStore.setMockWithKey('key-b', testMock);
+    expect(mockStore.getMock('key-a')).toBe(testMock);
+    expect(mockStore.getMock('key-b')).toBe(testMock);
+  });
+
+  it('should allow two different mocks with the same name to be stored under different keys (collision prevention)', () => {
+    const mock1 = { getMockName: () => 'same-name' } as unknown as ElectronMock;
+    const mock2 = { getMockName: () => 'same-name' } as unknown as ElectronMock;
+    mockStore.setMockWithKey('key-instance-0', mock1);
+    mockStore.setMockWithKey('key-instance-1', mock2);
+    expect(mockStore.getMock('key-instance-0')).toBe(mock1);
+    expect(mockStore.getMock('key-instance-1')).toBe(mock2);
+  });
+
+  it('should not be retrievable via the mock name', () => {
+    const testMock = { getMockName: () => 'mock name' } as unknown as ElectronMock;
+    mockStore.setMockWithKey('custom-key', testMock);
+    expect(() => mockStore.getMock('mock name')).toThrow('No mock registered for "mock name"');
+  });
+});
+
+describe('deleteMockByRef', () => {
+  it('should delete the entry that holds the given mock reference', () => {
+    const testMock = { getMockName: () => 'ref mock' } as unknown as ElectronMock;
+    mockStore.setMockWithKey('composite-key', testMock);
+
+    const result = mockStore.deleteMockByRef(testMock);
+
+    expect(result).toBe(true);
+    expect(() => mockStore.getMock('composite-key')).toThrow('No mock registered for "composite-key"');
+  });
+
+  it('should return false when the reference is not found', () => {
+    const testMock = { getMockName: () => 'not stored' } as unknown as ElectronMock;
+    expect(mockStore.deleteMockByRef(testMock)).toBe(false);
+  });
+
+  it('should only delete the entry matching the reference, leaving others intact', () => {
+    const mock1 = { getMockName: () => 'mock 1' } as unknown as ElectronMock;
+    const mock2 = { getMockName: () => 'mock 2' } as unknown as ElectronMock;
+    mockStore.setMockWithKey('key-1', mock1);
+    mockStore.setMockWithKey('key-2', mock2);
+
+    mockStore.deleteMockByRef(mock1);
+
+    expect(() => mockStore.getMock('key-1')).toThrow();
+    expect(mockStore.getMock('key-2')).toBe(mock2);
+  });
+
+  it('should find the mock even when stored under a composite null-byte key', () => {
+    const testMock = { getMockName: () => 'channel mock' } as unknown as ElectronMock;
+    const compositeKey = `electron.get-user\x00${0}`;
+    mockStore.setMockWithKey(compositeKey, testMock);
+
+    const result = mockStore.deleteMockByRef(testMock);
+
+    expect(result).toBe(true);
+    expect(() => mockStore.getMock(compositeKey)).toThrow();
+  });
+});

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -1078,7 +1078,9 @@ describe('Electron Worker Service', () => {
 
         // Root browser gets overwriteCommand calls (for click, doubleClick, setValue, clearValue)
         expect((rootBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
-        // Per-instance browser gets none — avoids double-wrap through root's override chain
+        // Per-instance browser gets no direct overwriteCommand call: WDIO's multiremote
+        // overwriteCommand wrapper propagates to all instances' __elementOverrides__ internally,
+        // so a separate call on each instance would double-wrap element commands.
         expect((electronBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
       });
     });

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -908,7 +908,7 @@ describe('Electron Worker Service', () => {
     });
 
     describe('patchBrowserUrl()', () => {
-      it('re-throws when the IPC injection script fails after navigation', async () => {
+      it('should re-throw when the IPC injection script fails after navigation', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
         await instance.before({}, [], browserModeBrowser);
 
@@ -921,14 +921,14 @@ describe('Electron Worker Service', () => {
         );
       });
 
-      it('resolves normally when the injection script succeeds after navigation', async () => {
+      it('should resolve normally when the injection script succeeds after navigation', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
         await instance.before({}, [], browserModeBrowser);
 
         await expect(browserModeBrowser.url('http://localhost:5173/settings')).resolves.toBeUndefined();
       });
 
-      it('does not run the injection script when url() is called without a href (get current URL)', async () => {
+      it('should not run the injection script when url() is called without a href', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
         await instance.before({}, [], browserModeBrowser);
 
@@ -940,8 +940,31 @@ describe('Electron Worker Service', () => {
       });
     });
 
+    describe('multiremote missing devServerUrl', () => {
+      it('throws SevereServiceError when an Electron instance has no devServerUrl (neither per-cap nor global)', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser' }, {});
+
+        browserModeBrowser.requestedCapabilities = {
+          alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
+        };
+
+        const rootBrowser = {
+          instances: ['app1'],
+          getInstance: (name: string) => (name === 'app1' ? browserModeBrowser : undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        const { SevereServiceError } = await import('webdriverio');
+        await expect(instance.before({}, [], rootBrowser)).rejects.toBeInstanceOf(SevereServiceError);
+      });
+    });
+
     describe('mixed multiremote (non-Electron instances skipped)', () => {
-      it('does not inject the IPC script into non-Electron multiremote instances', async () => {
+      it('should not inject the IPC script into non-Electron multiremote instances', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         const electronBrowser = {

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -67,9 +67,17 @@ vi.mock('../src/mockStore', () => {
     default: {
       getMocks: vi.fn().mockReturnValue([]),
       setMock: vi.fn(),
+      getMock: vi.fn().mockImplementation(() => {
+        throw new Error('No mock registered for key');
+      }),
+      setMockWithKey: vi.fn(),
     },
   };
 });
+
+vi.mock('../src/mock.js', () => ({
+  createElectronBrowserModeMock: vi.fn().mockResolvedValue({ __isElectronMock: true }),
+}));
 
 vi.mock('../src/logCapture', () => {
   return {
@@ -929,6 +937,80 @@ describe('Electron Worker Service', () => {
         const executeCallsAfter = (browserModeBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length;
 
         expect(executeCallsAfter).toBe(executeCallsBefore);
+      });
+    });
+
+    describe('root multiremote browser.electron.mock()', () => {
+      it('throws when mock() is called on the root multiremote browser in browser mode', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+
+        browserModeBrowser.requestedCapabilities = {
+          alwaysMatch: { browserName: 'electron' },
+        };
+
+        const rootBrowser = {
+          instances: ['app1'],
+          getInstance: (name: string) => (name === 'app1' ? browserModeBrowser : undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], rootBrowser);
+
+        await expect((rootBrowser as unknown as WebdriverIO.Browser).electron.mock('my_channel')).rejects.toThrow(
+          'browser.electron.mock() on the root multiremote browser is not supported in browser mode',
+        );
+      });
+
+      it('includes the channel name and per-instance guidance in the error message', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+
+        browserModeBrowser.requestedCapabilities = {
+          alwaysMatch: { browserName: 'electron' },
+        };
+
+        const rootBrowser = {
+          instances: ['app1'],
+          getInstance: (name: string) => (name === 'app1' ? browserModeBrowser : undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], rootBrowser);
+
+        await expect((rootBrowser as unknown as WebdriverIO.Browser).electron.mock('read_file')).rejects.toThrow(
+          "getInstance('name').electron.mock('read_file')",
+        );
+      });
+
+      it('allows mock() on a per-instance browser in multiremote browser mode', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+
+        browserModeBrowser.requestedCapabilities = {
+          alwaysMatch: { browserName: 'electron' },
+        };
+        (browserModeBrowser.execute as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+        const rootBrowser = {
+          instances: ['app1'],
+          getInstance: (name: string) => (name === 'app1' ? browserModeBrowser : undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], rootBrowser);
+
+        const perInstanceBrowser = rootBrowser.getInstance('app1') as WebdriverIO.Browser;
+        await expect(perInstanceBrowser.electron.mock('read_file')).resolves.toBeDefined();
       });
     });
   });

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -886,4 +886,50 @@ describe('Electron Worker Service', () => {
       });
     });
   });
+
+  describe('browser mode', () => {
+    let browserModeBrowser: WebdriverIO.Browser;
+
+    beforeEach(() => {
+      browserModeBrowser = {
+        url: vi.fn().mockResolvedValue(undefined),
+        execute: vi.fn().mockResolvedValue(undefined),
+        overwriteCommand: vi.fn(),
+        electron: {},
+      } as unknown as WebdriverIO.Browser;
+    });
+
+    describe('patchBrowserUrl()', () => {
+      it('re-throws when the IPC injection script fails after navigation', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+        await instance.before({}, [], browserModeBrowser);
+
+        (browserModeBrowser.execute as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+          new Error('Script injection blocked'),
+        );
+
+        await expect(browserModeBrowser.url('http://localhost:5173/settings')).rejects.toThrow(
+          'Script injection blocked',
+        );
+      });
+
+      it('resolves normally when the injection script succeeds after navigation', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+        await instance.before({}, [], browserModeBrowser);
+
+        await expect(browserModeBrowser.url('http://localhost:5173/settings')).resolves.toBeUndefined();
+      });
+
+      it('does not run the injection script when url() is called without a href (get current URL)', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+        await instance.before({}, [], browserModeBrowser);
+
+        const executeCallsBefore = (browserModeBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length;
+        await browserModeBrowser.url();
+        const executeCallsAfter = (browserModeBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length;
+
+        expect(executeCallsAfter).toBe(executeCallsBefore);
+      });
+    });
+  });
 });

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -940,12 +940,56 @@ describe('Electron Worker Service', () => {
       });
     });
 
+    describe('mixed multiremote (non-Electron instances skipped)', () => {
+      it('does not inject the IPC script into non-Electron multiremote instances', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+
+        const electronBrowser = {
+          url: vi.fn().mockResolvedValue(undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          requestedCapabilities: {
+            alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
+          },
+          electron: {},
+        } as unknown as WebdriverIO.Browser;
+
+        const firefoxBrowser = {
+          url: vi.fn().mockResolvedValue(undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          requestedCapabilities: {
+            alwaysMatch: { browserName: 'firefox' },
+          },
+          electron: {},
+        } as unknown as WebdriverIO.Browser;
+
+        const rootBrowser = {
+          instances: ['app1', 'ff1'],
+          getInstance: (name: string) => (name === 'app1' ? electronBrowser : firefoxBrowser),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], rootBrowser);
+
+        // Electron instance gets the injection script
+        expect((electronBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+        // Firefox instance gets no execute calls at all
+        expect((firefoxBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+        expect((firefoxBrowser.url as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+      });
+    });
+
     describe('root multiremote browser.electron.mock()', () => {
       it('throws when mock() is called on the root multiremote browser in browser mode', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         browserModeBrowser.requestedCapabilities = {
-          alwaysMatch: { browserName: 'electron' },
+          alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
         };
 
         const rootBrowser = {
@@ -969,7 +1013,7 @@ describe('Electron Worker Service', () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         browserModeBrowser.requestedCapabilities = {
-          alwaysMatch: { browserName: 'electron' },
+          alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
         };
 
         const rootBrowser = {
@@ -993,7 +1037,7 @@ describe('Electron Worker Service', () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         browserModeBrowser.requestedCapabilities = {
-          alwaysMatch: { browserName: 'electron' },
+          alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
         };
         (browserModeBrowser.execute as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -1005,6 +1005,82 @@ describe('Electron Worker Service', () => {
         expect((firefoxBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
         expect((firefoxBrowser.url as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
       });
+
+      it('re-injects only into Electron instances when root url() is called after navigation', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+
+        const electronBrowser = {
+          url: vi.fn().mockResolvedValue(undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          requestedCapabilities: {
+            alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
+          },
+          electron: {},
+        } as unknown as WebdriverIO.Browser;
+
+        const firefoxBrowser = {
+          url: vi.fn().mockResolvedValue(undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          requestedCapabilities: { alwaysMatch: { browserName: 'firefox' } },
+          electron: {},
+        } as unknown as WebdriverIO.Browser;
+
+        const rootBrowser = {
+          instances: ['app1', 'ff1'],
+          getInstance: (name: string) => (name === 'app1' ? electronBrowser : firefoxBrowser),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], rootBrowser);
+
+        // Navigate via root browser (simulates user calling mrBrowser.url('...'))
+        const electronExecuteBefore = (electronBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length;
+        const firefoxExecuteBefore = (firefoxBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length;
+
+        await (rootBrowser as unknown as WebdriverIO.Browser).url('http://localhost:5173/new-page');
+
+        // Only the Electron instance gets the re-injection execute call
+        expect((electronBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length).toBe(electronExecuteBefore + 1);
+        // Firefox instance gets no additional execute calls
+        expect((firefoxBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length).toBe(firefoxExecuteBefore);
+      });
+
+      it('installs command overrides only on the root browser, not on individual Electron instances', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+
+        const electronBrowser = {
+          url: vi.fn().mockResolvedValue(undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          requestedCapabilities: {
+            alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
+          },
+          electron: {},
+        } as unknown as WebdriverIO.Browser;
+
+        const rootBrowser = {
+          instances: ['app1'],
+          getInstance: (name: string) => (name === 'app1' ? electronBrowser : undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], rootBrowser);
+
+        // Root browser gets overwriteCommand calls (for click, doubleClick, setValue, clearValue)
+        expect((rootBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+        // Per-instance browser gets none — avoids double-wrap through root's override chain
+        expect((electronBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+      });
     });
 
     describe('root multiremote browser.electron.mock()', () => {

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -221,49 +221,13 @@ describe('Electron Worker Service', () => {
       await expect(instance.before({}, [], browser)).rejects.toThrow('Window not found');
     });
 
-    it('should install element command overrides with overwriteCommand', async () => {
+    it('should not install element command overrides in native mode', async () => {
       instance = new ElectronWorkerService({}, {});
 
       await instance.before({}, [], browser);
 
       const oc = vi.mocked((browser as any).overwriteCommand);
-      const calls = oc.mock.calls;
-      // overwriteCommand signature: (name, wrapper, isElement?)
-      const overridden = calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
-      expect(overridden).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'click', isElement: true }),
-          expect.objectContaining({ name: 'doubleClick', isElement: true }),
-          expect.objectContaining({ name: 'setValue', isElement: true }),
-          expect.objectContaining({ name: 'clearValue', isElement: true }),
-        ]),
-      );
-    });
-
-    it('should update mocks after overridden element command executes', async () => {
-      instance = new ElectronWorkerService({}, {});
-      await instance.before({}, [], browser);
-
-      // Prepare mock store to return a mock with update()
-      const storeModule = (await import('../src/mockStore.js')) as any;
-      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
-      storeModule.default.getMocks.mockReturnValueOnce([['id', mockObj]]);
-
-      // Find the override for 'click' and invoke it
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
-      expect(clickCall).toBeDefined();
-      const overrideFn = clickCall?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
-
-      expect(mockObj.update).toHaveBeenCalledTimes(1);
-      expect(original).toHaveBeenCalled();
+      expect(oc).not.toHaveBeenCalled();
     });
 
     it('should copy original api', async () => {
@@ -926,6 +890,22 @@ describe('Electron Worker Service', () => {
         await instance.before({}, [], browserModeBrowser);
 
         await expect(browserModeBrowser.url('http://localhost:5173/settings')).resolves.toBeUndefined();
+      });
+
+      it('should install element command overrides in browser mode', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+        await instance.before({}, [], browserModeBrowser);
+
+        const oc = vi.mocked((browserModeBrowser as any).overwriteCommand);
+        const overridden = oc.mock.calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
+        expect(overridden).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: 'click', isElement: true }),
+            expect.objectContaining({ name: 'doubleClick', isElement: true }),
+            expect.objectContaining({ name: 'setValue', isElement: true }),
+            expect.objectContaining({ name: 'clearValue', isElement: true }),
+          ]),
+        );
       });
 
       it('should not run the injection script when url() is called without a href', async () => {

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -221,49 +221,13 @@ describe('Electron Worker Service', () => {
       await expect(instance.before({}, [], browser)).rejects.toThrow('Window not found');
     });
 
-    it('should install element command overrides with overwriteCommand', async () => {
+    it('should not install element command overrides in native mode', async () => {
       instance = new ElectronWorkerService({}, {});
 
       await instance.before({}, [], browser);
 
       const oc = vi.mocked((browser as any).overwriteCommand);
-      const calls = oc.mock.calls;
-      // overwriteCommand signature: (name, wrapper, isElement?)
-      const overridden = calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
-      expect(overridden).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'click', isElement: true }),
-          expect.objectContaining({ name: 'doubleClick', isElement: true }),
-          expect.objectContaining({ name: 'setValue', isElement: true }),
-          expect.objectContaining({ name: 'clearValue', isElement: true }),
-        ]),
-      );
-    });
-
-    it('should update mocks after overridden element command executes', async () => {
-      instance = new ElectronWorkerService({}, {});
-      await instance.before({}, [], browser);
-
-      // Prepare mock store to return a mock with update()
-      const storeModule = (await import('../src/mockStore.js')) as any;
-      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
-      storeModule.default.getMocks.mockReturnValueOnce([['id', mockObj]]);
-
-      // Find the override for 'click' and invoke it
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
-      expect(clickCall).toBeDefined();
-      const overrideFn = clickCall?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
-
-      expect(mockObj.update).toHaveBeenCalledTimes(1);
-      expect(original).toHaveBeenCalled();
+      expect(oc).not.toHaveBeenCalled();
     });
 
     it('should copy original api', async () => {
@@ -1082,6 +1046,46 @@ describe('Electron Worker Service', () => {
         // overwriteCommand wrapper propagates to all instances' __elementOverrides__ internally,
         // so a separate call on each instance would double-wrap element commands.
         expect((electronBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+      });
+
+      it('installs the four expected element command overrides in browser mode', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+        await instance.before({}, [], browserModeBrowser);
+
+        const oc = vi.mocked((browserModeBrowser as any).overwriteCommand);
+        const overridden = oc.mock.calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
+        expect(overridden).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: 'click', isElement: true }),
+            expect.objectContaining({ name: 'doubleClick', isElement: true }),
+            expect.objectContaining({ name: 'setValue', isElement: true }),
+            expect.objectContaining({ name: 'clearValue', isElement: true }),
+          ]),
+        );
+      });
+
+      it('updates mocks after an overridden element command executes in browser mode', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+        await instance.before({}, [], browserModeBrowser);
+
+        const storeModule = (await import('../src/mockStore.js')) as any;
+        const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+        storeModule.default.getMocks.mockReturnValueOnce([['id', mockObj]]);
+
+        const oc = vi.mocked((browserModeBrowser as any).overwriteCommand);
+        const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
+        expect(clickCall).toBeDefined();
+        const overrideFn = clickCall?.[1] as unknown as (
+          this: WebdriverIO.Element,
+          original: (...args: unknown[]) => Promise<unknown>,
+          ...args: unknown[]
+        ) => Promise<unknown>;
+
+        const original = vi.fn().mockResolvedValue('ok');
+        await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
+
+        expect(mockObj.update).toHaveBeenCalledTimes(1);
+        expect(original).toHaveBeenCalled();
       });
     });
 

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -221,13 +221,46 @@ describe('Electron Worker Service', () => {
       await expect(instance.before({}, [], browser)).rejects.toThrow('Window not found');
     });
 
-    it('should not install element command overrides in native mode', async () => {
+    it('should install element command overrides with overwriteCommand', async () => {
       instance = new ElectronWorkerService({}, {});
 
       await instance.before({}, [], browser);
 
       const oc = vi.mocked((browser as any).overwriteCommand);
-      expect(oc).not.toHaveBeenCalled();
+      const calls = oc.mock.calls;
+      const overridden = calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
+      expect(overridden).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'click', isElement: true }),
+          expect.objectContaining({ name: 'doubleClick', isElement: true }),
+          expect.objectContaining({ name: 'setValue', isElement: true }),
+          expect.objectContaining({ name: 'clearValue', isElement: true }),
+        ]),
+      );
+    });
+
+    it('should update mocks after overridden element command executes', async () => {
+      instance = new ElectronWorkerService({}, {});
+      await instance.before({}, [], browser);
+
+      const storeModule = (await import('../src/mockStore.js')) as any;
+      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+      storeModule.default.getMocks.mockReturnValueOnce([['id', mockObj]]);
+
+      const oc = vi.mocked((browser as any).overwriteCommand);
+      const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
+      expect(clickCall).toBeDefined();
+      const overrideFn = clickCall?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const original = vi.fn().mockResolvedValue('ok');
+      await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
+
+      expect(mockObj.update).toHaveBeenCalledTimes(1);
+      expect(original).toHaveBeenCalled();
     });
 
     it('should copy original api', async () => {

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -221,13 +221,49 @@ describe('Electron Worker Service', () => {
       await expect(instance.before({}, [], browser)).rejects.toThrow('Window not found');
     });
 
-    it('should not install element command overrides in native mode', async () => {
+    it('should install element command overrides with overwriteCommand', async () => {
       instance = new ElectronWorkerService({}, {});
 
       await instance.before({}, [], browser);
 
       const oc = vi.mocked((browser as any).overwriteCommand);
-      expect(oc).not.toHaveBeenCalled();
+      const calls = oc.mock.calls;
+      // overwriteCommand signature: (name, wrapper, isElement?)
+      const overridden = calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
+      expect(overridden).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'click', isElement: true }),
+          expect.objectContaining({ name: 'doubleClick', isElement: true }),
+          expect.objectContaining({ name: 'setValue', isElement: true }),
+          expect.objectContaining({ name: 'clearValue', isElement: true }),
+        ]),
+      );
+    });
+
+    it('should update mocks after overridden element command executes', async () => {
+      instance = new ElectronWorkerService({}, {});
+      await instance.before({}, [], browser);
+
+      // Prepare mock store to return a mock with update()
+      const storeModule = (await import('../src/mockStore.js')) as any;
+      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+      storeModule.default.getMocks.mockReturnValueOnce([['id', mockObj]]);
+
+      // Find the override for 'click' and invoke it
+      const oc = vi.mocked((browser as any).overwriteCommand);
+      const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
+      expect(clickCall).toBeDefined();
+      const overrideFn = clickCall?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const original = vi.fn().mockResolvedValue('ok');
+      await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
+
+      expect(mockObj.update).toHaveBeenCalledTimes(1);
+      expect(original).toHaveBeenCalled();
     });
 
     it('should copy original api', async () => {
@@ -905,7 +941,7 @@ describe('Electron Worker Service', () => {
     });
 
     describe('multiremote missing devServerUrl', () => {
-      it('throws SevereServiceError when an Electron instance has no devServerUrl (neither per-cap nor global)', async () => {
+      it('should throw SevereServiceError when an Electron instance has no devServerUrl', async () => {
         instance = new ElectronWorkerService({ mode: 'browser' }, {});
 
         browserModeBrowser.requestedCapabilities = {
@@ -970,7 +1006,7 @@ describe('Electron Worker Service', () => {
         expect((firefoxBrowser.url as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
       });
 
-      it('re-injects only into Electron instances when root url() is called after navigation', async () => {
+      it('should re-inject only into Electron instances when root url() is called after navigation', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         const electronBrowser = {
@@ -1015,7 +1051,7 @@ describe('Electron Worker Service', () => {
         expect((firefoxBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length).toBe(firefoxExecuteBefore);
       });
 
-      it('installs command overrides only on the root browser, not on individual Electron instances', async () => {
+      it('should install command overrides only on the root browser, not on individual Electron instances', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         const electronBrowser = {
@@ -1047,50 +1083,10 @@ describe('Electron Worker Service', () => {
         // so a separate call on each instance would double-wrap element commands.
         expect((electronBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
       });
-
-      it('installs the four expected element command overrides in browser mode', async () => {
-        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
-        await instance.before({}, [], browserModeBrowser);
-
-        const oc = vi.mocked((browserModeBrowser as any).overwriteCommand);
-        const overridden = oc.mock.calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
-        expect(overridden).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ name: 'click', isElement: true }),
-            expect.objectContaining({ name: 'doubleClick', isElement: true }),
-            expect.objectContaining({ name: 'setValue', isElement: true }),
-            expect.objectContaining({ name: 'clearValue', isElement: true }),
-          ]),
-        );
-      });
-
-      it('updates mocks after an overridden element command executes in browser mode', async () => {
-        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
-        await instance.before({}, [], browserModeBrowser);
-
-        const storeModule = (await import('../src/mockStore.js')) as any;
-        const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
-        storeModule.default.getMocks.mockReturnValueOnce([['id', mockObj]]);
-
-        const oc = vi.mocked((browserModeBrowser as any).overwriteCommand);
-        const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
-        expect(clickCall).toBeDefined();
-        const overrideFn = clickCall?.[1] as unknown as (
-          this: WebdriverIO.Element,
-          original: (...args: unknown[]) => Promise<unknown>,
-          ...args: unknown[]
-        ) => Promise<unknown>;
-
-        const original = vi.fn().mockResolvedValue('ok');
-        await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
-
-        expect(mockObj.update).toHaveBeenCalledTimes(1);
-        expect(original).toHaveBeenCalled();
-      });
     });
 
     describe('root multiremote browser.electron.mock()', () => {
-      it('throws when mock() is called on the root multiremote browser in browser mode', async () => {
+      it('should throw when mock() is called on the root multiremote browser in browser mode', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         browserModeBrowser.requestedCapabilities = {
@@ -1114,7 +1110,7 @@ describe('Electron Worker Service', () => {
         );
       });
 
-      it('includes the channel name and per-instance guidance in the error message', async () => {
+      it('should include the channel name and per-instance guidance in the error message', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         browserModeBrowser.requestedCapabilities = {
@@ -1138,7 +1134,7 @@ describe('Electron Worker Service', () => {
         );
       });
 
-      it('allows mock() on a per-instance browser in multiremote browser mode', async () => {
+      it('should allow mock() on a per-instance browser in multiremote browser mode', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         browserModeBrowser.requestedCapabilities = {

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -263,6 +263,52 @@ describe('Electron Worker Service', () => {
       expect(original).toHaveBeenCalled();
     });
 
+    it('should run two scheduler batches when two overrides fire concurrently', async () => {
+      instance = new ElectronWorkerService({}, {});
+      await instance.before({}, [], browser);
+
+      const storeModule = (await import('../src/mockStore.js')) as any;
+      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+      storeModule.default.getMocks.mockReturnValue([['id', mockObj]]);
+
+      const oc = vi.mocked((browser as any).overwriteCommand);
+      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const original = vi.fn().mockResolvedValue('ok');
+      const p1 = overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      const p2 = overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      await Promise.all([p1, p2]);
+
+      expect(mockObj.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('should recover the scheduler after a batch update rejects', async () => {
+      instance = new ElectronWorkerService({}, {});
+      await instance.before({}, [], browser);
+
+      const storeModule = (await import('../src/mockStore.js')) as any;
+      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+      (mockObj.update as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'));
+      storeModule.default.getMocks.mockReturnValue([['id', mockObj]]);
+
+      const oc = vi.mocked((browser as any).overwriteCommand);
+      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const original = vi.fn().mockResolvedValue('ok');
+      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
+
+      expect(mockObj.update).toHaveBeenCalledTimes(2);
+    });
+
     it('should copy original api', async () => {
       instance = new ElectronWorkerService({}, {});
 

--- a/packages/electron-service/vitest.config.ts
+++ b/packages/electron-service/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     setupFiles: ['test/setup.ts'],
     // Test file discovery patterns
     include: ['test/**/*.spec.ts'],
-    exclude: [...configDefaults.exclude, 'example*/**/*'],
+    exclude: [...configDefaults.exclude, 'example*/**/*', 'test/integration/**'],
     // Coverage configuration
     coverage: {
       enabled: true,

--- a/packages/electron-service/vitest.integration.config.ts
+++ b/packages/electron-service/vitest.integration.config.ts
@@ -1,0 +1,15 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/integration/**/*.spec.ts'],
+    exclude: [...configDefaults.exclude],
+    sequence: { concurrent: false },
+    testTimeout: 30000,
+    hookTimeout: 15000,
+    teardownTimeout: 10000,
+    fileParallelism: false,
+  },
+});

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -81,7 +81,7 @@ export class ElectronAdapter implements FrameworkAdapter {
   const callback = (${callbackFnSource});
   let result;
   const mockObj = ${lookup};
-  await mockObj?.withImplementation?.(impl, async () => { result = await (_electron !== undefined ? callback(_electron) : callback()); });
+  await mockObj?.withImplementation?.(impl, async () => { result = await callback(); });
   return result;
 }`;
   }

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -1,47 +1,110 @@
 import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
+import { errorReconstructExpr, mockLookupExpr, WDIO_MOCK_SETUP_SCRIPT } from './injection.js';
 import type { IpcContext } from './ipcContext.js';
+import { buildContextSeedScript } from './ipcContext.js';
 import type { SerializedHandler } from './serialize.js';
+import { safeJson } from './serialize.js';
 
-/**
- * @internal Placeholder adapter — Electron support is not yet implemented.
- * All methods throw `'Not implemented'` at runtime. Do not use in production code.
- */
 export class ElectronAdapter implements FrameworkAdapter {
   readonly framework = 'electron' as const;
 
-  buildRegistrationScript(_mockName: string): string {
-    throw new Error('Not implemented');
+  buildRegistrationScript(mockName: string): string {
+    return `(_electron) => {
+  const spy = window.__wdio_spy__;
+  if (!spy?.fn) { throw new Error('@wdio/native-spy not available. Make sure browser mode is initialized in your test config.'); }
+  const mockFn = spy.fn();
+  mockFn.mockName(${JSON.stringify(`electron.${mockName}`)});
+  if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }
+  window.__wdio_mocks__[${JSON.stringify(mockName)}] = mockFn;
+  mockFn.mockClear();
+}`;
   }
 
-  buildSetImplementationScript(_mockName: string, _s: SerializedHandler, _once?: boolean): string {
-    throw new Error('Not implemented');
+  buildCallDataReadScript(mockName: string): string {
+    const lookup = mockLookupExpr(mockName);
+    return `(_electron) => {
+  const mockObj = ${lookup};
+  if (!mockObj?.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
+  const m = mockObj.mock;
+  return {
+    calls: JSON.parse(JSON.stringify(m.calls || [])),
+    results: JSON.parse(JSON.stringify(m.results || [])),
+    invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
+  };
+}`;
   }
 
-  buildInnerInvocationScript(_mockName: string, _method: InnerMockMethod): string {
-    throw new Error('Not implemented');
+  buildSetImplementationScript(mockName: string, s: SerializedHandler, once = false): string {
+    const lookup = mockLookupExpr(mockName);
+    const method = once ? 'mockImplementationOnce' : 'mockImplementation';
+    return `(_electron) => {
+  const mockObj = ${lookup};
+  if (mockObj) { mockObj.${method}?.((${s.source})); }
+}`;
   }
 
-  buildInnerSetterScript(_mockName: string, _method: InnerMockSetterMethod, _value: unknown): string {
-    throw new Error('Not implemented');
+  buildInnerInvocationScript(mockName: string, method: InnerMockMethod): string {
+    const lookup = mockLookupExpr(mockName);
+    return `(_electron) => {
+  const mockObj = ${lookup};
+  mockObj?.${method}?.();
+}`;
   }
 
-  buildCallDataReadScript(_mockName: string): string {
-    throw new Error('Not implemented');
+  buildInnerSetterScript(mockName: string, method: InnerMockSetterMethod, value: unknown): string {
+    const lookup = mockLookupExpr(mockName);
+    const serialized = safeJson(value);
+    const reconstruct = errorReconstructExpr('_v');
+    return `(_electron) => {
+  const _v = ${serialized};
+  const mockObj = ${lookup};
+  mockObj?.${method}?.(${reconstruct});
+}`;
   }
 
-  buildUnregistrationScript(_mockName: string): string {
-    throw new Error('Not implemented');
+  buildUnregistrationScript(mockName: string): string {
+    return `(_electron) => {
+  if (window.__wdio_mocks__?.[${JSON.stringify(mockName)}]) {
+    delete window.__wdio_mocks__[${JSON.stringify(mockName)}];
+  }
+}`;
   }
 
-  buildWithImplementationScript(_mockName: string, _implFnSource: string, _callbackFnSource: string): string {
-    throw new Error('Not implemented');
+  buildContextSeedScript(context: IpcContext): string {
+    return buildContextSeedScript(context);
   }
 
-  buildContextSeedScript(_context: IpcContext): string {
-    throw new Error('Not implemented');
+  buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string {
+    const lookup = mockLookupExpr(mockName);
+    return `async (_electron) => {
+  const impl = (${implFnSource});
+  const callback = (${callbackFnSource});
+  let result;
+  const mockObj = ${lookup};
+  await mockObj?.withImplementation?.(impl, async () => { result = await (_electron !== undefined ? callback(_electron) : callback()); });
+  return result;
+}`;
   }
 
   buildBrowserIpcInjectionScript(): string {
-    throw new Error('Not implemented');
+    return `(function() {
+${WDIO_MOCK_SETUP_SCRIPT}
+  if (!window.electron) { window.electron = {}; }
+  if (!window.electron.ipcRenderer) { window.electron.ipcRenderer = {}; }
+  window.electron.ipcRenderer.invoke = function(channel) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    var mock = window.__wdio_mocks__ && window.__wdio_mocks__[channel];
+    if (mock && typeof mock === 'function') {
+      return Promise.resolve().then(function() { return mock.apply(null, args); });
+    }
+    return Promise.reject(new Error('unmocked Electron IPC channel in browser mode: ' + channel));
+  };
+  window.electron.ipcRenderer.send = function(channel) {
+    throw new Error('unmocked Electron IPC channel in browser mode: ' + channel);
+  };
+  window.electron.ipcRenderer.sendSync = function(channel) {
+    throw new Error('unmocked Electron IPC channel in browser mode: ' + channel);
+  };
+})()`;
   }
 }

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -105,6 +105,10 @@ ${WDIO_MOCK_SETUP_SCRIPT}
   window.electron.ipcRenderer.sendSync = function(channel) {
     throw new Error('unmocked Electron IPC channel in browser mode: ' + channel);
   };
+  window.electron.ipcRenderer.on = function() {};
+  window.electron.ipcRenderer.once = function() {};
+  window.electron.ipcRenderer.removeListener = function() {};
+  window.electron.ipcRenderer.removeAllListeners = function() {};
 })()`;
   }
 }

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -106,9 +106,20 @@ ${WDIO_MOCK_SETUP_SCRIPT}
     return Promise.reject(new Error('unmocked Electron IPC channel in browser mode: ' + channel));
   };
   window.electron.ipcRenderer.send = function(channel) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    var mock = window.__wdio_mocks__ && window.__wdio_mocks__[channel];
+    if (mock && typeof mock === 'function') {
+      mock.apply(null, args);
+      return;
+    }
     throw new Error('unmocked Electron IPC channel in browser mode: ' + channel);
   };
   window.electron.ipcRenderer.sendSync = function(channel) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    var mock = window.__wdio_mocks__ && window.__wdio_mocks__[channel];
+    if (mock && typeof mock === 'function') {
+      return mock.apply(null, args);
+    }
     throw new Error('unmocked Electron IPC channel in browser mode: ' + channel);
   };
   window.electron.ipcRenderer.on = function() {};

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -26,9 +26,15 @@ export class ElectronAdapter implements FrameworkAdapter {
   const mockObj = ${lookup};
   if (!mockObj?.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
   const m = mockObj.mock;
+  const errorReplacer = function(_k, v) {
+    if (v instanceof Error) {
+      return { __wdioError: true, name: v.name, message: v.message, stack: v.stack };
+    }
+    return v;
+  };
   return {
-    calls: JSON.parse(JSON.stringify(m.calls || [])),
-    results: JSON.parse(JSON.stringify(m.results || [])),
+    calls: JSON.parse(JSON.stringify(m.calls || [], errorReplacer)),
+    results: JSON.parse(JSON.stringify(m.results || [], errorReplacer)),
     invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
   };
 }`;

--- a/packages/native-spy/src/interceptor/electron.ts
+++ b/packages/native-spy/src/interceptor/electron.ts
@@ -118,7 +118,15 @@ ${WDIO_MOCK_SETUP_SCRIPT}
     var args = Array.prototype.slice.call(arguments, 1);
     var mock = window.__wdio_mocks__ && window.__wdio_mocks__[channel];
     if (mock && typeof mock === 'function') {
-      return mock.apply(null, args);
+      var result = mock.apply(null, args);
+      if (result && typeof result.then === 'function') {
+        throw new Error(
+          'Electron sendSync mock returned a Promise for channel "' + channel + '". ' +
+          'sendSync is synchronous — use mockReturnValue(...) (not mockResolvedValue) ' +
+          'or a synchronous mockImplementation.'
+        );
+      }
+      return result;
     }
     throw new Error('unmocked Electron IPC channel in browser mode: ' + channel);
   };

--- a/packages/native-spy/src/interceptor/injection.ts
+++ b/packages/native-spy/src/interceptor/injection.ts
@@ -31,6 +31,14 @@ export const WDIO_MOCK_SETUP_SCRIPT = `  window.__wdio_call_id__ = window.__wdio
       _calls.push(args);
       _invocationCallOrder.push(window.__wdio_call_id__++);
       var impl = _implQueue.length > 0 ? _implQueue.shift() : _defaultImpl;
+      if (impl !== null && impl !== undefined && typeof impl === 'object' && impl.__wdioType) {
+        if (impl.__wdioType === 'resolve') {
+          _results.push({ type: 'return', value: impl.__wdioVal });
+          return Promise.resolve(impl.__wdioVal);
+        }
+        _results.push({ type: 'throw', value: impl.__wdioVal });
+        return Promise.reject(impl.__wdioVal);
+      }
       if (impl !== undefined) {
         try {
           var val = impl.apply(this, args);
@@ -42,13 +50,11 @@ export const WDIO_MOCK_SETUP_SCRIPT = `  window.__wdio_call_id__ = window.__wdio
         }
       } else if (_defaultRejectedValue !== NOT_SET) {
         var rv = _defaultRejectedValue;
-        var rejectedPromise = Promise.reject(rv);
-        _results.push({ type: 'return', value: rejectedPromise });
-        return rejectedPromise;
+        _results.push({ type: 'throw', value: rv });
+        return Promise.reject(rv);
       } else if (_defaultResolvedValue !== NOT_SET) {
-        var p = Promise.resolve(_defaultResolvedValue);
-        _results.push({ type: 'return', value: p });
-        return p;
+        _results.push({ type: 'return', value: _defaultResolvedValue });
+        return Promise.resolve(_defaultResolvedValue);
       } else if (_returnThis) {
         _results.push({ type: 'return', value: this });
         return this;
@@ -80,14 +86,14 @@ export const WDIO_MOCK_SETUP_SCRIPT = `  window.__wdio_call_id__ = window.__wdio
       _defaultRejectedValue = NOT_SET; _returnThis = false; return mockFn;
     };
     mockFn.mockResolvedValueOnce = function(val) {
-      _implQueue.push(function() { return Promise.resolve(val); }); return mockFn;
+      _implQueue.push({ __wdioType: 'resolve', __wdioVal: val }); return mockFn;
     };
     mockFn.mockRejectedValue = function(val) {
       _defaultImpl = undefined; _defaultRejectedValue = val; _defaultReturnValue = NOT_SET;
       _defaultResolvedValue = NOT_SET; _returnThis = false; return mockFn;
     };
     mockFn.mockRejectedValueOnce = function(val) {
-      _implQueue.push(function() { return Promise.reject(val); }); return mockFn;
+      _implQueue.push({ __wdioType: 'reject', __wdioVal: val }); return mockFn;
     };
     mockFn.mockClear = function() {
       _calls = []; _results = []; _invocationCallOrder = [];

--- a/packages/native-spy/src/interceptor/injection.ts
+++ b/packages/native-spy/src/interceptor/injection.ts
@@ -5,3 +5,120 @@ export function mockLookupExpr(mockName: string): string {
 export function errorReconstructExpr(varName: string): string {
   return `(${varName} && typeof ${varName} === 'object' && ${varName}.__wdioError === true ? new Error(${varName}.message) : ${varName})`;
 }
+
+/**
+ * Self-contained browser-side mock factory setup script (no imports).
+ * Emitted verbatim inside an IIFE by each framework adapter's
+ * buildBrowserIpcInjectionScript(). Sets up window.__wdio_call_id__,
+ * defines createMockFn, and assigns window.__wdio_spy__ + window.__wdio_mocks__.
+ * Callers append the framework-specific IPC patch after this block.
+ */
+export const WDIO_MOCK_SETUP_SCRIPT = `  window.__wdio_call_id__ = window.__wdio_call_id__ || 0;
+  var NOT_SET = {};
+  function createMockFn() {
+    var _name = 'spy';
+    var _defaultImpl;
+    var _implQueue = [];
+    var _defaultReturnValue = NOT_SET;
+    var _defaultResolvedValue = NOT_SET;
+    var _defaultRejectedValue = NOT_SET;
+    var _returnThis = false;
+    var _calls = [];
+    var _results = [];
+    var _invocationCallOrder = [];
+    function mockFn() {
+      var args = Array.prototype.slice.call(arguments);
+      _calls.push(args);
+      _invocationCallOrder.push(window.__wdio_call_id__++);
+      var impl = _implQueue.length > 0 ? _implQueue.shift() : _defaultImpl;
+      if (impl !== undefined) {
+        try {
+          var val = impl.apply(this, args);
+          _results.push({ type: 'return', value: val });
+          return val;
+        } catch (e) {
+          _results.push({ type: 'throw', value: e });
+          throw e;
+        }
+      } else if (_defaultRejectedValue !== NOT_SET) {
+        var rv = _defaultRejectedValue;
+        var rejectedPromise = Promise.reject(rv);
+        _results.push({ type: 'return', value: rejectedPromise });
+        return rejectedPromise;
+      } else if (_defaultResolvedValue !== NOT_SET) {
+        var p = Promise.resolve(_defaultResolvedValue);
+        _results.push({ type: 'return', value: p });
+        return p;
+      } else if (_returnThis) {
+        _results.push({ type: 'return', value: this });
+        return this;
+      } else if (_defaultReturnValue !== NOT_SET) {
+        _results.push({ type: 'return', value: _defaultReturnValue });
+        return _defaultReturnValue;
+      } else {
+        _results.push({ type: 'return', value: undefined });
+        return undefined;
+      }
+    }
+    mockFn._isMockFunction = true;
+    Object.defineProperty(mockFn, 'mock', {
+      get: function() { return { calls: _calls, results: _results, invocationCallOrder: _invocationCallOrder }; },
+      enumerable: true, configurable: true
+    });
+    mockFn.mockName = function(n) { _name = n; return mockFn; };
+    mockFn.getMockName = function() { return _name; };
+    mockFn.getMockImplementation = function() { return _defaultImpl; };
+    mockFn.mockImplementation = function(fn) { _defaultImpl = fn; _returnThis = false; return mockFn; };
+    mockFn.mockImplementationOnce = function(fn) { _implQueue.push(fn); return mockFn; };
+    mockFn.mockReturnValue = function(val) {
+      _defaultImpl = undefined; _defaultReturnValue = val; _defaultResolvedValue = NOT_SET;
+      _defaultRejectedValue = NOT_SET; _returnThis = false; return mockFn;
+    };
+    mockFn.mockReturnValueOnce = function(val) { _implQueue.push(function() { return val; }); return mockFn; };
+    mockFn.mockResolvedValue = function(val) {
+      _defaultImpl = undefined; _defaultResolvedValue = val; _defaultReturnValue = NOT_SET;
+      _defaultRejectedValue = NOT_SET; _returnThis = false; return mockFn;
+    };
+    mockFn.mockResolvedValueOnce = function(val) {
+      _implQueue.push(function() { return Promise.resolve(val); }); return mockFn;
+    };
+    mockFn.mockRejectedValue = function(val) {
+      _defaultImpl = undefined; _defaultRejectedValue = val; _defaultReturnValue = NOT_SET;
+      _defaultResolvedValue = NOT_SET; _returnThis = false; return mockFn;
+    };
+    mockFn.mockRejectedValueOnce = function(val) {
+      _implQueue.push(function() { return Promise.reject(val); }); return mockFn;
+    };
+    mockFn.mockClear = function() {
+      _calls = []; _results = []; _invocationCallOrder = [];
+      return mockFn;
+    };
+    mockFn.mockReset = function() {
+      mockFn.mockClear();
+      _implQueue = [];
+      _defaultImpl = undefined; _defaultReturnValue = NOT_SET;
+      _defaultResolvedValue = NOT_SET; _defaultRejectedValue = NOT_SET; _returnThis = false;
+      return mockFn;
+    };
+    mockFn.mockReturnThis = function() {
+      _returnThis = true; _defaultReturnValue = NOT_SET; _defaultResolvedValue = NOT_SET;
+      _defaultRejectedValue = NOT_SET; return mockFn;
+    };
+    mockFn.withImplementation = function(fn, callback) {
+      var prevImpl = _defaultImpl, prevQueue = _implQueue.slice(), prevReturnThis = _returnThis;
+      _defaultImpl = fn; _implQueue = []; _returnThis = false;
+      var result = callback();
+      if (result && typeof result.then === 'function') {
+        return result.then(function(r) {
+          _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis; return r;
+        }, function(e) {
+          _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis; throw e;
+        });
+      }
+      _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis;
+      return result;
+    };
+    return mockFn;
+  }
+  window.__wdio_spy__ = { fn: createMockFn };
+  if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }`;

--- a/packages/native-spy/src/interceptor/injection.ts
+++ b/packages/native-spy/src/interceptor/injection.ts
@@ -67,8 +67,9 @@ export const WDIO_MOCK_SETUP_SCRIPT = `  window.__wdio_call_id__ = window.__wdio
       }
     }
     mockFn._isMockFunction = true;
+    var _mockSnapshot = { calls: _calls, results: _results, invocationCallOrder: _invocationCallOrder };
     Object.defineProperty(mockFn, 'mock', {
-      get: function() { return { calls: _calls, results: _results, invocationCallOrder: _invocationCallOrder }; },
+      get: function() { return _mockSnapshot; },
       enumerable: true, configurable: true
     });
     mockFn.mockName = function(n) { _name = n; return mockFn; };

--- a/packages/native-spy/src/interceptor/injection.ts
+++ b/packages/native-spy/src/interceptor/injection.ts
@@ -126,5 +126,5 @@ export const WDIO_MOCK_SETUP_SCRIPT = `  window.__wdio_call_id__ = window.__wdio
     };
     return mockFn;
   }
-  window.__wdio_spy__ = { fn: createMockFn };
+  if (!window.__wdio_spy__) { window.__wdio_spy__ = { fn: createMockFn }; }
   if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }`;

--- a/packages/native-spy/src/interceptor/injection.ts
+++ b/packages/native-spy/src/interceptor/injection.ts
@@ -96,7 +96,7 @@ export const WDIO_MOCK_SETUP_SCRIPT = `  window.__wdio_call_id__ = window.__wdio
       _implQueue.push({ __wdioType: 'reject', __wdioVal: val }); return mockFn;
     };
     mockFn.mockClear = function() {
-      _calls = []; _results = []; _invocationCallOrder = [];
+      _calls.length = 0; _results.length = 0; _invocationCallOrder.length = 0;
       return mockFn;
     };
     mockFn.mockReset = function() {

--- a/packages/native-spy/src/interceptor/syncProtocol.ts
+++ b/packages/native-spy/src/interceptor/syncProtocol.ts
@@ -4,12 +4,36 @@ export interface MockCallData {
   invocationCallOrder: number[];
 }
 
+function reconstructErrors(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(reconstructErrors);
+  const obj = value as Record<string, unknown>;
+  if (obj.__wdioError === true) {
+    const err = new Error(typeof obj.message === 'string' ? obj.message : '');
+    if (typeof obj.name === 'string') err.name = obj.name;
+    if (typeof obj.stack === 'string') err.stack = obj.stack;
+    return err;
+  }
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(obj)) out[k] = reconstructErrors(obj[k]);
+  return out;
+}
+
 export function parseCallData(raw: unknown): MockCallData {
   if (!raw || typeof raw !== 'object') return { calls: [], results: [], invocationCallOrder: [] };
   const r = raw as Record<string, unknown>;
+  const calls = Array.isArray(r.calls)
+    ? (r.calls as unknown[][]).map((args) => (Array.isArray(args) ? args.map(reconstructErrors) : args) as unknown[])
+    : [];
+  const results = Array.isArray(r.results)
+    ? (r.results as MockCallData['results']).map((res) => ({
+        type: res.type,
+        value: reconstructErrors(res.value),
+      }))
+    : [];
   return {
-    calls: Array.isArray(r.calls) ? (r.calls as unknown[][]) : [],
-    results: Array.isArray(r.results) ? (r.results as MockCallData['results']) : [],
+    calls,
+    results,
     invocationCallOrder: Array.isArray(r.invocationCallOrder) ? (r.invocationCallOrder as number[]) : [],
   };
 }

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -1,5 +1,5 @@
 import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
-import { errorReconstructExpr, mockLookupExpr } from './injection.js';
+import { errorReconstructExpr, mockLookupExpr, WDIO_MOCK_SETUP_SCRIPT } from './injection.js';
 import type { IpcContext } from './ipcContext.js';
 import { buildContextSeedScript } from './ipcContext.js';
 import type { SerializedHandler } from './serialize.js';
@@ -76,115 +76,7 @@ export class TauriAdapter implements FrameworkAdapter {
 
   buildBrowserIpcInjectionScript(): string {
     return `(function() {
-  window.__wdio_call_id__ = window.__wdio_call_id__ || 0;
-  var NOT_SET = {};
-  function createMockFn() {
-    var _name = 'spy';
-    var _defaultImpl;
-    var _implQueue = [];
-    var _defaultReturnValue = NOT_SET;
-    var _defaultResolvedValue = NOT_SET;
-    var _defaultRejectedValue = NOT_SET;
-    var _returnThis = false;
-    var _calls = [];
-    var _results = [];
-    var _invocationCallOrder = [];
-    function mockFn() {
-      var args = Array.prototype.slice.call(arguments);
-      _calls.push(args);
-      _invocationCallOrder.push(window.__wdio_call_id__++);
-      var impl = _implQueue.length > 0 ? _implQueue.shift() : _defaultImpl;
-      if (impl !== undefined) {
-        try {
-          var val = impl.apply(this, args);
-          _results.push({ type: 'return', value: val });
-          return val;
-        } catch (e) {
-          _results.push({ type: 'throw', value: e });
-          throw e;
-        }
-      } else if (_defaultRejectedValue !== NOT_SET) {
-        var rv = _defaultRejectedValue;
-        var rejectedPromise = Promise.reject(rv);
-        _results.push({ type: 'return', value: rejectedPromise });
-        return rejectedPromise;
-      } else if (_defaultResolvedValue !== NOT_SET) {
-        var p = Promise.resolve(_defaultResolvedValue);
-        _results.push({ type: 'return', value: p });
-        return p;
-      } else if (_returnThis) {
-        _results.push({ type: 'return', value: this });
-        return this;
-      } else if (_defaultReturnValue !== NOT_SET) {
-        _results.push({ type: 'return', value: _defaultReturnValue });
-        return _defaultReturnValue;
-      } else {
-        _results.push({ type: 'return', value: undefined });
-        return undefined;
-      }
-    }
-    mockFn._isMockFunction = true;
-    Object.defineProperty(mockFn, 'mock', {
-      get: function() { return { calls: _calls, results: _results, invocationCallOrder: _invocationCallOrder }; },
-      enumerable: true, configurable: true
-    });
-    mockFn.mockName = function(n) { _name = n; return mockFn; };
-    mockFn.getMockName = function() { return _name; };
-    mockFn.getMockImplementation = function() { return _defaultImpl; };
-    mockFn.mockImplementation = function(fn) { _defaultImpl = fn; _returnThis = false; return mockFn; };
-    mockFn.mockImplementationOnce = function(fn) { _implQueue.push(fn); return mockFn; };
-    mockFn.mockReturnValue = function(val) {
-      _defaultImpl = undefined; _defaultReturnValue = val; _defaultResolvedValue = NOT_SET;
-      _defaultRejectedValue = NOT_SET; _returnThis = false; return mockFn;
-    };
-    mockFn.mockReturnValueOnce = function(val) { _implQueue.push(function() { return val; }); return mockFn; };
-    mockFn.mockResolvedValue = function(val) {
-      _defaultImpl = undefined; _defaultResolvedValue = val; _defaultReturnValue = NOT_SET;
-      _defaultRejectedValue = NOT_SET; _returnThis = false; return mockFn;
-    };
-    mockFn.mockResolvedValueOnce = function(val) {
-      _implQueue.push(function() { return Promise.resolve(val); }); return mockFn;
-    };
-    mockFn.mockRejectedValue = function(val) {
-      _defaultImpl = undefined; _defaultRejectedValue = val; _defaultReturnValue = NOT_SET;
-      _defaultResolvedValue = NOT_SET; _returnThis = false; return mockFn;
-    };
-    mockFn.mockRejectedValueOnce = function(val) {
-      _implQueue.push(function() { return Promise.reject(val); }); return mockFn;
-    };
-    mockFn.mockClear = function() {
-      _calls = []; _results = []; _invocationCallOrder = [];
-      return mockFn;
-    };
-    mockFn.mockReset = function() {
-      mockFn.mockClear();
-      _implQueue = [];
-      _defaultImpl = undefined; _defaultReturnValue = NOT_SET;
-      _defaultResolvedValue = NOT_SET; _defaultRejectedValue = NOT_SET; _returnThis = false;
-      return mockFn;
-    };
-    mockFn.mockReturnThis = function() {
-      _returnThis = true; _defaultReturnValue = NOT_SET; _defaultResolvedValue = NOT_SET;
-      _defaultRejectedValue = NOT_SET; return mockFn;
-    };
-    mockFn.withImplementation = function(fn, callback) {
-      var prevImpl = _defaultImpl, prevQueue = _implQueue.slice(), prevReturnThis = _returnThis;
-      _defaultImpl = fn; _implQueue = []; _returnThis = false;
-      var result = callback();
-      if (result && typeof result.then === 'function') {
-        return result.then(function(r) {
-          _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis; return r;
-        }, function(e) {
-          _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis; throw e;
-        });
-      }
-      _defaultImpl = prevImpl; _implQueue = prevQueue; _returnThis = prevReturnThis;
-      return result;
-    };
-    return mockFn;
-  }
-  window.__wdio_spy__ = { fn: createMockFn };
-  if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }
+${WDIO_MOCK_SETUP_SCRIPT}
   if (!window.__TAURI_INTERNALS__) { window.__TAURI_INTERNALS__ = {}; }
   window.__TAURI_INTERNALS__.invoke = function(cmd, args, options) {
     var mock = window.__wdio_mocks__ && window.__wdio_mocks__[cmd];

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -78,10 +78,105 @@ export class TauriAdapter implements FrameworkAdapter {
     return `(function() {
 ${WDIO_MOCK_SETUP_SCRIPT}
   if (!window.__TAURI_INTERNALS__) { window.__TAURI_INTERNALS__ = {}; }
+  if (!window.__TAURI_INTERNALS__.callbacks) {
+    var __wdio_callbacks__ = new Map();
+    var __wdio_uid__ = 0;
+    window.__TAURI_INTERNALS__.callbacks = __wdio_callbacks__;
+    window.__TAURI_INTERNALS__.transformCallback = function(cb, once) {
+      var id = ++__wdio_uid__;
+      __wdio_callbacks__.set(id, function(data) {
+        if (once) { __wdio_callbacks__.delete(id); }
+        return cb && cb(data);
+      });
+      return id;
+    };
+    window.__TAURI_INTERNALS__.runCallback = function(id, data) {
+      var cb = __wdio_callbacks__.get(id);
+      if (cb) { cb(data); }
+    };
+    window.__TAURI_INTERNALS__.unregisterCallback = function(id) {
+      __wdio_callbacks__.delete(id);
+    };
+  }
+  if (!window.__wdio_tauri_listeners__) { window.__wdio_tauri_listeners__ = {}; }
+  if (typeof window.__wdio_event_id_seq__ !== 'number') { window.__wdio_event_id_seq__ = 0; }
+  if (!window.__TAURI_EVENT_PLUGIN_INTERNALS__) {
+    window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+      unregisterListener: function(event, eventId) {
+        var bucket = window.__wdio_tauri_listeners__[event];
+        if (bucket) { delete bucket[eventId]; }
+      }
+    };
+  }
+  function __wdio_normalize_target__(t) {
+    if (t === undefined || t === null) { return { kind: 'Any' }; }
+    if (typeof t === 'string') { return { kind: 'AnyLabel', label: t }; }
+    return t;
+  }
+  function __wdio_target_matches__(subscriberTarget, emitTarget) {
+    var s = __wdio_normalize_target__(subscriberTarget);
+    var e = __wdio_normalize_target__(emitTarget);
+    if (s.kind === 'Any' || e.kind === 'Any') { return true; }
+    if (s.kind === 'App' || e.kind === 'App') { return s.kind === e.kind; }
+    return s.label === e.label;
+  }
+  window.__wdio_emit_tauri_event__ = function(eventName, payload, target) {
+    var bucket = window.__wdio_tauri_listeners__[eventName];
+    if (!bucket) { return; }
+    var ids = Object.keys(bucket);
+    for (var i = 0; i < ids.length; i++) {
+      var entry = bucket[ids[i]];
+      if (!entry) { continue; }
+      if (target !== undefined && !__wdio_target_matches__(entry.target, target)) { continue; }
+      window.__TAURI_INTERNALS__.runCallback(entry.handlerId, {
+        event: eventName,
+        id: Number(ids[i]),
+        payload: payload
+      });
+    }
+  };
+  function __wdio_handle_plugin_event__(cmd, args) {
+    if (cmd === 'plugin:event|listen') {
+      var eventId = ++window.__wdio_event_id_seq__;
+      var ev = args && args.event;
+      if (!window.__wdio_tauri_listeners__[ev]) { window.__wdio_tauri_listeners__[ev] = {}; }
+      window.__wdio_tauri_listeners__[ev][eventId] = {
+        handlerId: args && args.handler,
+        target: args && args.target
+      };
+      return Promise.resolve(eventId);
+    }
+    if (cmd === 'plugin:event|unlisten') {
+      var ev2 = args && args.event;
+      var id = args && args.eventId;
+      var bucket = window.__wdio_tauri_listeners__[ev2];
+      if (bucket) { delete bucket[id]; }
+      return Promise.resolve();
+    }
+    if (cmd === 'plugin:event|emit') {
+      window.__wdio_emit_tauri_event__(args && args.event, args && args.payload);
+      return Promise.resolve();
+    }
+    if (cmd === 'plugin:event|emit_to') {
+      window.__wdio_emit_tauri_event__(args && args.event, args && args.payload, args && args.target);
+      return Promise.resolve();
+    }
+    return Promise.resolve();
+  }
   window.__TAURI_INTERNALS__.invoke = function(cmd, args, options) {
     var mock = window.__wdio_mocks__ && window.__wdio_mocks__[cmd];
     if (mock && typeof mock === 'function') {
-      return Promise.resolve().then(function() { return mock(args, options); });
+      var mockResult = Promise.resolve().then(function() { return mock(args, options); });
+      if (cmd && cmd.indexOf('plugin:event|') === 0) {
+        return mockResult.then(function() { return __wdio_handle_plugin_event__(cmd, args); });
+      }
+      return mockResult;
+    }
+    if (cmd && cmd.indexOf('plugin:event|') === 0) {
+      return __wdio_handle_plugin_event__(cmd, args);
+    }
+    if (cmd && cmd.indexOf('plugin:') === 0) {
+      return Promise.resolve();
     }
     return Promise.reject(new Error('unmocked Tauri command in browser mode: ' + cmd));
   };

--- a/packages/native-spy/src/interceptor/tauri.ts
+++ b/packages/native-spy/src/interceptor/tauri.ts
@@ -26,9 +26,15 @@ export class TauriAdapter implements FrameworkAdapter {
   const mockObj = ${lookup};
   if (!mockObj?.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
   const m = mockObj.mock;
+  const errorReplacer = function(_k, v) {
+    if (v instanceof Error) {
+      return { __wdioError: true, name: v.name, message: v.message, stack: v.stack };
+    }
+    return v;
+  };
   return {
-    calls: JSON.parse(JSON.stringify(m.calls || [])),
-    results: JSON.parse(JSON.stringify(m.results || [])),
+    calls: JSON.parse(JSON.stringify(m.calls || [], errorReplacer)),
+    results: JSON.parse(JSON.stringify(m.results || [], errorReplacer)),
     invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
   };
 }`;

--- a/packages/native-spy/src/mock.ts
+++ b/packages/native-spy/src/mock.ts
@@ -147,11 +147,11 @@ export function fn<T extends (...args: unknown[]) => unknown = (...args: unknown
   mockFn.getMockName = (): string => mockNameValue;
 
   mockFn.mockClear = function (this: Mock<T>): Mock<T> {
-    state.calls = [];
-    state.contexts = [];
-    state.results = [];
-    state.invocationCallOrder = [];
-    state.instances = [];
+    state.calls.length = 0;
+    state.contexts.length = 0;
+    state.results.length = 0;
+    state.invocationCallOrder.length = 0;
+    state.instances.length = 0;
     implementationQueue.length = 0;
     return this;
   };

--- a/packages/native-spy/test/interceptor/electron-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/electron-browser.spec.ts
@@ -1,0 +1,155 @@
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+import { ElectronAdapter } from '../../src/interceptor/electron.js';
+import { createIpcInterceptor } from '../../src/interceptor/index.js';
+
+function runInBrowserContext(script: string, windowProps: Record<string, unknown> = {}) {
+  const window: Record<string, unknown> = { ...windowProps };
+  const ctx = vm.createContext({ window, Promise });
+  vm.runInContext(script, ctx);
+  return window;
+}
+
+describe('ElectronAdapter.buildBrowserIpcInjectionScript', () => {
+  const adapter = new ElectronAdapter();
+
+  it('should set window.__wdio_spy__ with a fn factory', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    expect(typeof (window.__wdio_spy__ as Record<string, unknown>)?.fn).toBe('function');
+  });
+
+  it('should create window.__wdio_mocks__ if absent', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    expect(window.__wdio_mocks__).toEqual({});
+  });
+
+  it('should not overwrite existing window.__wdio_mocks__', () => {
+    const existing = { 'my-channel': () => {} };
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script, { __wdio_mocks__: existing });
+    expect(window.__wdio_mocks__).toBe(existing);
+  });
+
+  it('should create window.electron.ipcRenderer if absent', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const ipcRenderer = (window.electron as Record<string, unknown>)?.ipcRenderer as Record<string, unknown>;
+    expect(typeof ipcRenderer?.invoke).toBe('function');
+    expect(typeof ipcRenderer?.send).toBe('function');
+    expect(typeof ipcRenderer?.sendSync).toBe('function');
+  });
+
+  it('should preserve existing window.electron object and only patch ipcRenderer', () => {
+    const existingElectron = { other: 'value' };
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script, { electron: existingElectron });
+    const electron = window.electron as Record<string, unknown>;
+    expect(electron.other).toBe('value');
+    const ipcRenderer = electron.ipcRenderer as Record<string, unknown>;
+    expect(typeof ipcRenderer?.invoke).toBe('function');
+  });
+
+  it('should reject with error for unmocked invoke calls', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    const invoke = ipcRenderer.invoke as (channel: string, ...args: unknown[]) => Promise<unknown>;
+    await expect(invoke('unknown-channel')).rejects.toThrow(
+      'unmocked Electron IPC channel in browser mode: unknown-channel',
+    );
+  });
+
+  it('should route invoke to window.__wdio_mocks__[channel] when registered', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    (window.__wdio_mocks__ as Record<string, unknown>)['get-data'] = (x: unknown) => `result:${x}`;
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    const invoke = ipcRenderer.invoke as (channel: string, ...args: unknown[]) => Promise<unknown>;
+    await expect(invoke('get-data', 'hello')).resolves.toBe('result:hello');
+  });
+
+  it('should spread args to the registered mock', async () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    let capturedArgs: unknown[];
+    (window.__wdio_mocks__ as Record<string, unknown>)['multi-arg'] = (...args: unknown[]) => {
+      capturedArgs = args;
+      return 'ok';
+    };
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    const invoke = ipcRenderer.invoke as (channel: string, ...args: unknown[]) => Promise<unknown>;
+    await invoke('multi-arg', 'a', 'b', 'c');
+    expect(capturedArgs!).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should throw synchronously for send on unmocked channels', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    const send = ipcRenderer.send as (channel: string) => void;
+    expect(() => send('some-channel')).toThrow('unmocked Electron IPC channel in browser mode: some-channel');
+  });
+
+  it('should throw synchronously for sendSync on unmocked channels', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    const sendSync = ipcRenderer.sendSync as (channel: string) => void;
+    expect(() => sendSync('sync-channel')).toThrow('unmocked Electron IPC channel in browser mode: sync-channel');
+  });
+
+  describe('fn()', () => {
+    it('should create a mock with empty call history', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      const mock = mockFn.mock as Record<string, unknown>;
+      expect(mock.calls).toEqual([]);
+      expect(mock.results).toEqual([]);
+      expect(mock.invocationCallOrder).toEqual([]);
+    });
+
+    it('should record calls and results', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => (...a: unknown[]) => unknown)();
+      mockFn('arg1', 'arg2');
+      const mock = (mockFn as unknown as Record<string, unknown>).mock as Record<string, unknown[][]>;
+      expect(mock.calls).toEqual([['arg1', 'arg2']]);
+    });
+
+    it('should support mockReturnValue', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn.mockReturnValue as (v: unknown) => void)(42);
+      expect((mockFn as unknown as (...a: unknown[]) => unknown)()).toBe(42);
+    });
+
+    it('should support mockClear', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      (mockFn as unknown as (...a: unknown[]) => unknown)('x');
+      (mockFn.mockClear as () => void)();
+      const mock = mockFn.mock as Record<string, unknown[]>;
+      expect(mock.calls).toEqual([]);
+      expect(mock.results).toEqual([]);
+    });
+  });
+});
+
+describe('createIpcInterceptor buildBrowserIpcInjectionScript delegation', () => {
+  it('should delegate to the ElectronAdapter', () => {
+    const interceptor = createIpcInterceptor('electron');
+    const script = interceptor.buildBrowserIpcInjectionScript();
+    expect(script).toContain('window.__wdio_spy__');
+    expect(script).toContain('ipcRenderer');
+  });
+});

--- a/packages/native-spy/test/interceptor/electron-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/electron-browser.spec.ts
@@ -156,6 +156,86 @@ describe('ElectronAdapter.buildBrowserIpcInjectionScript', () => {
       expect(mock.calls).toEqual([]);
       expect(mock.results).toEqual([]);
     });
+
+    describe('async result serialization', () => {
+      it('should record actual value in results for mockResolvedValue', () => {
+        const script = adapter.buildBrowserIpcInjectionScript();
+        const window = runInBrowserContext(script);
+        const spy = window.__wdio_spy__ as Record<string, unknown>;
+        const mockFn = (spy.fn as () => Record<string, unknown>)();
+        (mockFn.mockResolvedValue as (v: unknown) => void)({ data: 42 });
+        const returned = (mockFn as unknown as (...a: unknown[]) => Promise<unknown>)();
+        returned.catch(() => {});
+        const mock = mockFn.mock as Record<string, Array<{ type: string; value: unknown }>>;
+        expect(mock.results[0]).toEqual({ type: 'return', value: { data: 42 } });
+      });
+
+      it('should record actual value in results for mockRejectedValue', () => {
+        const script = adapter.buildBrowserIpcInjectionScript();
+        const window = runInBrowserContext(script);
+        const spy = window.__wdio_spy__ as Record<string, unknown>;
+        const mockFn = (spy.fn as () => Record<string, unknown>)();
+        (mockFn.mockRejectedValue as (v: unknown) => void)('err-reason');
+        const returned = (mockFn as unknown as (...a: unknown[]) => Promise<unknown>)();
+        returned.catch(() => {});
+        const mock = mockFn.mock as Record<string, Array<{ type: string; value: unknown }>>;
+        expect(mock.results[0]).toEqual({ type: 'throw', value: 'err-reason' });
+      });
+
+      it('should record actual value in results for mockResolvedValueOnce', () => {
+        const script = adapter.buildBrowserIpcInjectionScript();
+        const window = runInBrowserContext(script);
+        const spy = window.__wdio_spy__ as Record<string, unknown>;
+        const mockFn = (spy.fn as () => Record<string, unknown>)();
+        (mockFn.mockResolvedValueOnce as (v: unknown) => void)({ data: 99 });
+        const returned = (mockFn as unknown as (...a: unknown[]) => Promise<unknown>)();
+        returned.catch(() => {});
+        const mock = mockFn.mock as Record<string, Array<{ type: string; value: unknown }>>;
+        expect(mock.results[0]).toEqual({ type: 'return', value: { data: 99 } });
+      });
+
+      it('should record actual value in results for mockRejectedValueOnce', () => {
+        const script = adapter.buildBrowserIpcInjectionScript();
+        const window = runInBrowserContext(script);
+        const spy = window.__wdio_spy__ as Record<string, unknown>;
+        const mockFn = (spy.fn as () => Record<string, unknown>)();
+        (mockFn.mockRejectedValueOnce as (v: unknown) => void)('once-err');
+        const returned = (mockFn as unknown as (...a: unknown[]) => Promise<unknown>)();
+        returned.catch(() => {});
+        const mock = mockFn.mock as Record<string, Array<{ type: string; value: unknown }>>;
+        expect(mock.results[0]).toEqual({ type: 'throw', value: 'once-err' });
+      });
+
+      it('should fall back to mockResolvedValue after the queue is consumed', () => {
+        const script = adapter.buildBrowserIpcInjectionScript();
+        const window = runInBrowserContext(script);
+        const spy = window.__wdio_spy__ as Record<string, unknown>;
+        const mockFn = (spy.fn as () => Record<string, unknown>)();
+        (mockFn.mockResolvedValue as (v: unknown) => void)('default');
+        (mockFn.mockResolvedValueOnce as (v: unknown) => void)('once');
+        const invoke = mockFn as unknown as (...a: unknown[]) => Promise<unknown>;
+        invoke().catch(() => {});
+        invoke().catch(() => {});
+        const mock = mockFn.mock as Record<string, Array<{ type: string; value: unknown }>>;
+        expect(mock.results[0]).toEqual({ type: 'return', value: 'once' });
+        expect(mock.results[1]).toEqual({ type: 'return', value: 'default' });
+      });
+
+      it('should fall back to mockRejectedValue after the queue is consumed', () => {
+        const script = adapter.buildBrowserIpcInjectionScript();
+        const window = runInBrowserContext(script);
+        const spy = window.__wdio_spy__ as Record<string, unknown>;
+        const mockFn = (spy.fn as () => Record<string, unknown>)();
+        (mockFn.mockRejectedValue as (v: unknown) => void)('default-err');
+        (mockFn.mockRejectedValueOnce as (v: unknown) => void)('once-err');
+        const invoke = mockFn as unknown as (...a: unknown[]) => Promise<unknown>;
+        invoke().catch(() => {});
+        invoke().catch(() => {});
+        const mock = mockFn.mock as Record<string, Array<{ type: string; value: unknown }>>;
+        expect(mock.results[0]).toEqual({ type: 'throw', value: 'once-err' });
+        expect(mock.results[1]).toEqual({ type: 'throw', value: 'default-err' });
+      });
+    });
   });
 });
 

--- a/packages/native-spy/test/interceptor/electron-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/electron-browser.spec.ts
@@ -100,6 +100,20 @@ describe('ElectronAdapter.buildBrowserIpcInjectionScript', () => {
     expect(() => sendSync('sync-channel')).toThrow('unmocked Electron IPC channel in browser mode: sync-channel');
   });
 
+  it('should provide no-op stubs for on, once, removeListener, removeAllListeners', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    expect(typeof ipcRenderer.on).toBe('function');
+    expect(typeof ipcRenderer.once).toBe('function');
+    expect(typeof ipcRenderer.removeListener).toBe('function');
+    expect(typeof ipcRenderer.removeAllListeners).toBe('function');
+    expect(() => (ipcRenderer.on as Function)('channel', () => {})).not.toThrow();
+    expect(() => (ipcRenderer.once as Function)('channel', () => {})).not.toThrow();
+    expect(() => (ipcRenderer.removeListener as Function)('channel', () => {})).not.toThrow();
+    expect(() => (ipcRenderer.removeAllListeners as Function)('channel')).not.toThrow();
+  });
+
   describe('fn()', () => {
     it('should create a mock with empty call history', () => {
       const script = adapter.buildBrowserIpcInjectionScript();

--- a/packages/native-spy/test/interceptor/electron-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/electron-browser.spec.ts
@@ -161,6 +161,14 @@ describe('ElectronAdapter.buildBrowserIpcInjectionScript', () => {
       expect(mock.invocationCallOrder).toEqual([]);
     });
 
+    it('should return the same mock object identity across reads', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      const window = runInBrowserContext(script);
+      const spy = window.__wdio_spy__ as Record<string, unknown>;
+      const mockFn = (spy.fn as () => Record<string, unknown>)();
+      expect(mockFn.mock).toBe(mockFn.mock);
+    });
+
     it('should record calls and results', () => {
       const script = adapter.buildBrowserIpcInjectionScript();
       const window = runInBrowserContext(script);

--- a/packages/native-spy/test/interceptor/electron-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/electron-browser.spec.ts
@@ -19,6 +19,14 @@ describe('ElectronAdapter.buildBrowserIpcInjectionScript', () => {
     expect(typeof (window.__wdio_spy__ as Record<string, unknown>)?.fn).toBe('function');
   });
 
+  it('should preserve an existing __wdio_spy__ across re-injection', () => {
+    const existingFn = (): unknown => 'existing';
+    const window: Record<string, unknown> = { __wdio_spy__: { fn: existingFn } };
+    const ctx = vm.createContext({ window, Promise });
+    vm.runInContext(adapter.buildBrowserIpcInjectionScript(), ctx);
+    expect((window.__wdio_spy__ as { fn: unknown }).fn).toBe(existingFn);
+  });
+
   it('should create window.__wdio_mocks__ if absent', () => {
     const script = adapter.buildBrowserIpcInjectionScript();
     const window = runInBrowserContext(script);
@@ -98,6 +106,33 @@ describe('ElectronAdapter.buildBrowserIpcInjectionScript', () => {
     const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
     const sendSync = ipcRenderer.sendSync as (channel: string) => void;
     expect(() => sendSync('sync-channel')).toThrow('unmocked Electron IPC channel in browser mode: sync-channel');
+  });
+
+  it('should throw with a clear message when a sendSync mock returns a Promise', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = (window.__wdio_spy__ as { fn: () => { mockResolvedValue: (v: unknown) => unknown } }).fn;
+    const mock = spy();
+    (mock as { mockResolvedValue: (v: unknown) => void }).mockResolvedValue('value');
+    (window.__wdio_mocks__ as Record<string, unknown>)['sync-channel'] = mock;
+
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    const sendSync = ipcRenderer.sendSync as (channel: string) => unknown;
+    expect(() => sendSync('sync-channel')).toThrow(/sendSync is synchronous/);
+    expect(() => sendSync('sync-channel')).toThrow(/sync-channel/);
+  });
+
+  it('should return the unwrapped value when a sendSync mock returns synchronously', () => {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    const window = runInBrowserContext(script);
+    const spy = (window.__wdio_spy__ as { fn: () => { mockReturnValue: (v: unknown) => unknown } }).fn;
+    const mock = spy();
+    (mock as { mockReturnValue: (v: unknown) => void }).mockReturnValue(42);
+    (window.__wdio_mocks__ as Record<string, unknown>)['sync-channel'] = mock;
+
+    const ipcRenderer = (window.electron as Record<string, unknown>).ipcRenderer as Record<string, unknown>;
+    const sendSync = ipcRenderer.sendSync as (channel: string) => unknown;
+    expect(sendSync('sync-channel')).toBe(42);
   });
 
   it('should provide no-op stubs for on, once, removeListener, removeAllListeners', () => {

--- a/packages/native-spy/test/interceptor/index.spec.ts
+++ b/packages/native-spy/test/interceptor/index.spec.ts
@@ -5,28 +5,28 @@ describe('createIpcInterceptor', () => {
   describe('tauri', () => {
     const interceptor = createIpcInterceptor('tauri');
 
-    it('reports tauri framework', () => {
+    it('should report tauri framework', () => {
       expect(interceptor.framework).toBe('tauri');
     });
 
-    it('serializeHandler captures function source', () => {
+    it('should serializeHandler captures function source', () => {
       const fn = () => 42;
       const { source } = interceptor.serializeHandler(fn);
       expect(source).toContain('42');
     });
 
-    it('buildRegistrationScript delegates to adapter', () => {
+    it('should buildRegistrationScript delegate to adapter', () => {
       const script = interceptor.buildRegistrationScript('cmd');
       expect(script).toContain('__wdio_spy__');
     });
 
-    it('buildSetImplementationScript accepts SerializedHandler', () => {
+    it('should buildSetImplementationScript accept SerializedHandler', () => {
       const s = interceptor.serializeHandler(() => 1);
       const script = interceptor.buildSetImplementationScript('cmd', s);
       expect(script).toContain('mockImplementation');
     });
 
-    it('buildWithImplementationScript takes function objects', () => {
+    it('should buildWithImplementationScript take function objects', () => {
       const script = interceptor.buildWithImplementationScript(
         'cmd',
         () => 1,
@@ -35,14 +35,14 @@ describe('createIpcInterceptor', () => {
       expect(script).toContain('withImplementation');
     });
 
-    it('parseCallData returns empty data for null', () => {
+    it('should parseCallData return empty data for null', () => {
       const data = interceptor.parseCallData(null);
       expect(data.calls).toEqual([]);
       expect(data.results).toEqual([]);
       expect(data.invocationCallOrder).toEqual([]);
     });
 
-    it('parseCallData parses valid call data', () => {
+    it('should parseCallData parse valid call data', () => {
       const raw = { calls: [[1, 2]], results: [{ type: 'return', value: 3 }], invocationCallOrder: [0] };
       const data = interceptor.parseCallData(raw);
       expect(data.calls).toEqual([[1, 2]]);
@@ -50,36 +50,44 @@ describe('createIpcInterceptor', () => {
     });
   });
 
-  describe('electron stub', () => {
+  describe('electron', () => {
     const interceptor = createIpcInterceptor('electron');
 
-    it('reports electron framework', () => {
+    it('should report electron framework', () => {
       expect(interceptor.framework).toBe('electron');
     });
 
-    it('throws Not implemented for buildRegistrationScript', () => {
-      expect(() => interceptor.buildRegistrationScript('cmd')).toThrow('Not implemented');
+    it('should buildRegistrationScript produce a mock registration script', () => {
+      const script = interceptor.buildRegistrationScript('my-channel');
+      expect(script).toContain('__wdio_spy__');
+      expect(script).toContain('my-channel');
+    });
+
+    it('should buildBrowserIpcInjectionScript patch ipcRenderer', () => {
+      const script = interceptor.buildBrowserIpcInjectionScript();
+      expect(script).toContain('ipcRenderer');
+      expect(script).toContain('__wdio_mocks__');
     });
   });
 
   describe('context management', () => {
-    it('starts with empty context', () => {
+    it('should start with empty context', () => {
       const interceptor = createIpcInterceptor('tauri');
       expect(interceptor.getContext()).toEqual({});
     });
 
-    it('initializes with provided context', () => {
+    it('should initialize with provided context', () => {
       const interceptor = createIpcInterceptor('tauri', { context: { foo: 'bar' } });
       expect(interceptor.getContext()).toEqual({ foo: 'bar' });
     });
 
-    it('setContext merges into existing context', () => {
+    it('should setContext merge into existing context', () => {
       const interceptor = createIpcInterceptor('tauri', { context: { a: 1 } });
       interceptor.setContext({ b: 2 });
       expect(interceptor.getContext()).toEqual({ a: 1, b: 2 });
     });
 
-    it('buildContextSeedScript generates a script with context', () => {
+    it('should buildContextSeedScript generate a script with context', () => {
       const interceptor = createIpcInterceptor('tauri');
       const script = interceptor.buildContextSeedScript({ x: 99 });
       expect(script).toContain('__wdio_ipc_context__');

--- a/packages/native-spy/test/interceptor/index.spec.ts
+++ b/packages/native-spy/test/interceptor/index.spec.ts
@@ -9,44 +9,54 @@ describe('createIpcInterceptor', () => {
       expect(interceptor.framework).toBe('tauri');
     });
 
-    it('should serializeHandler captures function source', () => {
-      const fn = () => 42;
-      const { source } = interceptor.serializeHandler(fn);
-      expect(source).toContain('42');
+    describe('serializeHandler', () => {
+      it('should capture function source', () => {
+        const fn = () => 42;
+        const { source } = interceptor.serializeHandler(fn);
+        expect(source).toContain('42');
+      });
     });
 
-    it('should buildRegistrationScript delegate to adapter', () => {
-      const script = interceptor.buildRegistrationScript('cmd');
-      expect(script).toContain('__wdio_spy__');
+    describe('buildRegistrationScript', () => {
+      it('should delegate to adapter', () => {
+        const script = interceptor.buildRegistrationScript('cmd');
+        expect(script).toContain('__wdio_spy__');
+      });
     });
 
-    it('should buildSetImplementationScript accept SerializedHandler', () => {
-      const s = interceptor.serializeHandler(() => 1);
-      const script = interceptor.buildSetImplementationScript('cmd', s);
-      expect(script).toContain('mockImplementation');
+    describe('buildSetImplementationScript', () => {
+      it('should accept SerializedHandler', () => {
+        const s = interceptor.serializeHandler(() => 1);
+        const script = interceptor.buildSetImplementationScript('cmd', s);
+        expect(script).toContain('mockImplementation');
+      });
     });
 
-    it('should buildWithImplementationScript take function objects', () => {
-      const script = interceptor.buildWithImplementationScript(
-        'cmd',
-        () => 1,
-        () => 2,
-      );
-      expect(script).toContain('withImplementation');
+    describe('buildWithImplementationScript', () => {
+      it('should take function objects', () => {
+        const script = interceptor.buildWithImplementationScript(
+          'cmd',
+          () => 1,
+          () => 2,
+        );
+        expect(script).toContain('withImplementation');
+      });
     });
 
-    it('should parseCallData return empty data for null', () => {
-      const data = interceptor.parseCallData(null);
-      expect(data.calls).toEqual([]);
-      expect(data.results).toEqual([]);
-      expect(data.invocationCallOrder).toEqual([]);
-    });
+    describe('parseCallData', () => {
+      it('should return empty data for null', () => {
+        const data = interceptor.parseCallData(null);
+        expect(data.calls).toEqual([]);
+        expect(data.results).toEqual([]);
+        expect(data.invocationCallOrder).toEqual([]);
+      });
 
-    it('should parseCallData parse valid call data', () => {
-      const raw = { calls: [[1, 2]], results: [{ type: 'return', value: 3 }], invocationCallOrder: [0] };
-      const data = interceptor.parseCallData(raw);
-      expect(data.calls).toEqual([[1, 2]]);
-      expect(data.results[0].type).toBe('return');
+      it('should parse valid call data', () => {
+        const raw = { calls: [[1, 2]], results: [{ type: 'return', value: 3 }], invocationCallOrder: [0] };
+        const data = interceptor.parseCallData(raw);
+        expect(data.calls).toEqual([[1, 2]]);
+        expect(data.results[0].type).toBe('return');
+      });
     });
   });
 
@@ -57,16 +67,20 @@ describe('createIpcInterceptor', () => {
       expect(interceptor.framework).toBe('electron');
     });
 
-    it('should buildRegistrationScript produce a mock registration script', () => {
-      const script = interceptor.buildRegistrationScript('my-channel');
-      expect(script).toContain('__wdio_spy__');
-      expect(script).toContain('my-channel');
+    describe('buildRegistrationScript', () => {
+      it('should produce a mock registration script', () => {
+        const script = interceptor.buildRegistrationScript('my-channel');
+        expect(script).toContain('__wdio_spy__');
+        expect(script).toContain('my-channel');
+      });
     });
 
-    it('should buildBrowserIpcInjectionScript patch ipcRenderer', () => {
-      const script = interceptor.buildBrowserIpcInjectionScript();
-      expect(script).toContain('ipcRenderer');
-      expect(script).toContain('__wdio_mocks__');
+    describe('buildBrowserIpcInjectionScript', () => {
+      it('should patch ipcRenderer', () => {
+        const script = interceptor.buildBrowserIpcInjectionScript();
+        expect(script).toContain('ipcRenderer');
+        expect(script).toContain('__wdio_mocks__');
+      });
     });
   });
 
@@ -81,13 +95,13 @@ describe('createIpcInterceptor', () => {
       expect(interceptor.getContext()).toEqual({ foo: 'bar' });
     });
 
-    it('should setContext merge into existing context', () => {
+    it('should merge into existing context', () => {
       const interceptor = createIpcInterceptor('tauri', { context: { a: 1 } });
       interceptor.setContext({ b: 2 });
       expect(interceptor.getContext()).toEqual({ a: 1, b: 2 });
     });
 
-    it('should buildContextSeedScript generate a script with context', () => {
+    it('should generate a script with context', () => {
       const interceptor = createIpcInterceptor('tauri');
       const script = interceptor.buildContextSeedScript({ x: 99 });
       expect(script).toContain('__wdio_ipc_context__');

--- a/packages/native-spy/test/interceptor/integration.spec.ts
+++ b/packages/native-spy/test/interceptor/integration.spec.ts
@@ -23,102 +23,145 @@ function evalScript(script: string, win: SyntheticWindow): unknown {
 describe('TauriAdapter integration (synthetic window)', () => {
   const interceptor = createIpcInterceptor('tauri');
 
-  it('buildRegistrationScript creates a mock in __wdio_mocks__', () => {
-    const win = makeSyntheticWindow();
-    const script = interceptor.buildRegistrationScript('my_cmd');
-    evalScript(script, win);
-    expect(typeof win.__wdio_mocks__['my_cmd']).toBe('function');
+  describe('buildRegistrationScript', () => {
+    it('should create a mock in __wdio_mocks__', () => {
+      const win = makeSyntheticWindow();
+      const script = interceptor.buildRegistrationScript('my_cmd');
+      evalScript(script, win);
+      expect(typeof win.__wdio_mocks__['my_cmd']).toBe('function');
+    });
+
+    it('should call mockClear so calls start empty', () => {
+      const win = makeSyntheticWindow();
+      const script = interceptor.buildRegistrationScript('my_cmd');
+      evalScript(script, win);
+      const mock = win.__wdio_mocks__['my_cmd'];
+      mock('some_arg');
+      evalScript(script, win);
+      expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(0);
+    });
   });
 
-  it('buildRegistrationScript calls mockClear so calls start empty', () => {
-    const win = makeSyntheticWindow();
-    const script = interceptor.buildRegistrationScript('my_cmd');
-    evalScript(script, win);
-    const mock = win.__wdio_mocks__['my_cmd'];
-    mock('some_arg');
-    evalScript(script, win);
-    expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(0);
+  describe('buildCallDataReadScript', () => {
+    it('should return call data', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+      win.__wdio_mocks__['my_cmd']('arg1');
+      win.__wdio_mocks__['my_cmd']('arg2');
+
+      const readScript = interceptor.buildCallDataReadScript('my_cmd');
+      const raw = evalScript(readScript, win);
+      const data = interceptor.parseCallData(raw);
+      expect(data.calls).toHaveLength(2);
+    });
+
+    it('should round-trip Error results without losing detail', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+      const mock = win.__wdio_mocks__['my_cmd'];
+      mock.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => mock()).toThrow('boom');
+
+      const raw = evalScript(interceptor.buildCallDataReadScript('my_cmd'), win);
+      const data = interceptor.parseCallData(raw);
+      expect(data.results).toHaveLength(1);
+      expect(data.results[0].type).toBe('throw');
+      expect(data.results[0].value).toBeInstanceOf(Error);
+      expect((data.results[0].value as Error).message).toBe('boom');
+    });
+
+    it('should round-trip Error arguments in calls', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+      const mock = win.__wdio_mocks__['my_cmd'];
+      mock(new Error('arg-error'));
+
+      const raw = evalScript(interceptor.buildCallDataReadScript('my_cmd'), win);
+      const data = interceptor.parseCallData(raw);
+      expect(data.calls[0][0]).toBeInstanceOf(Error);
+      expect((data.calls[0][0] as Error).message).toBe('arg-error');
+    });
   });
 
-  it('buildCallDataReadScript returns call data', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
-    win.__wdio_mocks__['my_cmd']('arg1');
-    win.__wdio_mocks__['my_cmd']('arg2');
+  describe('buildSetImplementationScript', () => {
+    it('should set implementation', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
 
-    const readScript = interceptor.buildCallDataReadScript('my_cmd');
-    const raw = evalScript(readScript, win);
-    const data = interceptor.parseCallData(raw);
-    expect(data.calls).toHaveLength(2);
+      const s = interceptor.serializeHandler(() => 'hello');
+      evalScript(interceptor.buildSetImplementationScript('my_cmd', s), win);
+
+      const result = win.__wdio_mocks__['my_cmd']();
+      expect(result).toBe('hello');
+    });
+
+    it('should use mockImplementationOnce when once=true', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+
+      const s = interceptor.serializeHandler(() => 'once');
+      evalScript(interceptor.buildSetImplementationScript('my_cmd', s, true), win);
+
+      expect(win.__wdio_mocks__['my_cmd']()).toBe('once');
+      expect(win.__wdio_mocks__['my_cmd']()).toBeUndefined();
+    });
   });
 
-  it('buildSetImplementationScript sets implementation', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+  describe('buildInnerSetterScript', () => {
+    it('should set return value for mockReturnValue', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+      evalScript(interceptor.buildInnerSetterScript('my_cmd', 'mockReturnValue', 42), win);
+      expect(win.__wdio_mocks__['my_cmd']()).toBe(42);
+    });
 
-    const s = interceptor.serializeHandler(() => 'hello');
-    evalScript(interceptor.buildSetImplementationScript('my_cmd', s), win);
+    it('should reconstruct Error for mockRejectedValue', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+      evalScript(interceptor.buildInnerSetterScript('my_cmd', 'mockRejectedValue', new Error('fail msg')), win);
 
-    const result = win.__wdio_mocks__['my_cmd']();
-    expect(result).toBe('hello');
+      expect(() => win.__wdio_mocks__['my_cmd']()).toThrow('fail msg');
+    });
   });
 
-  it('buildSetImplementationScript once=true uses mockImplementationOnce', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+  describe('buildInnerInvocationScript', () => {
+    it('should empty call history for mockClear', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+      win.__wdio_mocks__['my_cmd']('test');
+      expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(1);
 
-    const s = interceptor.serializeHandler(() => 'once');
-    evalScript(interceptor.buildSetImplementationScript('my_cmd', s, true), win);
-
-    expect(win.__wdio_mocks__['my_cmd']()).toBe('once');
-    expect(win.__wdio_mocks__['my_cmd']()).toBeUndefined();
+      evalScript(interceptor.buildInnerInvocationScript('my_cmd', 'mockClear'), win);
+      expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(0);
+    });
   });
 
-  it('buildInnerSetterScript mockReturnValue sets return value', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
-    evalScript(interceptor.buildInnerSetterScript('my_cmd', 'mockReturnValue', 42), win);
-    expect(win.__wdio_mocks__['my_cmd']()).toBe(42);
+  describe('buildUnregistrationScript', () => {
+    it('should remove mock from __wdio_mocks__', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
+      expect(win.__wdio_mocks__['my_cmd']).toBeDefined();
+
+      evalScript(interceptor.buildUnregistrationScript('my_cmd'), win);
+      expect(win.__wdio_mocks__['my_cmd']).toBeUndefined();
+    });
   });
 
-  it('buildInnerSetterScript mockRejectedValue with Error reconstructs correctly', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
-    evalScript(interceptor.buildInnerSetterScript('my_cmd', 'mockRejectedValue', new Error('fail msg')), win);
+  describe('buildContextSeedScript', () => {
+    it('should seed __wdio_ipc_context__', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildContextSeedScript({ userId: 'abc' }), win);
+      expect(win.__wdio_ipc_context__?.userId).toBe('abc');
+    });
 
-    expect(() => win.__wdio_mocks__['my_cmd']()).toThrow('fail msg');
-  });
-
-  it('buildInnerInvocationScript mockClear empties call history', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
-    win.__wdio_mocks__['my_cmd']('test');
-    expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(1);
-
-    evalScript(interceptor.buildInnerInvocationScript('my_cmd', 'mockClear'), win);
-    expect(win.__wdio_mocks__['my_cmd'].mock.calls).toHaveLength(0);
-  });
-
-  it('buildUnregistrationScript removes mock from __wdio_mocks__', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildRegistrationScript('my_cmd'), win);
-    expect(win.__wdio_mocks__['my_cmd']).toBeDefined();
-
-    evalScript(interceptor.buildUnregistrationScript('my_cmd'), win);
-    expect(win.__wdio_mocks__['my_cmd']).toBeUndefined();
-  });
-
-  it('buildContextSeedScript seeds __wdio_ipc_context__', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildContextSeedScript({ userId: 'abc' }), win);
-    expect(win.__wdio_ipc_context__?.userId).toBe('abc');
-  });
-
-  it('buildContextSeedScript is idempotent (Object.assign merges)', () => {
-    const win = makeSyntheticWindow();
-    evalScript(interceptor.buildContextSeedScript({ a: 1 }), win);
-    evalScript(interceptor.buildContextSeedScript({ b: 2 }), win);
-    expect(win.__wdio_ipc_context__?.a).toBe(1);
-    expect(win.__wdio_ipc_context__?.b).toBe(2);
+    it('should be idempotent (Object.assign merges)', () => {
+      const win = makeSyntheticWindow();
+      evalScript(interceptor.buildContextSeedScript({ a: 1 }), win);
+      evalScript(interceptor.buildContextSeedScript({ b: 2 }), win);
+      expect(win.__wdio_ipc_context__?.a).toBe(1);
+      expect(win.__wdio_ipc_context__?.b).toBe(2);
+    });
   });
 });

--- a/packages/native-spy/test/interceptor/tauri-browser.spec.ts
+++ b/packages/native-spy/test/interceptor/tauri-browser.spec.ts
@@ -199,6 +199,157 @@ describe('TauriAdapter.buildBrowserIpcInjectionScript', () => {
   });
 });
 
+describe('TauriAdapter browser-mode events', () => {
+  const adapter = new TauriAdapter();
+
+  type Listener = (data: { event: string; id: number; payload: unknown }) => void;
+  type Window = {
+    __TAURI_INTERNALS__: {
+      invoke: (cmd: string, args?: unknown, options?: unknown) => Promise<unknown>;
+      transformCallback: (cb: Listener, once?: boolean) => number;
+      runCallback: (id: number, data: unknown) => void;
+      callbacks: Map<number, unknown>;
+    };
+    __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: (event: string, eventId: number) => void };
+    __wdio_emit_tauri_event__: (event: string, payload?: unknown, target?: unknown) => void;
+    __wdio_tauri_listeners__: Record<string, Record<number, { handlerId: number; target?: unknown }>>;
+    __wdio_mocks__: Record<string, unknown>;
+  };
+
+  function setup(extraProps: Record<string, unknown> = {}) {
+    const script = adapter.buildBrowserIpcInjectionScript();
+    return runInBrowserContext(script, extraProps) as unknown as Window;
+  }
+
+  it('should resolve plugin:event|listen with a numeric eventId', async () => {
+    const window = setup();
+    const handlerId = window.__TAURI_INTERNALS__.transformCallback(() => {});
+    const id = (await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'Any' },
+      handler: handlerId,
+    })) as number;
+    expect(typeof id).toBe('number');
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it('should fire the registered handler when emit is dispatched via __wdio_emit_tauri_event__', async () => {
+    const window = setup();
+    const received: unknown[] = [];
+    const handlerId = window.__TAURI_INTERNALS__.transformCallback((data) => received.push(data));
+    await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'Any' },
+      handler: handlerId,
+    });
+    window.__wdio_emit_tauri_event__('foo', { x: 1 });
+    expect(received).toHaveLength(1);
+    const ev = received[0] as { event: string; id: number; payload: { x: number } };
+    expect(ev.event).toBe('foo');
+    expect(ev.payload).toEqual({ x: 1 });
+    expect(typeof ev.id).toBe('number');
+  });
+
+  it('should remove the listener via plugin:event|unlisten', async () => {
+    const window = setup();
+    const received: unknown[] = [];
+    const handlerId = window.__TAURI_INTERNALS__.transformCallback((data) => received.push(data));
+    const id = (await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'Any' },
+      handler: handlerId,
+    })) as number;
+    await window.__TAURI_INTERNALS__.invoke('plugin:event|unlisten', { event: 'foo', eventId: id });
+    window.__wdio_emit_tauri_event__('foo', 'payload');
+    expect(received).toHaveLength(0);
+  });
+
+  it('should also remove the listener via __TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener', async () => {
+    const window = setup();
+    const received: unknown[] = [];
+    const handlerId = window.__TAURI_INTERNALS__.transformCallback((data) => received.push(data));
+    const id = (await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'Any' },
+      handler: handlerId,
+    })) as number;
+    window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener('foo', id);
+    window.__wdio_emit_tauri_event__('foo', 'payload');
+    expect(received).toHaveLength(0);
+  });
+
+  it('should fire a once-handler exactly once', async () => {
+    const window = setup();
+    const received: unknown[] = [];
+    const handlerId = window.__TAURI_INTERNALS__.transformCallback((data) => received.push(data), true);
+    await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'Any' },
+      handler: handlerId,
+    });
+    window.__wdio_emit_tauri_event__('foo', 'first');
+    window.__wdio_emit_tauri_event__('foo', 'second');
+    expect(received).toHaveLength(1);
+    expect((received[0] as { payload: string }).payload).toBe('first');
+  });
+
+  it('should filter listeners by target on emit_to', async () => {
+    const window = setup();
+    const mainReceived: unknown[] = [];
+    const otherReceived: unknown[] = [];
+    const mainHandlerId = window.__TAURI_INTERNALS__.transformCallback((data) => mainReceived.push(data));
+    const otherHandlerId = window.__TAURI_INTERNALS__.transformCallback((data) => otherReceived.push(data));
+    await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'AnyLabel', label: 'main' },
+      handler: mainHandlerId,
+    });
+    await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'AnyLabel', label: 'other' },
+      handler: otherHandlerId,
+    });
+    window.__wdio_emit_tauri_event__('foo', 'msg', 'main');
+    expect(mainReceived).toHaveLength(1);
+    expect(otherReceived).toHaveLength(0);
+    window.__wdio_emit_tauri_event__('foo', 'msg2');
+    expect(mainReceived).toHaveLength(2);
+    expect(otherReceived).toHaveLength(1);
+  });
+
+  it('should record plugin:event|emit on a user mock and still dispatch to subscribers', async () => {
+    const window = setup();
+    const emitCalls: unknown[] = [];
+    window.__wdio_mocks__['plugin:event|emit'] = (args: unknown) => {
+      emitCalls.push(args);
+    };
+    const received: unknown[] = [];
+    const handlerId = window.__TAURI_INTERNALS__.transformCallback((data) => received.push(data));
+    await window.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+      event: 'foo',
+      target: { kind: 'Any' },
+      handler: handlerId,
+    });
+    await window.__TAURI_INTERNALS__.invoke('plugin:event|emit', { event: 'foo', payload: 42 });
+    expect(emitCalls).toEqual([{ event: 'foo', payload: 42 }]);
+    expect(received).toHaveLength(1);
+    expect((received[0] as { payload: number }).payload).toBe(42);
+  });
+
+  it('should resolve other plugin:* commands with undefined when not mocked', async () => {
+    const window = setup();
+    await expect(window.__TAURI_INTERNALS__.invoke('plugin:fs|read', {})).resolves.toBeUndefined();
+    await expect(window.__TAURI_INTERNALS__.invoke('plugin:window|close', {})).resolves.toBeUndefined();
+  });
+
+  it('should still reject non-plugin commands when not mocked', async () => {
+    const window = setup();
+    await expect(window.__TAURI_INTERNALS__.invoke('my_unknown_cmd', {})).rejects.toThrow(
+      'unmocked Tauri command in browser mode: my_unknown_cmd',
+    );
+  });
+});
+
 describe('createIpcInterceptor buildBrowserIpcInjectionScript delegation', () => {
   it('should delegate to the TauriAdapter', () => {
     const interceptor = createIpcInterceptor('tauri');

--- a/packages/native-types/src/electron.ts
+++ b/packages/native-types/src/electron.ts
@@ -175,6 +175,18 @@ export interface ElectronServiceOptions extends Omit<BaseServiceOptions, Electro
    * @example 'config/electron-builder-staging.config.js'
    */
   electronBuilderConfig?: string;
+  /**
+   * Run mode for the Electron service.
+   * 'browser' runs the frontend in plain Chrome against a dev server with IPC intercepted
+   * at the JS boundary. No Electron binary, no CDP bridge, no display server required.
+   * @default 'native'
+   */
+  mode?: 'native' | 'browser';
+  /**
+   * URL of the Vite (or other) dev server to navigate to when mode is 'browser'.
+   * Required when mode === 'browser'. e.g. 'http://localhost:5173'
+   */
+  devServerUrl?: string;
 }
 
 /**
@@ -246,6 +258,17 @@ export interface ElectronServiceGlobalOptions
    * @default false
    */
   apparmorAutoInstall?: boolean | 'sudo';
+  /**
+   * Run mode for the Electron service.
+   * 'browser' skips binary detection, CDP bridge, and Chromedriver setup.
+   * @default 'native'
+   */
+  mode?: 'native' | 'browser';
+  /**
+   * URL of the dev server to navigate to when mode is 'browser'.
+   * Required when mode === 'browser'. e.g. 'http://localhost:5173'
+   */
+  devServerUrl?: string;
 }
 
 export type ApiCommand = { name: string; bridgeProp: string };

--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -72,6 +72,7 @@ export type {
   TauriAPIs,
   TauriBrowserExtension,
   TauriCapabilities,
+  TauriEventTarget,
   TauriExecuteOptions,
   TauriMock,
   TauriMockInstance,

--- a/packages/native-types/src/tauri.ts
+++ b/packages/native-types/src/tauri.ts
@@ -77,6 +77,18 @@ export interface TauriMock<TArgs extends unknown[] = unknown[], TReturns = unkno
 }
 
 /**
+ * Tauri event target descriptor — mirrors the EventTarget union from
+ * @tauri-apps/api/event without requiring a runtime dependency on it.
+ */
+export type TauriEventTarget =
+  | { kind: 'Any' }
+  | { kind: 'AnyLabel'; label: string }
+  | { kind: 'App' }
+  | { kind: 'Window'; label: string }
+  | { kind: 'Webview'; label: string }
+  | { kind: 'WebviewWindow'; label: string };
+
+/**
  * Options for browser.tauri.execute() per-call overrides
  * Use withExecuteOptions() from @wdio/tauri-service to create properly-typed options
  */
@@ -260,6 +272,30 @@ export interface TauriServiceAPI {
    * ```
    */
   listWindows: () => Promise<string[]>;
+
+  /**
+   * Emit a Tauri event from the test process to listeners registered in the frontend
+   * via `listen()` / `once()` from `@tauri-apps/api/event`.
+   *
+   * Works in both modes:
+   * - Browser mode: routes through the in-browser listener registry
+   * - Native mode: routes through the real Tauri `event.emit()` / `event.emitTo()` via the backend
+   *
+   * @param event - Event name to emit (e.g. `'data-loaded'`)
+   * @param payload - Optional event payload (JSON-serialised across the boundary)
+   * @param target - Optional target filter — string is treated as `{ kind: 'AnyLabel', label }`,
+   *                 or pass an explicit `TauriEventTarget`. Omit to emit to all subscribers.
+   *
+   * @example
+   * ```js
+   * // Frontend: const unlisten = await listen('data-loaded', (e) => updateUI(e.payload));
+   * await browser.tauri.emitEvent('data-loaded', { rows: 3 });
+   *
+   * // Targeted emit — only listeners that subscribed with target: 'main' fire
+   * await browser.tauri.emitEvent('focus-window', undefined, 'main');
+   * ```
+   */
+  emitEvent: <T = unknown>(event: string, payload?: T, target?: string | TauriEventTarget) => Promise<void>;
 }
 
 /**

--- a/packages/tauri-service/README.md
+++ b/packages/tauri-service/README.md
@@ -19,6 +19,7 @@ Enables cross-platform E2E testing of Tauri apps via the extensive WebdriverIO e
 - 📊 Backend and frontend log capture
 - 🖥️ Multiremote testing support
 - 🏃 Per-worker driver spawning for parallel testing
+- 🌍 Browser mode — test the Tauri frontend in plain Chrome against a Vite dev server, no Tauri binary or driver required
 
 ## Installation
 
@@ -71,6 +72,7 @@ See [Configuration Reference](./docs/configuration.md) for all options.
 - [Platform Support](./docs/platform-support.md) - Windows, Linux, macOS
 
 **Guides**
+- [Browser Mode](./docs/browser-mode.md) - Test the renderer in Chrome without a Tauri binary
 - [Usage Examples](./docs/usage-examples.md) - Common testing patterns
 - [Log Forwarding](./docs/log-forwarding.md) - Capture app logs
 - [Edge WebDriver (Windows)](./docs/edge-webdriver-windows.md) - Windows-specific setup

--- a/packages/tauri-service/docs/api-reference.md
+++ b/packages/tauri-service/docs/api-reference.md
@@ -40,6 +40,8 @@ const result = await browser.tauri.execute('window.location.href');
 
 **Note:** Requires tauri-plugin-wdio to be installed. See [Plugin Setup](./plugin-setup.md).
 
+**Browser Mode:** Not available. `browser.tauri.execute()` requires a live Tauri backend and plugin bridge. Use `browser.execute()` for renderer-side code, or `browser.tauri.mock()` to intercept Tauri commands.
+
 ---
 
 ### `browser.tauri.mock(command)`
@@ -60,6 +62,26 @@ await mock.mockReturnValue('mocked file content');
 const content = await browser.tauri.execute(({ core }) => core.invoke('read_file'));
 expect(content).toBe('mocked file content');
 ```
+
+**Browser Mode:** Works in browser mode — this is the primary testing API in browser mode. The `command` argument is the Tauri command name (matching what the frontend passes to `invoke()`). Trigger the command via a UI interaction or `browser.execute(() => window.__TAURI_INTERNALS__.invoke('command-name'))`, then call `update()` and assert.
+
+```typescript
+// Browser mode — mock a Tauri command
+const mockReadFile = await browser.tauri.mock('read_file');
+await mockReadFile.mockResolvedValue('mocked file content');
+
+// Trigger the command (via UI or directly)
+await browser.execute(() => window.__TAURI_INTERNALS__.invoke('read_file'));
+
+// Sync call data and assert
+await mockReadFile.update();
+expect(mockReadFile).toHaveBeenCalledTimes(1);
+```
+
+See the [Browser Mode Guide](./browser-mode.md) for a full usage walkthrough.
+
+**See Also:**
+- [Browser Mode Guide](./browser-mode.md)
 
 ---
 
@@ -154,6 +176,8 @@ await browser.waitUntil(async () => {
 
 See [Deeplink Testing](./deeplink-testing.md) for full usage guide.
 
+**Browser Mode:** Not available. There is no Tauri process to receive the deeplink.
+
 ---
 
 ### `browser.tauri.switchWindow(label)`
@@ -179,6 +203,8 @@ await browser.tauri.switchWindow('main');
 
 **Note:** The window label must exist in your Tauri app. Use `browser.tauri.listWindows()` to get available labels.
 
+**Browser Mode:** Not available. Multi-window support requires a running Tauri app; there is no window-switching concept in browser mode.
+
 ---
 
 ### `browser.tauri.listWindows()`
@@ -192,6 +218,8 @@ Get a list of all available Tauri window labels in the application.
 const windows = await browser.tauri.listWindows();
 console.log(windows); // ['main', 'settings', 'dialog']
 ```
+
+**Browser Mode:** Not available. Throws for the same reason as `switchWindow()`.
 
 ---
 

--- a/packages/tauri-service/docs/api-reference.md
+++ b/packages/tauri-service/docs/api-reference.md
@@ -44,6 +44,40 @@ const result = await browser.tauri.execute('window.location.href');
 
 ---
 
+### `browser.tauri.emitEvent(event, payload?, target?)`
+
+Emit a Tauri event to all listeners registered via `listen()` or `once()` in the frontend. The same call works in both native and browser mode — in native mode it routes through Tauri's real `event.emit()` / `event.emitTo()` via the plugin bridge; in browser mode it dispatches through the in-page listener registry installed by the IPC injection.
+
+**Parameters:**
+- `event` (string) - The event name to emit
+- `payload?` (T) - Optional payload, JSON-serialized to listeners
+- `target?` (string | TauriEventTarget) - Optional target filter — emits only to listeners whose `target` matches. Pass a window/webview label as a string, or a structured `TauriEventTarget` object.
+
+**Returns:** `Promise<void>`
+
+**Example:**
+```typescript
+// Frontend subscribes via @tauri-apps/api/event
+import { listen } from '@tauri-apps/api/event';
+const unlisten = await listen<{ rows: number }>('data-loaded', (e) => {
+  document.querySelector('#count')!.textContent = String(e.payload.rows);
+});
+
+// Test emits the event — same line works in native and browser mode
+await browser.tauri.emitEvent('data-loaded', { rows: 3 });
+await expect($('#count')).toHaveText('3');
+
+// Targeted emit — only listeners that subscribed with target 'main' receive it
+await browser.tauri.emitEvent('focus-window', undefined, 'main');
+```
+
+**Browser Mode:** Routes through the in-page registry installed by the IPC injection. `listen()`, `once()`, and `unlisten()` work as expected. See the [Events section in the Browser Mode guide](./browser-mode.md#events) for details.
+
+**See Also:**
+- [Browser Mode Guide — Events](./browser-mode.md#events)
+
+---
+
 ### `browser.tauri.mock(command)`
 
 Mock a specific Tauri backend command. Returns a TauriMock object for configuring the mock behavior.

--- a/packages/tauri-service/docs/browser-mode.md
+++ b/packages/tauri-service/docs/browser-mode.md
@@ -1,0 +1,294 @@
+# Browser Mode
+
+Browser mode lets you test your Tauri frontend UI in plain Chrome against a running Vite dev server — no Tauri binary, no tauri-driver, no WebKitWebDriver or msedgedriver. Tauri commands are intercepted at the `window.__TAURI_INTERNALS__.invoke()` JavaScript boundary in the renderer, so you can mock individual commands and assert on call arguments just like in native mode.
+
+## Overview
+
+### What Is It?
+
+In normal (`native`) mode the service launches your compiled Tauri app, drives it via tauri-driver and a platform WebDriver, and communicates with the backend through the plugin bridge. Browser mode replaces all of that with a standard Chrome session: it sets `browserName` to `'chrome'`, navigates to your dev server URL, and injects a lightweight script that patches `window.__TAURI_INTERNALS__.invoke` so your Tauri commands can be intercepted in tests.
+
+### Why Use It?
+
+- **No build step needed** — point the service at `vite dev` and start testing immediately.
+- **Fast feedback** — no Tauri startup, no Rust compilation, no driver negotiation.
+- **Standard browser devtools** — Chrome DevTools and HMR work as normal during development.
+
+### When to Use It
+
+Browser mode is the right choice when your tests are renderer-focused: asserting UI state, verifying that components call the correct Tauri commands with the right arguments, or checking that the renderer handles mock responses correctly.
+
+It is **not** suitable when your tests need to:
+
+- Call `browser.tauri.execute()` to run code with access to the Tauri plugin bridge
+- Test window management with `browser.tauri.switchWindow()` or `browser.tauri.listWindows()`
+- Use `browser.tauri.triggerDeeplink()`
+- Assert on real command round-trips to a running Rust backend
+
+For those scenarios use native mode (the default).
+
+## Setup
+
+### 1. Start Your Dev Server
+
+Browser mode requires a running Vite dev server. Tauri's default port is `1420`:
+
+```bash
+vite dev
+# or: pnpm tauri dev (starts Vite and the Tauri binary; only Vite is needed for browser mode)
+```
+
+### 2. Configure the Service
+
+Set `mode: 'browser'` and provide `devServerUrl` in your WDIO configuration. No `appBinaryPath`, `tauri:options`, or driver config is needed.
+
+_`wdio.conf.ts`_
+
+```ts
+export const config = {
+  services: ['@wdio/tauri-service'],
+  capabilities: [
+    {
+      browserName: 'tauri',
+      'wdio:tauriServiceOptions': {
+        mode: 'browser',
+        devServerUrl: 'http://localhost:1420',
+      },
+    },
+  ],
+};
+```
+
+You can also set `mode` and `devServerUrl` at the global service level so all capabilities inherit them:
+
+```ts
+export const config = {
+  services: [
+    [
+      '@wdio/tauri-service',
+      {
+        mode: 'browser',
+        devServerUrl: 'http://localhost:1420',
+      },
+    ],
+  ],
+  capabilities: [
+    { browserName: 'tauri' },
+  ],
+};
+```
+
+Capability-level options take precedence over service-level ones. All capabilities in a session must use the same mode; mixing `'native'` and `'browser'` across capabilities throws a `SevereServiceError` at startup.
+
+## IPC Mocking
+
+### How It Works
+
+When the session starts, the service injects a script into the page that:
+
+1. Creates `window.__wdio_mocks__` — a registry of per-command mock functions.
+2. Patches `window.__TAURI_INTERNALS__.invoke` to look up `window.__wdio_mocks__[command]` and call it; throws if the command has no registered mock.
+3. Stubs `window.__TAURI_INTERNALS__.transformCallback` and related internals as no-ops where applicable.
+
+The injection script runs again after every `browser.url()` navigation because a page load wipes `window` state.
+
+### Mocking a Command
+
+```ts
+// In your test
+const mockReadFile = await browser.tauri.mock('read_file');
+await mockReadFile.mockResolvedValue('mocked file content');
+```
+
+The command name must match the string your frontend passes to `invoke()`:
+
+```ts
+// In your renderer code (e.g., via @tauri-apps/api/core)
+import { invoke } from '@tauri-apps/api/core';
+const content = await invoke('read_file', { path: '/some/file' });
+```
+
+### Asserting on Calls
+
+After triggering the relevant UI action, call `update()` to sync call data from the browser-side spy to the outer mock object, then assert:
+
+```ts
+await $('button#load-file').click(); // triggers invoke('read_file', ...)
+
+await mockReadFile.update();
+expect(mockReadFile).toHaveBeenCalledTimes(1);
+expect(mockReadFile.mock.calls[0]).toEqual([{ path: '/some/file' }]);
+```
+
+Element commands (`click`, `doubleClick`, `setValue`, `clearValue`) trigger `update()` automatically on all active mocks, so you often don't need to call it explicitly after those interactions.
+
+You can also trigger a command directly from the test without a UI interaction:
+
+```ts
+await browser.execute(() => window.__TAURI_INTERNALS__.invoke('read_file', { path: '/test' }));
+await mockReadFile.update();
+expect(mockReadFile).toHaveBeenCalledTimes(1);
+```
+
+### Setting Implementations
+
+All standard mock methods are available:
+
+```ts
+// Return a fixed value
+await mockReadFile.mockReturnValue('file content');
+
+// Resolve a promise (for async commands)
+await mockReadFile.mockResolvedValue('file content');
+
+// Use a function for dynamic responses
+await mockReadFile.mockImplementation((args) => {
+  return `content of ${args.path}`;
+});
+
+// Respond differently on the first call, then fall back
+await mockReadFile.mockResolvedValueOnce('first call content');
+await mockReadFile.mockResolvedValue('default content');
+```
+
+### Restoring a Mock
+
+`mockRestore()` deregisters the command from `window.__wdio_mocks__`. After restoring, any `invoke` call to that command will throw the "unmocked command" error.
+
+```ts
+await mockReadFile.mockRestore();
+```
+
+## Mock Lifecycle Across Tests
+
+### `mock(command)` Is Idempotent
+
+Calling `browser.tauri.mock(command)` multiple times for the same command is safe. The service returns the existing mock if the browser-side entry is still live, or silently re-registers it (without resetting call history or implementation) if a navigation wiped `window.__wdio_mocks__`.
+
+This means it is safe to call `mock(command)` in both `beforeAll` and `beforeEach`:
+
+```ts
+describe('File panel', () => {
+  let mockReadFile: TauriMock;
+
+  beforeAll(async () => {
+    mockReadFile = await browser.tauri.mock('read_file');
+    await mockReadFile.mockResolvedValue('default content');
+  });
+
+  beforeEach(async () => {
+    // Safe to call again — returns the same mock, implementation is preserved
+    mockReadFile = await browser.tauri.mock('read_file');
+    await mockReadFile.mockClear(); // Reset call history only
+  });
+
+  it('displays file content', async () => {
+    await $('button#load-file').click();
+    await mockReadFile.update();
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+### Clearing vs Resetting
+
+| Method | Effect |
+|--------|--------|
+| `mockClear()` | Clears `.mock.calls`, `.mock.results`, `.mock.invocationCallOrder`. Implementation unchanged. |
+| `mockReset()` | Clears history **and** removes the implementation (returns `undefined` on next call). |
+| `mockRestore()` | Removes the mock entirely from `window.__wdio_mocks__`. |
+
+Use `mockClear()` in `beforeEach` when you want a clean call history but want to keep the implementation set up in `beforeAll`.
+
+## Navigation
+
+`browser.url()` is patched by the service to re-run the IPC injection script after every navigation. This re-creates `window.__wdio_mocks__` (as an empty object) and patches `window.__TAURI_INTERNALS__.invoke` again, so existing mock handles remain valid — calling `mock(command)` after navigation re-registers the browser-side entry on demand.
+
+```ts
+it('preserves mock handles across navigation', async () => {
+  const mockGetConfig = await browser.tauri.mock('get_config');
+  await mockGetConfig.mockResolvedValue({ theme: 'dark' });
+
+  // Navigate to another route
+  await browser.url('http://localhost:1420/settings');
+
+  // Re-register and use — same outer mock object, fresh browser-side spy
+  await browser.tauri.mock('get_config');
+  await mockGetConfig.mockResolvedValue({ theme: 'dark' }); // Re-set implementation
+  await $('button#load-config').click();
+  await mockGetConfig.update();
+  expect(mockGetConfig).toHaveBeenCalledTimes(1);
+});
+```
+
+### Timing Caveat
+
+The injection script runs after `browser.url()` resolves (document `readyState` is `complete`). Any `invoke()` calls your app makes during module-level initialization — before the first `DOMContentLoaded` — happen before the script is injected and will not be intercepted.
+
+**Workaround:** Create a Vite plugin that imports the injection script as a top-level module in your dev build, so it runs before any app code.
+
+## Limitations
+
+| Feature | Browser Mode |
+|---------|-------------|
+| `browser.tauri.execute()` | Throws — no Tauri backend or plugin bridge |
+| `browser.tauri.triggerDeeplink()` | Throws — no Tauri process |
+| `browser.tauri.switchWindow()` | Throws — multi-window requires a native Tauri app |
+| `browser.tauri.listWindows()` | Throws — same reason as `switchWindow()` |
+| Backend log capture (`captureBackendLogs`) | Not available — no Rust process |
+| Frontend log capture (`captureFrontendLogs`) | Available — Chrome session, standard console capture |
+| Automatic window focus management | Disabled — standard Chrome window switching applies |
+| `window.__TAURI_INTERNALS__.invoke` event listeners | Not intercepted — fire-and-forget listeners are no-ops |
+
+## Multiremote
+
+Each named multiremote instance gets its own isolated mock registry. Mocking the same command on two instances is safe; they do not share `window.__wdio_mocks__`.
+
+_`wdio.conf.ts`_
+
+```ts
+export const config = {
+  services: [['@wdio/tauri-service', { mode: 'browser' }]],
+  capabilities: {
+    app1: {
+      capabilities: {
+        browserName: 'tauri',
+        'wdio:tauriServiceOptions': { devServerUrl: 'http://localhost:1420' },
+      },
+    },
+    app2: {
+      capabilities: {
+        browserName: 'tauri',
+        'wdio:tauriServiceOptions': { devServerUrl: 'http://localhost:1420' },
+      },
+    },
+  },
+};
+```
+
+```ts
+// In tests — each instance mocks independently
+const mock1 = await browser.getInstance('app1').tauri.mock('read_file');
+const mock2 = await browser.getInstance('app2').tauri.mock('read_file');
+
+await mock1.mockResolvedValue('content from app1');
+await mock2.mockResolvedValue('content from app2');
+```
+
+## Troubleshooting
+
+### `"unmocked Tauri command in browser mode: <command>"`
+
+Your renderer called `invoke(command)` before a mock was registered for that command. Call `browser.tauri.mock(command)` before the code path that triggers the command.
+
+### Mock returns `undefined` after navigation
+
+The browser-side mock was wiped by the navigation. Call `browser.tauri.mock(command)` again to re-register it and re-apply any implementation you need.
+
+### App commands during startup are not intercepted
+
+The injection script runs after page load. If your app invokes commands during module initialization, those calls happen before the script is active. See the [timing caveat](#timing-caveat) above.
+
+### Dev server not running
+
+The service throws a `SevereServiceError` if `devServerUrl` is missing or not a valid URL. A connection-refused error from Chrome means the dev server is not running — start Vite before launching the test suite.

--- a/packages/tauri-service/docs/browser-mode.md
+++ b/packages/tauri-service/docs/browser-mode.md
@@ -239,6 +239,30 @@ The injection script runs after `browser.url()` resolves (document `readyState` 
 | Frontend log capture (`captureFrontendLogs`) | Available — Chrome session, standard console capture |
 | Automatic window focus management | Disabled — standard Chrome window switching applies |
 | `window.__TAURI_INTERNALS__.invoke` event listeners | Not intercepted — fire-and-forget listeners are no-ops |
+| `mock.withImplementation()` | Serialised to browser page — see below |
+
+### `withImplementation` in browser mode
+
+`mock.withImplementation(implFn, callbackFn)` serialises **both** functions via `.toString()` and executes them inside the browser page using `executeAsync`. This means:
+
+- The `callbackFn` runs in the browser page, **not** in the Node.js test-runner process.
+- It cannot close over test-runner variables, call WebdriverIO commands (`browser.$()`, `browser.click()`, etc.), or use Node.js APIs (`fs`, `path`, etc.) — those symbols do not exist in the page context.
+- Only use `withImplementation` when both functions are fully self-contained browser-side snippets.
+
+For the common pattern of "use a temporary implementation while performing a UI action", use `mockImplementation` + `mockRestore` instead:
+
+```ts
+const mock = await browser.tauri.mock('read_file');
+await mock.mockImplementation(() => 'temporary content');
+
+// Perform your UI action using standard WebdriverIO commands
+await $('button#load-file').click();
+await mock.update();
+expect(mock).toHaveBeenCalledTimes(1);
+
+// Restore the original implementation
+await mock.mockRestore();
+```
 
 ## Multiremote
 

--- a/packages/tauri-service/docs/browser-mode.md
+++ b/packages/tauri-service/docs/browser-mode.md
@@ -159,6 +159,87 @@ await mockReadFile.mockResolvedValue('default content');
 await mockReadFile.mockRestore();
 ```
 
+## Events
+
+Tauri's event API (`listen` / `once` / `unlisten` / `emit` / `emitTo` from `@tauri-apps/api/event`) works in browser mode. The IPC injection routes the underlying `plugin:event|*` invocations through an in-page listener registry, so frontend subscriptions resolve and tests can dispatch events to them.
+
+### How It Works
+
+The injection script:
+
+1. Provides minimal stubs for `window.__TAURI_INTERNALS__.callbacks`, `transformCallback`, `runCallback`, and `unregisterCallback` (the bridge that real Tauri ships uses).
+2. Maintains `window.__wdio_tauri_listeners__` — a per-event registry of `{ handlerId, target }` entries keyed by a monotonic event id.
+3. Intercepts `plugin:event|listen` to register the handler and resolve with a numeric event id.
+4. Intercepts `plugin:event|unlisten` and `__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener` to remove handlers.
+5. Intercepts `plugin:event|emit` / `plugin:event|emit_to` so they dispatch via `runCallback` to subscribed handlers, with target filtering.
+
+If a user mock is set on `plugin:event|listen` / `unlisten` / `emit` / `emit_to`, the call is recorded by the mock for assertion purposes **and** the registry still applies the side effect — so subscriptions and dispatches keep working while you spy.
+
+### Emitting from Tests
+
+```ts
+// Frontend
+import { listen } from '@tauri-apps/api/event';
+const unlisten = await listen<number>('count-updated', (e) => {
+  document.querySelector('#count')!.textContent = String(e.payload);
+});
+
+// Test
+await browser.tauri.emitEvent('count-updated', 42);
+await expect($('#count')).toHaveText('42');
+```
+
+`browser.tauri.emitEvent()` is mode-agnostic — the same line works in native mode (where it routes through Tauri's real `event.emit()` via the plugin bridge) and in browser mode (where it routes through the in-page registry).
+
+### Targeted Emit
+
+Pass a third argument to restrict which listeners receive the event. Subscribers that registered with a matching `target` (or with `Any`) receive it; others do not.
+
+```ts
+// Frontend — listen only on the 'main' window
+await listen('focus', cb, { target: { kind: 'AnyLabel', label: 'main' } });
+
+// Test — emit only to 'main'
+await browser.tauri.emitEvent('focus', undefined, 'main');
+// Listeners registered against 'other' do NOT fire
+```
+
+The `target` argument accepts a string label (treated as `AnyLabel`) or a structured `TauriEventTarget` object: `{ kind: 'Any' | 'AnyLabel' | 'App' | 'Window' | 'Webview' | 'WebviewWindow', label?: string }`.
+
+### Asserting on Frontend `emit()` Calls
+
+Your frontend may call `emit()` itself (e.g. to broadcast UI events). Mock the underlying plugin command to spy on those calls — subscribers still fire because the registry runs alongside the mock:
+
+```ts
+const emitMock = await browser.tauri.mock('plugin:event|emit');
+
+await $('button#publish').click();
+await emitMock.update();
+
+expect(emitMock).toHaveBeenCalledTimes(1);
+expect(emitMock.mock.calls[0][0]).toEqual({ event: 'published', payload: { id: 7 } });
+```
+
+### `once()` Semantics
+
+`once()` from `@tauri-apps/api/event` is built on `listen()` with a self-removing handler — no special handling is needed. The handler fires exactly once; subsequent emits are ignored.
+
+```ts
+import { once } from '@tauri-apps/api/event';
+let calls = 0;
+await once('one-shot', () => { calls += 1; });
+
+await browser.tauri.emitEvent('one-shot');
+await browser.tauri.emitEvent('one-shot');
+// calls === 1
+```
+
+### Limitations
+
+- **Backend-emitted Tauri-internal events** (`tauri://resize`, `tauri://focus`, etc.) only fire if the test explicitly emits them — there is no real window/webview to source them. In native mode these fire naturally as the OS events occur.
+- **Listeners are wiped on navigation** — `browser.url()` rebuilds the registry. Subscriptions created before navigation will not fire afterwards. This matches the native-mode behaviour after a webview reload.
+- **Other plugin commands** (e.g. `plugin:fs|*`, `plugin:dialog|*`) are not registry-routed; they no-op resolve to `undefined` unless you explicitly mock them.
+
 ## Mock Lifecycle Across Tests
 
 ### `mock(command)` Is Idempotent

--- a/packages/tauri-service/docs/browser-mode.md
+++ b/packages/tauri-service/docs/browser-mode.md
@@ -244,23 +244,16 @@ await browser.tauri.emitEvent('one-shot');
 
 ### `mock(command)` Is Idempotent
 
-Calling `browser.tauri.mock(command)` multiple times for the same command is safe. The service returns the existing mock if the browser-side entry is still live, or silently re-registers it (without resetting call history or implementation) if a navigation wiped `window.__wdio_mocks__`.
-
-This means it is safe to call `mock(command)` in both `beforeAll` and `beforeEach`:
+Calling `browser.tauri.mock(command)` multiple times for the same command is safe, but the service always **fully resets** the existing mock (via `mockReset()`) before returning it — both call history and any previously-set implementation are cleared on every call. Set the implementation in `beforeEach` rather than relying on `beforeAll` setup persisting.
 
 ```ts
 describe('File panel', () => {
   let mockReadFile: TauriMock;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    // mock() fully resets — re-set the implementation each test
     mockReadFile = await browser.tauri.mock('read_file');
     await mockReadFile.mockResolvedValue('default content');
-  });
-
-  beforeEach(async () => {
-    // Safe to call again — returns the same mock, implementation is preserved
-    mockReadFile = await browser.tauri.mock('read_file');
-    await mockReadFile.mockClear(); // Reset call history only
   });
 
   it('displays file content', async () => {
@@ -283,19 +276,21 @@ Use `mockClear()` in `beforeEach` when you want a clean call history but want to
 
 ## Navigation
 
-`browser.url()` is patched by the service to re-run the IPC injection script after every navigation. This re-creates `window.__wdio_mocks__` (as an empty object) and patches `window.__TAURI_INTERNALS__.invoke` again, so existing mock handles remain valid — calling `mock(command)` after navigation re-registers the browser-side entry on demand.
+`browser.url()` is patched by the service to re-run the IPC injection script after every navigation. This re-creates `window.__wdio_mocks__` (as an empty object) and patches `window.__TAURI_INTERNALS__.invoke` again. Existing mock handles remain valid as JS objects, but their browser-side entries are gone — calling `mock(command)` alone after navigation will not re-register them. To recover, call `mockRestore()` (which removes the entry from the worker-side store) and then `mock(command)` to re-create the browser-side entry.
 
 ```ts
-it('preserves mock handles across navigation', async () => {
-  const mockGetConfig = await browser.tauri.mock('get_config');
+it('re-registers mocks after navigation', async () => {
+  let mockGetConfig = await browser.tauri.mock('get_config');
   await mockGetConfig.mockResolvedValue({ theme: 'dark' });
 
-  // Navigate to another route
+  // Navigate to another route — wipes window.__wdio_mocks__
   await browser.url('http://localhost:1420/settings');
 
-  // Re-register and use — same outer mock object, fresh browser-side spy
-  await browser.tauri.mock('get_config');
-  await mockGetConfig.mockResolvedValue({ theme: 'dark' }); // Re-set implementation
+  // The browser-side entry is gone. Restore (removes from store), then mock() to re-create.
+  await mockGetConfig.mockRestore();
+  mockGetConfig = await browser.tauri.mock('get_config');
+  await mockGetConfig.mockResolvedValue({ theme: 'dark' });
+
   await $('button#load-config').click();
   await mockGetConfig.update();
   expect(mockGetConfig).toHaveBeenCalledTimes(1);
@@ -388,7 +383,7 @@ Your renderer called `invoke(command)` before a mock was registered for that com
 
 ### Mock returns `undefined` after navigation
 
-The browser-side mock was wiped by the navigation. Call `browser.tauri.mock(command)` again to re-register it and re-apply any implementation you need.
+The browser-side entry was wiped by the navigation, and calling `mock(command)` alone will not re-register it (the worker-side mock is reset but the browser-side spy is not re-created). Call `mock.mockRestore()` first to delete the worker-side entry, then call `browser.tauri.mock(command)` to re-create both sides, and re-apply any implementation you need.
 
 ### App commands during startup are not intercepted
 

--- a/packages/tauri-service/docs/configuration.md
+++ b/packages/tauri-service/docs/configuration.md
@@ -264,6 +264,41 @@ statusPollTimeout: 5000
 
 ---
 
+### `devServerUrl` (string, required in browser mode)
+
+URL of the Vite (or other) dev server to navigate to when `mode: 'browser'` is set. Validated with `new URL()` at startup; throws a `SevereServiceError` if missing or malformed when browser mode is active.
+
+**Example:**
+```typescript
+devServerUrl: 'http://localhost:1420'  // Tauri Vite default
+```
+
+**Default:** `undefined`
+
+**Note:** Only used when `mode: 'browser'`. Has no effect in native mode. See [Browser Mode](./browser-mode.md).
+
+---
+
+### `mode` ('native' | 'browser', optional)
+
+Controls how the service connects to your application.
+
+- `'native'` (default) — launches your compiled Tauri binary via tauri-driver and WebKitWebDriver/msedgedriver.
+- `'browser'` — skips all driver and binary setup; sets `browserName = 'chrome'`, navigates to `devServerUrl`, and intercepts `window.__TAURI_INTERNALS__.invoke` so Tauri commands can be mocked without a running Rust backend.
+
+**Example:**
+```typescript
+mode: 'browser'
+```
+
+**Default:** `'native'`
+
+> **Note:** All capabilities in a session must use the same mode. Mixing `'native'` and `'browser'` across capabilities throws a `SevereServiceError` at startup.
+
+See [Browser Mode](./browser-mode.md) for setup, mocking, and limitations.
+
+---
+
 ### `clearMocks` (boolean, optional)
 
 If `true`, all mock call history is cleared before each test. Equivalent to calling `browser.tauri.clearAllMocks()` in a `beforeEach`.

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -322,6 +322,7 @@ export default class TauriWorkerService {
           await browser.execute(injectionScript);
         } catch (error) {
           log.warn('Failed to re-inject IPC script after navigation:', error);
+          throw error;
         }
       }
       return result;

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -1,5 +1,5 @@
 import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
-import type { TauriAPIs, TauriServiceAPI } from '@wdio/native-types';
+import type { TauriAPIs, TauriEventTarget, TauriServiceAPI } from '@wdio/native-types';
 import { createLogger, hasSemicolonOutsideQuotes, waitUntilWindowAvailable } from '@wdio/native-utils';
 import { execute } from './commands/execute.js';
 import { clearAllMocks, isMockFunction, mock, resetAllMocks, restoreAllMocks } from './commands/mock.js';
@@ -407,6 +407,52 @@ export default class TauriWorkerService {
           );
         }
         return listWindowLabels(browser);
+      },
+
+      emitEvent: async <T = unknown>(
+        eventName: string,
+        payload?: T,
+        target?: string | TauriEventTarget,
+      ): Promise<void> => {
+        const args: [string, unknown, unknown] = [eventName, payload, target];
+        if (browserMode) {
+          await (browser.execute as (fn: (...a: unknown[]) => unknown, ...a: unknown[]) => Promise<unknown>)(
+            (...inner: unknown[]) => {
+              const [ev, p, t] = inner as [string, unknown, unknown];
+              // @ts-expect-error - window exists in browser context
+              const w = window as {
+                __wdio_emit_tauri_event__?: (e: string, p: unknown, t: unknown) => void;
+              };
+              if (!w.__wdio_emit_tauri_event__) {
+                throw new Error('Tauri event registry not initialised — is browser mode active?');
+              }
+              w.__wdio_emit_tauri_event__(ev, p, t);
+            },
+            ...args,
+          );
+        } else {
+          await execute(
+            browser,
+            (tauri: TauriAPIs, ...a: unknown[]) => {
+              const [ev, p, t] = a as [string, unknown, unknown];
+              const ev2 = tauri.event as
+                | {
+                    emit: (name: string, payload?: unknown) => Promise<void>;
+                    emitTo: (target: unknown, name: string, payload?: unknown) => Promise<void>;
+                  }
+                | undefined;
+              if (!ev2) {
+                throw new Error('Tauri event API not available — is @tauri-apps/api loaded?');
+              }
+              if (t === undefined) {
+                return ev2.emit(ev, p);
+              }
+              return ev2.emitTo(t, ev, p);
+            },
+            ...args,
+          );
+        }
+        await updateAllMocks();
       },
     };
   }

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -415,7 +415,6 @@ export default class TauriWorkerService {
         payload?: T,
         target?: string | TauriEventTarget,
       ): Promise<void> => {
-        const args: [string, unknown, unknown] = [eventName, payload, target];
         if (browserMode) {
           await (browser.execute as (fn: (...a: unknown[]) => unknown, ...a: unknown[]) => Promise<unknown>)(
             (...inner: unknown[]) => {
@@ -429,7 +428,23 @@ export default class TauriWorkerService {
               }
               w.__wdio_emit_tauri_event__(ev, p, t);
             },
-            ...args,
+            eventName,
+            payload,
+            target,
+          );
+        } else if (target === undefined) {
+          await execute(
+            browser,
+            (tauri: TauriAPIs, ...a: unknown[]) => {
+              const [ev, p] = a as [string, unknown];
+              const ev2 = tauri.event as { emit: (name: string, payload?: unknown) => Promise<void> } | undefined;
+              if (!ev2) {
+                throw new Error('Tauri event API not available — is @tauri-apps/api loaded?');
+              }
+              return ev2.emit(ev, p);
+            },
+            eventName,
+            payload,
           );
         } else {
           await execute(
@@ -437,20 +452,16 @@ export default class TauriWorkerService {
             (tauri: TauriAPIs, ...a: unknown[]) => {
               const [ev, p, t] = a as [string, unknown, unknown];
               const ev2 = tauri.event as
-                | {
-                    emit: (name: string, payload?: unknown) => Promise<void>;
-                    emitTo: (target: unknown, name: string, payload?: unknown) => Promise<void>;
-                  }
+                | { emitTo: (target: unknown, name: string, payload?: unknown) => Promise<void> }
                 | undefined;
               if (!ev2) {
                 throw new Error('Tauri event API not available — is @tauri-apps/api loaded?');
               }
-              if (t === undefined) {
-                return ev2.emit(ev, p);
-              }
               return ev2.emitTo(t, ev, p);
             },
-            ...args,
+            eventName,
+            payload,
+            target,
           );
         }
         await updateAllMocks();

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -57,6 +57,7 @@ function createMockBrowser(overrides: Record<string, unknown> = {}): WebdriverIO
   return {
     execute: vi.fn().mockResolvedValue(undefined),
     executeAsync: vi.fn().mockResolvedValue(undefined),
+    url: vi.fn().mockResolvedValue(undefined),
     isMultiremote: false,
     sessionId: 'test-session-123',
     instances: [],
@@ -465,6 +466,93 @@ describe('TauriWorkerService', () => {
       } finally {
         Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
       }
+    });
+  });
+
+  describe('tauri.emitEvent()', () => {
+    it('should be exposed on the tauri API', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+      expect(typeof (mockBrowser as any).tauri.emitEvent).toBe('function');
+    });
+
+    it('should call browser.execute with the helper invocation in browser mode', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(undefined);
+      const mockBrowser = createMockBrowser({ execute: mockExecute });
+      const service = new TauriWorkerService(
+        { mode: 'browser', devServerUrl: 'http://localhost:1420' },
+        { 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: 'http://localhost:1420' } },
+      );
+      await service.before({} as any, [], mockBrowser);
+
+      mockExecute.mockClear();
+      await (mockBrowser as any).tauri.emitEvent('foo', { x: 1 });
+
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [fn, ...args] = mockExecute.mock.calls[0];
+      expect(typeof fn).toBe('function');
+      expect(args).toEqual(['foo', { x: 1 }, undefined]);
+    });
+
+    it('should pass the target through in browser mode', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(undefined);
+      const mockBrowser = createMockBrowser({ execute: mockExecute });
+      const service = new TauriWorkerService(
+        { mode: 'browser', devServerUrl: 'http://localhost:1420' },
+        { 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: 'http://localhost:1420' } },
+      );
+      await service.before({} as any, [], mockBrowser);
+
+      mockExecute.mockClear();
+      await (mockBrowser as any).tauri.emitEvent('focus', null, 'main');
+
+      const [, , , target] = mockExecute.mock.calls[0];
+      expect(target).toBe('main');
+    });
+
+    it('should call execute() with a function that uses tauri.event in native mode', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      vi.mocked(executeCommand).mockResolvedValueOnce(undefined as any);
+
+      await (mockBrowser as any).tauri.emitEvent('foo', 'payload');
+
+      expect(executeCommand).toHaveBeenCalledTimes(1);
+      const [, fn, ...args] = vi.mocked(executeCommand).mock.calls[0];
+      expect(typeof fn).toBe('function');
+      expect(args).toEqual(['foo', 'payload', undefined]);
+    });
+
+    it('should call updateAllMocks after emitting in browser mode', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(undefined);
+      const mockBrowser = createMockBrowser({ execute: mockExecute });
+      const service = new TauriWorkerService(
+        { mode: 'browser', devServerUrl: 'http://localhost:1420' },
+        { 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: 'http://localhost:1420' } },
+      );
+      await service.before({} as any, [], mockBrowser);
+
+      vi.mocked(mockStore.getMocks).mockReturnValue([]);
+
+      await (mockBrowser as any).tauri.emitEvent('foo');
+
+      expect(mockStore.getMocks).toHaveBeenCalled();
+    });
+
+    it('should call updateAllMocks after emitting in native mode', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      vi.mocked(executeCommand).mockResolvedValueOnce(undefined as any);
+      vi.mocked(mockStore.getMocks).mockReturnValue([]);
+
+      await (mockBrowser as any).tauri.emitEvent('foo');
+
+      expect(mockStore.getMocks).toHaveBeenCalled();
     });
   });
 

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -523,7 +523,41 @@ describe('TauriWorkerService', () => {
       expect(executeCommand).toHaveBeenCalledTimes(1);
       const [, fn, ...args] = vi.mocked(executeCommand).mock.calls[0];
       expect(typeof fn).toBe('function');
-      expect(args).toEqual(['foo', 'payload', undefined]);
+      expect(args).toEqual(['foo', 'payload']);
+    });
+
+    it('should route through tauri.event.emit() when target is omitted in native mode', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      vi.mocked(executeCommand).mockResolvedValueOnce(undefined as any);
+      await (mockBrowser as any).tauri.emitEvent('foo', 'payload');
+
+      const [, fn, ...args] = vi.mocked(executeCommand).mock.calls[0];
+      const emit = vi.fn().mockResolvedValue(undefined);
+      const emitTo = vi.fn().mockResolvedValue(undefined);
+      await (fn as any)({ event: { emit, emitTo } }, ...args);
+
+      expect(emit).toHaveBeenCalledWith('foo', 'payload');
+      expect(emitTo).not.toHaveBeenCalled();
+    });
+
+    it('should route through tauri.event.emitTo() when target is provided in native mode', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      vi.mocked(executeCommand).mockResolvedValueOnce(undefined as any);
+      await (mockBrowser as any).tauri.emitEvent('foo', 'payload', 'main');
+
+      const [, fn, ...args] = vi.mocked(executeCommand).mock.calls[0];
+      const emit = vi.fn().mockResolvedValue(undefined);
+      const emitTo = vi.fn().mockResolvedValue(undefined);
+      await (fn as any)({ event: { emit, emitTo } }, ...args);
+
+      expect(emitTo).toHaveBeenCalledWith('main', 'foo', 'payload');
+      expect(emit).not.toHaveBeenCalled();
     });
 
     it('should call updateAllMocks after emitting in browser mode', async () => {


### PR DESCRIPTION
Mirror Tauri's browser mode for Electron: adds mode='browser' +
devServerUrl to ElectronServiceOptions/GlobalOptions, skips binary
detection and CDP bridge in launcher, injects ipcRenderer IPC stub
into the browser page, and exposes browser.electron.mock(channel) for
test-side IPC channel mocking.

Also extracts WDIO_MOCK_SETUP_SCRIPT from TauriAdapter into a shared
injection.ts constant so both adapters compose from the same browser-
side mock factory, and fully implements ElectronAdapter (previously all
stubs) with all FrameworkAdapter methods.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>