### PR TITLE
docs: add Electrobun to planned support roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 - **React Native** - Popular mobile and desktop framework
 - **Flutter** - Google's UI toolkit for mobile and beyond
 - **Capacitor** - Ionic's cross-platform mobile framework
+- **Electrobun** - TypeScript-first desktop apps with system webviews and the Bun runtime
 - **Neutralino** - Lightweight desktop applications
 
 See [ROADMAP.md](./ROADMAP.md) for detailed sequencing, os support, and timelines.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,8 +28,8 @@ The table below quantifies the key factors used to prioritise and sequence plann
 | **Flutter** | Mobile | ~175k | Appium Flutter Driver | ✅ Production-ready | Reuses React Native mobile scaffold | Appium Flutter Driver maintenance, Dart VM | Medium |
 | **Ionic / Capacitor** | Mobile | ~52k / ~15k | Appium WebView context switching | ✅ Proven | Reuses mobile scaffold; pure WebView — zero new complexity | Appium server, native WebView availability | Low |
 | **Dioxus** | Desktop | ~34k | Wry webview → CDP (shared with Tauri) | 🟡 Emerging | High — same Wry/CDP patterns as Tauri service | Wry maturity, Dioxus desktop stability | Low–Medium |
+| **Electrobun** | Desktop | ~11.7k | Native CDP (port 9222 by convention) | 🟡 Emerging | Medium — CDP attach patterns from Electron service; no driver process | Bun runtime, system webviews, OOPIF (per-tab) target routing | Medium |
 | **Neutralino** | Desktop | ~7.9k | System webview → CDP (devtools endpoint) | 🟡 Emerging | Medium — similar endpoint detection to Electron service | System webview (WebView2 / WebKitGTK) | Low |
-| **Electrobun** | Desktop | ~11.7k | Native CDP (port 9222) | 🟡 Emerging (Beta) | Medium — CDP attach patterns from Electron service; no driver process | Bun runtime, system webviews, OOPIF (per-tab) target routing | Medium |
 | **Dioxus Mobile** | Mobile | *(same repo)* | Cargo Mobile 2 — experimental | 🔴 Early-stage | Reuses mobile scaffold + Dioxus desktop learnings | Cargo Mobile 2 maturity, platform bridge stability | High |
 | **React Native Desktop** | Desktop | *(same repo)* | Less mature than mobile counterpart | 🟡 Emerging | Leverages Phase 2 mobile experience | React Native Desktop renderer maturity | Medium–High |
 
@@ -111,10 +111,10 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Growing momentum in the lightweight desktop space (~12MB bundles, sub-50ms startup)
 - TypeScript-first authoring with Bun runtime, no Node.js requirement
 - System webview model aligns with Tauri/Dioxus patterns
-- MIT-licensed, active beta with v1 already shipped
+- MIT-licensed; v1 line shipped, APIs still stabilizing
 
 **Technical approach:**
-- Direct CDP attachment via WebSocket (default port 9222, configurable via `ELECTROBUN_CDP_PORT`)
+- Direct CDP attachment via WebSocket on the underlying webview's debugger port (port 9222 by `agent-electrobun` convention; the WDIO service will define its own override mechanism rather than rely on a built-in Electrobun env var)
 - No external driver process — connect like Electron, not Tauri
 - Multi-target session management for OOPIF webviews (shell vs per-tab CDP targets, classified by URL path)
 - Observation/input-only protocol calls — no `Page.navigate` on attach (would destroy app state)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ The table below quantifies the key factors used to prioritise and sequence plann
 | **Ionic / Capacitor** | Mobile | ~52k / ~15k | Appium WebView context switching | ✅ Proven | Reuses mobile scaffold; pure WebView — zero new complexity | Appium server, native WebView availability | Low |
 | **Dioxus** | Desktop | ~34k | Wry webview → CDP (shared with Tauri) | 🟡 Emerging | High — same Wry/CDP patterns as Tauri service | Wry maturity, Dioxus desktop stability | Low–Medium |
 | **Neutralino** | Desktop | ~7.9k | System webview → CDP (devtools endpoint) | 🟡 Emerging | Medium — similar endpoint detection to Electron service | System webview (WebView2 / WebKitGTK) | Low |
+| **Electrobun** | Desktop | ~11.7k | Native CDP (port 9222) | 🟡 Emerging (Beta) | Medium — CDP attach patterns from Electron service; no driver process | Bun runtime, system webviews, OOPIF (per-tab) target routing | Medium |
 | **Dioxus Mobile** | Mobile | *(same repo)* | Cargo Mobile 2 — experimental | 🔴 Early-stage | Reuses mobile scaffold + Dioxus desktop learnings | Cargo Mobile 2 maturity, platform bridge stability | High |
 | **React Native Desktop** | Desktop | *(same repo)* | Less mature than mobile counterpart | 🟡 Emerging | Leverages Phase 2 mobile experience | React Native Desktop renderer maturity | Medium–High |
 
@@ -101,7 +102,25 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Standard Appium WebView context switching
 - appPackage/appActivity capabilities
 
-### Phase 5: Neutralino Desktop (Q2 2027)
+### Phase 5: Electrobun Desktop (Q2 2027)
+**Priority:** Medium - Emerging TypeScript-first desktop framework
+
+**Target Platforms:** macOS 14+, Windows 11+, Linux (Ubuntu 22.04+)
+
+**Why Electrobun:**
+- Growing momentum in the lightweight desktop space (~12MB bundles, sub-50ms startup)
+- TypeScript-first authoring with Bun runtime, no Node.js requirement
+- System webview model aligns with Tauri/Dioxus patterns
+- MIT-licensed, active beta with v1 already shipped
+
+**Technical approach:**
+- Direct CDP attachment via WebSocket (default port 9222, configurable via `ELECTROBUN_CDP_PORT`)
+- No external driver process — connect like Electron, not Tauri
+- Multi-target session management for OOPIF webviews (shell vs per-tab CDP targets, classified by URL path)
+- Observation/input-only protocol calls — no `Page.navigate` on attach (would destroy app state)
+- Reuse `@wdio/electron-cdp-bridge` patterns; likely add a sibling bridge with multi-target routing
+
+### Phase 6: Neutralino Desktop (Q3 2027)
 **Priority:** Low - Niche use case
 
 **Target Platforms:** Windows, macOS, Linux
@@ -117,7 +136,7 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Electron service patterns (devtools endpoint detection)
 - Standard WebdriverIO parallelization
 
-### Phase 6: Dioxus Mobile Experimental (Q3 2027)
+### Phase 7: Dioxus Mobile Experimental (Q4 2027)
 **Priority:** Low - Experimental platform
 
 **Target Platforms:** iOS, Android (experimental)
@@ -127,7 +146,7 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Reuses established mobile scaffold
 - Completes Rust ecosystem coverage
 
-### Phase 7: React Native Desktop (Q4 2027)
+### Phase 8: React Native Desktop (Q1 2028)
 **Priority:** Low - Desktop expansion
 
 **Target Platforms:** Windows, macOS, Linux

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,7 +114,7 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - MIT-licensed; v1 line shipped, APIs still stabilizing
 
 **Technical approach:**
-- Direct CDP attachment via WebSocket on the underlying webview's debugger port (port 9222 by `agent-electrobun` convention; the WDIO service will define its own override mechanism rather than rely on a built-in Electrobun env var)
+- Direct CDP attachment via WebSocket on the underlying webview's debugger port (the third-party [agent-electrobun](https://github.com/Ataraxy-Labs/agent-electrobun) CLI defaults to 9222 for Electrobun apps; the WDIO service will define its own override mechanism rather than rely on a built-in Electrobun env var)
 - No external driver process — connect like Electron, not Tauri
 - Multi-target session management for OOPIF webviews (shell vs per-tab CDP targets, classified by URL path)
 - Observation/input-only protocol calls — no `Page.navigate` on attach (would destroy app state)


### PR DESCRIPTION
## Summary
- Adds **Electrobun** to the planned support list (`README.md`) and Phase 5 of the roadmap (`ROADMAP.md`), reflecting its growing momentum (~11.7k stars, beta) in the lightweight TypeScript desktop space.
- Cascades Neutralino → Phase 6, Dioxus Mobile → Phase 7, React Native Desktop → Phase 8, with quarter labels updated accordingly.
- Adds a row to the Framework Compatibility Analysis table summarising Electrobun's automation surface (CDP on port 9222, no driver process, OOPIF complexity).

## Why this slot
Electrobun is feasible to support via WDIO and *easier* to wire up than Tauri (no driver-proxy needed — CDP is exposed natively), but harder than Electron because of its OOPIF model: each tab is a separate OS process with its own CDP target, and naive `connectOverCDP()` flows (e.g. Playwright's) break the app by navigating on attach. Reuse target: `@wdio/electron-cdp-bridge` patterns with multi-target routing.

Dioxus retains Phase 1 priority as previously planned. Electrobun supersedes Neutralino's slot due to more momentum (~11.7k vs ~7.9k stars) and a similar architectural fit.

## Test plan
- [ ] Render `ROADMAP.md` and confirm phases 1–8 are sequential with consistent quarter labels (Q2 2026 → Q1 2028)
- [ ] Confirm new row in compatibility table aligns column-wise with existing rows
- [ ] Confirm Electrobun appears in `README.md` Planned Support list between Capacitor and Neutralino

🤖 Generated with [Claude Code](https://claude.com/claude-code)