### PR TITLE
feat(dioxus): @wdio/dioxus-service MVP — scaffolding + bridge IPC + execute + log capture + mocking

### DIFF
--- a/.claude/skills/add-native-service/SKILL.md
+++ b/.claude/skills/add-native-service/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: Add Native Service
+description: Process for adding a new framework service (e.g. @wdio/dioxus-service, @wdio/electrobun-service, @wdio/capacitor-service) to this monorepo. Use this skill when the user asks to add support for a new desktop or mobile framework, when extending the supported-frameworks list in ROADMAP.md, or when bootstrapping any new @wdio/<framework>-service package.
+---
+
+# Add Native Service
+
+A runbook for bootstrapping a new WebdriverIO service package in this monorepo. Distilled from the Dioxus service implementation (PR1 + PR2 of branch `feat/dioxus-mvp`); will be refined as subsequent services land.
+
+This skill assumes the new service follows the established pattern: a TypeScript service package, optional Rust crate(s) for in-app bridge / driver plumbing, fixtures, E2E specs, and CI gating.
+
+## When to use
+
+- A new framework (Electrobun, Neutralino, Flutter, React Native, Capacitor, etc.) is being added to the supported-frameworks list per `ROADMAP.md`.
+- An existing pre-1.0 service is being promoted to its first real package (Phase 0 spike → first MVP).
+- You need to validate that a new framework can be automated before committing to a service implementation.
+
+## When NOT to use
+
+- Adding features to an already-shipped service (`@wdio/tauri-service`, `@wdio/electron-service`, `@wdio/dioxus-service`) — those have their own conventions documented in each package's README.
+- Pure refactors of `@wdio/native-core` — see `agent-os/specs/<spec>/IMPLEMENTATION_PLAN.md` for the standards extraction process.
+
+## High-level architecture
+
+```
+@wdio/native-types       — type-only; framework-specific types + module augmentation
+@wdio/native-utils       — generic primitives (logger, Result, config readers)
+@wdio/native-spy         — mock framework + per-framework interceptor adapters
+@wdio/native-core        — shared launcher infrastructure (PortManager, DriverPool,
+                            DriverProcess, BaseLauncher, logCapture skeleton, logWriter,
+                            deeplink helpers, logLevel)
+@wdio/<framework>-service — your new package
+packages/<framework>-bridge — Rust crate (optional, if the app needs in-app plumbing)
+packages/<framework>-driver — Rust crate (optional, if external WebDriver proxy needed)
+```
+
+Reuse what you can from `@wdio/native-core` (port management, driver lifecycle, log writer); add framework-specific behaviour on top.
+
+## Process
+
+### Phase 0 — Pre-implementation spike
+
+Validate the platform constraints before writing any production code. Spikes are throwaway — they live in `/spike/<service-name>-spike/` (gitignored).
+
+1. Create the spike directory and a minimal app that uses the framework's public API.
+2. Identify the **single most consequential unknown** for the service. Examples:
+   - Dioxus: "can a third-party crate flip Wry's `set_allows_automation`?"
+   - Electrobun: "is there a stable CDP port and what's the discovery convention?"
+   - Capacitor: "what WebView context name does Appium see?"
+3. Write code that tries to exercise that unknown. If it fails, identify the workaround (upstream patch needed? alternate API? scope reduction?).
+4. Write `spike/FINDINGS.md` capturing:
+   - The question, the answer, and the citations (file paths, source snippets).
+   - The decision tree for the production implementation.
+   - Any platform-by-platform variance (often the most important section — see the Dioxus matrix where the same Wry API is a no-op on Win/Mac but blocking on Linux).
+5. Apply the findings to the implementation plan: update Risks, Platform Matrix, and Phasing.
+
+The spike is throwaway code — its output is the FINDINGS document, not the source. Don't merge the spike directory.
+
+### Phase 1 — TypeScript service skeleton
+
+Create `packages/<framework>-service/` with:
+
+```
+packages/<framework>-service/
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts                    (unit, parallel)
+├── vitest.integration.config.ts        (integration, fileParallelism: false)
+└── src/
+    ├── index.ts                        public exports (default = worker, launcher = launch service)
+    ├── launcher.ts                     extends BaseLauncher
+    ├── service.ts                      installs browser.<framework>.* surface
+    ├── errors.ts                       SevereServiceError helpers
+    └── types.ts                        re-exports public types from @wdio/native-types
+```
+
+**Conventions:**
+
+- Initial version: `1.0.0-next.0` (pre-release).
+- `package.json` must include `@wdio/native-core`, `@wdio/native-spy`, `@wdio/native-types`, `@wdio/native-utils` as workspace deps. Mirror `@wdio/tauri-service`'s package.json structure exactly — exports, scripts, devDependencies, peerDependencies. The build script is `tsx ../../scripts/build-package.ts`.
+- `vitest.integration.config.ts` MUST use `fileParallelism: false` + 30s timeout + `setupFiles: ['test/integration/setup.ts']`.
+- `tsconfig.json` extends `../../tsconfig.base.json`, output to `./dist`, root `./src`.
+
+**`launcher.ts`:** extend `BaseLauncher` from `@wdio/native-core`. Implement `onPrepare` and `onComplete`. Guard with platform-specific `SevereServiceError` throws when a platform/provider combination is known unsupportable (per spike findings).
+
+**Types in `@wdio/native-types/src/<framework>.ts`:**
+- `<Framework>APIs` — bridge-installed window surface
+- `<Framework>ExecuteOptions` — per-call execute overrides
+- `<Framework>Mock<T,R>` + `<Framework>MockInstance` — mock function shapes (mirror `TauriMock`)
+- `<Framework>ServiceAPI` — full `browser.<framework>.*` interface
+- `<Framework>ServiceOptions` + `<Framework>ServiceGlobalOptions` — config shapes
+- `<Framework>DriverProvider` — `'external' | 'embedded'` union (use `'external'`, NOT `'official'` — the latter is deprecated and only kept as a Tauri alias)
+- `<Framework>Capabilities` — capability shape (interface, NOT extending `Capabilities.RequestedStandaloneCapabilities` directly because dynamic members confuse Rollup; intersect with it at the service level if needed)
+- `<Framework>BrowserExtension` — adds `<framework>` field to BrowserBase
+
+Then wire into `@wdio/native-types/src/index.ts`:
+- `export type { ... } from './<framework>.js';`
+- `BrowserExtension extends ... <Framework>BrowserExtension {}`
+- `declare global { namespace WebdriverIO { interface Browser extends ... }`, `interface Capabilities { 'wdio:<framework>ServiceOptions'?: ... }`, `interface ServiceOption extends ... <Framework>ServiceGlobalOptions {}`
+
+### Phase 2 — Rust crates (if needed)
+
+Two patterns:
+
+**Driver crate** (e.g. `packages/<framework>-driver/` → `wdio-<framework>-driver`): forked from `tauri-driver` if the framework uses Wry. ~200 LOC delta:
+- Rename crate + binary to `wdio-<framework>-driver` (the `wdio-` prefix leaves the unprefixed namespace free for the framework's project).
+- Capability namespace: `"<framework>:options"` (matches your TS `<framework>:options` capability key).
+- Env var: `<FRAMEWORK>_WEBVIEW_AUTOMATION` (and drop the legacy `TAURI_AUTOMATION` form).
+- Document the upstream-sync policy in the crate's README.
+
+**Bridge crate** (e.g. `packages/<framework>-bridge/` → `wdio-<framework>-bridge`): new code. v1 minimum slice is just `automation.rs` (reads `<FRAMEWORK>_WEBVIEW_AUTOMATION`, logs state). Full IPC (`wdio://` custom protocol + invoke command bus + log forwarder + guest-js) is Phase 3 work, not Phase 2.
+
+**Cargo conventions:**
+- Edition `"2021"`, rust-version `"1.77.2"` (matches tauri-driver).
+- License `Apache-2.0 OR MIT`.
+- Initial version `1.0.0-rc.0`.
+- `with-bridge` feature flag (default off) so release builds can compile out the crate.
+
+**Gitignore at repo root:**
+```
+packages/*/target/
+packages/*/Cargo.lock
+```
+
+(Matches existing tauri-plugin convention — Cargo.lock for these crates is not committed.)
+
+### Phase 3 — Tests
+
+**Conventions:**
+- Use `it('should ...')` throughout. Never `it('does X', ...)` or `it('returns Y', ...)`. Tauri's existing suite is the reference.
+- Test files: `test/<module>.spec.ts` for unit, `test/integration/<module>.integration.spec.ts` for integration.
+- Mock at the `@wdio/native-core` boundary, not at local module boundaries. If a service module is a thin wrapper around core, the test should `vi.mock('@wdio/native-core', ...)` with a Map-backed in-memory fake — see `packages/tauri-service/test/driverPool.spec.ts` for the reference pattern.
+- Rust unit tests: inline `#[cfg(test)] mod tests` blocks. Use `should_*` function names.
+
+**Minimum spec inventory at Phase 1 commit:**
+- `test/index.spec.ts` — public export shape
+- `test/errors.spec.ts` — error helpers
+- `test/launcher.spec.ts` — platform × provider matrix (especially any SevereServiceError throws)
+
+Coverage target: ≥80% statement coverage per `AGENTS.md`. Thin-wrapper packages can declare an exception in `vitest.config.ts` with a comment explaining why.
+
+### Phase 4 — CI gates
+
+In `.github/workflows/_ci-detect-changes.reusable.yml`:
+
+1. Add `run_<framework>` to the outputs declarations + computation.
+2. Add filters under `paths-filter`:
+   - `<framework>_service`: `packages/<framework>-service/**`, plus any Rust crate paths.
+   - `e2e_<framework>`: `e2e/test/<framework>/**`, `e2e/wdio.<framework>.conf.ts`, etc.
+   - `fixtures_<framework>`: `fixtures/e2e-apps/<framework>/**`, `fixtures/package-tests/<framework>-app/**`.
+3. **Extend the `shared` filter** to include any new packages added under `packages/native-*` (e.g., `packages/native-spy/**`, `packages/native-core/**` — these are easy to forget and were latent CI gaps before Dioxus).
+4. Add `RUN_<FRAMEWORK>` to the lint-only gate.
+
+In `.github/workflows/ci.yml`: add `<framework>`-gated jobs mirroring Tauri's set, conditioned on `needs.detect-changes.outputs.run_<framework> == 'true'`.
+
+New reusable workflows (clone from Tauri equivalents):
+- `_ci-build-<framework>-apps.reusable.yml`
+- `_ci-build-<framework>-e2e-app.reusable.yml`
+- `_ci-build-<framework>-package-app.reusable.yml`
+- `_ci-e2e-<framework>-all-providers.reusable.yml`
+
+Extend `_ci-package.reusable.yml` and `_ci-package-docker.reusable.yml` to accept `<framework>` in the service matrix.
+
+### Phase 5 — Fixtures, E2E specs, docs, release pipeline
+
+This phase is large and is broken out per the standard 4-PR split (see Plan / PR split below). At the very least, before merging the MVP:
+
+- `fixtures/e2e-apps/<framework>/` — minimal app demonstrating execute + mock + multi-window.
+- `e2e/test/<framework>/{api,application,execute-advanced,execute-data-types,logging,logging.external,mocking,window}.spec.ts` — core E2E set, mirroring `e2e/test/tauri/`.
+- `e2e/wdio.<framework>.conf.ts` (provider `'external'`) + `e2e/wdio.<framework>-embedded.conf.ts` (provider `'embedded'`).
+- `packages/<framework>-service/README.md` + `docs/` set (quick-start, configuration, api-reference, usage-examples, plugin-setup, platform-support, troubleshooting, release-notes/v1.0.0.md).
+- Each Rust crate gets its own README.
+- Root `README.md`, `ROADMAP.md`, `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/*.md` updates.
+- Release pipeline: update `.github/workflows/release.yml` + `_release.reusable.yml` for npm publish (`@wdio/<framework>-service`, `@wdio/<framework>-bridge`) and crates.io publish (`wdio-<framework>-driver`, `wdio-<framework>-bridge`, `wdio-<framework>-embedded-driver`).
+
+## Naming conventions
+
+| What | Convention | Example |
+|---|---|---|
+| npm service package | `@wdio/<framework>-service` | `@wdio/dioxus-service` |
+| npm bridge JS bundle | `@wdio/<framework>-bridge` (no `-js` suffix) | `@wdio/dioxus-bridge` |
+| Rust bridge crate | `wdio-<framework>-bridge` | `wdio-dioxus-bridge` |
+| Rust driver crate | `wdio-<framework>-driver` (NOT `<framework>-driver`) | `wdio-dioxus-driver` |
+| Rust embedded crate | `wdio-<framework>-embedded-driver` | `wdio-dioxus-embedded-driver` |
+| Capability key | `<framework>:options` | `dioxus:options` |
+| WDIO service options key | `wdio:<framework>ServiceOptions` | `wdio:dioxusServiceOptions` |
+| Window namespace | `window.__WDIO_<FRAMEWORK>__` | `window.__WDIO_DIOXUS__` |
+| Automation env var | `<FRAMEWORK>_WEBVIEW_AUTOMATION` | `DIOXUS_WEBVIEW_AUTOMATION` |
+| Browser API surface | `browser.<framework>.*` | `browser.dioxus.execute(...)` |
+
+**Why `wdio-` prefix on Rust crates:** Leaves the unprefixed namespace (e.g. `dioxus-driver`) free for the framework's own project, which may want to use it for their official tooling.
+
+**Provider names:** Use `'external'` and `'embedded'`. `'official'` is a deprecated Tauri alias only — don't introduce it on new services.
+
+## Plan / PR split
+
+For a service this size, default to a 4-PR stacked split:
+
+| PR | Branch (off main) | Scope |
+|---|---|---|
+| **PR1: Foundation** | `feat/<service>-foundation` | Any `@wdio/native-core` extractions needed; deprecation aliases on existing services. |
+| **PR2: MVP** | `feat/<service>-mvp` (off PR1) | TS service skeleton, Rust crate skeletons, basic execute + mock, minimum CI. |
+| **PR3: Feature Complete** | `feat/<service>-feature-complete` (off PR2) | Multi-window, deeplink, embedded provider, browser mode, macOS, visual testing. |
+| **PR4: Ship** | `feat/<service>-ship` (off PR3) | Package-test fixture, full doc set, complete CI, release pipeline. |
+
+Each PR must have green tests on all three suites (`@wdio/<framework>-service`, `@wdio/tauri-service`, `@wdio/electron-service`) plus any Rust `cargo test`. No regressions, ever.
+
+## Common gotchas
+
+1. **Spike before commit.** The Dioxus spike revealed Linux `'external'` was blocked by an upstream Dioxus API gap. Doing the spike first scoped v1 to Windows-only `'external'` rather than blocking the whole release on an external dependency. Always run a Phase 0 spike.
+
+2. **Don't extract speculatively.** During PR1, the Dioxus plan called for extracting `logForwarder` + `logParser` into `@wdio/native-core`. The audit revealed those are too framework-specific to unify (Tauri text-line vs Electron CDP events). Only `shouldLog` was genuinely shared. Audit before extracting; extract only what's actually duplicated bit-for-bit.
+
+3. **Mock at the right boundary.** When a service module is a thin wrapper around `@wdio/native-core`, tests must mock at the core boundary (`vi.mock('@wdio/native-core', ...)`) not the local module. Otherwise the mock won't reach the actual spawn/IO call. Pattern: Map-backed in-memory fake. See `packages/tauri-service/test/driverPool.spec.ts`.
+
+4. **`Capabilities.RequestedStandaloneCapabilities` cannot be extended.** Rollup's TS plugin can't extend dynamic-member interfaces. Declare `<Framework>Capabilities` as a plain interface and intersect with `Capabilities.RequestedStandaloneCapabilities` at the service-level type aliases (see `TauriServiceRequestedStandaloneCapabilities` for the pattern).
+
+5. **Async log writer close.** Core's `LogWriter.close()` is async (calls `stream.end(callback)` and waits for flush). When porting Tauri-style synchronous `close()` callers, mock `end: vi.fn((cb?) => cb?.())` so the underlying promise resolves in tests, and remember to `await` close calls.
+
+6. **`shared` paths-filter gaps.** `packages/native-spy/**` and `packages/native-core/**` need to be in the `shared` filter of `_ci-detect-changes.reusable.yml`. Easy to miss; resulted in latent CI gaps before Dioxus PR1.
+
+7. **Gitignore Rust build artefacts.** `packages/*/target/` and `packages/*/Cargo.lock` go in the root `.gitignore`. Forgetting this can result in a 42 MB accidental commit of build artifacts (yes, this happened during Dioxus PR2).
+
+8. **Rust env-var tests use `unsafe { std::env::set_var(...) }`** in 2024 edition. Tests should be in a single `mod tests` to avoid parallel-test interference, or clean up afterwards.
+
+## Verification checklist (per PR)
+
+Before merging each PR:
+
+- [ ] `pnpm --filter @wdio/<framework>-service typecheck` clean
+- [ ] `pnpm --filter @wdio/<framework>-service test:unit` green (all `it('should ...')`)
+- [ ] `pnpm --filter @wdio/<framework>-service test:coverage` ≥ 80%
+- [ ] `pnpm --filter @wdio/tauri-service test:unit` no regressions
+- [ ] `pnpm --filter @wdio/electron-service test:unit` no regressions
+- [ ] `pnpm --filter @wdio/native-core test:unit` no regressions
+- [ ] `cargo check` clean for each new Rust crate
+- [ ] `cargo test` green for each new Rust crate
+- [ ] No `packages/*/target/` files staged
+
+## Reference implementations
+
+- **Dioxus service** — `packages/dioxus-service/`, `packages/dioxus-bridge/`, `packages/dioxus-driver/`. The reference for this skill.
+- **Tauri service** — `packages/tauri-service/`. The mature, fully-shipped reference (multi-window, multiremote, browser mode, all three providers).
+- **Electron service** — `packages/electron-service/`. The CDP-based alternative architecture; useful when the framework doesn't use Wry.
+- **Plan files** — `~/.claude/plans/<plan-name>.md`. Always start with a plan that captures Strategy decisions, Package layout, Phasing, Risks, and Open decisions.
+- **Spike findings** — `spike/FINDINGS.md`. Captures the Phase 0 spike for whatever question is being investigated.
+
+## Versioning over time
+
+This skill captures the process as of PR2 of the Dioxus service. Update it as later phases land:
+
+- After PR2 MVP: add specifics about bridge IPC (invoke.rs, log_bridge.rs) and guest-js bundle layout.
+- After PR3 Feature Complete: add specifics about embedded WebDriver crates and macOS quirks.
+- After PR4 Ship: add the full release / publishing checklist with concrete `gh release` + `cargo publish` flow.
+- Promote skill from `.claude/skills/add-native-service/SKILL.md` to a markdown reference in `agent-os/standards/` once a third service has gone through the process and the patterns are settled.

--- a/.github/workflows/_ci-build-dioxus-crates.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-crates.reusable.yml
@@ -1,0 +1,76 @@
+name: Build Dioxus Crates (Reusable)
+
+permissions:
+  contents: read
+
+# Reusable job that verifies the wdio-dioxus-bridge and wdio-dioxus-driver
+# Rust crates compile cleanly and their unit tests pass. Gated on
+# `run_dioxus` from _ci-detect-changes.reusable.yml.
+#
+# v1 scope: Linux only. The bridge crate has unit tests; the driver crate
+# is a transparent WebDriver proxy with no unit tests (covered by E2E later).
+# Cross-platform validation (Windows for the external provider, macOS for
+# the embedded provider) lands in PR3 / Feature Complete.
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system to run on'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+jobs:
+  build:
+    name: Cargo check + test
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry + target dirs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/dioxus-bridge/target
+            packages/dioxus-driver/target
+          key: ${{ runner.os }}-cargo-dioxus-${{ hashFiles('packages/dioxus-bridge/Cargo.toml', 'packages/dioxus-driver/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-dioxus-
+
+      - name: Install Linux WebKit dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev
+
+      # Build the guest-js bundle so the bridge crate's build.rs can embed it.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile --filter @wdio/dioxus-bridge
+      - name: Build dioxus-bridge guest-js
+        run: pnpm --filter @wdio/dioxus-bridge build
+
+      - name: cargo check (wdio-dioxus-bridge)
+        run: cargo check
+        working-directory: packages/dioxus-bridge
+
+      - name: cargo test (wdio-dioxus-bridge)
+        run: cargo test
+        working-directory: packages/dioxus-bridge
+
+      - name: cargo check (wdio-dioxus-driver)
+        run: cargo check
+        working-directory: packages/dioxus-driver

--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -18,6 +18,9 @@ on:
       run_tauri:
         description: 'Whether to run Tauri-related tests and builds'
         value: ${{ jobs.detect.outputs.run_tauri }}
+      run_dioxus:
+        description: 'Whether to run Dioxus-related tests and builds'
+        value: ${{ jobs.detect.outputs.run_dioxus }}
       has_shared_changes:
         description: 'Whether shared packages changed (affects both services)'
         value: ${{ jobs.detect.outputs.has_shared_changes }}
@@ -32,6 +35,7 @@ jobs:
     outputs:
       run_electron: ${{ steps.determine.outputs.run_electron || 'false' }}
       run_tauri: ${{ steps.determine.outputs.run_tauri || 'false' }}
+      run_dioxus: ${{ steps.determine.outputs.run_dioxus || 'false' }}
       has_shared_changes: ${{ steps.determine.outputs.has_shared_changes || 'false' }}
       run_lint_only: ${{ steps.determine.outputs.run_lint_only || 'false' }}
 
@@ -60,10 +64,18 @@ jobs:
               - 'packages/tauri-service/**'
               - 'packages/tauri-plugin/**'
 
-            # Shared packages (affect both services)
+            # Dioxus service packages
+            dioxus_service:
+              - 'packages/dioxus-service/**'
+              - 'packages/dioxus-bridge/**'
+              - 'packages/dioxus-driver/**'
+
+            # Shared packages (affect all services)
             shared:
               - 'packages/native-types/**'
               - 'packages/native-utils/**'
+              - 'packages/native-core/**'
+              - 'packages/native-spy/**'
               - 'packages/bundler/**'
 
             # E2E tests
@@ -73,6 +85,10 @@ jobs:
             e2e_tauri:
               - 'e2e/test/tauri/**'
               - 'e2e/wdio.tauri.conf.ts'
+            e2e_dioxus:
+              - 'e2e/test/dioxus/**'
+              - 'e2e/wdio.dioxus.conf.ts'
+              - 'e2e/wdio.dioxus-embedded.conf.ts'
 
             # Test fixtures and apps
             fixtures_electron:
@@ -81,6 +97,9 @@ jobs:
               - 'fixtures/e2e-apps/electron-script/**'
             fixtures_tauri:
               - 'fixtures/e2e-apps/tauri/**'
+            fixtures_dioxus:
+              - 'fixtures/e2e-apps/dioxus/**'
+              - 'fixtures/package-tests/dioxus-app/**'
 
             # Infrastructure (always triggers both)
             infra:
@@ -106,6 +125,7 @@ jobs:
           if [ "${{ inputs.force_all }}" = "true" ]; then
             echo "run_electron=true" >> $GITHUB_OUTPUT
             echo "run_tauri=true" >> $GITHUB_OUTPUT
+            echo "run_dioxus=true" >> $GITHUB_OUTPUT
             echo "has_shared_changes=true" >> $GITHUB_OUTPUT
             echo "::notice::Force all mode enabled - running all tests"
             exit 0
@@ -115,21 +135,27 @@ jobs:
           echo "docs=${{ steps.changes.outputs.docs }}"
           echo "electron_service=${{ steps.changes.outputs.electron_service }}"
           echo "tauri_service=${{ steps.changes.outputs.tauri_service }}"
+          echo "dioxus_service=${{ steps.changes.outputs.dioxus_service }}"
           echo "shared=${{ steps.changes.outputs.shared }}"
           echo "e2e_electron=${{ steps.changes.outputs.e2e_electron }}"
           echo "e2e_tauri=${{ steps.changes.outputs.e2e_tauri }}"
+          echo "e2e_dioxus=${{ steps.changes.outputs.e2e_dioxus }}"
           echo "fixtures_electron=${{ steps.changes.outputs.fixtures_electron }}"
           echo "fixtures_tauri=${{ steps.changes.outputs.fixtures_tauri }}"
+          echo "fixtures_dioxus=${{ steps.changes.outputs.fixtures_dioxus }}"
           echo "infra=${{ steps.changes.outputs.infra }}"
 
           DOCS=${{ steps.changes.outputs.docs }}
           ELECTRON=${{ steps.changes.outputs.electron_service }}
           TAURI=${{ steps.changes.outputs.tauri_service }}
+          DIOXUS=${{ steps.changes.outputs.dioxus_service }}
           SHARED=${{ steps.changes.outputs.shared }}
           E2E_ELECTRON=${{ steps.changes.outputs.e2e_electron }}
           E2E_TAURI=${{ steps.changes.outputs.e2e_tauri }}
+          E2E_DIOXUS=${{ steps.changes.outputs.e2e_dioxus }}
           FIXTURES_ELECTRON=${{ steps.changes.outputs.fixtures_electron }}
           FIXTURES_TAURI=${{ steps.changes.outputs.fixtures_tauri }}
+          FIXTURES_DIOXUS=${{ steps.changes.outputs.fixtures_dioxus }}
           INFRA=${{ steps.changes.outputs.infra }}
 
           # Electron runs if: electron_service || e2e_electron || fixtures_electron || shared || infra
@@ -144,15 +170,22 @@ jobs:
             RUN_TAURI="false"
           fi
 
+          # Dioxus runs if: dioxus_service || e2e_dioxus || fixtures_dioxus || shared || infra
+          RUN_DIOXUS=$(echo "$DIOXUS $E2E_DIOXUS $FIXTURES_DIOXUS $SHARED $INFRA" | grep -o 'true' | head -1 || echo "")
+          if [ -z "$RUN_DIOXUS" ]; then
+            RUN_DIOXUS="false"
+          fi
+
           # Lint-only mode when no service-impacting changes detected
           # Covers docs-only PRs, config-only edits outside infra, etc.
           RUN_LINT_ONLY="false"
-          if [ "$RUN_ELECTRON" = "false" ] && [ "$RUN_TAURI" = "false" ]; then
+          if [ "$RUN_ELECTRON" = "false" ] && [ "$RUN_TAURI" = "false" ] && [ "$RUN_DIOXUS" = "false" ]; then
             RUN_LINT_ONLY="true"
           fi
 
           echo "run_electron=$RUN_ELECTRON" >> $GITHUB_OUTPUT
           echo "run_tauri=$RUN_TAURI" >> $GITHUB_OUTPUT
+          echo "run_dioxus=$RUN_DIOXUS" >> $GITHUB_OUTPUT
           echo "has_shared_changes=$SHARED" >> $GITHUB_OUTPUT
           echo "run_lint_only=$RUN_LINT_ONLY" >> $GITHUB_OUTPUT
 
@@ -164,21 +197,26 @@ jobs:
           echo "| Documentation | $DOCS |" >> $GITHUB_STEP_SUMMARY
           echo "| Electron service | $ELECTRON |" >> $GITHUB_STEP_SUMMARY
           echo "| Tauri service | $TAURI |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dioxus service | $DIOXUS |" >> $GITHUB_STEP_SUMMARY
           echo "| Shared packages | $SHARED |" >> $GITHUB_STEP_SUMMARY
           echo "| E2E Electron | $E2E_ELECTRON |" >> $GITHUB_STEP_SUMMARY
           echo "| E2E Tauri | $E2E_TAURI |" >> $GITHUB_STEP_SUMMARY
+          echo "| E2E Dioxus | $E2E_DIOXUS |" >> $GITHUB_STEP_SUMMARY
           echo "| Fixtures Electron | $FIXTURES_ELECTRON |" >> $GITHUB_STEP_SUMMARY
           echo "| Fixtures Tauri | $FIXTURES_TAURI |" >> $GITHUB_STEP_SUMMARY
+          echo "| Fixtures Dioxus | $FIXTURES_DIOXUS |" >> $GITHUB_STEP_SUMMARY
           echo "| Infrastructure | $INFRA |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Decisions" >> $GITHUB_STEP_SUMMARY
           echo "- **Run Electron**: $RUN_ELECTRON" >> $GITHUB_STEP_SUMMARY
           echo "- **Run Tauri**: $RUN_TAURI" >> $GITHUB_STEP_SUMMARY
+          echo "- **Run Dioxus**: $RUN_DIOXUS" >> $GITHUB_STEP_SUMMARY
           echo "- **Lint only (no service changes)**: $RUN_LINT_ONLY" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Outputs" >> $GITHUB_STEP_SUMMARY
           echo "- \`run_electron\`: $RUN_ELECTRON" >> $GITHUB_STEP_SUMMARY
           echo "- \`run_tauri\`: $RUN_TAURI" >> $GITHUB_STEP_SUMMARY
+          echo "- \`run_dioxus\`: $RUN_DIOXUS" >> $GITHUB_STEP_SUMMARY
           echo "- \`has_shared_changes\`: $SHARED" >> $GITHUB_STEP_SUMMARY
           echo "- \`run_lint_only\`: $RUN_LINT_ONLY" >> $GITHUB_STEP_SUMMARY
 
@@ -187,13 +225,17 @@ jobs:
           echo "  Documentation: $DOCS"
           echo "  Electron service: $ELECTRON"
           echo "  Tauri service: $TAURI"
+          echo "  Dioxus service: $DIOXUS"
           echo "  Shared packages: $SHARED"
           echo "  E2E Electron: $E2E_ELECTRON"
           echo "  E2E Tauri: $E2E_TAURI"
+          echo "  E2E Dioxus: $E2E_DIOXUS"
           echo "  Fixtures Electron: $FIXTURES_ELECTRON"
           echo "  Fixtures Tauri: $FIXTURES_TAURI"
+          echo "  Fixtures Dioxus: $FIXTURES_DIOXUS"
           echo "  Infrastructure: $INFRA"
           echo ""
           echo "  Run Electron: $RUN_ELECTRON"
           echo "  Run Tauri: $RUN_TAURI"
+          echo "  Run Dioxus: $RUN_DIOXUS"
           echo "  Run lint only: $RUN_LINT_ONLY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,19 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
 
+  # Build Dioxus Rust crates - only if Dioxus tests will run.
+  # v1 scope: Linux only. wdio-dioxus-driver is Windows-targeted but
+  # cargo check on Linux still validates the dependency graph and platform-
+  # neutral code paths. Cross-platform verification lands in PR3.
+  build-dioxus-crates-linux:
+    name: Build Dioxus Crates [Linux]
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-crates.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
+
   # Build Tauri package test apps - only if Tauri package tests will run
   build-tauri-package-app-linux:
     name: Build Tauri Package Test App [Linux]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Phase -1 spike (Dioxus automation API check) — throwaway code, do not commit
 /spike/
 
+# Rust build artefacts
+packages/*/target/
+packages/*/Cargo.lock
+
 # Logs
 logs
 logs-*

--- a/packages/dioxus-bridge/Cargo.toml
+++ b/packages/dioxus-bridge/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "wdio-dioxus-bridge"
+version = "1.0.0-rc.0"
+authors = ["WebdriverIO Community"]
+categories = ["development-tools::testing", "gui"]
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/webdriverio/desktop-mobile"
+repository = "https://github.com/webdriverio/desktop-mobile"
+description = "Bridge crate that exposes a wdio:// IPC channel inside Dioxus desktop apps for use with @wdio/dioxus-service"
+readme = "README.md"
+edition = "2021"
+rust-version = "1.77.2"
+
+# v1 ships only the automation env-var reader. The full bridge IPC
+# (wdio:// custom protocol + invoke command bus + log forwarder + guest-js
+# injection) lands in subsequent Phase 2 commits.
+
+[lib]
+name = "wdio_dioxus_bridge"
+path = "src/lib.rs"
+
+[dependencies]
+dioxus-desktop = "0.7"
+tracing = "0.1"
+
+[features]
+default = []
+# Compile-time gate: turning this off makes `install()` a true no-op (used by
+# release builds where bridge plumbing must not ship). Test/CI builds leave
+# `default = []` so callers explicitly opt in via `with-bridge`. Mirrors the
+# `#[cfg(debug_assertions)]` discipline documented in plugin-setup.md.
+with-bridge = []

--- a/packages/dioxus-bridge/Cargo.toml
+++ b/packages/dioxus-bridge/Cargo.toml
@@ -21,6 +21,8 @@ path = "src/lib.rs"
 
 [dependencies]
 dioxus-desktop = "0.7"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tracing = "0.1"
 
 [features]

--- a/packages/dioxus-bridge/README.md
+++ b/packages/dioxus-bridge/README.md
@@ -1,0 +1,53 @@
+# wdio-dioxus-bridge
+
+Rust bridge crate that exposes a `wdio://` IPC channel and automation
+detection inside Dioxus desktop apps, consumed by
+[`@wdio/dioxus-service`](../dioxus-service/).
+
+## v1 status
+
+This crate is being built up incrementally. The current published surface is:
+
+- `wdio_dioxus_bridge::install(config) -> Config` — drop-in helper that wires the
+  bridge into your Dioxus `Config`.
+- `wdio_dioxus_bridge::automation::is_requested()` — true when
+  `DIOXUS_WEBVIEW_AUTOMATION=true` is set in the process env (i.e. the app is
+  running under `@wdio/dioxus-service`).
+
+The full bridge IPC (`wdio://` custom protocol + invoke command bus + log
+forwarder + guest-js bundle) lands in subsequent Phase 2 commits.
+
+## Quick start
+
+```toml
+[dev-dependencies]
+wdio-dioxus-bridge = "1"
+```
+
+Wire into `main.rs`, guarded for debug builds so the bridge never ships in
+release binaries:
+
+```rust,ignore
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+
+    #[cfg(debug_assertions)]
+    {
+        config = wdio_dioxus_bridge::install(config);
+    }
+
+    dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+}
+```
+
+> The `#[cfg(debug_assertions)]` guard is intentional — production builds
+> should not ship test plumbing. See
+> `packages/dioxus-service/docs/plugin-setup.md` for the rationale.
+
+## Naming
+
+The companion npm package shipping the guest-js bundle is `@wdio/dioxus-bridge`
+(no `-js` suffix), matching the convention from `@wdio/tauri-plugin`. The Rust
+crate is named `wdio-dioxus-bridge` ("bridge" rather than "plugin" because
+Dioxus has no plugin-trait system — see
+`packages/native-core/src/driverProcess.ts` discussion).

--- a/packages/dioxus-bridge/build.rs
+++ b/packages/dioxus-bridge/build.rs
@@ -1,0 +1,28 @@
+// Build-time helper: copy the bundled guest-js into OUT_DIR so lib.rs can
+// embed it via include_str!. If the bundle hasn't been built yet (e.g.
+// `cargo check` runs before `pnpm build:js`), emit a no-op placeholder so
+// the crate still compiles — the bridge just won't inject anything until
+// the bundle is rebuilt.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+  let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR is set by cargo");
+  let out_path = PathBuf::from(&out_dir).join("guest_js_bundle.js");
+
+  let src = PathBuf::from("guest-js/dist-js/index.js");
+
+  let bundle = if src.exists() {
+    fs::read_to_string(&src).expect("read guest-js bundle")
+  } else {
+    String::from("/* @wdio/dioxus-bridge guest-js not built yet; run `pnpm --filter @wdio/dioxus-bridge build` */")
+  };
+
+  fs::write(&out_path, bundle).expect("write OUT_DIR/guest_js_bundle.js");
+
+  println!("cargo:rerun-if-changed=guest-js/dist-js/index.js");
+  println!("cargo:rerun-if-changed=guest-js/index.ts");
+  println!("cargo:rerun-if-changed=build.rs");
+}

--- a/packages/dioxus-bridge/guest-js/__tests__/index.spec.ts
+++ b/packages/dioxus-bridge/guest-js/__tests__/index.spec.ts
@@ -86,4 +86,81 @@ describe('@wdio/dioxus-bridge guest-js', () => {
     const { invoke } = await import('../index.js');
     await expect(invoke('nope')).rejects.toThrow(/wdio:\/\/ invoke failed/);
   });
+
+  describe('console wrapper', () => {
+    it('should forward console.log calls to log_frontend with info level', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ json: async () => ({ ok: true, value: null }) });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      // Reset the install guard so the wrapper installs in this test.
+      (window as unknown as Record<string, unknown>).__WDIO_DIOXUS_CONSOLE_INSTALLED__ = undefined;
+      await import('../index.js');
+
+      console.log('hello world');
+      // The forward is async; await a microtask before checking.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const calls = fetchMock.mock.calls.filter((c) => {
+        const body = JSON.parse((c[1] as { body: string }).body);
+        return body.command === 'log_frontend';
+      });
+      expect(calls.length).toBeGreaterThan(0);
+      const body = JSON.parse(calls[calls.length - 1][1].body);
+      expect(body.args.level).toBe('info');
+      expect(body.args.message).toBe('hello world');
+    });
+
+    it('should map console.error to error level', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ json: async () => ({ ok: true, value: null }) });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      (window as unknown as Record<string, unknown>).__WDIO_DIOXUS_CONSOLE_INSTALLED__ = undefined;
+      await import('../index.js');
+
+      console.error('boom');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const calls = fetchMock.mock.calls.filter((c) => {
+        const body = JSON.parse((c[1] as { body: string }).body);
+        return body.command === 'log_frontend';
+      });
+      const body = JSON.parse(calls[calls.length - 1][1].body);
+      expect(body.args.level).toBe('error');
+    });
+
+    it('should JSON-stringify non-string args', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ json: async () => ({ ok: true, value: null }) });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      (window as unknown as Record<string, unknown>).__WDIO_DIOXUS_CONSOLE_INSTALLED__ = undefined;
+      await import('../index.js');
+
+      console.info('status', { code: 200 }, true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const calls = fetchMock.mock.calls.filter((c) => {
+        const body = JSON.parse((c[1] as { body: string }).body);
+        return body.command === 'log_frontend';
+      });
+      const body = JSON.parse(calls[calls.length - 1][1].body);
+      expect(body.args.message).toContain('status');
+      expect(body.args.message).toContain('{"code":200}');
+      expect(body.args.message).toContain('true');
+    });
+
+    it('should not install twice on the same window', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ json: async () => ({ ok: true, value: null }) });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      (window as unknown as Record<string, unknown>).__WDIO_DIOXUS_CONSOLE_INSTALLED__ = undefined;
+      await import('../index.js');
+      const wrapperAfterFirst = console.log;
+
+      // Force the module to re-evaluate. The install guard should hold.
+      vi.resetModules();
+      await import('../index.js');
+
+      expect(console.log).toBe(wrapperAfterFirst);
+    });
+  });
 });

--- a/packages/dioxus-bridge/guest-js/__tests__/index.spec.ts
+++ b/packages/dioxus-bridge/guest-js/__tests__/index.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('@wdio/dioxus-bridge guest-js', () => {
+  let originalFetch: typeof globalThis.fetch | undefined;
+  let originalDioxus: typeof window.__WDIO_DIOXUS__;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalDioxus = window.__WDIO_DIOXUS__;
+    // Re-import the module each test so the install side-effect re-runs.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalFetch === undefined) {
+      (globalThis as { fetch?: typeof fetch }).fetch = undefined;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
+    window.__WDIO_DIOXUS__ = originalDioxus;
+    vi.restoreAllMocks();
+  });
+
+  it('should install invoke on window.__WDIO_DIOXUS__', async () => {
+    await import('../index.js');
+    expect(window.__WDIO_DIOXUS__).toBeDefined();
+    expect(typeof window.__WDIO_DIOXUS__?.invoke).toBe('function');
+  });
+
+  it('should POST to wdio://invoke with the command + args envelope', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ ok: true, value: 'pong' }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { invoke } = await import('../index.js');
+    await invoke('__ping', { foo: 'bar' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'wdio://invoke',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: '__ping', args: { foo: 'bar' } }),
+      }),
+    );
+  });
+
+  it('should default args to null when omitted', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ ok: true, value: null }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { invoke } = await import('../index.js');
+    await invoke('__ping');
+
+    const lastCall = fetchMock.mock.calls[0];
+    const body = JSON.parse(lastCall?.[1].body as string);
+    expect(body.args).toBeNull();
+  });
+
+  it('should resolve with the response value on success', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ ok: true, value: { greeting: 'hello' } }),
+    }) as unknown as typeof fetch;
+
+    const { invoke } = await import('../index.js');
+    await expect(invoke('echo', { greeting: 'hello' })).resolves.toEqual({ greeting: 'hello' });
+  });
+
+  it('should reject with the response error message on failure', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ ok: false, error: 'unknown wdio:// command: nope' }),
+    }) as unknown as typeof fetch;
+
+    const { invoke } = await import('../index.js');
+    await expect(invoke('nope')).rejects.toThrow(/unknown wdio:\/\/ command: nope/);
+  });
+
+  it('should reject with a fallback message when the error string is absent', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ ok: false }),
+    }) as unknown as typeof fetch;
+
+    const { invoke } = await import('../index.js');
+    await expect(invoke('nope')).rejects.toThrow(/wdio:\/\/ invoke failed/);
+  });
+});

--- a/packages/dioxus-bridge/guest-js/index.ts
+++ b/packages/dioxus-bridge/guest-js/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Guest-side JS bundle for `wdio-dioxus-bridge`.
+ *
+ * The Rust crate embeds this bundle via `build.rs` and injects it into the
+ * Dioxus app's webview through `Config::with_custom_head`. At runtime it
+ * exposes `window.__WDIO_DIOXUS__.invoke(command, args)` — a thin fetch
+ * wrapper around the `wdio://invoke` custom protocol.
+ *
+ * @wdio/dioxus-service uses `browser.execute` to dispatch this invoke into
+ * the page when running E2E specs; tests can also call it directly from the
+ * frontend code under test (e.g., to opt into mocking).
+ *
+ * Phase 3 will add the mock-interception Proxy here, mirroring
+ * packages/tauri-plugin/guest-js/index.ts's `window.__wdio_spy__` /
+ * `window.__wdio_mocks__` shape. For now this is the minimum viable IPC
+ * client.
+ */
+
+declare global {
+  interface Window {
+    __WDIO_DIOXUS__?: {
+      invoke?: (cmd: string, args?: unknown) => Promise<unknown>;
+    };
+  }
+}
+
+interface InvokeResponse {
+  ok: boolean;
+  value?: unknown;
+  error?: string;
+}
+
+/**
+ * Send a JSON-encoded command to the `wdio://invoke` protocol and unwrap the
+ * response envelope. Resolves with the `value` on success; rejects with the
+ * `error` string on failure.
+ */
+export async function invoke(command: string, args?: unknown): Promise<unknown> {
+  const response = await fetch('wdio://invoke', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ command, args: args ?? null }),
+  });
+  const body = (await response.json()) as InvokeResponse;
+  if (body.ok) {
+    return body.value;
+  }
+  throw new Error(body.error ?? 'wdio:// invoke failed with no error message');
+}
+
+// Install on the window. Re-installing is safe — subsequent calls overwrite
+// the previous `invoke`, which lets debug-mode hot-reload swap in newer
+// versions of this bundle without leaving a stale function behind.
+if (!window.__WDIO_DIOXUS__) {
+  window.__WDIO_DIOXUS__ = {};
+}
+window.__WDIO_DIOXUS__.invoke = invoke;

--- a/packages/dioxus-bridge/guest-js/index.ts
+++ b/packages/dioxus-bridge/guest-js/index.ts
@@ -55,3 +55,41 @@ if (!window.__WDIO_DIOXUS__) {
   window.__WDIO_DIOXUS__ = {};
 }
 window.__WDIO_DIOXUS__.invoke = invoke;
+
+/**
+ * Wrap a console method so each call is forwarded to the bridge's
+ * `log_frontend` Rust command in addition to going to the original method.
+ * Errors from the forward are swallowed silently — losing a frontend log
+ * line beats locking up the page.
+ */
+function wrapConsoleMethod(method: 'log' | 'info' | 'warn' | 'error' | 'debug', level: string): void {
+  const original = console[method].bind(console);
+  console[method] = (...args: unknown[]) => {
+    original(...args);
+    const message = args
+      .map((arg) => {
+        if (typeof arg === 'string') return arg;
+        try {
+          return JSON.stringify(arg);
+        } catch {
+          return String(arg);
+        }
+      })
+      .join(' ');
+    void invoke('log_frontend', { level, message }).catch(() => {
+      // Intentionally swallow — see comment above.
+    });
+  };
+}
+
+// Install the console wrapper exactly once per webview load. Re-installing
+// would create a chain of wrappers and exponentially amplify each log call.
+const CONSOLE_INSTALLED_KEY = '__WDIO_DIOXUS_CONSOLE_INSTALLED__';
+if (!(window as unknown as Record<string, unknown>)[CONSOLE_INSTALLED_KEY]) {
+  wrapConsoleMethod('log', 'info');
+  wrapConsoleMethod('info', 'info');
+  wrapConsoleMethod('warn', 'warn');
+  wrapConsoleMethod('error', 'error');
+  wrapConsoleMethod('debug', 'debug');
+  (window as unknown as Record<string, unknown>)[CONSOLE_INSTALLED_KEY] = true;
+}

--- a/packages/dioxus-bridge/package.json
+++ b/packages/dioxus-bridge/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@wdio/dioxus-bridge",
+  "version": "1.0.0-next.0",
+  "description": "Guest-side JS bundle for the wdio-dioxus-bridge Rust crate. Installs window.__WDIO_DIOXUS__.invoke for use by @wdio/dioxus-service.",
+  "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/dioxus-bridge",
+  "type": "module",
+  "main": "./dist-js/index.js",
+  "types": "./dist-js/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist-js/index.d.ts",
+        "default": "./dist-js/index.js"
+      }
+    }
+  },
+  "files": [
+    "README.md",
+    "dist-js",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "pnpm build:js",
+    "build:js": "tsx scripts/build-guest-js.ts",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "dioxus",
+    "webdriverio",
+    "wdio",
+    "testing",
+    "automation"
+  ],
+  "author": "WebdriverIO Community",
+  "license": "MIT",
+  "engines": {
+    "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "^4.1.0",
+    "esbuild": "^0.27.4",
+    "happy-dom": "^15.11.7",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webdriverio/desktop-mobile.git",
+    "directory": "packages/dioxus-bridge"
+  },
+  "bugs": {
+    "url": "https://github.com/webdriverio/desktop-mobile/issues"
+  }
+}

--- a/packages/dioxus-bridge/scripts/build-guest-js.ts
+++ b/packages/dioxus-bridge/scripts/build-guest-js.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env tsx
+
+/**
+ * Build script for the Dioxus bridge guest-js (browser-side code).
+ *
+ * Mirrors packages/tauri-plugin/scripts/build-guest-js.ts. Bundles the
+ * TypeScript source into a single ES module so it can be loaded directly
+ * in the browser without a bundler, then emits TypeScript declarations
+ * for npm consumers.
+ *
+ * Outputs:
+ * - dist-js/index.js    Bundled ES module
+ * - dist-js/index.d.ts  Type declarations
+ *
+ * The Rust crate (wdio-dioxus-bridge) embeds dist-js/index.js via build.rs
+ * and injects it into the Dioxus webview through Config::with_custom_head.
+ */
+
+import { execSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '..');
+
+async function main(): Promise<void> {
+  console.log('🔨 Building Dioxus bridge guest-js...');
+
+  try {
+    await build({
+      entryPoints: [join(packageRoot, 'guest-js/index.ts')],
+      bundle: true,
+      format: 'esm',
+      outfile: join(packageRoot, 'dist-js/index.js'),
+      platform: 'browser',
+      target: 'es2020',
+    });
+
+    console.log('✅ JavaScript bundle created');
+
+    execSync('tsc --project tsconfig.json --emitDeclarationOnly', {
+      cwd: packageRoot,
+      stdio: 'inherit',
+    });
+
+    console.log('✅ Type declarations generated');
+    console.log('🎉 Build complete!');
+  } catch (error) {
+    console.error('❌ Build failed:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/dioxus-bridge/src/automation.rs
+++ b/packages/dioxus-bridge/src/automation.rs
@@ -1,0 +1,85 @@
+//! Automation env-var detection.
+//!
+//! `@wdio/dioxus-service`'s launcher sets `DIOXUS_WEBVIEW_AUTOMATION=true` on
+//! the spawned driver process (which then propagates to the Dioxus app via
+//! msedgedriver / WebKitWebDriver). The bridge crate reads this at startup
+//! to detect "we're running under test" and to (eventually) flip Wry's
+//! `WebContext::set_allows_automation`.
+//!
+//! **v1 status:** Dioxus's public Config API doesn't expose `WebContext`,
+//! so this function currently only *reports* whether the env var is set
+//! (via the `tracing` crate). Flipping the flag requires an upstream Dioxus
+//! PR — see `spike/FINDINGS.md`. The function exists now so the API surface
+//! is in place; once the upstream PR lands, this module will gain the call
+//! to `WebContext::set_allows_automation(true)` and Linux `'external'`
+//! provider unblocks.
+
+const ENV_VAR: &str = "DIOXUS_WEBVIEW_AUTOMATION";
+
+/// True when `DIOXUS_WEBVIEW_AUTOMATION=true` is set in the process env.
+pub fn is_requested() -> bool {
+  std::env::var(ENV_VAR).as_deref() == Ok("true")
+}
+
+/// Log the current automation env-var state. Called from `crate::install`.
+pub fn report() {
+  if is_requested() {
+    tracing::info!(
+      target: "wdio_dioxus_bridge",
+      "{ENV_VAR}=true detected — running under @wdio/dioxus-service. Note: in v1, \
+       this crate cannot flip Wry's automation mode from a third-party hook. See \
+       spike/FINDINGS.md."
+    );
+  } else {
+    tracing::debug!(target: "wdio_dioxus_bridge", "{ENV_VAR} not set — automation disabled");
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // Use a unique env-var name in tests to avoid interference between tests.
+  // The actual `is_requested` reads from the const ENV_VAR — we exercise the
+  // public surface via std::env::set_var/remove_var.
+
+  #[test]
+  fn should_report_false_when_env_var_unset() {
+    // SAFETY: tests are single-threaded by default; setting env vars is
+    // valid in this context.
+    unsafe {
+      std::env::remove_var(ENV_VAR);
+    }
+    assert!(!is_requested());
+  }
+
+  #[test]
+  fn should_report_true_when_env_var_is_true() {
+    unsafe {
+      std::env::set_var(ENV_VAR, "true");
+    }
+    assert!(is_requested());
+    unsafe {
+      std::env::remove_var(ENV_VAR);
+    }
+  }
+
+  #[test]
+  fn should_report_false_when_env_var_is_other_value() {
+    unsafe {
+      std::env::set_var(ENV_VAR, "yes");
+    }
+    assert!(!is_requested());
+    unsafe {
+      std::env::set_var(ENV_VAR, "1");
+    }
+    assert!(!is_requested());
+    unsafe {
+      std::env::set_var(ENV_VAR, "");
+    }
+    assert!(!is_requested());
+    unsafe {
+      std::env::remove_var(ENV_VAR);
+    }
+  }
+}

--- a/packages/dioxus-bridge/src/automation.rs
+++ b/packages/dioxus-bridge/src/automation.rs
@@ -38,48 +38,73 @@ pub fn report() {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::sync::Mutex;
 
-  // Use a unique env-var name in tests to avoid interference between tests.
-  // The actual `is_requested` reads from the const ENV_VAR — we exercise the
-  // public surface via std::env::set_var/remove_var.
+  // Cargo runs unit tests in this module *concurrently* by default (one
+  // thread per logical CPU). `std::env::set_var` / `remove_var` mutate the
+  // whole process environment, so without serialisation two tests racing
+  // each other can read stale values. We guard every env-var mutation
+  // with this lock to keep them deterministic.
+  static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+  /// RAII helper: take the env-var lock, set ENV_VAR to the supplied value
+  /// (or remove it when `None`), and ensure it's removed when the guard
+  /// drops so a test failure in the middle never leaks state.
+  struct EnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+  }
+
+  impl EnvGuard {
+    fn new(value: Option<&str>) -> Self {
+      let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+      // SAFETY: we hold the process-wide lock for the duration of the
+      // EnvGuard, so no other test in this module can race us.
+      unsafe {
+        match value {
+          Some(v) => std::env::set_var(ENV_VAR, v),
+          None => std::env::remove_var(ENV_VAR),
+        }
+      }
+      Self { _lock: lock }
+    }
+  }
+
+  impl Drop for EnvGuard {
+    fn drop(&mut self) {
+      // SAFETY: still inside the locked critical section.
+      unsafe {
+        std::env::remove_var(ENV_VAR);
+      }
+    }
+  }
 
   #[test]
   fn should_report_false_when_env_var_unset() {
-    // SAFETY: tests are single-threaded by default; setting env vars is
-    // valid in this context.
-    unsafe {
-      std::env::remove_var(ENV_VAR);
-    }
+    let _g = EnvGuard::new(None);
     assert!(!is_requested());
   }
 
   #[test]
   fn should_report_true_when_env_var_is_true() {
-    unsafe {
-      std::env::set_var(ENV_VAR, "true");
-    }
+    let _g = EnvGuard::new(Some("true"));
     assert!(is_requested());
-    unsafe {
-      std::env::remove_var(ENV_VAR);
-    }
   }
 
   #[test]
-  fn should_report_false_when_env_var_is_other_value() {
-    unsafe {
-      std::env::set_var(ENV_VAR, "yes");
-    }
+  fn should_report_false_when_env_var_is_yes() {
+    let _g = EnvGuard::new(Some("yes"));
     assert!(!is_requested());
-    unsafe {
-      std::env::set_var(ENV_VAR, "1");
-    }
+  }
+
+  #[test]
+  fn should_report_false_when_env_var_is_one() {
+    let _g = EnvGuard::new(Some("1"));
     assert!(!is_requested());
-    unsafe {
-      std::env::set_var(ENV_VAR, "");
-    }
+  }
+
+  #[test]
+  fn should_report_false_when_env_var_is_empty_string() {
+    let _g = EnvGuard::new(Some(""));
     assert!(!is_requested());
-    unsafe {
-      std::env::remove_var(ENV_VAR);
-    }
   }
 }

--- a/packages/dioxus-bridge/src/invoke.rs
+++ b/packages/dioxus-bridge/src/invoke.rs
@@ -1,0 +1,226 @@
+//! `wdio://invoke` custom-protocol command bus.
+//!
+//! The bridge registers a `wdio://` URI handler via [`dioxus_desktop::Config::with_custom_protocol`].
+//! Each request is a POST whose body is JSON of shape `{"command": String, "args": Json}`;
+//! the response is `{"ok": true, "value": Json}` on success or
+//! `{"ok": false, "error": String}` on failure.
+//!
+//! Commands are registered through [`CommandRegistry`] — one shared registry per
+//! installed bridge, populated at startup. A built-in `__ping` command returns
+//! `{"value": "pong"}` so `@wdio/dioxus-service` can sanity-check that the IPC
+//! channel is alive before relying on it.
+//!
+//! Future bridge milestones will add: `__windowState` (for multi-window
+//! support), `__listWindows`, `__execEval` (the `dx` field on
+//! `window.__WDIO_DIOXUS__`), and mock-related plumbing for the
+//! `@wdio/native-spy` DioxusAdapter.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use dioxus_desktop::wry::http::{HeaderValue, Request, Response, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// A registered command handler. Receives the JSON args from the wire and
+/// returns either a JSON value to send back, or an error string.
+pub type CommandHandler = Arc<dyn Fn(Value) -> Result<Value, String> + Send + Sync + 'static>;
+
+/// Per-bridge command registry. Created in [`crate::install`] and populated
+/// with the built-in commands; callers can register additional commands via
+/// [`CommandRegistry::register`] before `install()` runs.
+#[derive(Clone, Default)]
+pub struct CommandRegistry {
+  handlers: Arc<RwLock<HashMap<String, CommandHandler>>>,
+}
+
+impl CommandRegistry {
+  pub fn new() -> Self {
+    let registry = Self::default();
+    registry.register_builtins();
+    registry
+  }
+
+  fn register_builtins(&self) {
+    // __ping — returns "pong" so the service can verify the IPC channel works.
+    self.register("__ping", |_args| Ok(json!("pong")));
+  }
+
+  /// Register a command handler. Replaces any existing handler with the same name.
+  pub fn register<F>(&self, command: impl Into<String>, handler: F)
+  where
+    F: Fn(Value) -> Result<Value, String> + Send + Sync + 'static,
+  {
+    self
+      .handlers
+      .write()
+      .expect("CommandRegistry lock poisoned")
+      .insert(command.into(), Arc::new(handler));
+  }
+
+  /// Look up and call a handler. Returns the response body that should be
+  /// written into the HTTP response.
+  pub fn dispatch(&self, command: &str, args: Value) -> InvokeResponseBody {
+    let handler = {
+      let map = self.handlers.read().expect("CommandRegistry lock poisoned");
+      map.get(command).cloned()
+    };
+
+    match handler {
+      Some(h) => match h(args) {
+        Ok(value) => InvokeResponseBody::Ok { ok: true, value },
+        Err(error) => InvokeResponseBody::Err { ok: false, error },
+      },
+      None => InvokeResponseBody::Err {
+        ok: false,
+        error: format!("unknown wdio:// command: {command}"),
+      },
+    }
+  }
+}
+
+#[derive(Deserialize)]
+struct InvokeRequestBody {
+  command: String,
+  #[serde(default)]
+  args: Value,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum InvokeResponseBody {
+  Ok { ok: bool, value: Value },
+  Err { ok: bool, error: String },
+}
+
+impl InvokeResponseBody {
+  fn malformed(reason: impl Into<String>) -> Self {
+    Self::Err {
+      ok: false,
+      error: reason.into(),
+    }
+  }
+}
+
+/// Handle a single `wdio://` request. Pure function — easy to unit-test.
+pub fn handle_invoke_request(
+  registry: &CommandRegistry,
+  request: &Request<Vec<u8>>,
+) -> Response<Cow<'static, [u8]>> {
+  let parsed: Result<InvokeRequestBody, _> = serde_json::from_slice(request.body());
+  let body = match parsed {
+    Ok(req) => registry.dispatch(&req.command, req.args),
+    Err(err) => InvokeResponseBody::malformed(format!("invalid JSON request: {err}")),
+  };
+
+  let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| {
+    // Should never happen — serde_json::to_vec on our own types is infallible.
+    br#"{"ok":false,"error":"failed to serialise response"}"#.to_vec()
+  });
+
+  let status = match body {
+    InvokeResponseBody::Ok { .. } => StatusCode::OK,
+    InvokeResponseBody::Err { .. } => StatusCode::OK,
+    // wdio:// responses always use 200; failure is communicated in the JSON.
+    // Reserving non-200 for genuine HTTP-layer errors keeps the JS-side
+    // unwrap simpler.
+  };
+
+  let mut response = Response::new(Cow::Owned(bytes));
+  *response.status_mut() = status;
+  response.headers_mut().insert(
+    "content-type",
+    HeaderValue::from_static("application/json"),
+  );
+  response
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn req(body: &str) -> Request<Vec<u8>> {
+    Request::builder()
+      .method("POST")
+      .uri("wdio://invoke")
+      .body(body.as_bytes().to_vec())
+      .unwrap()
+  }
+
+  fn parse_body(response: &Response<Cow<'static, [u8]>>) -> Value {
+    serde_json::from_slice(response.body()).unwrap()
+  }
+
+  #[test]
+  fn should_round_trip_the_builtin_ping_command() {
+    let registry = CommandRegistry::new();
+    let response = handle_invoke_request(&registry, &req(r#"{"command":"__ping"}"#));
+    let body = parse_body(&response);
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["value"], "pong");
+  }
+
+  #[test]
+  fn should_return_error_for_unknown_command() {
+    let registry = CommandRegistry::new();
+    let response = handle_invoke_request(&registry, &req(r#"{"command":"nope"}"#));
+    let body = parse_body(&response);
+    assert_eq!(body["ok"], false);
+    assert!(body["error"].as_str().unwrap().contains("unknown wdio:// command: nope"));
+  }
+
+  #[test]
+  fn should_return_error_for_malformed_json() {
+    let registry = CommandRegistry::new();
+    let response = handle_invoke_request(&registry, &req("not-json"));
+    let body = parse_body(&response);
+    assert_eq!(body["ok"], false);
+    assert!(body["error"].as_str().unwrap().contains("invalid JSON request"));
+  }
+
+  #[test]
+  fn should_forward_args_to_registered_handlers() {
+    let registry = CommandRegistry::new();
+    registry.register("echo", |args| Ok(args));
+    let response = handle_invoke_request(&registry, &req(r#"{"command":"echo","args":{"hello":"world"}}"#));
+    let body = parse_body(&response);
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["value"]["hello"], "world");
+  }
+
+  #[test]
+  fn should_propagate_handler_errors() {
+    let registry = CommandRegistry::new();
+    registry.register("boom", |_args| Err("kaboom".to_string()));
+    let response = handle_invoke_request(&registry, &req(r#"{"command":"boom"}"#));
+    let body = parse_body(&response);
+    assert_eq!(body["ok"], false);
+    assert_eq!(body["error"], "kaboom");
+  }
+
+  #[test]
+  fn should_default_args_to_null_when_omitted() {
+    let mut received = None;
+    let registry = CommandRegistry::new();
+    let received_clone = Arc::new(std::sync::Mutex::new(received.take()));
+    let received_clone_2 = received_clone.clone();
+    registry.register("captureargs", move |args| {
+      *received_clone_2.lock().unwrap() = Some(args.clone());
+      Ok(Value::Null)
+    });
+    let _ = handle_invoke_request(&registry, &req(r#"{"command":"captureargs"}"#));
+    received = received_clone.lock().unwrap().clone();
+    assert_eq!(received.unwrap(), Value::Null);
+  }
+
+  #[test]
+  fn should_allow_replacing_a_handler() {
+    let registry = CommandRegistry::new();
+    registry.register("greet", |_| Ok(json!("hi")));
+    registry.register("greet", |_| Ok(json!("hello again")));
+    let response = handle_invoke_request(&registry, &req(r#"{"command":"greet"}"#));
+    let body = parse_body(&response);
+    assert_eq!(body["value"], "hello again");
+  }
+}

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -2,9 +2,10 @@
 //! want to be testable via `@wdio/dioxus-service`.
 //!
 //! v1 ships the automation env-var reader ([`automation`]) and the
-//! `wdio://invoke` IPC channel ([`invoke`]). Subsequent milestones will add
-//! `log_bridge.rs` (frontend/backend log forwarding via the bridge), window
-//! state tracking, and the deeplink reference handler.
+//! `wdio://invoke` IPC channel ([`invoke`]), plus injection of the
+//! `@wdio/dioxus-bridge` guest-js bundle into the webview. Subsequent
+//! milestones will add `log_bridge.rs` (frontend/backend log forwarding),
+//! window state tracking, and the deeplink reference handler.
 //!
 //! # Quick start
 //!
@@ -36,15 +37,22 @@ use dioxus_desktop::Config;
 
 pub use invoke::CommandRegistry;
 
+/// The bundled `@wdio/dioxus-bridge` guest-js — populated at build time by
+/// `build.rs` from `guest-js/dist-js/index.js`. When the bundle hasn't been
+/// built yet, the placeholder is a no-op comment and the bridge silently
+/// degrades to "no JS injected"; rerun `pnpm --filter @wdio/dioxus-bridge
+/// build` to repopulate.
+const GUEST_JS_BUNDLE: &str = include_str!(concat!(env!("OUT_DIR"), "/guest_js_bundle.js"));
+
 /// Install the WDIO bridge into a Dioxus [`Config`]:
 ///
 /// 1. Reports the [`automation`] env-var state via tracing.
-/// 2. Registers a `wdio://` custom protocol handler backed by a fresh
+/// 2. Registers the `wdio://` custom protocol handler backed by a fresh
 ///    [`CommandRegistry`] (with the built-in `__ping` command).
-/// 3. Returns the [`Config`] for chainability with the app's own builders.
-///
-/// To register additional commands, call [`install_with_registry`] instead
-/// and pre-populate the registry before passing it in.
+/// 3. Injects the `@wdio/dioxus-bridge` guest-js bundle into the webview's
+///    document `<head>` so `window.__WDIO_DIOXUS__.invoke` is available
+///    before any app code runs.
+/// 4. Returns the [`Config`] for chainability with the app's own builders.
 pub fn install(config: Config) -> Config {
   install_with_registry(config, CommandRegistry::new())
 }
@@ -55,7 +63,11 @@ pub fn install_with_registry(config: Config, registry: CommandRegistry) -> Confi
   automation::report();
 
   let registry_for_handler = registry;
-  config.with_custom_protocol("wdio".to_string(), move |_webview_id, request| {
-    invoke::handle_invoke_request(&registry_for_handler, &request)
-  })
+  config
+    .with_custom_protocol("wdio".to_string(), move |_webview_id, request| {
+      invoke::handle_invoke_request(&registry_for_handler, &request)
+    })
+    .with_custom_head(format!(
+      "<script type=\"module\">{GUEST_JS_BUNDLE}</script>"
+    ))
 }

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -1,9 +1,10 @@
 //! `wdio-dioxus-bridge` — bridge crate consumed by Dioxus desktop apps that
 //! want to be testable via `@wdio/dioxus-service`.
 //!
-//! v1 ships only the automation env-var reader ([`automation`]). The full
-//! bridge IPC (`wdio://` custom protocol + invoke command bus + log forwarder
-//! + guest-js bundle) lands in Phase 2 of the dioxus-service rollout.
+//! v1 ships the automation env-var reader ([`automation`]) and the
+//! `wdio://invoke` IPC channel ([`invoke`]). Subsequent milestones will add
+//! `log_bridge.rs` (frontend/backend log forwarding via the bridge), window
+//! state tracking, and the deeplink reference handler.
 //!
 //! # Quick start
 //!
@@ -29,22 +30,32 @@
 //! ```
 
 pub mod automation;
+pub mod invoke;
 
 use dioxus_desktop::Config;
 
-/// Install the WDIO bridge into a Dioxus [`Config`]. Reads
-/// `DIOXUS_WEBVIEW_AUTOMATION` (set by `@wdio/dioxus-service` when spawning
-/// the app under test) and logs whether automation was requested.
+pub use invoke::CommandRegistry;
+
+/// Install the WDIO bridge into a Dioxus [`Config`]:
 ///
-/// **v1 limitation:** Dioxus's public Config API has no hook to flip Wry's
-/// automation mode on Linux (see `spike/FINDINGS.md`). This function logs the
-/// detected env-var state but cannot itself enable WebKitWebDriver attach.
-/// Provider `'external'` is consequently Windows-only in v1; Linux users are
-/// directed to `provider: 'embedded'` by the launcher.
+/// 1. Reports the [`automation`] env-var state via tracing.
+/// 2. Registers a `wdio://` custom protocol handler backed by a fresh
+///    [`CommandRegistry`] (with the built-in `__ping` command).
+/// 3. Returns the [`Config`] for chainability with the app's own builders.
 ///
-/// Returns the (currently unmodified) [`Config`] for chainability with future
-/// Phase 2 builders.
+/// To register additional commands, call [`install_with_registry`] instead
+/// and pre-populate the registry before passing it in.
 pub fn install(config: Config) -> Config {
+  install_with_registry(config, CommandRegistry::new())
+}
+
+/// Variant of [`install`] that accepts a pre-populated [`CommandRegistry`].
+/// Use this when the app needs custom commands beyond the built-ins.
+pub fn install_with_registry(config: Config, registry: CommandRegistry) -> Config {
   automation::report();
-  config
+
+  let registry_for_handler = registry;
+  config.with_custom_protocol("wdio".to_string(), move |_webview_id, request| {
+    invoke::handle_invoke_request(&registry_for_handler, &request)
+  })
 }

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -1,0 +1,50 @@
+//! `wdio-dioxus-bridge` — bridge crate consumed by Dioxus desktop apps that
+//! want to be testable via `@wdio/dioxus-service`.
+//!
+//! v1 ships only the automation env-var reader ([`automation`]). The full
+//! bridge IPC (`wdio://` custom protocol + invoke command bus + log forwarder
+//! + guest-js bundle) lands in Phase 2 of the dioxus-service rollout.
+//!
+//! # Quick start
+//!
+//! Add to `Cargo.toml`:
+//! ```toml
+//! [dependencies.wdio-dioxus-bridge]
+//! version = "1"
+//! features = ["with-bridge"]
+//! ```
+//!
+//! Wire into your `main.rs`, guarded for debug builds so the bridge never
+//! ships in release:
+//!
+//! ```ignore
+//! fn main() {
+//!     let mut config = dioxus::desktop::Config::new();
+//!     #[cfg(debug_assertions)]
+//!     {
+//!         config = wdio_dioxus_bridge::install(config);
+//!     }
+//!     dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+//! }
+//! ```
+
+pub mod automation;
+
+use dioxus_desktop::Config;
+
+/// Install the WDIO bridge into a Dioxus [`Config`]. Reads
+/// `DIOXUS_WEBVIEW_AUTOMATION` (set by `@wdio/dioxus-service` when spawning
+/// the app under test) and logs whether automation was requested.
+///
+/// **v1 limitation:** Dioxus's public Config API has no hook to flip Wry's
+/// automation mode on Linux (see `spike/FINDINGS.md`). This function logs the
+/// detected env-var state but cannot itself enable WebKitWebDriver attach.
+/// Provider `'external'` is consequently Windows-only in v1; Linux users are
+/// directed to `provider: 'embedded'` by the launcher.
+///
+/// Returns the (currently unmodified) [`Config`] for chainability with future
+/// Phase 2 builders.
+pub fn install(config: Config) -> Config {
+  automation::report();
+  config
+}

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -32,10 +32,12 @@
 
 pub mod automation;
 pub mod invoke;
+pub mod log_bridge;
 
 use dioxus_desktop::Config;
 
 pub use invoke::CommandRegistry;
+pub use log_bridge::FRONTEND_MARKER;
 
 /// The bundled `@wdio/dioxus-bridge` guest-js — populated at build time by
 /// `build.rs` from `guest-js/dist-js/index.js`. When the bundle hasn't been
@@ -61,6 +63,7 @@ pub fn install(config: Config) -> Config {
 /// Use this when the app needs custom commands beyond the built-ins.
 pub fn install_with_registry(config: Config, registry: CommandRegistry) -> Config {
   automation::report();
+  log_bridge::register(&registry);
 
   let registry_for_handler = registry;
   config

--- a/packages/dioxus-bridge/src/log_bridge.rs
+++ b/packages/dioxus-bridge/src/log_bridge.rs
@@ -1,0 +1,104 @@
+//! Frontend → backend log bridge.
+//!
+//! Registers a `log_frontend` command on the [`crate::invoke::CommandRegistry`].
+//! The guest-js console wrapper intercepts `console.log/info/warn/error/debug`
+//! calls and forwards each line through `dx.invoke('log_frontend', { level,
+//! message })`. The Rust handler emits the line to stdout with a
+//! `[WDIO-FRONTEND][<LEVEL>]` marker so the launcher's log capture can
+//! distinguish frontend lines from backend (Rust-side) tracing output.
+//!
+//! Backend logs flow through the standard `tracing` infrastructure — the
+//! launcher captures the Dioxus app's stdout/stderr via
+//! `@wdio/native-core`'s stream-based capture and routes each line through
+//! @wdio/dioxus-service's parseLogLine.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::invoke::CommandRegistry;
+
+/// Marker emitted on every line forwarded from the frontend. The TS-side
+/// parser splits on this token to classify lines as frontend logs.
+pub const FRONTEND_MARKER: &str = "[WDIO-FRONTEND]";
+
+#[derive(Debug, Deserialize)]
+struct LogFrontendArgs {
+  #[serde(default)]
+  level: String,
+  #[serde(default)]
+  message: String,
+}
+
+/// Register `log_frontend` on the supplied [`CommandRegistry`].
+///
+/// The handler receives `{ level: String, message: String }` and prints a
+/// marked line to stdout. Returns the same registry for chainability.
+pub fn register(registry: &CommandRegistry) -> &CommandRegistry {
+  registry.register("log_frontend", |args: Value| {
+    let parsed: LogFrontendArgs = serde_json::from_value(args).map_err(|e| format!("invalid log_frontend args: {e}"))?;
+    let level = if parsed.level.is_empty() {
+      "INFO".to_string()
+    } else {
+      parsed.level.to_uppercase()
+    };
+    println!("{FRONTEND_MARKER}[{level}] {}", parsed.message);
+    Ok(json!(null))
+  });
+  registry
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::invoke::{handle_invoke_request, CommandRegistry};
+  use dioxus_desktop::wry::http::Request;
+
+  fn req(body: &str) -> Request<Vec<u8>> {
+    Request::builder()
+      .method("POST")
+      .uri("wdio://invoke")
+      .body(body.as_bytes().to_vec())
+      .unwrap()
+  }
+
+  fn response_body(response: &dioxus_desktop::wry::http::Response<std::borrow::Cow<'static, [u8]>>) -> Value {
+    serde_json::from_slice(response.body()).unwrap()
+  }
+
+  #[test]
+  fn should_register_log_frontend_command() {
+    let registry = CommandRegistry::new();
+    register(&registry);
+    let response = handle_invoke_request(
+      &registry,
+      &req(r#"{"command":"log_frontend","args":{"level":"info","message":"hello"}}"#),
+    );
+    let body = response_body(&response);
+    assert_eq!(body["ok"], true);
+  }
+
+  #[test]
+  fn should_default_level_to_info_when_omitted() {
+    let registry = CommandRegistry::new();
+    register(&registry);
+    let response = handle_invoke_request(
+      &registry,
+      &req(r#"{"command":"log_frontend","args":{"message":"plain"}}"#),
+    );
+    let body = response_body(&response);
+    assert_eq!(body["ok"], true);
+  }
+
+  #[test]
+  fn should_reject_malformed_args() {
+    let registry = CommandRegistry::new();
+    register(&registry);
+    let response = handle_invoke_request(
+      &registry,
+      &req(r#"{"command":"log_frontend","args":"not-an-object"}"#),
+    );
+    let body = response_body(&response);
+    assert_eq!(body["ok"], false);
+    assert!(body["error"].as_str().unwrap().contains("invalid log_frontend args"));
+  }
+}

--- a/packages/dioxus-bridge/tsconfig.json
+++ b/packages/dioxus-bridge/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2020",
+      "DOM"
+    ],
+    "declaration": true,
+    "outDir": "./dist-js",
+    "rootDir": "./guest-js",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": [
+    "guest-js/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist-js",
+    "guest-js/__tests__"
+  ]
+}

--- a/packages/dioxus-bridge/vitest.config.ts
+++ b/packages/dioxus-bridge/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'happy-dom',
+    include: ['guest-js/**/*.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['guest-js/**/*.ts'],
+      exclude: ['guest-js/**/__tests__/**', 'guest-js/**/*.spec.ts'],
+    },
+  },
+});

--- a/packages/dioxus-driver/Cargo.toml
+++ b/packages/dioxus-driver/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "wdio-dioxus-driver"
+version = "1.0.0-rc.0"
+authors = ["WebdriverIO Community"]
+categories = ["gui", "web-programming"]
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/webdriverio/desktop-mobile"
+repository = "https://github.com/webdriverio/desktop-mobile"
+description = "WebDriver intermediary node for Dioxus desktop applications (forked from tauri-driver)"
+readme = "README.md"
+edition = "2021"
+rust-version = "1.77.2"
+
+# Forked from tauri-driver 2.0.6 (Tauri Programme within The Commons Conservancy,
+# Apache-2.0 OR MIT). Diff: crate/binary renamed to wdio-dioxus-driver; capability
+# namespace tauri:options → dioxus:options; env var TAURI_WEBVIEW_AUTOMATION →
+# DIOXUS_WEBVIEW_AUTOMATION; legacy TAURI_AUTOMATION dropped. See README for the
+# upstream-sync policy.
+
+[[bin]]
+name = "wdio-dioxus-driver"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+futures = "0.3"
+futures-util = "0.3"
+http-body-util = "0.1"
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = [
+  "client",
+  "client-legacy",
+  "http1",
+  "server",
+  "tokio",
+] }
+pico-args = { version = "0.5", features = ["eq-separator"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros"] }
+which = "8"
+
+[target."cfg(unix)".dependencies]
+signal-hook = "0.4"
+signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
+
+[target."cfg(windows)".dependencies]
+win32job = "2"

--- a/packages/dioxus-driver/README.md
+++ b/packages/dioxus-driver/README.md
@@ -1,0 +1,52 @@
+# wdio-dioxus-driver
+
+WebDriver intermediary node for [Dioxus](https://dioxuslabs.com/) desktop applications. Forked from [`tauri-driver`](https://github.com/tauri-apps/tauri/tree/dev/crates/tauri-driver) (Apache-2.0 OR MIT, Tauri Programme within The Commons Conservancy).
+
+## Why fork?
+
+`tauri-driver` is ~80% framework-agnostic WebDriver-proxy glue, but its capability namespace (`tauri:options`) and automation env var (`TAURI_WEBVIEW_AUTOMATION`) name it explicitly for Tauri. We use `wdio-dioxus-driver` rather than the unprefixed `dioxus-driver` to leave that namespace free for the Dioxus project itself.
+
+## Diff vs. upstream
+
+| Concern | upstream `tauri-driver` | `wdio-dioxus-driver` |
+|---|---|---|
+| Capability key | `tauri:options` | `dioxus:options` |
+| Automation env var | `TAURI_WEBVIEW_AUTOMATION` + legacy `TAURI_AUTOMATION` | `DIOXUS_WEBVIEW_AUTOMATION` only |
+| Native driver mapping (Windows) | `ms:edgeOptions` | unchanged |
+| Native driver mapping (Linux) | `webkitgtk:browserOptions` | unchanged |
+| Crate name | `tauri-driver` | `wdio-dioxus-driver` |
+| Binary name | `tauri-driver` | `wdio-dioxus-driver` |
+
+## Platform support
+
+| Platform | Status |
+|---|---|
+| Windows | ✅ Supported in v1 |
+| Linux | 🚫 Blocked in v1 — requires an upstream Dioxus PR exposing Wry's automation toggle (see [spike/FINDINGS.md](../../spike/FINDINGS.md)). v1.1 once that lands. |
+| macOS | ❌ Not supported (inherits upstream `tauri-driver`'s limitation) |
+
+`@wdio/dioxus-service` users on Linux and macOS should use `driverProvider: 'embedded'` instead — see [`@wdio/dioxus-service`](../dioxus-service/) docs.
+
+## Install
+
+```sh
+cargo install wdio-dioxus-driver
+```
+
+## Use
+
+`@wdio/dioxus-service` invokes `wdio-dioxus-driver` automatically when `driverProvider: 'external'` is set. Running it standalone:
+
+```sh
+wdio-dioxus-driver --port 4444 --native-port 4445
+```
+
+## Upstream-sync policy
+
+We track upstream `tauri-driver` minor versions. Sync calendar: quarterly. Sync procedure:
+
+1. `git fetch tauri-upstream && git diff tauri-upstream/dev:crates/tauri-driver our:packages/dioxus-driver`
+2. Apply non-rename changes verbatim where possible.
+3. Re-test on Windows in CI.
+
+When `tauri-driver` adds Linux Wry-automation support upstream, drop the v1 Linux block here and add a follow-up issue tracking removal of the bridge crate's `automation.rs` env-var path.

--- a/packages/dioxus-driver/src/cli.rs
+++ b/packages/dioxus-driver/src/cli.rs
@@ -1,0 +1,59 @@
+// Forked from tauri-driver 2.0.6 — argument parsing layer.
+
+use std::path::PathBuf;
+
+const HELP: &str = "\
+USAGE: wdio-dioxus-driver [FLAGS] [OPTIONS]
+
+FLAGS:
+  -h, --help              Prints help information
+
+OPTIONS:
+  --port NUMBER           Sets the wdio-dioxus-driver intermediary port
+  --native-port NUMBER    Sets the port of the underlying WebDriver
+  --native-host HOST      Sets the host of the underlying WebDriver (Linux only)
+  --native-driver PATH    Sets the path to the native WebDriver binary
+";
+
+#[derive(Debug, Clone)]
+pub struct Args {
+  pub port: u16,
+  pub native_port: u16,
+  pub native_host: String,
+  pub native_driver: Option<PathBuf>,
+}
+
+impl From<pico_args::Arguments> for Args {
+  fn from(mut args: pico_args::Arguments) -> Self {
+    if args.contains(["-h", "--help"]) {
+      println!("{HELP}");
+      std::process::exit(0);
+    }
+
+    let native_driver = match args.opt_value_from_str("--native-driver") {
+      Ok(native_driver) => native_driver,
+      Err(e) => {
+        eprintln!("Error while parsing option --native-driver: {e}");
+        std::process::exit(1);
+      }
+    };
+
+    let parsed = Args {
+      port: args.value_from_str("--port").unwrap_or(4444),
+      native_port: args.value_from_str("--native-port").unwrap_or(4445),
+      native_host: args
+        .value_from_str("--native-host")
+        .unwrap_or(String::from("127.0.0.1")),
+      native_driver,
+    };
+
+    let rest = args.finish();
+    if !rest.is_empty() {
+      eprintln!("Error: unused arguments left: {rest:?}");
+      eprintln!("{HELP}");
+      std::process::exit(1);
+    }
+
+    parsed
+  }
+}

--- a/packages/dioxus-driver/src/main.rs
+++ b/packages/dioxus-driver/src/main.rs
@@ -1,0 +1,57 @@
+// Forked from tauri-driver 2.0.6 (Tauri Programme within The Commons Conservancy,
+// Apache-2.0 OR MIT). Diff vs. upstream is intentionally minimal — see
+// README.md for the upstream-sync policy.
+
+//! Cross-platform WebDriver server for Dioxus desktop applications.
+//!
+//! This is a [WebDriver Intermediary Node](https://www.w3.org/TR/webdriver/#dfn-intermediary-nodes)
+//! that wraps the native WebDriver server (msedgedriver on Windows,
+//! WebKitWebDriver on Linux) for platforms that Dioxus's Wry backend supports.
+//! Your WebDriver client connects to the running `wdio-dioxus-driver` server,
+//! and the driver handles starting the native WebDriver server for you behind
+//! the scenes. It requires two separate ports since two distinct
+//! [WebDriver Remote Ends](https://www.w3.org/TR/webdriver/#dfn-remote-ends) run.
+//!
+//! v1 supports Windows only (matching the spike findings in
+//! `spike/FINDINGS.md` — Linux requires an upstream Dioxus PR exposing Wry's
+//! automation toggle).
+
+#[cfg(any(target_os = "linux", windows))]
+mod cli;
+#[cfg(any(target_os = "linux", windows))]
+mod server;
+#[cfg(any(target_os = "linux", windows))]
+mod webdriver;
+
+#[cfg(not(any(target_os = "linux", windows)))]
+fn main() {
+  println!("wdio-dioxus-driver is not supported on this platform");
+  std::process::exit(1);
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn main() {
+  let args = pico_args::Arguments::from_env().into();
+
+  #[cfg(windows)]
+  let _job_handle = {
+    let job = win32job::Job::create().unwrap();
+    let mut info = job.query_extended_limit_info().unwrap();
+    info.limit_kill_on_job_close();
+    job.set_extended_limit_info(&info).unwrap();
+    job.assign_current_process().unwrap();
+    job
+  };
+
+  // start the native webdriver on the port specified in args
+  let mut driver = webdriver::native(&args);
+  let driver = driver
+    .spawn()
+    .expect("error while running native webdriver");
+
+  // start our webdriver intermediary node
+  if let Err(e) = server::run(args, driver) {
+    eprintln!("error while running server: {e}");
+    std::process::exit(1);
+  }
+}

--- a/packages/dioxus-driver/src/server.rs
+++ b/packages/dioxus-driver/src/server.rs
@@ -1,0 +1,252 @@
+// Forked from tauri-driver 2.0.6 — HTTP proxy between WDIO and the native
+// WebDriver subprocess.
+//
+// Diff vs. upstream:
+//   - `TAURI_OPTIONS` constant + `TauriOptions` struct renamed to
+//     `DIOXUS_OPTIONS` / `DioxusOptions`.
+//   - The capability-rewrite mapping reads `"dioxus:options"` instead of
+//     `"tauri:options"`; output formats (`ms:edgeOptions`,
+//     `webkitgtk:browserOptions`) are unchanged because those are dictated by
+//     msedgedriver / WebKitWebDriver, not by us.
+
+use crate::cli::Args;
+use anyhow::Error;
+use futures_util::TryFutureExt;
+use http_body_util::{BodyExt, Full};
+use hyper::{
+  body::{Bytes, Incoming},
+  header::CONTENT_LENGTH,
+  http::uri::Authority,
+  service::service_fn,
+  Method, Request, Response,
+};
+use hyper_util::{
+  client::legacy::{connect::HttpConnector, Client},
+  rt::{TokioExecutor, TokioIo},
+  server::conn::auto,
+};
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use std::path::PathBuf;
+use std::process::Child;
+use tokio::net::TcpListener;
+
+const DIOXUS_OPTIONS: &str = "dioxus:options";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DioxusOptions {
+  application: PathBuf,
+  #[serde(default)]
+  args: Vec<String>,
+  #[cfg(target_os = "windows")]
+  #[serde(default)]
+  webview_options: Option<Value>,
+}
+
+impl DioxusOptions {
+  #[cfg(target_os = "linux")]
+  fn into_native_object(self) -> Map<String, Value> {
+    let mut map = Map::new();
+    map.insert(
+      "webkitgtk:browserOptions".into(),
+      json!({"binary": self.application, "args": self.args}),
+    );
+    map
+  }
+
+  #[cfg(target_os = "windows")]
+  fn into_native_object(self) -> Map<String, Value> {
+    let mut ms_edge_options = Map::new();
+    ms_edge_options.insert(
+      "binary".into(),
+      json!(self.application.with_extension("exe")),
+    );
+    ms_edge_options.insert("args".into(), self.args.into());
+
+    if let Some(webview_options) = self.webview_options {
+      ms_edge_options.insert("webviewOptions".into(), webview_options);
+    }
+
+    let mut map = Map::new();
+    map.insert("ms:edgeChromium".into(), json!(true));
+    map.insert("browserName".into(), json!("webview2"));
+    map.insert("ms:edgeOptions".into(), ms_edge_options.into());
+    map
+  }
+}
+
+async fn handle(
+  client: Client<HttpConnector, Full<Bytes>>,
+  req: Request<Incoming>,
+  args: Args,
+) -> Result<Response<Incoming>, Error> {
+  // manipulate a new session to convert options to the native driver format
+  let new_req: Request<Full<Bytes>> =
+    if let (&Method::POST, "/session") = (req.method(), req.uri().path()) {
+      let (mut parts, body) = req.into_parts();
+
+      // get the body from the future stream and parse it as json
+      let body = body.collect().await?.to_bytes().to_vec();
+      let json: Value = serde_json::from_slice(&body)?;
+
+      // rewrite dioxus:options to the native driver shape
+      let json = map_capabilities(json);
+
+      // serialize json and update the content-length header to be accurate
+      let bytes = serde_json::to_vec(&json)?;
+      parts.headers.insert(CONTENT_LENGTH, bytes.len().into());
+
+      Request::from_parts(parts, Full::new(bytes.into()))
+    } else {
+      let (parts, body) = req.into_parts();
+
+      let body = body.collect().await?.to_bytes().to_vec();
+
+      Request::from_parts(parts, Full::new(body.into()))
+    };
+
+  client
+    .request(forward_to_native_driver(new_req, args)?)
+    .err_into()
+    .await
+}
+
+/// Transform the request to a request for the native webdriver server.
+fn forward_to_native_driver(
+  mut req: Request<Full<Bytes>>,
+  args: Args,
+) -> Result<Request<Full<Bytes>>, Error> {
+  let host: Authority = {
+    let headers = req.headers_mut();
+    headers.remove("host").expect("hyper request has host")
+  }
+  .to_str()?
+  .parse()?;
+
+  let path = req
+    .uri()
+    .path_and_query()
+    .expect("hyper request has uri")
+    .clone();
+
+  let uri = format!(
+    "http://{}:{}{}",
+    host.host(),
+    args.native_port,
+    path.as_str()
+  );
+
+  let (mut parts, body) = req.into_parts();
+  parts.uri = uri.parse()?;
+  Ok(Request::from_parts(parts, body))
+}
+
+/// only happy path for now, no errors
+fn map_capabilities(mut json: Value) -> Value {
+  let mut native = None;
+  if let Some(capabilities) = json.get_mut("capabilities") {
+    if let Some(always_match) = capabilities.get_mut("alwaysMatch") {
+      if let Some(always_match) = always_match.as_object_mut() {
+        if let Some(dioxus_options) = always_match.remove(DIOXUS_OPTIONS) {
+          if let Ok(options) = serde_json::from_value::<DioxusOptions>(dioxus_options) {
+            native = Some(options.into_native_object());
+          }
+        }
+
+        if let Some(native) = native.clone() {
+          always_match.extend(native);
+        }
+      }
+    }
+  }
+
+  if let Some(native) = native {
+    if let Some(desired) = json.get_mut("desiredCapabilities") {
+      if let Some(desired) = desired.as_object_mut() {
+        desired.remove(DIOXUS_OPTIONS);
+        desired.extend(native);
+      }
+    }
+  }
+
+  json
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn run(args: Args, mut _driver: Child) -> Result<(), Error> {
+  #[cfg(unix)]
+  let (signals_handle, signals_task) = {
+    use futures_util::StreamExt;
+    use signal_hook::consts::signal::*;
+
+    let signals = signal_hook_tokio::Signals::new([SIGTERM, SIGINT, SIGQUIT])?;
+    let signals_handle = signals.handle();
+    let signals_task = tokio::spawn(async move {
+      let mut signals = signals.fuse();
+      #[allow(clippy::never_loop)]
+      while let Some(signal) = signals.next().await {
+        match signal {
+          SIGTERM | SIGINT | SIGQUIT => {
+            _driver
+              .kill()
+              .expect("unable to kill native webdriver server");
+            std::process::exit(0);
+          }
+          _ => unreachable!(),
+        }
+      }
+    });
+    (signals_handle, signals_task)
+  };
+
+  let address = std::net::SocketAddr::from(([127, 0, 0, 1], args.port));
+
+  // the client we use to proxy requests to the native webdriver
+  let client = Client::builder(TokioExecutor::new())
+    .http1_preserve_header_case(true)
+    .http1_title_case_headers(true)
+    .retry_canceled_requests(false)
+    .build_http();
+
+  // set up a http1 server that uses the service we just created
+  let srv = async move {
+    if let Ok(listener) = TcpListener::bind(address).await {
+      loop {
+        let client = client.clone();
+        let args = args.clone();
+        if let Ok((stream, _)) = listener.accept().await {
+          let io = TokioIo::new(stream);
+
+          tokio::task::spawn(async move {
+            if let Err(err) = auto::Builder::new(TokioExecutor::new())
+              .http1()
+              .title_case_headers(true)
+              .preserve_header_case(true)
+              .serve_connection(
+                io,
+                service_fn(|request| handle(client.clone(), request, args.clone())),
+              )
+              .await
+            {
+              println!("Error serving connection: {err:?}");
+            }
+          });
+        } else {
+          println!("accept new stream fail, ignore here");
+        }
+      }
+    } else {
+      println!("can not listen to address: {address:?}");
+    }
+  };
+  srv.await;
+
+  #[cfg(unix)]
+  {
+    signals_handle.close();
+    signals_task.await?;
+  }
+
+  Ok(())
+}

--- a/packages/dioxus-driver/src/webdriver.rs
+++ b/packages/dioxus-driver/src/webdriver.rs
@@ -1,0 +1,66 @@
+// Forked from tauri-driver 2.0.6 — native WebDriver subprocess setup.
+//
+// Diff vs. upstream:
+//   - `TAURI_AUTOMATION` (legacy 1.x) env var dropped.
+//   - `TAURI_WEBVIEW_AUTOMATION` → `DIOXUS_WEBVIEW_AUTOMATION`. The env var is
+//     consumed by `wdio-dioxus-bridge`'s automation.rs inside the Dioxus app
+//     binary (see packages/dioxus-bridge/src/automation.rs); on Windows it's
+//     a no-op at the Wry level, but we set it anyway for forward compat with
+//     the bridge crate.
+
+use crate::cli::Args;
+use std::{
+  env::current_dir,
+  process::{Command, Stdio},
+};
+
+// the name of the binary to find in $PATH
+#[cfg(target_os = "linux")]
+const DRIVER_BINARY: &str = "WebKitWebDriver";
+
+#[cfg(target_os = "windows")]
+const DRIVER_BINARY: &str = "msedgedriver.exe";
+
+/// Find the native driver binary in the PATH, or exits the process with an error.
+pub fn native(args: &Args) -> Command {
+  let native_binary = match args.native_driver.as_deref() {
+    Some(custom) => {
+      if custom.exists() {
+        custom.to_owned()
+      } else {
+        eprintln!(
+          "can not find the supplied binary path {}. This is currently required.",
+          custom.display()
+        );
+        match current_dir() {
+          Ok(cwd) => eprintln!("current working directory: {}", cwd.display()),
+          Err(error) => eprintln!("can not find current working directory: {error}"),
+        }
+        std::process::exit(1);
+      }
+    }
+    None => match which::which(DRIVER_BINARY) {
+      Ok(binary) => binary,
+      Err(error) => {
+        eprintln!(
+          "can not find binary {DRIVER_BINARY} in the PATH. This is currently required. \
+          You can also pass a custom path with --native-driver"
+        );
+        eprintln!("{error:?}");
+        std::process::exit(1);
+      }
+    },
+  };
+
+  let mut cmd = Command::new(native_binary);
+  cmd.env("DIOXUS_WEBVIEW_AUTOMATION", "true");
+  cmd.arg(format!("--port={}", args.native_port));
+  cmd.arg(format!("--host={}", args.native_host));
+
+  // Don't inherit stdout from parent to prevent native WebDriver binary/HTTP protocol data
+  // from corrupting wdio-dioxus-driver's stdout (which gets captured by the test framework).
+  // Keep stderr inherited so WebDriver logs/errors are still visible.
+  cmd.stdout(Stdio::null());
+
+  cmd
+}

--- a/packages/dioxus-service/package.json
+++ b/packages/dioxus-service/package.json
@@ -1,0 +1,99 @@
+{
+  "name": "@wdio/dioxus-service",
+  "version": "1.0.0-next.0",
+  "description": "WebdriverIO service for testing Dioxus desktop applications",
+  "author": "WebdriverIO Community",
+  "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/dioxus-service",
+  "license": "MIT",
+  "engines": {
+    "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": [
+      {
+        "import": {
+          "types": "./dist/esm/index.d.ts",
+          "default": "./dist/esm/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/index.d.ts",
+          "default": "./dist/cjs/index.js"
+        }
+      },
+      "./dist/cjs/index.js"
+    ]
+  },
+  "files": [
+    "dist",
+    "docs",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsx ../../scripts/build-package.ts",
+    "build:watch": "tsx ../../scripts/build-package.ts --watch",
+    "clean": "shx rm -rf dist",
+    "clean:dist": "shx rm -rf dist",
+    "dev": "pnpm run build:watch",
+    "lint": "biome check --linter-enabled=true --formatter-enabled=false src/",
+    "lint:fix": "biome check --write --linter-enabled=true --formatter-enabled=false src/",
+    "test": "vitest run",
+    "test:unit": "vitest run --config vitest.config.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration:watch": "vitest --config vitest.integration.config.ts",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wdio/globals": "catalog:default",
+    "@wdio/logger": "catalog:default",
+    "@wdio/native-core": "workspace:*",
+    "@wdio/native-spy": "workspace:*",
+    "@wdio/native-types": "workspace:*",
+    "@wdio/native-utils": "workspace:*",
+    "@wdio/spec-reporter": "catalog:default",
+    "@wdio/types": "catalog:default",
+    "debug": "^4.4.3",
+    "get-port": "^7.1.0",
+    "tslib": "^2.8.1",
+    "webdriverio": "catalog:default"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.12",
+    "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "^4.1.0",
+    "shx": "^0.4.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  },
+  "peerDependencies": {
+    "webdriverio": "^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "webdriverio": {
+      "optional": false
+    }
+  },
+  "keywords": [
+    "webdriverio",
+    "wdio",
+    "wdio-service",
+    "dioxus",
+    "testing",
+    "e2e",
+    "desktop"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webdriverio/desktop-mobile.git",
+    "directory": "packages/dioxus-service"
+  },
+  "bugs": {
+    "url": "https://github.com/webdriverio/desktop-mobile/issues"
+  }
+}

--- a/packages/dioxus-service/src/commands/allMocks.ts
+++ b/packages/dioxus-service/src/commands/allMocks.ts
@@ -1,0 +1,49 @@
+// Mock-lifecycle helpers — clear/reset/restore across every mock the
+// service has created. Each is filterable by `prefix` so multi-suite
+// runs can isolate to e.g. all `dioxus.fs.*` mocks.
+
+import type { DioxusMock } from '@wdio/native-types';
+
+import mockStore from '../mockStore.js';
+
+function matchesPrefix(name: string, prefix?: string): boolean {
+  if (!prefix) {
+    return true;
+  }
+  // Outer mocks are named `dioxus.<command>` (see mock.ts). Match against
+  // both the bare command and the prefixed form so callers can pass either.
+  const stripped = name.startsWith('dioxus.') ? name.slice('dioxus.'.length) : name;
+  return name.startsWith(prefix) || stripped.startsWith(prefix);
+}
+
+async function forEachMock(prefix: string | undefined, fn: (m: DioxusMock) => Promise<unknown>): Promise<void> {
+  for (const [name, m] of mockStore.getMocks()) {
+    if (matchesPrefix(name, prefix)) {
+      await fn(m);
+    }
+  }
+}
+
+export async function clearAllMocks(prefix?: string): Promise<void> {
+  await forEachMock(prefix, (m) => m.mockClear());
+}
+
+export async function resetAllMocks(prefix?: string): Promise<void> {
+  await forEachMock(prefix, (m) => m.mockReset());
+}
+
+export async function restoreAllMocks(prefix?: string): Promise<void> {
+  await forEachMock(prefix, (m) => m.mockRestore());
+}
+
+/**
+ * True iff `candidate` is a DioxusMock — checked structurally via the
+ * `__isDioxusMock: true` flag created in mock.ts.
+ */
+export function isMockFunction(candidate: unknown): boolean {
+  if (candidate == null || typeof candidate !== 'function') {
+    return false;
+  }
+  const flag = (candidate as { __isDioxusMock?: unknown }).__isDioxusMock;
+  return flag === true;
+}

--- a/packages/dioxus-service/src/commands/execute.ts
+++ b/packages/dioxus-service/src/commands/execute.ts
@@ -1,15 +1,22 @@
 // browser.dioxus.execute implementation.
 //
-// Phase 2 MVP: minimum viable execute that wraps WDIO's `browser.execute` and
-// exposes the bridge's `window.__WDIO_DIOXUS__` to the script as `dx`. Mirrors
-// the public surface of `browser.tauri.execute(...)` but without the
-// windowLabel sentinel + multi-window routing (those land in a Phase 4 commit
-// alongside the bridge's window_state module).
+// Two entry points for browser-side JS:
 //
-// Accepts either a function or a raw string script. Function form is
-// serialised to its source representation and wrapped so it receives
-// `(dx, ...args)`. String form is passed through unchanged with `arguments`
-// being the WDIO-supplied args.
+//   - `execute`: the user-facing API. Accepts a function or a raw string
+//     script. Function form serialises to source and wraps so the user's
+//     callback receives `dx = window.__WDIO_DIOXUS__` as its first arg.
+//     String form is passed through unchanged — users writing strings get
+//     the standard WDIO behaviour where the body is wrapped as
+//     `function() { ${body} }` and `arguments` is bound to the spread args.
+//
+//   - `runInterceptorScript`: the internal helper consumed by mock.ts. The
+//     DioxusAdapter scripts are arrow-function literals (e.g. `(_dx) => { ... }`)
+//     which must be *invoked*, not just defined. This helper wraps them as
+//     `return (${script})()` before passing to `browser.execute`, mirroring
+//     the Tauri analogue (packages/tauri-service/src/mock.ts).
+//
+// Multi-window routing + the windowLabel sentinel from Tauri's equivalent
+// are deferred to a Phase 4 multi-window commit.
 
 import type { DioxusAPIs } from '@wdio/native-types';
 
@@ -20,6 +27,12 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
 ): Promise<ReturnValue> {
   if (typeof script === 'function') {
     const fnSource = script.toString();
+    // Inline the args as JSON literals rather than relying on `arguments`.
+    // WDIO's exact wrapping of the string script is not contractually fixed
+    // (older versions used `function() { ... }`, but modern wrappers may
+    // emit arrow functions — and arrow functions have no own `arguments`
+    // binding). Inlining keeps the call-site portable.
+    const argsLiteral = args.map((a) => JSON.stringify(a) ?? 'undefined').join(', ');
     const wrapped = `
       const userFn = (${fnSource});
       const dx = window.__WDIO_DIOXUS__;
@@ -29,10 +42,22 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
           'Did you forget to call wdio_dioxus_bridge::install(config) in your Dioxus main.rs?'
         );
       }
-      return await Promise.resolve(userFn(dx, ...arguments));
+      return await Promise.resolve(userFn(dx, ${argsLiteral}));
     `;
-    return (await browser.execute(wrapped, ...args)) as ReturnValue;
+    return (await browser.execute(wrapped)) as ReturnValue;
   }
 
   return (await browser.execute(script, ...args)) as ReturnValue;
+}
+
+/**
+ * Internal helper for invoking DioxusAdapter scripts. Each adapter-built
+ * script is an arrow-function literal — wrapping with `return (${script})()`
+ * is what actually invokes it. Without this wrap the function is defined
+ * but never called and `window.__wdio_mocks__` is never populated.
+ *
+ * Not exported from the package's public surface — only consumed by mock.ts.
+ */
+export async function runInterceptorScript<T>(browser: WebdriverIO.Browser, script: string): Promise<T> {
+  return browser.execute(`return (${script})()`) as Promise<T>;
 }

--- a/packages/dioxus-service/src/commands/execute.ts
+++ b/packages/dioxus-service/src/commands/execute.ts
@@ -22,7 +22,7 @@ import type { DioxusAPIs } from '@wdio/native-types';
 
 export async function execute<ReturnValue, InnerArguments extends unknown[] = unknown[]>(
   browser: WebdriverIO.Browser,
-  script: string | ((dx: DioxusAPIs, ...args: InnerArguments) => ReturnValue | Promise<ReturnValue>),
+  script: string | ((dx: DioxusAPIs, ...args: InnerArguments) => ReturnValue),
   ...args: InnerArguments
 ): Promise<ReturnValue> {
   if (typeof script === 'function') {
@@ -32,6 +32,11 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
     // (older versions used `function() { ... }`, but modern wrappers may
     // emit arrow functions — and arrow functions have no own `arguments`
     // binding). Inlining keeps the call-site portable.
+    //
+    // The wrapper body MUST stay synchronous: WebDriver's executeScript
+    // wraps the string in a non-async function, so `await` here would be
+    // a SyntaxError at runtime. Users that need promise-returning scripts
+    // should reach for executeAsync (not yet exposed on browser.dioxus).
     const argsLiteral = args.map((a) => JSON.stringify(a) ?? 'undefined').join(', ');
     const wrapped = `
       const userFn = (${fnSource});
@@ -42,7 +47,7 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
           'Did you forget to call wdio_dioxus_bridge::install(config) in your Dioxus main.rs?'
         );
       }
-      return await Promise.resolve(userFn(dx, ${argsLiteral}));
+      return userFn(dx, ${argsLiteral});
     `;
     return (await browser.execute(wrapped)) as ReturnValue;
   }

--- a/packages/dioxus-service/src/commands/execute.ts
+++ b/packages/dioxus-service/src/commands/execute.ts
@@ -1,0 +1,38 @@
+// browser.dioxus.execute implementation.
+//
+// Phase 2 MVP: minimum viable execute that wraps WDIO's `browser.execute` and
+// exposes the bridge's `window.__WDIO_DIOXUS__` to the script as `dx`. Mirrors
+// the public surface of `browser.tauri.execute(...)` but without the
+// windowLabel sentinel + multi-window routing (those land in a Phase 4 commit
+// alongside the bridge's window_state module).
+//
+// Accepts either a function or a raw string script. Function form is
+// serialised to its source representation and wrapped so it receives
+// `(dx, ...args)`. String form is passed through unchanged with `arguments`
+// being the WDIO-supplied args.
+
+import type { DioxusAPIs } from '@wdio/native-types';
+
+export async function execute<ReturnValue, InnerArguments extends unknown[] = unknown[]>(
+  browser: WebdriverIO.Browser,
+  script: string | ((dx: DioxusAPIs, ...args: InnerArguments) => ReturnValue | Promise<ReturnValue>),
+  ...args: InnerArguments
+): Promise<ReturnValue> {
+  if (typeof script === 'function') {
+    const fnSource = script.toString();
+    const wrapped = `
+      const userFn = (${fnSource});
+      const dx = window.__WDIO_DIOXUS__;
+      if (!dx || typeof dx.invoke !== 'function') {
+        throw new Error(
+          '[wdio-dioxus-service] window.__WDIO_DIOXUS__.invoke is not installed. ' +
+          'Did you forget to call wdio_dioxus_bridge::install(config) in your Dioxus main.rs?'
+        );
+      }
+      return await Promise.resolve(userFn(dx, ...arguments));
+    `;
+    return (await browser.execute(wrapped, ...args)) as ReturnValue;
+  }
+
+  return (await browser.execute(script, ...args)) as ReturnValue;
+}

--- a/packages/dioxus-service/src/commands/mock.ts
+++ b/packages/dioxus-service/src/commands/mock.ts
@@ -1,0 +1,9 @@
+// browser.dioxus.mock(command) — public entry point.
+
+import type { DioxusMock } from '@wdio/native-types';
+
+import { createMock } from '../mock.js';
+
+export async function mock(command: string, browserContext?: WebdriverIO.Browser): Promise<DioxusMock> {
+  return createMock(command, browserContext);
+}

--- a/packages/dioxus-service/src/constants/logging.ts
+++ b/packages/dioxus-service/src/constants/logging.ts
@@ -1,0 +1,25 @@
+// Log-capture constants shared between logParser and logForwarder.
+
+/**
+ * Marker emitted by the bridge's log_bridge.rs every time a frontend
+ * console.* call is forwarded. logParser splits on this token to classify
+ * lines as 'frontend' vs 'backend'.
+ *
+ * Must match `wdio_dioxus_bridge::log_bridge::FRONTEND_MARKER` in the Rust
+ * crate. If you change one, change the other.
+ */
+export const FRONTEND_MARKER = '[WDIO-FRONTEND]';
+
+/**
+ * Public prefixes used in formatted log output. The service stamps these
+ * onto every line forwarded to the WDIO logger so multi-framework tests
+ * can tell `[Dioxus:Backend]` lines apart from `[Tauri:Backend]` /
+ * `[Electron:MainProcess]`.
+ */
+export const PREFIXES = {
+  backend: '[Dioxus:Backend]',
+  frontend: '[Dioxus:Frontend]',
+} as const;
+
+/** Format `[WDIO-FRONTEND][LEVEL] message`. */
+export const WDIO_FRONTEND_PATTERN = /^\[WDIO-FRONTEND\]\[(INFO|WARN|ERROR|DEBUG|TRACE)\]\s*/i;

--- a/packages/dioxus-service/src/errors.ts
+++ b/packages/dioxus-service/src/errors.ts
@@ -1,0 +1,27 @@
+// Error classes / message constants for the Dioxus service.
+//
+// `SevereServiceError` (re-exported from webdriverio) signals to the WDIO
+// runner that the failure is non-recoverable and the run should abort — used
+// when we detect a configuration that fundamentally can't work, e.g.
+// `driverProvider: 'external'` on Linux (blocked pending an upstream Dioxus
+// PR per spike/FINDINGS.md).
+
+import { SevereServiceError } from 'webdriverio';
+
+export { SevereServiceError };
+
+/**
+ * Compose the error message thrown when a user selects
+ * `driverProvider: 'external'` on Linux. The message points them at
+ * `'embedded'` and explains why the external path doesn't work here yet.
+ */
+export function linuxExternalProviderUnsupported(): Error {
+  return new SevereServiceError(
+    "driverProvider: 'external' is not supported on Linux in this release. " +
+      "Use driverProvider: 'embedded' instead (this is the recommended path on " +
+      'all platforms). Linux external-provider support is pending an upstream ' +
+      'Dioxus PR that exposes Wry automation mode — see ' +
+      'https://github.com/webdriverio/desktop-mobile/blob/main/spike/FINDINGS.md ' +
+      'for context.',
+  );
+}

--- a/packages/dioxus-service/src/index.ts
+++ b/packages/dioxus-service/src/index.ts
@@ -1,0 +1,20 @@
+// @wdio/dioxus-service entry point.
+//
+// - Default export: the worker-side service (registered automatically by
+//   the WDIO test runner via `services: ['@wdio/dioxus-service']`).
+// - Named `launcher` export: the main-process launcher (auto-detected by
+//   the runner using the standard service convention).
+
+import DioxusLaunchService from './launcher.js';
+import DioxusWorkerService from './service.js';
+
+export { DioxusLaunchService as launcher };
+export default DioxusWorkerService;
+
+export { linuxExternalProviderUnsupported, SevereServiceError } from './errors.js';
+export type {
+  DioxusCapabilities,
+  DioxusDriverProvider,
+  DioxusServiceGlobalOptions,
+  DioxusServiceOptions,
+} from './types.js';

--- a/packages/dioxus-service/src/launcher.ts
+++ b/packages/dioxus-service/src/launcher.ts
@@ -1,0 +1,72 @@
+// @wdio/dioxus-service launcher.
+//
+// PR2 Phase 1 (MVP): minimum viable launcher for provider `'external'` on
+// Windows. Linux `'external'` is blocked per spike/FINDINGS.md; the launcher
+// throws SevereServiceError at onPrepare. macOS users must use
+// `'embedded'` (matching the Tauri precedent — wdio-dioxus-driver inherits
+// tauri-driver's Windows-only support, minus Linux for us).
+//
+// Provider `'embedded'` is wired up in a later phase once
+// `wdio-dioxus-embedded-driver` is on crates.io.
+
+import { BaseLauncher } from '@wdio/native-core';
+import { createLogger } from '@wdio/native-utils';
+import type { Options } from '@wdio/types';
+
+import { linuxExternalProviderUnsupported } from './errors.js';
+import type { DioxusCapabilities, DioxusServiceGlobalOptions, DioxusServiceOptions } from './types.js';
+
+const log = createLogger('dioxus-service', 'launcher');
+
+export default class DioxusLaunchService extends BaseLauncher {
+  constructor(
+    private options: DioxusServiceGlobalOptions,
+    capabilities: DioxusCapabilities,
+    config: Options.Testrunner,
+  ) {
+    super({
+      basePort: options.dioxusDriverPort ?? 4444,
+      baseNativePort: (options.dioxusDriverPort ?? 4444) + 1,
+    });
+    log.debug('DioxusLaunchService initialised');
+    log.debug('Capabilities:', JSON.stringify(capabilities, null, 2));
+    log.debug('Config:', JSON.stringify(config, null, 2));
+  }
+
+  async onPrepare(
+    _config: Options.Testrunner,
+    capabilities: DioxusCapabilities[] | Record<string, { capabilities: DioxusCapabilities }>,
+  ): Promise<void> {
+    const firstCap = Array.isArray(capabilities) ? capabilities[0] : Object.values(capabilities)[0]?.capabilities;
+    const mergedOptions = mergeOptions(this.options, firstCap?.['wdio:dioxusServiceOptions']);
+
+    const provider = mergedOptions.driverProvider ?? 'embedded';
+    if (provider === 'external' && process.platform === 'linux') {
+      throw linuxExternalProviderUnsupported();
+    }
+
+    log.info(`Dioxus service onPrepare — provider: ${provider}, platform: ${process.platform}`);
+
+    // Phase 1 stops here. Driver subprocess spawning lands in a follow-on
+    // commit once the wdio-dioxus-driver crate is built and the bridge crate
+    // is consumable by a Dioxus fixture app.
+  }
+
+  async onComplete(): Promise<void> {
+    await this.stopAllDrivers();
+  }
+}
+
+function mergeOptions(
+  globalOptions: DioxusServiceGlobalOptions,
+  capabilityOptions?: DioxusServiceOptions,
+): DioxusServiceOptions {
+  return {
+    ...globalOptions,
+    ...capabilityOptions,
+    captureBackendLogs: capabilityOptions?.captureBackendLogs ?? globalOptions.captureBackendLogs ?? false,
+    captureFrontendLogs: capabilityOptions?.captureFrontendLogs ?? globalOptions.captureFrontendLogs ?? false,
+    backendLogLevel: capabilityOptions?.backendLogLevel ?? globalOptions.backendLogLevel ?? 'info',
+    frontendLogLevel: capabilityOptions?.frontendLogLevel ?? globalOptions.frontendLogLevel ?? 'info',
+  };
+}

--- a/packages/dioxus-service/src/logForwarder.ts
+++ b/packages/dioxus-service/src/logForwarder.ts
@@ -1,0 +1,84 @@
+// Dioxus log forwarder.
+//
+// Receives parsed log records from parseLogLine (or directly from callers)
+// and routes them to either:
+//   1. The standalone log file (when @wdio/native-core's LogWriter for
+//      'dioxus-service' has been initialised — typical of standalone-mode
+//      session helpers).
+//   2. The WDIO logger (test-runner mode).
+//
+// Each line is stamped with a `[Dioxus:Backend]` or `[Dioxus:Frontend]`
+// prefix so multi-framework test runs can tell sources apart.
+
+import { getLogWriter, isLogWriterInitialized, shouldLog } from '@wdio/native-core';
+import type { LogLevel } from '@wdio/native-types';
+import { createLogger } from '@wdio/native-utils';
+
+import { PREFIXES } from './constants/logging.js';
+
+const SERVICE_NAME = 'dioxus-service';
+
+type WdioLogger = ReturnType<typeof createLogger>;
+
+let cachedLogger: WdioLogger | undefined;
+
+function getLogger(): WdioLogger {
+  if (!cachedLogger) {
+    cachedLogger = createLogger(SERVICE_NAME, 'service');
+  }
+  return cachedLogger;
+}
+
+function getLoggerMethod(logger: WdioLogger, level: LogLevel): (...args: unknown[]) => void {
+  switch (level) {
+    case 'trace':
+    case 'debug':
+      return logger.debug.bind(logger);
+    case 'info':
+      return logger.info.bind(logger);
+    case 'warn':
+      return logger.warn.bind(logger);
+    case 'error':
+      return logger.error.bind(logger);
+    default:
+      return logger.info.bind(logger);
+  }
+}
+
+/**
+ * Stamp the configured `[Dioxus:Backend]` / `[Dioxus:Frontend]` prefix on
+ * `message`, optionally with a multiremote instance ID.
+ */
+function formatLogMessage(source: 'backend' | 'frontend', message: string, instanceId?: string): string {
+  const prefix = source === 'frontend' ? PREFIXES.frontend : PREFIXES.backend;
+  const instanceLabel = instanceId ? `:${instanceId}` : '';
+  // Inject the instanceId before the closing bracket, e.g. [Dioxus:Backend:browserA]
+  const stampedPrefix = instanceId ? prefix.replace(/\]$/, `${instanceLabel}]`) : prefix;
+  return `${stampedPrefix} ${message}`;
+}
+
+/**
+ * Forward a parsed log to the active sink. No-op when `level` is below
+ * `minLevel` per [`shouldLog`].
+ */
+export function forwardLog(
+  source: 'backend' | 'frontend',
+  level: LogLevel,
+  message: string,
+  minLevel: LogLevel,
+  instanceId?: string,
+): void {
+  if (!shouldLog(level, minLevel)) {
+    return;
+  }
+
+  const formatted = formatLogMessage(source, message, instanceId);
+
+  if (isLogWriterInitialized(SERVICE_NAME)) {
+    getLogWriter(SERVICE_NAME).write(formatted);
+    return;
+  }
+
+  const loggerMethod = getLoggerMethod(getLogger(), level);
+  loggerMethod(formatted);
+}

--- a/packages/dioxus-service/src/logParser.ts
+++ b/packages/dioxus-service/src/logParser.ts
@@ -1,0 +1,72 @@
+// Parse a single stdout/stderr line from the Dioxus app subprocess into a
+// structured log record.
+//
+// Two kinds of lines flow through here:
+// 1. Frontend lines emitted by the bridge's log_bridge.rs, prefixed
+//    `[WDIO-FRONTEND][LEVEL] message`. We classify these as `source: 'frontend'`
+//    and strip the marker.
+// 2. Backend lines from the Rust app via tracing/println, no special prefix.
+//    We attempt to extract a level by scanning for `INFO|WARN|ERROR|DEBUG|TRACE`
+//    tokens; default to `info` when no level marker is present.
+
+import type { LogLevel } from '@wdio/native-types';
+
+import { FRONTEND_MARKER, WDIO_FRONTEND_PATTERN } from './constants/logging.js';
+
+export interface ParsedLog {
+  level: LogLevel;
+  message: string;
+  raw: string;
+  source: 'backend' | 'frontend';
+}
+
+const LEVEL_PATTERNS: Array<{ level: LogLevel; pattern: RegExp }> = [
+  { level: 'error', pattern: /\b(ERROR|Error|error)\b/i },
+  { level: 'warn', pattern: /\b(WARN|Warn|warn|WARNING|Warning|warning)\b/i },
+  { level: 'info', pattern: /\b(INFO|Info|info)\b/i },
+  { level: 'debug', pattern: /\b(DEBUG|Debug|debug)\b/i },
+  { level: 'trace', pattern: /\b(TRACE|Trace|trace)\b/i },
+];
+
+function detectLevel(line: string): LogLevel {
+  for (const { level, pattern } of LEVEL_PATTERNS) {
+    if (pattern.test(line)) {
+      return level;
+    }
+  }
+  return 'info';
+}
+
+/**
+ * Parse one stdout/stderr line. Returns `undefined` for empty input;
+ * everything non-empty yields a structured record.
+ */
+export function parseLogLine(line: string): ParsedLog | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (trimmed.startsWith(FRONTEND_MARKER)) {
+    const match = trimmed.match(WDIO_FRONTEND_PATTERN);
+    const level = (match?.[1]?.toLowerCase() as LogLevel | undefined) ?? 'info';
+    // Strip the full `[WDIO-FRONTEND][LEVEL]` prefix when present; fall back
+    // to stripping the bare `[WDIO-FRONTEND]` marker otherwise.
+    const message = match
+      ? trimmed.replace(WDIO_FRONTEND_PATTERN, '').trim()
+      : trimmed.slice(FRONTEND_MARKER.length).trim();
+    return {
+      level,
+      message,
+      raw: trimmed,
+      source: 'frontend',
+    };
+  }
+
+  return {
+    level: detectLevel(trimmed),
+    message: trimmed,
+    raw: trimmed,
+    source: 'backend',
+  };
+}

--- a/packages/dioxus-service/src/logParser.ts
+++ b/packages/dioxus-service/src/logParser.ts
@@ -20,21 +20,34 @@ export interface ParsedLog {
   source: 'backend' | 'frontend';
 }
 
-const LEVEL_PATTERNS: Array<{ level: LogLevel; pattern: RegExp }> = [
-  { level: 'error', pattern: /\b(ERROR|Error|error)\b/i },
-  { level: 'warn', pattern: /\b(WARN|Warn|warn|WARNING|Warning|warning)\b/i },
-  { level: 'info', pattern: /\b(INFO|Info|info)\b/i },
-  { level: 'debug', pattern: /\b(DEBUG|Debug|debug)\b/i },
-  { level: 'trace', pattern: /\b(TRACE|Trace|trace)\b/i },
-];
-
+/**
+ * Detect the log level on a backend line by finding the **leftmost** level
+ * token preceded by a word boundary (start-of-line or whitespace).
+ *
+ * Rust `tracing` / `log` emit the level as the first non-timestamp token
+ * in each line. By anchoring to a leading word boundary and returning the
+ * first regex match, level tokens that appear inside the message body
+ * (e.g. `"check error.log"` or `"in ERROR.handler"`) cannot override the
+ * canonical leading level — the line's actual header is always further
+ * left.
+ *
+ * `WARNING` is normalised to `'warn'` for tracing's verbose form. We don't
+ * split on the first colon (an earlier attempt did and broke on
+ * timestamps like `12:00:00`): the leftmost-match property handles
+ * timestamps with embedded colons natively.
+ */
 function detectLevel(line: string): LogLevel {
-  for (const { level, pattern } of LEVEL_PATTERNS) {
-    if (pattern.test(line)) {
-      return level;
-    }
+  const m = line.match(
+    /(?:^|\s)(ERROR|Error|error|WARNING|Warning|warning|WARN|Warn|warn|INFO|Info|info|DEBUG|Debug|debug|TRACE|Trace|trace)\b/,
+  );
+  if (!m) {
+    return 'info';
   }
-  return 'info';
+  const token = m[1].toLowerCase();
+  if (token === 'warning' || token === 'warn') {
+    return 'warn';
+  }
+  return token as LogLevel;
 }
 
 /**

--- a/packages/dioxus-service/src/mock.ts
+++ b/packages/dioxus-service/src/mock.ts
@@ -20,7 +20,7 @@ import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import type { AbstractFn, DioxusMock } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 
-import { execute as dioxusExecute } from './commands/execute.js';
+import { runInterceptorScript } from './commands/execute.js';
 import mockStore from './mockStore.js';
 
 const log = createLogger('dioxus-service', 'mock');
@@ -47,11 +47,11 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   const originalMock = outerMock.mock;
 
   log.debug(`[${command}] Registering inner mock in webview`);
-  await dioxusExecute<void>(browserToUse, interceptor.buildRegistrationScript(command));
+  await runInterceptorScript<void>(browserToUse, interceptor.buildRegistrationScript(command));
   log.debug(`[${command}] Inner mock registered`);
 
   mock.update = async () => {
-    const raw = await dioxusExecute<unknown>(browserToUse, interceptor.buildCallDataReadScript(command));
+    const raw = await runInterceptorScript<unknown>(browserToUse, interceptor.buildCallDataReadScript(command));
     const sync = interceptor.parseCallData(raw);
     const existing = originalMock.calls.length;
 
@@ -77,33 +77,42 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
 
   mock.mockImplementation = async (implFn: AbstractFn) => {
     const s = interceptor.serializeHandler(implFn);
-    await dioxusExecute<void>(browserToUse, interceptor.buildSetImplementationScript(command, s));
+    await runInterceptorScript<void>(browserToUse, interceptor.buildSetImplementationScript(command, s));
     return mock;
   };
 
   mock.mockImplementationOnce = async (implFn: AbstractFn) => {
     const s = interceptor.serializeHandler(implFn);
-    await dioxusExecute<void>(browserToUse, interceptor.buildSetImplementationScript(command, s, true));
+    await runInterceptorScript<void>(browserToUse, interceptor.buildSetImplementationScript(command, s, true));
     return mock;
   };
 
   mock.mockReturnValue = async (value: unknown) => {
-    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockReturnValue', value));
+    await runInterceptorScript<void>(
+      browserToUse,
+      interceptor.buildInnerSetterScript(command, 'mockReturnValue', value),
+    );
     return mock;
   };
 
   mock.mockReturnValueOnce = async (value: unknown) => {
-    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockReturnValueOnce', value));
+    await runInterceptorScript<void>(
+      browserToUse,
+      interceptor.buildInnerSetterScript(command, 'mockReturnValueOnce', value),
+    );
     return mock;
   };
 
   mock.mockResolvedValue = async (value: unknown) => {
-    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockResolvedValue', value));
+    await runInterceptorScript<void>(
+      browserToUse,
+      interceptor.buildInnerSetterScript(command, 'mockResolvedValue', value),
+    );
     return mock;
   };
 
   mock.mockResolvedValueOnce = async (value: unknown) => {
-    await dioxusExecute<void>(
+    await runInterceptorScript<void>(
       browserToUse,
       interceptor.buildInnerSetterScript(command, 'mockResolvedValueOnce', value),
     );
@@ -111,12 +120,15 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   };
 
   mock.mockRejectedValue = async (value: unknown) => {
-    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockRejectedValue', value));
+    await runInterceptorScript<void>(
+      browserToUse,
+      interceptor.buildInnerSetterScript(command, 'mockRejectedValue', value),
+    );
     return mock;
   };
 
   mock.mockRejectedValueOnce = async (value: unknown) => {
-    await dioxusExecute<void>(
+    await runInterceptorScript<void>(
       browserToUse,
       interceptor.buildInnerSetterScript(command, 'mockRejectedValueOnce', value),
     );
@@ -124,14 +136,14 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   };
 
   mock.mockClear = async () => {
-    await dioxusExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockClear'));
+    await runInterceptorScript<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockClear'));
     outerMockClear();
     return mock;
   };
 
   mock.mockReset = async () => {
     const currentName = outerMock.getMockName();
-    await dioxusExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReset'));
+    await runInterceptorScript<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReset'));
     outerMockClear();
     outerMockReset();
     outerMock.mockName(currentName);
@@ -139,14 +151,14 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   };
 
   mock.mockRestore = async () => {
-    await dioxusExecute<void>(browserToUse, interceptor.buildUnregistrationScript(command));
+    await runInterceptorScript<void>(browserToUse, interceptor.buildUnregistrationScript(command));
     outerMockClear();
     mockStore.deleteMock(`dioxus.${command}`);
     return mock;
   };
 
   mock.mockReturnThis = async () => {
-    await dioxusExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReturnThis'));
+    await runInterceptorScript<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReturnThis'));
     return mock;
   };
 

--- a/packages/dioxus-service/src/mock.ts
+++ b/packages/dioxus-service/src/mock.ts
@@ -1,0 +1,156 @@
+// createMock — the workhorse behind browser.dioxus.mock(commandName).
+//
+// A Dioxus mock is two cooperating objects:
+//   1. The "outer mock" — a vitest-flavoured `fn()` from @wdio/native-spy
+//      that lives in the test process. Tests inspect it via `mock.mock.calls`.
+//   2. The "inner mock" — a JS function on `window.__wdio_mocks__[command]`
+//      inside the Dioxus app's webview, installed via DioxusAdapter.
+//
+// User-facing setters (mockReturnValue, mockImplementation, etc.) write to
+// the inner mock via browser.execute. After every assertion-touching method,
+// `mock.update()` syncs the inner mock's call history back into the outer
+// mock so the test sees up-to-date state.
+//
+// Lean v1: no browser-mode special case (mode: 'browser' lands in PR3) and
+// no wrapperMock destructuring proxy (Tauri's pattern, defer until users
+// ask).
+
+import { fn as vitestFn } from '@wdio/native-spy';
+import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
+import type { AbstractFn, DioxusMock } from '@wdio/native-types';
+import { createLogger } from '@wdio/native-utils';
+
+import { execute as dioxusExecute } from './commands/execute.js';
+import mockStore from './mockStore.js';
+
+const log = createLogger('dioxus-service', 'mock');
+const interceptor = createIpcInterceptor('dioxus');
+
+/**
+ * Create a mock for a Dioxus wdio:// command. Registers the inner mock in
+ * the browser, wires the outer mock with `update()` + lifecycle methods,
+ * stores it in the registry, and returns it.
+ */
+export async function createMock(command: string, browserContext?: WebdriverIO.Browser): Promise<DioxusMock> {
+  log.debug(`[${command}] createMock — starting`);
+  const browserToUse = (browserContext ?? browser) as WebdriverIO.Browser;
+
+  const outerMock = vitestFn();
+  const outerMockClear = outerMock.mockClear;
+  const outerMockReset = outerMock.mockReset;
+
+  outerMock.mockName(`dioxus.${command}`);
+
+  const mock = outerMock as unknown as DioxusMock;
+  mock.__isDioxusMock = true;
+
+  const originalMock = outerMock.mock;
+
+  log.debug(`[${command}] Registering inner mock in webview`);
+  await dioxusExecute<void>(browserToUse, interceptor.buildRegistrationScript(command));
+  log.debug(`[${command}] Inner mock registered`);
+
+  mock.update = async () => {
+    const raw = await dioxusExecute<unknown>(browserToUse, interceptor.buildCallDataReadScript(command));
+    const sync = interceptor.parseCallData(raw);
+    const existing = originalMock.calls.length;
+
+    if (sync.calls.length < existing) {
+      // Inner shrank (mockClear or page reload). Replace state wholesale.
+      (originalMock.calls as unknown[][]).length = 0;
+      (originalMock.results as { type: string; value: unknown }[]).length = 0;
+      (originalMock.invocationCallOrder as number[]).length = 0;
+    }
+
+    const startAt = sync.calls.length < existing ? 0 : existing;
+    for (let i = startAt; i < sync.calls.length; i++) {
+      (originalMock.calls as unknown[][]).push(sync.calls[i]);
+      (originalMock.results as { type: string; value: unknown }[]).push(
+        sync.results[i] ?? { type: 'return', value: undefined },
+      );
+      (originalMock.invocationCallOrder as number[]).push(
+        sync.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+      );
+    }
+    return mock;
+  };
+
+  mock.mockImplementation = async (implFn: AbstractFn) => {
+    const s = interceptor.serializeHandler(implFn);
+    await dioxusExecute<void>(browserToUse, interceptor.buildSetImplementationScript(command, s));
+    return mock;
+  };
+
+  mock.mockImplementationOnce = async (implFn: AbstractFn) => {
+    const s = interceptor.serializeHandler(implFn);
+    await dioxusExecute<void>(browserToUse, interceptor.buildSetImplementationScript(command, s, true));
+    return mock;
+  };
+
+  mock.mockReturnValue = async (value: unknown) => {
+    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockReturnValue', value));
+    return mock;
+  };
+
+  mock.mockReturnValueOnce = async (value: unknown) => {
+    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockReturnValueOnce', value));
+    return mock;
+  };
+
+  mock.mockResolvedValue = async (value: unknown) => {
+    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockResolvedValue', value));
+    return mock;
+  };
+
+  mock.mockResolvedValueOnce = async (value: unknown) => {
+    await dioxusExecute<void>(
+      browserToUse,
+      interceptor.buildInnerSetterScript(command, 'mockResolvedValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockRejectedValue = async (value: unknown) => {
+    await dioxusExecute<void>(browserToUse, interceptor.buildInnerSetterScript(command, 'mockRejectedValue', value));
+    return mock;
+  };
+
+  mock.mockRejectedValueOnce = async (value: unknown) => {
+    await dioxusExecute<void>(
+      browserToUse,
+      interceptor.buildInnerSetterScript(command, 'mockRejectedValueOnce', value),
+    );
+    return mock;
+  };
+
+  mock.mockClear = async () => {
+    await dioxusExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockClear'));
+    outerMockClear();
+    return mock;
+  };
+
+  mock.mockReset = async () => {
+    const currentName = outerMock.getMockName();
+    await dioxusExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReset'));
+    outerMockClear();
+    outerMockReset();
+    outerMock.mockName(currentName);
+    return mock;
+  };
+
+  mock.mockRestore = async () => {
+    await dioxusExecute<void>(browserToUse, interceptor.buildUnregistrationScript(command));
+    outerMockClear();
+    mockStore.deleteMock(`dioxus.${command}`);
+    return mock;
+  };
+
+  mock.mockReturnThis = async () => {
+    await dioxusExecute<void>(browserToUse, interceptor.buildInnerInvocationScript(command, 'mockReturnThis'));
+    return mock;
+  };
+
+  mockStore.setMock(mock);
+  log.debug(`[${command}] Mock ready`);
+  return mock;
+}

--- a/packages/dioxus-service/src/mockStore.ts
+++ b/packages/dioxus-service/src/mockStore.ts
@@ -1,0 +1,42 @@
+// Per-process registry of all DioxusMocks ever created. Used by the
+// clearAllMocks / resetAllMocks / restoreAllMocks lifecycle helpers and by
+// session cleanup.
+
+import type { DioxusMock } from '@wdio/native-types';
+
+export class DioxusServiceMockStore {
+  #mocks: Map<string, DioxusMock>;
+
+  constructor() {
+    this.#mocks = new Map<string, DioxusMock>();
+  }
+
+  setMock(mock: DioxusMock): DioxusMock {
+    this.#mocks.set(mock.getMockName(), mock);
+    return mock;
+  }
+
+  getMock(mockId: string): DioxusMock {
+    const mock = this.#mocks.get(mockId);
+    if (!mock) {
+      throw new Error(`No mock registered for "${mockId}"`);
+    }
+    return mock;
+  }
+
+  getMocks(): Array<[string, DioxusMock]> {
+    return Array.from(this.#mocks.entries());
+  }
+
+  deleteMock(mockId: string): boolean {
+    return this.#mocks.delete(mockId);
+  }
+
+  /** Empty the store. Called from session cleanup to prevent leaks across runs. */
+  clear(): void {
+    this.#mocks.clear();
+  }
+}
+
+const mockStore = new DioxusServiceMockStore();
+export default mockStore;

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -1,0 +1,22 @@
+// @wdio/dioxus-service worker service.
+//
+// PR2 Phase 1: minimum viable worker. The `before()` hook installs a
+// placeholder `browser.dioxus` object so capability + service-wiring tests
+// pass. The actual `execute`, `mock`, etc. surface lands in Phase 2 once
+// the bridge crate's `wdio://` IPC channel is wired up.
+
+import { createLogger } from '@wdio/native-utils';
+
+const log = createLogger('dioxus-service', 'service');
+
+export default class DioxusWorkerService {
+  constructor(_options: unknown, _capabilities: unknown) {
+    log.debug('DioxusWorkerService initialised');
+  }
+
+  async before(_capabilities: unknown, _specs: string[], browser: WebdriverIO.Browser): Promise<void> {
+    log.debug('DioxusWorkerService.before — installing browser.dioxus placeholder');
+    // Placeholder: real API surface installed in Phase 2.
+    (browser as unknown as { dioxus: Record<string, unknown> }).dioxus = {};
+  }
+}

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -1,13 +1,14 @@
 // @wdio/dioxus-service worker service.
 //
-// PR2 Phase 2: installs `browser.dioxus.execute` via the bridge's
-// `window.__WDIO_DIOXUS__` IPC channel. Mocking + multi-window routing land
-// in Phase 3 / Phase 4 alongside the DioxusAdapter in @wdio/native-spy and
-// the bridge's window_state module.
+// PR2 Phase 3: installs the full `browser.dioxus.*` surface — execute +
+// mock + mock-lifecycle helpers. Multi-window routing and triggerDeeplink
+// land in PR3 alongside the bridge's window_state module.
 
 import { createLogger } from '@wdio/native-utils';
 
+import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from './commands/allMocks.js';
 import { execute } from './commands/execute.js';
+import { mock } from './commands/mock.js';
 
 const log = createLogger('dioxus-service', 'service');
 
@@ -21,10 +22,15 @@ export default class DioxusWorkerService {
 
     // biome-ignore lint/suspicious/noExplicitAny: WebdriverIO.Browser augmentation
     // happens via @wdio/native-types module augmentation; the cast is a transient
-    // accommodation for the in-progress migration. Phase 3 tightens this.
+    // accommodation for the in-progress migration.
     const dioxus: any = {
       execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>
         execute<R, A>(browser, script, ...args),
+      mock: (command: string) => mock(command, browser),
+      clearAllMocks,
+      resetAllMocks,
+      restoreAllMocks,
+      isMockFunction,
     };
     (browser as unknown as { dioxus: typeof dioxus }).dioxus = dioxus;
   }

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -4,13 +4,16 @@
 // mock + mock-lifecycle helpers. Multi-window routing and triggerDeeplink
 // land in PR3 alongside the bridge's window_state module.
 
+import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import { createLogger } from '@wdio/native-utils';
 
 import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from './commands/allMocks.js';
 import { execute } from './commands/execute.js';
 import { mock } from './commands/mock.js';
+import mockStore from './mockStore.js';
 
 const log = createLogger('dioxus-service', 'service');
+const interceptor = createIpcInterceptor('dioxus');
 
 export default class DioxusWorkerService {
   constructor(_options: unknown, _capabilities: unknown) {
@@ -19,6 +22,30 @@ export default class DioxusWorkerService {
 
   async before(_capabilities: unknown, _specs: string[], browser: WebdriverIO.Browser): Promise<void> {
     log.debug('DioxusWorkerService.before — installing browser.dioxus');
+
+    // Inject the @wdio/native-spy mock-factory infrastructure
+    // (`window.__wdio_spy__` + `window.__wdio_mocks__`) and patch
+    // `window.__WDIO_DIOXUS__.invoke` so registered mocks intercept calls.
+    // Without this, every browser.dioxus.mock() call would fail at
+    // registration with "@wdio/native-spy not available" because the
+    // DioxusAdapter's buildRegistrationScript hard-guards on
+    // `window.__wdio_spy__?.fn`.
+    //
+    // Phase 4 caveat: this script runs once at session start. If the test
+    // navigates to a fresh page (browser.url) the spy infrastructure is
+    // lost. Persistent re-injection on navigation will land alongside
+    // the Tauri-style plugin-served setup in a later phase.
+    try {
+      await browser.execute(interceptor.buildBrowserIpcInjectionScript());
+      log.debug('Injected @wdio/native-spy setup + wdio:// invoke patch');
+    } catch (err) {
+      log.warn(
+        'Failed to inject mock-spy infrastructure in before(); ' +
+          'browser.dioxus.mock() calls will fail. Is wdio_dioxus_bridge::install() ' +
+          'wired into the Dioxus app? Underlying error:',
+        err,
+      );
+    }
 
     // biome-ignore lint/suspicious/noExplicitAny: WebdriverIO.Browser augmentation
     // happens via @wdio/native-types module augmentation; the cast is a transient
@@ -33,5 +60,23 @@ export default class DioxusWorkerService {
       isMockFunction,
     };
     (browser as unknown as { dioxus: typeof dioxus }).dioxus = dioxus;
+  }
+
+  /**
+   * Drop every mock from the process-wide singleton store at the end of
+   * the spec. Without this, a WDIO worker that processes multiple spec
+   * files sequentially carries mocks created in spec A into spec B —
+   * `clearAllMocks()` / `resetAllMocks()` / `restoreAllMocks()` would
+   * then iterate over those stale mocks and dispatch inner-mock scripts
+   * to a browser session that may already have moved on.
+   *
+   * We deliberately only `clear()` the JS-side registry, not call
+   * `restoreAllMocks()` (which would try to unregister inner mocks in
+   * the webview). The inner mocks die with the webview at session
+   * teardown anyway.
+   */
+  async after(): Promise<void> {
+    log.debug('DioxusWorkerService.after — clearing process-wide mockStore');
+    mockStore.clear();
   }
 }

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -1,11 +1,13 @@
 // @wdio/dioxus-service worker service.
 //
-// PR2 Phase 1: minimum viable worker. The `before()` hook installs a
-// placeholder `browser.dioxus` object so capability + service-wiring tests
-// pass. The actual `execute`, `mock`, etc. surface lands in Phase 2 once
-// the bridge crate's `wdio://` IPC channel is wired up.
+// PR2 Phase 2: installs `browser.dioxus.execute` via the bridge's
+// `window.__WDIO_DIOXUS__` IPC channel. Mocking + multi-window routing land
+// in Phase 3 / Phase 4 alongside the DioxusAdapter in @wdio/native-spy and
+// the bridge's window_state module.
 
 import { createLogger } from '@wdio/native-utils';
+
+import { execute } from './commands/execute.js';
 
 const log = createLogger('dioxus-service', 'service');
 
@@ -15,8 +17,15 @@ export default class DioxusWorkerService {
   }
 
   async before(_capabilities: unknown, _specs: string[], browser: WebdriverIO.Browser): Promise<void> {
-    log.debug('DioxusWorkerService.before — installing browser.dioxus placeholder');
-    // Placeholder: real API surface installed in Phase 2.
-    (browser as unknown as { dioxus: Record<string, unknown> }).dioxus = {};
+    log.debug('DioxusWorkerService.before — installing browser.dioxus');
+
+    // biome-ignore lint/suspicious/noExplicitAny: WebdriverIO.Browser augmentation
+    // happens via @wdio/native-types module augmentation; the cast is a transient
+    // accommodation for the in-progress migration. Phase 3 tightens this.
+    const dioxus: any = {
+      execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>
+        execute<R, A>(browser, script, ...args),
+    };
+    (browser as unknown as { dioxus: typeof dioxus }).dioxus = dioxus;
   }
 }

--- a/packages/dioxus-service/src/types.ts
+++ b/packages/dioxus-service/src/types.ts
@@ -1,0 +1,9 @@
+// Extended service options for `@wdio/dioxus-service`. Builds on the shared
+// types in @wdio/native-types with implementation-specific fields needed by
+// the launcher / service.
+
+import type { DioxusServiceOptions as BaseDioxusServiceOptions } from '@wdio/native-types';
+
+export type { DioxusCapabilities, DioxusDriverProvider, DioxusServiceGlobalOptions } from '@wdio/native-types';
+
+export type DioxusServiceOptions = BaseDioxusServiceOptions;

--- a/packages/dioxus-service/test/commands/allMocks.spec.ts
+++ b/packages/dioxus-service/test/commands/allMocks.spec.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from '../../src/commands/allMocks.js';
+import mockStore from '../../src/mockStore.js';
+
+function fakeMock(name: string) {
+  return {
+    getMockName: () => name,
+    mockClear: vi.fn().mockResolvedValue(undefined),
+    mockReset: vi.fn().mockResolvedValue(undefined),
+    mockRestore: vi.fn().mockResolvedValue(undefined),
+    __isDioxusMock: true,
+  } as unknown as Parameters<typeof mockStore.setMock>[0] & {
+    mockClear: ReturnType<typeof vi.fn>;
+    mockReset: ReturnType<typeof vi.fn>;
+    mockRestore: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('all-mocks helpers', () => {
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  describe('clearAllMocks', () => {
+    it('should call mockClear on every registered mock when no prefix is given', async () => {
+      const a = fakeMock('dioxus.a');
+      const b = fakeMock('dioxus.b');
+      mockStore.setMock(a);
+      mockStore.setMock(b);
+
+      await clearAllMocks();
+
+      expect((a as unknown as { mockClear: ReturnType<typeof vi.fn> }).mockClear).toHaveBeenCalled();
+      expect((b as unknown as { mockClear: ReturnType<typeof vi.fn> }).mockClear).toHaveBeenCalled();
+    });
+
+    it('should filter by prefix', async () => {
+      const a = fakeMock('dioxus.fs.read');
+      const b = fakeMock('dioxus.fs.write');
+      const c = fakeMock('dioxus.net.fetch');
+      mockStore.setMock(a);
+      mockStore.setMock(b);
+      mockStore.setMock(c);
+
+      await clearAllMocks('fs');
+
+      expect((a as unknown as { mockClear: ReturnType<typeof vi.fn> }).mockClear).toHaveBeenCalled();
+      expect((b as unknown as { mockClear: ReturnType<typeof vi.fn> }).mockClear).toHaveBeenCalled();
+      expect((c as unknown as { mockClear: ReturnType<typeof vi.fn> }).mockClear).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetAllMocks', () => {
+    it('should call mockReset on each mock', async () => {
+      const a = fakeMock('dioxus.a');
+      mockStore.setMock(a);
+      await resetAllMocks();
+      expect((a as unknown as { mockReset: ReturnType<typeof vi.fn> }).mockReset).toHaveBeenCalled();
+    });
+  });
+
+  describe('restoreAllMocks', () => {
+    it('should call mockRestore on each mock', async () => {
+      const a = fakeMock('dioxus.a');
+      mockStore.setMock(a);
+      await restoreAllMocks();
+      expect((a as unknown as { mockRestore: ReturnType<typeof vi.fn> }).mockRestore).toHaveBeenCalled();
+    });
+  });
+
+  describe('isMockFunction', () => {
+    it('should return true for a value with __isDioxusMock=true', () => {
+      const fn = (() => undefined) as unknown as Record<string, unknown>;
+      fn.__isDioxusMock = true;
+      expect(isMockFunction(fn)).toBe(true);
+    });
+
+    it('should return false for a plain function', () => {
+      expect(isMockFunction(() => undefined)).toBe(false);
+    });
+
+    it('should return false for non-functions', () => {
+      expect(isMockFunction({ __isDioxusMock: true })).toBe(false);
+      expect(isMockFunction(null)).toBe(false);
+      expect(isMockFunction(undefined)).toBe(false);
+      expect(isMockFunction('string')).toBe(false);
+    });
+  });
+});

--- a/packages/dioxus-service/test/commands/execute.spec.ts
+++ b/packages/dioxus-service/test/commands/execute.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { execute } from '../../src/commands/execute.js';
+import { execute, runInterceptorScript } from '../../src/commands/execute.js';
 
 function browserStub(returnValue: unknown = undefined): WebdriverIO.Browser {
   const execute = vi.fn().mockResolvedValue(returnValue);
@@ -32,7 +32,12 @@ describe('execute command', () => {
     expect(wrappedScript).toContain('window.__WDIO_DIOXUS__');
     expect(wrappedScript).toContain('userFn');
     expect(wrappedScript).toContain('dx.invoke');
-    expect(forwardedArgs).toEqual([42]);
+    // Args are inlined into the wrapper script as JSON literals — no extra
+    // positional args are forwarded to browser.execute. This keeps the
+    // wrapper portable across WDIO versions that may wrap the script body
+    // in an arrow function (where `arguments` would be unavailable).
+    expect(forwardedArgs).toEqual([]);
+    expect(wrappedScript).toContain('userFn(dx, 42)');
   });
 
   it('should embed an error message when the bridge is not installed', async () => {
@@ -49,11 +54,39 @@ describe('execute command', () => {
     await expect(execute(browser, 'return {}')).resolves.toEqual({ hello: 'world' });
   });
 
-  it('should forward multiple positional args to browser.execute', async () => {
+  it('should inline multiple positional args as JSON into the wrapper', async () => {
     const browser = browserStub();
     await execute(browser, (_dx, _a: number, _b: string, _c: boolean) => null, 1, 'two', true);
 
-    const [, ...forwarded] = vi.mocked(browser.execute).mock.calls[0] as [string, ...unknown[]];
-    expect(forwarded).toEqual([1, 'two', true]);
+    const [wrappedScript, ...forwarded] = vi.mocked(browser.execute).mock.calls[0] as [string, ...unknown[]];
+    // No forwarded positional args — they're inlined into the wrapper.
+    expect(forwarded).toEqual([]);
+    expect(wrappedScript).toContain('userFn(dx, 1, "two", true)');
+  });
+
+  it('should JSON-serialise complex args inline', async () => {
+    const browser = browserStub();
+    await execute(browser, (_dx, _payload: { greeting: string }) => null, { greeting: 'hello' });
+
+    const [wrappedScript] = vi.mocked(browser.execute).mock.calls[0] as [string];
+    expect(wrappedScript).toContain('userFn(dx, {"greeting":"hello"})');
+  });
+});
+
+describe('runInterceptorScript', () => {
+  it('should wrap the script as `return (script)()` so arrow functions actually invoke', async () => {
+    const browser = browserStub('ok');
+    const adapterScript = '(_dx) => { window.__wdio_mocks__.greet = 42; }';
+
+    await runInterceptorScript(browser, adapterScript);
+
+    const [actualScript] = vi.mocked(browser.execute).mock.calls[0] as [string];
+    expect(actualScript).toBe(`return (${adapterScript})()`);
+  });
+
+  it('should return the value produced by browser.execute', async () => {
+    const browser = browserStub({ calls: [['a']], results: [], invocationCallOrder: [1] });
+    const result = await runInterceptorScript(browser, '(_dx) => ({ calls: [["a"]] })');
+    expect(result).toEqual({ calls: [['a']], results: [], invocationCallOrder: [1] });
   });
 });

--- a/packages/dioxus-service/test/commands/execute.spec.ts
+++ b/packages/dioxus-service/test/commands/execute.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { execute } from '../../src/commands/execute.js';
+
+function browserStub(returnValue: unknown = undefined): WebdriverIO.Browser {
+  const execute = vi.fn().mockResolvedValue(returnValue);
+  return { execute } as unknown as WebdriverIO.Browser;
+}
+
+describe('execute command', () => {
+  it('should pass through a string script unmodified', async () => {
+    const browser = browserStub('result');
+    const result = await execute(browser, 'return 1 + 2', 'arg1');
+
+    expect(browser.execute).toHaveBeenCalledWith('return 1 + 2', 'arg1');
+    expect(result).toBe('result');
+  });
+
+  it('should wrap a function script with the dx-injection scaffold', async () => {
+    const browser = browserStub('value');
+
+    await execute(
+      browser,
+      function userFn(dx, x: number) {
+        return dx.invoke('echo', x);
+      },
+      42,
+    );
+
+    const [wrappedScript, ...forwardedArgs] = vi.mocked(browser.execute).mock.calls[0] as [string, ...unknown[]];
+    expect(typeof wrappedScript).toBe('string');
+    expect(wrappedScript).toContain('window.__WDIO_DIOXUS__');
+    expect(wrappedScript).toContain('userFn');
+    expect(wrappedScript).toContain('dx.invoke');
+    expect(forwardedArgs).toEqual([42]);
+  });
+
+  it('should embed an error message when the bridge is not installed', async () => {
+    const browser = browserStub();
+    await execute(browser, (dx) => dx.invoke('__ping'));
+
+    const [wrappedScript] = vi.mocked(browser.execute).mock.calls[0] as [string];
+    expect(wrappedScript).toContain('window.__WDIO_DIOXUS__.invoke is not installed');
+    expect(wrappedScript).toContain('wdio_dioxus_bridge::install');
+  });
+
+  it('should return the value produced by browser.execute', async () => {
+    const browser = browserStub({ hello: 'world' });
+    await expect(execute(browser, 'return {}')).resolves.toEqual({ hello: 'world' });
+  });
+
+  it('should forward multiple positional args to browser.execute', async () => {
+    const browser = browserStub();
+    await execute(browser, (_dx, _a: number, _b: string, _c: boolean) => null, 1, 'two', true);
+
+    const [, ...forwarded] = vi.mocked(browser.execute).mock.calls[0] as [string, ...unknown[]];
+    expect(forwarded).toEqual([1, 'two', true]);
+  });
+});

--- a/packages/dioxus-service/test/errors.spec.ts
+++ b/packages/dioxus-service/test/errors.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { linuxExternalProviderUnsupported, SevereServiceError } from '../src/errors.js';
+
+describe('errors', () => {
+  describe('linuxExternalProviderUnsupported', () => {
+    it('should return a SevereServiceError instance', () => {
+      const err = linuxExternalProviderUnsupported();
+      expect(err).toBeInstanceOf(SevereServiceError);
+    });
+
+    it('should point users at the embedded provider', () => {
+      expect(linuxExternalProviderUnsupported().message).toContain("'embedded'");
+    });
+
+    it('should explain why external is unsupported on Linux', () => {
+      expect(linuxExternalProviderUnsupported().message).toContain('upstream Dioxus');
+    });
+
+    it('should reference the spike findings document', () => {
+      expect(linuxExternalProviderUnsupported().message).toContain('FINDINGS.md');
+    });
+  });
+});

--- a/packages/dioxus-service/test/index.spec.ts
+++ b/packages/dioxus-service/test/index.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+describe('@wdio/dioxus-service public exports', () => {
+  it('should expose the worker service as the default export', async () => {
+    const mod = await import('../src/index.js');
+    expect(mod.default).toBeTypeOf('function');
+    expect(mod.default.name).toBe('DioxusWorkerService');
+  });
+
+  it('should expose the launch service as the named "launcher" export', async () => {
+    const { launcher } = await import('../src/index.js');
+    expect(launcher).toBeTypeOf('function');
+    expect(launcher.name).toBe('DioxusLaunchService');
+  });
+
+  it('should re-export the linuxExternalProviderUnsupported helper', async () => {
+    const { linuxExternalProviderUnsupported } = await import('../src/index.js');
+    const err = linuxExternalProviderUnsupported();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("driverProvider: 'external'");
+    expect(err.message).toContain('Linux');
+    expect(err.message).toContain("'embedded'");
+  });
+
+  it('should re-export SevereServiceError', async () => {
+    const { SevereServiceError } = await import('../src/index.js');
+    expect(SevereServiceError).toBeTypeOf('function');
+  });
+});

--- a/packages/dioxus-service/test/integration/setup.ts
+++ b/packages/dioxus-service/test/integration/setup.ts
@@ -1,0 +1,8 @@
+// Shared setup for @wdio/dioxus-service integration tests.
+//
+// Currently a no-op — integration tests are added once the launcher
+// actually spawns subprocesses (post-PR3, when the 'external' and
+// 'embedded' providers come online). The file exists so the
+// `setupFiles: ['test/integration/setup.ts']` reference in
+// vitest.integration.config.ts resolves cleanly even before there are
+// integration specs to run.

--- a/packages/dioxus-service/test/launcher.spec.ts
+++ b/packages/dioxus-service/test/launcher.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DioxusLaunchService from '../src/launcher.js';
+import type { DioxusCapabilities, DioxusServiceGlobalOptions } from '../src/types.js';
+
+const baseConfig = {} as Parameters<DioxusLaunchService['onPrepare']>[0];
+
+describe('DioxusLaunchService', () => {
+  const originalPlatform = process.platform;
+
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { value, writable: true });
+  }
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.restoreAllMocks();
+  });
+
+  describe('onPrepare', () => {
+    it('should throw SevereServiceError on Linux + provider=external', async () => {
+      setPlatform('linux');
+      const launcher = new DioxusLaunchService(
+        { driverProvider: 'external' } as DioxusServiceGlobalOptions,
+        {} as DioxusCapabilities,
+        baseConfig,
+      );
+
+      await expect(launcher.onPrepare(baseConfig, [{} as DioxusCapabilities])).rejects.toThrow(
+        /'external' is not supported on Linux/,
+      );
+    });
+
+    it('should not throw on Linux + provider=embedded', async () => {
+      setPlatform('linux');
+      const launcher = new DioxusLaunchService(
+        { driverProvider: 'embedded' } as DioxusServiceGlobalOptions,
+        {} as DioxusCapabilities,
+        baseConfig,
+      );
+
+      await expect(launcher.onPrepare(baseConfig, [{} as DioxusCapabilities])).resolves.toBeUndefined();
+    });
+
+    it('should not throw on Windows + provider=external', async () => {
+      setPlatform('win32');
+      const launcher = new DioxusLaunchService(
+        { driverProvider: 'external' } as DioxusServiceGlobalOptions,
+        {} as DioxusCapabilities,
+        baseConfig,
+      );
+
+      await expect(launcher.onPrepare(baseConfig, [{} as DioxusCapabilities])).resolves.toBeUndefined();
+    });
+
+    it('should not throw on macOS + provider=embedded', async () => {
+      setPlatform('darwin');
+      const launcher = new DioxusLaunchService(
+        { driverProvider: 'embedded' } as DioxusServiceGlobalOptions,
+        {} as DioxusCapabilities,
+        baseConfig,
+      );
+
+      await expect(launcher.onPrepare(baseConfig, [{} as DioxusCapabilities])).resolves.toBeUndefined();
+    });
+
+    it('should default to embedded provider when none specified', async () => {
+      setPlatform('linux');
+      const launcher = new DioxusLaunchService({} as DioxusServiceGlobalOptions, {} as DioxusCapabilities, baseConfig);
+
+      await expect(launcher.onPrepare(baseConfig, [{} as DioxusCapabilities])).resolves.toBeUndefined();
+    });
+
+    it('should read driverProvider from capability-level options when present', async () => {
+      setPlatform('linux');
+      const launcher = new DioxusLaunchService(
+        { driverProvider: 'embedded' } as DioxusServiceGlobalOptions,
+        {} as DioxusCapabilities,
+        baseConfig,
+      );
+
+      const caps: DioxusCapabilities[] = [
+        { 'wdio:dioxusServiceOptions': { driverProvider: 'external' } } as DioxusCapabilities,
+      ];
+
+      await expect(launcher.onPrepare(baseConfig, caps)).rejects.toThrow(/'external' is not supported on Linux/);
+    });
+  });
+
+  describe('onComplete', () => {
+    it('should resolve without error when no drivers were started', async () => {
+      const launcher = new DioxusLaunchService({} as DioxusServiceGlobalOptions, {} as DioxusCapabilities, baseConfig);
+
+      await expect(launcher.onComplete()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/dioxus-service/test/logForwarder.spec.ts
+++ b/packages/dioxus-service/test/logForwarder.spec.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isLogWriterInitialized = vi.fn();
+const getLogWriter = vi.fn();
+const shouldLog = vi.fn();
+const debug = vi.fn();
+const info = vi.fn();
+const warn = vi.fn();
+const error = vi.fn();
+const writerWrite = vi.fn();
+
+vi.mock('@wdio/native-core', () => ({
+  isLogWriterInitialized: (...args: unknown[]) => isLogWriterInitialized(...args),
+  getLogWriter: (...args: unknown[]) => getLogWriter(...args),
+  shouldLog: (...args: unknown[]) => shouldLog(...args),
+}));
+
+vi.mock('@wdio/native-utils', () => ({
+  createLogger: () => ({ debug, info, warn, error }),
+}));
+
+describe('forwardLog', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isLogWriterInitialized.mockReset().mockReturnValue(false);
+    getLogWriter.mockReset().mockReturnValue({ write: writerWrite });
+    shouldLog.mockReset().mockReturnValue(true);
+    debug.mockReset();
+    info.mockReset();
+    warn.mockReset();
+    error.mockReset();
+    writerWrite.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should suppress the log when shouldLog returns false', async () => {
+    shouldLog.mockReturnValue(false);
+    const { forwardLog } = await import('../src/logForwarder.js');
+
+    forwardLog('backend', 'debug', 'hidden', 'info');
+
+    expect(info).not.toHaveBeenCalled();
+    expect(writerWrite).not.toHaveBeenCalled();
+  });
+
+  it('should route to the WDIO logger when no LogWriter is initialised', async () => {
+    isLogWriterInitialized.mockReturnValue(false);
+    const { forwardLog } = await import('../src/logForwarder.js');
+
+    forwardLog('backend', 'info', 'hello', 'info');
+
+    expect(info).toHaveBeenCalledWith('[Dioxus:Backend] hello');
+    expect(writerWrite).not.toHaveBeenCalled();
+  });
+
+  it('should route to the LogWriter file when one is initialised', async () => {
+    isLogWriterInitialized.mockReturnValue(true);
+    const { forwardLog } = await import('../src/logForwarder.js');
+
+    forwardLog('backend', 'info', 'to-file', 'info');
+
+    expect(writerWrite).toHaveBeenCalledWith('[Dioxus:Backend] to-file');
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it('should use the frontend prefix for frontend source', async () => {
+    isLogWriterInitialized.mockReturnValue(false);
+    const { forwardLog } = await import('../src/logForwarder.js');
+
+    forwardLog('frontend', 'warn', 'browser warning', 'info');
+
+    expect(warn).toHaveBeenCalledWith('[Dioxus:Frontend] browser warning');
+  });
+
+  it('should inject the instance ID into the prefix for multiremote', async () => {
+    isLogWriterInitialized.mockReturnValue(false);
+    const { forwardLog } = await import('../src/logForwarder.js');
+
+    forwardLog('backend', 'info', 'mr', 'info', 'browserA');
+
+    expect(info).toHaveBeenCalledWith('[Dioxus:Backend:browserA] mr');
+  });
+
+  it('should map trace + debug levels to the debug logger method', async () => {
+    isLogWriterInitialized.mockReturnValue(false);
+    const { forwardLog } = await import('../src/logForwarder.js');
+
+    forwardLog('backend', 'debug', 'd', 'debug');
+    forwardLog('backend', 'trace', 't', 'trace');
+
+    expect(debug).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/dioxus-service/test/logParser.spec.ts
+++ b/packages/dioxus-service/test/logParser.spec.ts
@@ -48,6 +48,19 @@ describe('parseLogLine', () => {
     expect(parseLogLine('plain log without a level')?.level).toBe('info');
   });
 
+  it('should not match a level token that appears in the message body', () => {
+    // The token "error" is inside the message ("error.log"), not the level
+    // header. detectLevel restricts its search to the prefix before the
+    // first colon.
+    const result = parseLogLine('2025-01-01T12:00:00Z INFO my_module: cannot find file — check error.log');
+    expect(result?.level).toBe('info');
+  });
+
+  it('should detect the level from the prefix when the message body would also match', () => {
+    const result = parseLogLine('2025-01-01T12:00:00Z WARN my_module: deprecated path used in error.handler');
+    expect(result?.level).toBe('warn');
+  });
+
   it('should preserve the raw line', () => {
     const raw = '  [WDIO-FRONTEND][INFO] padded  ';
     expect(parseLogLine(raw)?.raw).toBe(raw.trim());

--- a/packages/dioxus-service/test/logParser.spec.ts
+++ b/packages/dioxus-service/test/logParser.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseLogLine } from '../src/logParser.js';
+
+describe('parseLogLine', () => {
+  it('should return undefined for empty input', () => {
+    expect(parseLogLine('')).toBeUndefined();
+    expect(parseLogLine('   ')).toBeUndefined();
+  });
+
+  it('should classify [WDIO-FRONTEND] lines as frontend', () => {
+    const result = parseLogLine('[WDIO-FRONTEND][INFO] hello from app');
+    expect(result?.source).toBe('frontend');
+    expect(result?.level).toBe('info');
+    expect(result?.message).toBe('hello from app');
+  });
+
+  it('should propagate the frontend log level from the marker', () => {
+    expect(parseLogLine('[WDIO-FRONTEND][ERROR] boom')?.level).toBe('error');
+    expect(parseLogLine('[WDIO-FRONTEND][WARN] caution')?.level).toBe('warn');
+    expect(parseLogLine('[WDIO-FRONTEND][DEBUG] verbose')?.level).toBe('debug');
+    expect(parseLogLine('[WDIO-FRONTEND][TRACE] very verbose')?.level).toBe('trace');
+  });
+
+  it('should default frontend level to info when the bracket is missing', () => {
+    const result = parseLogLine('[WDIO-FRONTEND] no-level-bracket');
+    expect(result?.source).toBe('frontend');
+    expect(result?.level).toBe('info');
+    expect(result?.message).toBe('no-level-bracket');
+  });
+
+  it('should classify non-frontend lines as backend', () => {
+    const result = parseLogLine('INFO some::module: app started');
+    expect(result?.source).toBe('backend');
+    expect(result?.level).toBe('info');
+  });
+
+  it('should detect error level in backend lines', () => {
+    expect(parseLogLine('ERROR connection refused')?.level).toBe('error');
+    expect(parseLogLine('thread main panicked at error: explode')?.level).toBe('error');
+  });
+
+  it('should detect warn level in backend lines', () => {
+    expect(parseLogLine('WARN deprecation notice')?.level).toBe('warn');
+  });
+
+  it('should default backend level to info when no marker is present', () => {
+    expect(parseLogLine('plain log without a level')?.level).toBe('info');
+  });
+
+  it('should preserve the raw line', () => {
+    const raw = '  [WDIO-FRONTEND][INFO] padded  ';
+    expect(parseLogLine(raw)?.raw).toBe(raw.trim());
+  });
+});

--- a/packages/dioxus-service/test/mock.spec.ts
+++ b/packages/dioxus-service/test/mock.spec.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMock } from '../src/mock.js';
+import mockStore from '../src/mockStore.js';
+
+function makeBrowser(): WebdriverIO.Browser {
+  return { execute: vi.fn().mockResolvedValue(undefined) } as unknown as WebdriverIO.Browser;
+}
+
+describe('createMock', () => {
+  beforeEach(() => {
+    mockStore.clear();
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('should return an object flagged as a DioxusMock', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+    expect((m as unknown as { __isDioxusMock: boolean }).__isDioxusMock).toBe(true);
+  });
+
+  it('should name the outer mock dioxus.<command>', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+    expect(m.getMockName()).toBe('dioxus.greet');
+  });
+
+  it('should register the inner mock via browser.execute', async () => {
+    const browser = makeBrowser();
+    await createMock('greet', browser);
+    expect(browser.execute).toHaveBeenCalled();
+    const [firstScript] = vi.mocked(browser.execute).mock.calls[0] as [string];
+    expect(firstScript).toContain('dioxus.greet');
+    expect(firstScript).toContain('__wdio_spy__');
+  });
+
+  it('should store the mock in the singleton mockStore', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+    expect(mockStore.getMock('dioxus.greet')).toBe(m);
+  });
+
+  it('should expose async lifecycle methods', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+
+    expect(typeof m.mockImplementation).toBe('function');
+    expect(typeof m.mockImplementationOnce).toBe('function');
+    expect(typeof m.mockReturnValue).toBe('function');
+    expect(typeof m.mockReturnValueOnce).toBe('function');
+    expect(typeof m.mockResolvedValue).toBe('function');
+    expect(typeof m.mockResolvedValueOnce).toBe('function');
+    expect(typeof m.mockRejectedValue).toBe('function');
+    expect(typeof m.mockRejectedValueOnce).toBe('function');
+    expect(typeof m.mockClear).toBe('function');
+    expect(typeof m.mockReset).toBe('function');
+    expect(typeof m.mockRestore).toBe('function');
+    expect(typeof m.mockReturnThis).toBe('function');
+    expect(typeof m.update).toBe('function');
+  });
+
+  it('should forward mockReturnValue to browser.execute with the setter script', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+    vi.mocked(browser.execute).mockClear();
+
+    await m.mockReturnValue('hello');
+
+    const [script] = vi.mocked(browser.execute).mock.calls[0] as [string];
+    expect(script).toContain('mockReturnValue');
+    expect(script).toContain('greet');
+    expect(script).toContain('"hello"');
+  });
+
+  it('should forward mockResolvedValue to browser.execute', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+    vi.mocked(browser.execute).mockClear();
+
+    await m.mockResolvedValue({ ok: true });
+
+    const [script] = vi.mocked(browser.execute).mock.calls[0] as [string];
+    expect(script).toContain('mockResolvedValue');
+  });
+
+  it('should forward mockClear to browser.execute and clear the outer mock', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+    // Simulate a call landing on the outer mock so we can verify it gets cleared.
+    (m as unknown as (...a: unknown[]) => unknown)('arg');
+    expect(m.mock.calls.length).toBe(1);
+
+    vi.mocked(browser.execute).mockClear();
+    await m.mockClear();
+
+    const [script] = vi.mocked(browser.execute).mock.calls[0] as [string];
+    expect(script).toContain('mockClear');
+    expect(m.mock.calls.length).toBe(0);
+  });
+
+  it('should remove the mock from the store on mockRestore', async () => {
+    const browser = makeBrowser();
+    const m = await createMock('greet', browser);
+    expect(mockStore.getMocks()).toHaveLength(1);
+
+    await m.mockRestore();
+    expect(mockStore.getMocks()).toHaveLength(0);
+  });
+
+  it('should append new inner-mock calls to the outer state on update()', async () => {
+    const browser = makeBrowser();
+    // Registration call (returns undefined). Then read-call data returns
+    // one inner call.
+    vi.mocked(browser.execute)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        calls: [['arg1']],
+        results: [{ type: 'return', value: 42 }],
+        invocationCallOrder: [1],
+      });
+
+    const m = await createMock('greet', browser);
+    await m.update();
+
+    expect(m.mock.calls).toEqual([['arg1']]);
+    expect(m.mock.results).toEqual([{ type: 'return', value: 42 }]);
+  });
+
+  it('should reset the outer state when the inner shrinks', async () => {
+    const browser = makeBrowser();
+    vi.mocked(browser.execute)
+      .mockResolvedValueOnce(undefined)
+      // First update: two calls.
+      .mockResolvedValueOnce({
+        calls: [['a'], ['b']],
+        results: [
+          { type: 'return', value: 1 },
+          { type: 'return', value: 2 },
+        ],
+        invocationCallOrder: [1, 2],
+      })
+      // Second update: inner cleared, only one call now.
+      .mockResolvedValueOnce({
+        calls: [['c']],
+        results: [{ type: 'return', value: 3 }],
+        invocationCallOrder: [3],
+      });
+
+    const m = await createMock('greet', browser);
+    await m.update();
+    expect(m.mock.calls).toEqual([['a'], ['b']]);
+
+    await m.update();
+    expect(m.mock.calls).toEqual([['c']]);
+  });
+});

--- a/packages/dioxus-service/test/mockStore.spec.ts
+++ b/packages/dioxus-service/test/mockStore.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import mockStore, { DioxusServiceMockStore } from '../src/mockStore.js';
+
+function fakeMock(name: string) {
+  return { getMockName: () => name } as unknown as Parameters<typeof mockStore.setMock>[0];
+}
+
+describe('DioxusServiceMockStore', () => {
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  it('should expose a singleton default export', () => {
+    expect(mockStore).toBeInstanceOf(DioxusServiceMockStore);
+  });
+
+  it('should store and retrieve a mock by name', () => {
+    const m = fakeMock('dioxus.greet');
+    mockStore.setMock(m);
+    expect(mockStore.getMock('dioxus.greet')).toBe(m);
+  });
+
+  it('should throw when looking up an unregistered mock', () => {
+    expect(() => mockStore.getMock('dioxus.missing')).toThrow(/No mock registered/);
+  });
+
+  it('should list all registered mocks', () => {
+    mockStore.setMock(fakeMock('dioxus.a'));
+    mockStore.setMock(fakeMock('dioxus.b'));
+    expect(
+      mockStore
+        .getMocks()
+        .map(([n]) => n)
+        .sort(),
+    ).toEqual(['dioxus.a', 'dioxus.b']);
+  });
+
+  it('should delete an individual mock', () => {
+    mockStore.setMock(fakeMock('dioxus.a'));
+    expect(mockStore.deleteMock('dioxus.a')).toBe(true);
+    expect(mockStore.getMocks()).toEqual([]);
+  });
+
+  it('should return false when deleting a non-existent mock', () => {
+    expect(mockStore.deleteMock('dioxus.missing')).toBe(false);
+  });
+
+  it('should clear all mocks', () => {
+    mockStore.setMock(fakeMock('dioxus.a'));
+    mockStore.setMock(fakeMock('dioxus.b'));
+    mockStore.clear();
+    expect(mockStore.getMocks()).toEqual([]);
+  });
+});

--- a/packages/dioxus-service/test/service.spec.ts
+++ b/packages/dioxus-service/test/service.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import DioxusWorkerService from '../src/service.js';
+
+function makeBrowser(): WebdriverIO.Browser {
+  return { execute: vi.fn() } as unknown as WebdriverIO.Browser;
+}
+
+describe('DioxusWorkerService', () => {
+  it('should install browser.dioxus on before()', async () => {
+    const browser = makeBrowser();
+    const service = new DioxusWorkerService({}, {});
+
+    await service.before({}, [], browser);
+
+    expect((browser as unknown as { dioxus: { execute: unknown } }).dioxus).toBeDefined();
+    expect(typeof (browser as unknown as { dioxus: { execute: unknown } }).dioxus.execute).toBe('function');
+  });
+
+  it('should route browser.dioxus.execute through the underlying browser.execute', async () => {
+    const browser = makeBrowser();
+    vi.mocked(browser.execute).mockResolvedValueOnce('out');
+
+    const service = new DioxusWorkerService({}, {});
+    await service.before({}, [], browser);
+
+    const result = await (browser as unknown as { dioxus: { execute: (s: string) => Promise<string> } }).dioxus.execute(
+      'return 1',
+    );
+
+    expect(result).toBe('out');
+    expect(browser.execute).toHaveBeenCalledWith('return 1');
+  });
+});

--- a/packages/dioxus-service/test/service.spec.ts
+++ b/packages/dioxus-service/test/service.spec.ts
@@ -6,6 +6,17 @@ function makeBrowser(): WebdriverIO.Browser {
   return { execute: vi.fn() } as unknown as WebdriverIO.Browser;
 }
 
+type Installed = {
+  dioxus: {
+    execute: (s: string) => Promise<unknown>;
+    mock: (command: string) => Promise<unknown>;
+    clearAllMocks: (prefix?: string) => Promise<void>;
+    resetAllMocks: (prefix?: string) => Promise<void>;
+    restoreAllMocks: (prefix?: string) => Promise<void>;
+    isMockFunction: (x: unknown) => boolean;
+  };
+};
+
 describe('DioxusWorkerService', () => {
   it('should install browser.dioxus on before()', async () => {
     const browser = makeBrowser();
@@ -13,8 +24,14 @@ describe('DioxusWorkerService', () => {
 
     await service.before({}, [], browser);
 
-    expect((browser as unknown as { dioxus: { execute: unknown } }).dioxus).toBeDefined();
-    expect(typeof (browser as unknown as { dioxus: { execute: unknown } }).dioxus.execute).toBe('function');
+    const dioxus = (browser as unknown as Installed).dioxus;
+    expect(dioxus).toBeDefined();
+    expect(typeof dioxus.execute).toBe('function');
+    expect(typeof dioxus.mock).toBe('function');
+    expect(typeof dioxus.clearAllMocks).toBe('function');
+    expect(typeof dioxus.resetAllMocks).toBe('function');
+    expect(typeof dioxus.restoreAllMocks).toBe('function');
+    expect(typeof dioxus.isMockFunction).toBe('function');
   });
 
   it('should route browser.dioxus.execute through the underlying browser.execute', async () => {
@@ -24,11 +41,22 @@ describe('DioxusWorkerService', () => {
     const service = new DioxusWorkerService({}, {});
     await service.before({}, [], browser);
 
-    const result = await (browser as unknown as { dioxus: { execute: (s: string) => Promise<string> } }).dioxus.execute(
-      'return 1',
-    );
+    const result = await (browser as unknown as Installed).dioxus.execute('return 1');
 
     expect(result).toBe('out');
     expect(browser.execute).toHaveBeenCalledWith('return 1');
+  });
+
+  it('should expose a working isMockFunction', async () => {
+    const browser = makeBrowser();
+    const service = new DioxusWorkerService({}, {});
+    await service.before({}, [], browser);
+
+    const { isMockFunction } = (browser as unknown as Installed).dioxus;
+    const fakeMock = (() => undefined) as unknown as Record<string, unknown>;
+    fakeMock.__isDioxusMock = true;
+
+    expect(isMockFunction(fakeMock)).toBe(true);
+    expect(isMockFunction(() => undefined)).toBe(false);
   });
 });

--- a/packages/dioxus-service/test/service.spec.ts
+++ b/packages/dioxus-service/test/service.spec.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
-
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import mockStore from '../src/mockStore.js';
 import DioxusWorkerService from '../src/service.js';
 
 function makeBrowser(): WebdriverIO.Browser {
-  return { execute: vi.fn() } as unknown as WebdriverIO.Browser;
+  return { execute: vi.fn().mockResolvedValue(undefined) } as unknown as WebdriverIO.Browser;
 }
 
 type Installed = {
@@ -18,6 +18,10 @@ type Installed = {
 };
 
 describe('DioxusWorkerService', () => {
+  afterEach(() => {
+    mockStore.clear();
+  });
+
   it('should install browser.dioxus on before()', async () => {
     const browser = makeBrowser();
     const service = new DioxusWorkerService({}, {});
@@ -36,7 +40,9 @@ describe('DioxusWorkerService', () => {
 
   it('should route browser.dioxus.execute through the underlying browser.execute', async () => {
     const browser = makeBrowser();
-    vi.mocked(browser.execute).mockResolvedValueOnce('out');
+    // First call: the injection script (handled by service.before).
+    // Second call: the dioxus.execute under test — return 'out'.
+    vi.mocked(browser.execute).mockResolvedValueOnce(undefined).mockResolvedValueOnce('out');
 
     const service = new DioxusWorkerService({}, {});
     await service.before({}, [], browser);
@@ -58,5 +64,42 @@ describe('DioxusWorkerService', () => {
 
     expect(isMockFunction(fakeMock)).toBe(true);
     expect(isMockFunction(() => undefined)).toBe(false);
+  });
+
+  it('should inject the @wdio/native-spy mock-factory + invoke patch in before()', async () => {
+    const browser = makeBrowser();
+    const service = new DioxusWorkerService({}, {});
+
+    await service.before({}, [], browser);
+
+    // The first browser.execute call should be the injection script that
+    // installs window.__wdio_spy__ and patches window.__WDIO_DIOXUS__.invoke.
+    const calls = vi.mocked(browser.execute).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const [firstScript] = calls[0] as [string];
+    expect(firstScript).toContain('__wdio_spy__');
+    expect(firstScript).toContain('window.__WDIO_DIOXUS__');
+  });
+
+  it('should not throw when injection fails (degrades to warn-and-continue)', async () => {
+    const browser = makeBrowser();
+    vi.mocked(browser.execute).mockRejectedValueOnce(new Error('webview not ready'));
+    const service = new DioxusWorkerService({}, {});
+
+    await expect(service.before({}, [], browser)).resolves.toBeUndefined();
+    // browser.dioxus is still installed even after the injection failure.
+    expect((browser as unknown as Installed).dioxus).toBeDefined();
+  });
+
+  it('should clear the process-wide mockStore in after()', async () => {
+    const fakeMock = { getMockName: () => 'dioxus.greet' };
+    // biome-ignore lint/suspicious/noExplicitAny: test-only cast
+    mockStore.setMock(fakeMock as any);
+    expect(mockStore.getMocks()).toHaveLength(1);
+
+    const service = new DioxusWorkerService({}, {});
+    await service.after();
+
+    expect(mockStore.getMocks()).toHaveLength(0);
   });
 });

--- a/packages/dioxus-service/tsconfig.json
+++ b/packages/dioxus-service/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/dioxus-service/vitest.config.ts
+++ b/packages/dioxus-service/vitest.config.ts
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.spec.ts'],
+    exclude: [...configDefaults.exclude, 'test/integration/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.d.ts', '**/types/**'],
+    },
+  },
+});

--- a/packages/dioxus-service/vitest.integration.config.ts
+++ b/packages/dioxus-service/vitest.integration.config.ts
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/integration/**/*.spec.ts'],
+    exclude: [...configDefaults.exclude],
+    sequence: { concurrent: false },
+    testTimeout: 30000,
+    hookTimeout: 15000,
+    teardownTimeout: 10000,
+    fileParallelism: false,
+    setupFiles: ['test/integration/setup.ts'],
+  },
+});

--- a/packages/dioxus-service/vitest.integration.config.ts
+++ b/packages/dioxus-service/vitest.integration.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     environment: 'node',
     include: ['test/integration/**/*.spec.ts'],
     exclude: [...configDefaults.exclude],
+    // Don't fail when there are no integration tests yet — the integration
+    // suite lands once the launcher actually spawns subprocesses.
+    passWithNoTests: true,
     sequence: { concurrent: false },
     testTimeout: 30000,
     hookTimeout: 15000,

--- a/packages/native-spy/src/interceptor/dioxus.ts
+++ b/packages/native-spy/src/interceptor/dioxus.ts
@@ -1,0 +1,127 @@
+import type { FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
+import { errorReconstructExpr, mockLookupExpr, WDIO_MOCK_SETUP_SCRIPT } from './injection.js';
+import type { IpcContext } from './ipcContext.js';
+import { buildContextSeedScript } from './ipcContext.js';
+import type { SerializedHandler } from './serialize.js';
+import { safeJson } from './serialize.js';
+
+/**
+ * Mock interceptor adapter for `@wdio/dioxus-service`.
+ *
+ * Mirrors {@link import('./tauri.js').TauriAdapter}'s registration / call-
+ * data / implementation scripts but targets `window.__WDIO_DIOXUS__.invoke`
+ * (installed by `@wdio/dioxus-bridge`) instead of Tauri's
+ * `window.__TAURI_INTERNALS__.invoke`. Dioxus has no plugin event-bus
+ * equivalent, so `buildBrowserIpcInjectionScript` is much simpler.
+ */
+export class DioxusAdapter implements FrameworkAdapter {
+  readonly framework = 'dioxus' as const;
+
+  buildRegistrationScript(mockName: string): string {
+    return `(_dx) => {
+  const spy = window.__wdio_spy__;
+  if (!spy?.fn) { throw new Error('@wdio/native-spy not available. Ensure @wdio/dioxus-bridge is installed in your Dioxus Config via wdio_dioxus_bridge::install(cfg).'); }
+  const mockFn = spy.fn();
+  mockFn.mockName(${JSON.stringify(`dioxus.${mockName}`)});
+  if (!window.__wdio_mocks__) { window.__wdio_mocks__ = {}; }
+  window.__wdio_mocks__[${JSON.stringify(mockName)}] = mockFn;
+  mockFn.mockClear();
+}`;
+  }
+
+  buildCallDataReadScript(mockName: string): string {
+    const lookup = mockLookupExpr(mockName);
+    return `(_dx) => {
+  const mockObj = ${lookup};
+  if (!mockObj?.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
+  const m = mockObj.mock;
+  const errorReplacer = function(_k, v) {
+    if (v instanceof Error) {
+      return { __wdioError: true, name: v.name, message: v.message, stack: v.stack };
+    }
+    return v;
+  };
+  return {
+    calls: JSON.parse(JSON.stringify(m.calls || [], errorReplacer)),
+    results: JSON.parse(JSON.stringify(m.results || [], errorReplacer)),
+    invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
+  };
+}`;
+  }
+
+  buildSetImplementationScript(mockName: string, s: SerializedHandler, once = false): string {
+    const lookup = mockLookupExpr(mockName);
+    const method = once ? 'mockImplementationOnce' : 'mockImplementation';
+    return `(_dx) => {
+  const mockObj = ${lookup};
+  if (mockObj) { mockObj.${method}?.((${s.source})); }
+}`;
+  }
+
+  buildInnerInvocationScript(mockName: string, method: InnerMockMethod): string {
+    const lookup = mockLookupExpr(mockName);
+    return `(_dx) => {
+  const mockObj = ${lookup};
+  mockObj?.${method}?.();
+}`;
+  }
+
+  buildInnerSetterScript(mockName: string, method: InnerMockSetterMethod, value: unknown): string {
+    const lookup = mockLookupExpr(mockName);
+    const serialized = safeJson(value);
+    const reconstruct = errorReconstructExpr('_v');
+    return `(_dx) => {
+  const _v = ${serialized};
+  const mockObj = ${lookup};
+  mockObj?.${method}?.(${reconstruct});
+}`;
+  }
+
+  buildUnregistrationScript(mockName: string): string {
+    return `(_dx) => {
+  if (window.__wdio_mocks__?.[${JSON.stringify(mockName)}]) {
+    delete window.__wdio_mocks__[${JSON.stringify(mockName)}];
+  }
+}`;
+  }
+
+  buildContextSeedScript(context: IpcContext): string {
+    return buildContextSeedScript(context);
+  }
+
+  /**
+   * Browser-context init script. Sets up `window.__wdio_spy__` /
+   * `window.__wdio_mocks__` and patches `window.__WDIO_DIOXUS__.invoke` so
+   * registered mocks intercept calls before they hit the bridge's
+   * `wdio://invoke` protocol.
+   */
+  buildBrowserIpcInjectionScript(): string {
+    return `(function() {
+${WDIO_MOCK_SETUP_SCRIPT}
+  if (!window.__WDIO_DIOXUS__) { window.__WDIO_DIOXUS__ = {}; }
+  var __wdio_original_invoke__ = window.__WDIO_DIOXUS__.invoke;
+  window.__WDIO_DIOXUS__.invoke = function(cmd, args) {
+    var mock = window.__wdio_mocks__ && window.__wdio_mocks__[cmd];
+    if (mock && typeof mock === 'function') {
+      return Promise.resolve().then(function() { return mock(args); });
+    }
+    if (typeof __wdio_original_invoke__ === 'function') {
+      return __wdio_original_invoke__(cmd, args);
+    }
+    return Promise.reject(new Error('unmocked Dioxus command and no bridge invoke installed: ' + cmd));
+  };
+})()`;
+  }
+
+  buildWithImplementationScript(mockName: string, implFnSource: string, callbackFnSource: string): string {
+    const lookup = mockLookupExpr(mockName);
+    return `async (_dx) => {
+  const impl = (${implFnSource});
+  const callback = (${callbackFnSource});
+  let result;
+  const mockObj = ${lookup};
+  await mockObj?.withImplementation?.(impl, async () => { result = await (_dx !== undefined ? callback(_dx) : callback()); });
+  return result;
+}`;
+  }
+}

--- a/packages/native-spy/src/interceptor/framework.ts
+++ b/packages/native-spy/src/interceptor/framework.ts
@@ -1,7 +1,7 @@
 import type { IpcContext } from './ipcContext.js';
 import type { SerializedHandler } from './serialize.js';
 
-export type Framework = 'tauri' | 'electron';
+export type Framework = 'tauri' | 'electron' | 'dioxus';
 export type InnerMockMethod = 'mockClear' | 'mockReset' | 'mockReturnThis';
 export type InnerMockSetterMethod =
   | 'mockReturnValue'

--- a/packages/native-spy/src/interceptor/index.ts
+++ b/packages/native-spy/src/interceptor/index.ts
@@ -1,3 +1,4 @@
+import { DioxusAdapter } from './dioxus.js';
 import { ElectronAdapter } from './electron.js';
 import type { Framework, FrameworkAdapter, InnerMockMethod, InnerMockSetterMethod } from './framework.js';
 import type { IpcContext } from './ipcContext.js';
@@ -109,6 +110,7 @@ class IpcInterceptorImpl implements IpcInterceptor {
 }
 
 export function createIpcInterceptor(framework: Framework, options?: InterceptorOptions): IpcInterceptor {
-  const adapter: FrameworkAdapter = framework === 'tauri' ? new TauriAdapter() : new ElectronAdapter();
+  const adapter: FrameworkAdapter =
+    framework === 'tauri' ? new TauriAdapter() : framework === 'dioxus' ? new DioxusAdapter() : new ElectronAdapter();
   return new IpcInterceptorImpl(adapter, options);
 }

--- a/packages/native-spy/test/interceptor/dioxus.spec.ts
+++ b/packages/native-spy/test/interceptor/dioxus.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import { DioxusAdapter } from '../../src/interceptor/dioxus.js';
+
+describe('DioxusAdapter', () => {
+  const adapter = new DioxusAdapter();
+
+  describe('framework', () => {
+    it('should identify as dioxus', () => {
+      expect(adapter.framework).toBe('dioxus');
+    });
+  });
+
+  describe('buildRegistrationScript', () => {
+    it('should return a function-shaped string with _dx parameter', () => {
+      const script = adapter.buildRegistrationScript('my_command');
+      expect(script.trim()).toMatch(/^\(_dx\)/);
+    });
+
+    it('should use the mock name as the __wdio_mocks__ key', () => {
+      const script = adapter.buildRegistrationScript('get_platform');
+      expect(script).toContain('"get_platform"');
+    });
+
+    it('should set the mock name to dioxus.<command>', () => {
+      const script = adapter.buildRegistrationScript('my_cmd');
+      expect(script).toContain('dioxus.my_cmd');
+    });
+
+    it('should call mockClear after registration', () => {
+      const script = adapter.buildRegistrationScript('cmd');
+      expect(script).toContain('mockClear()');
+    });
+
+    it('should check for __wdio_spy__', () => {
+      const script = adapter.buildRegistrationScript('cmd');
+      expect(script).toContain('__wdio_spy__');
+    });
+
+    it('should reference the dioxus bridge install in the not-installed error', () => {
+      const script = adapter.buildRegistrationScript('cmd');
+      expect(script).toContain('wdio_dioxus_bridge::install');
+    });
+  });
+
+  describe('buildCallDataReadScript', () => {
+    it('should embed the mock name lookup', () => {
+      const script = adapter.buildCallDataReadScript('my_cmd');
+      expect(script).toContain('"my_cmd"');
+      expect(script).toContain('mockObj.mock');
+    });
+
+    it('should fall back to empty arrays when the mock is missing', () => {
+      const script = adapter.buildCallDataReadScript('my_cmd');
+      expect(script).toContain('calls: []');
+    });
+
+    it('should preserve Errors via a custom replacer', () => {
+      const script = adapter.buildCallDataReadScript('cmd');
+      expect(script).toContain('__wdioError');
+    });
+  });
+
+  describe('buildSetImplementationScript', () => {
+    it('should use mockImplementation by default', () => {
+      const script = adapter.buildSetImplementationScript('cmd', { source: '() => 42' });
+      expect(script).toContain('mockImplementation');
+      expect(script).not.toContain('mockImplementationOnce');
+    });
+
+    it('should use mockImplementationOnce when once=true', () => {
+      const script = adapter.buildSetImplementationScript('cmd', { source: '() => 42' }, true);
+      expect(script).toContain('mockImplementationOnce');
+    });
+
+    it('should embed the handler source', () => {
+      const script = adapter.buildSetImplementationScript('cmd', { source: '() => "hello"' });
+      expect(script).toContain('"hello"');
+    });
+  });
+
+  describe('buildInnerInvocationScript', () => {
+    it('should call the chosen mockClear/mockReset/mockReturnThis method', () => {
+      expect(adapter.buildInnerInvocationScript('cmd', 'mockClear')).toContain('mockClear?.()');
+      expect(adapter.buildInnerInvocationScript('cmd', 'mockReset')).toContain('mockReset?.()');
+      expect(adapter.buildInnerInvocationScript('cmd', 'mockReturnThis')).toContain('mockReturnThis?.()');
+    });
+  });
+
+  describe('buildUnregistrationScript', () => {
+    it('should delete the mock from __wdio_mocks__', () => {
+      const script = adapter.buildUnregistrationScript('cmd');
+      expect(script).toContain('delete window.__wdio_mocks__');
+      expect(script).toContain('"cmd"');
+    });
+  });
+
+  describe('buildBrowserIpcInjectionScript', () => {
+    it('should patch window.__WDIO_DIOXUS__.invoke', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      expect(script).toContain('window.__WDIO_DIOXUS__');
+      expect(script).toContain('window.__WDIO_DIOXUS__.invoke');
+    });
+
+    it('should preserve the original invoke as __wdio_original_invoke__', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      expect(script).toContain('__wdio_original_invoke__');
+    });
+
+    it('should dispatch through __wdio_mocks__ when a mock is registered', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      expect(script).toContain('__wdio_mocks__');
+      expect(script).toContain('mock(args)');
+    });
+
+    it('should reject with a helpful error when neither a mock nor original invoke is available', () => {
+      const script = adapter.buildBrowserIpcInjectionScript();
+      expect(script).toContain('unmocked Dioxus command');
+    });
+  });
+
+  describe('createIpcInterceptor', () => {
+    it('should return a DioxusAdapter when framework is dioxus', async () => {
+      const { createIpcInterceptor } = await import('../../src/interceptor/index.js');
+      const interceptor = createIpcInterceptor('dioxus');
+      expect(interceptor.framework).toBe('dioxus');
+    });
+  });
+});

--- a/packages/native-types/src/dioxus.ts
+++ b/packages/native-types/src/dioxus.ts
@@ -47,17 +47,6 @@ export interface DioxusAPIs {
   [key: string]: unknown;
 }
 
-/**
- * Per-call overrides for `browser.dioxus.execute()`. Use `withExecuteOptions()`
- * from `@wdio/dioxus-service` to construct properly-typed instances.
- */
-export interface DioxusExecuteOptions {
-  /** Window label to target (overrides the session default). */
-  windowLabel?: string;
-  /** Sentinel field used to disambiguate options from positional args. */
-  __wdioOptions__: true;
-}
-
 interface DioxusMockContext extends ServiceMockContext {
   results: MockResult[];
 }
@@ -91,14 +80,12 @@ export interface DioxusMock<TArgs extends unknown[] = unknown[], TReturns = unkn
 /**
  * Public `browser.dioxus.*` surface installed by `@wdio/dioxus-service`.
  *
- * `emitEvent` deferred to v1.1 per spec — Dioxus has no native event bus.
+ * Surface in this MVP: `execute`, `mock`, and the mock-lifecycle helpers.
+ * `triggerDeeplink`, `switchWindow`, `listWindows`, and per-call execute
+ * options land in PR3 alongside the bridge's `window_state` + `deeplink`
+ * modules. `emitEvent` is deferred to v1.1 — Dioxus has no native event bus.
  */
 export interface DioxusServiceAPI {
-  execute<R, A extends unknown[]>(
-    script: string | ((dx: DioxusAPIs, ...a: A) => R),
-    options: DioxusExecuteOptions,
-    ...args: A
-  ): Promise<R>;
   execute<R, A extends unknown[]>(script: string | ((dx: DioxusAPIs, ...a: A) => R), ...args: A): Promise<R>;
 
   mock(command: string): Promise<DioxusMock>;
@@ -106,10 +93,6 @@ export interface DioxusServiceAPI {
   clearAllMocks(prefix?: string): Promise<void>;
   resetAllMocks(prefix?: string): Promise<void>;
   restoreAllMocks(prefix?: string): Promise<void>;
-
-  triggerDeeplink(url: string): Promise<void>;
-  switchWindow(label: string): Promise<void>;
-  listWindows(): Promise<string[]>;
 }
 
 export interface DioxusServiceOptions extends BaseServiceOptions, DriverProviderConfig {

--- a/packages/native-types/src/dioxus.ts
+++ b/packages/native-types/src/dioxus.ts
@@ -1,0 +1,194 @@
+import type { Mock } from '@wdio/native-spy';
+import type {
+  AbstractFn,
+  BaseServiceGlobalOptions,
+  BaseServiceOptions,
+  BrowserBase,
+  DriverProviderConfig,
+  LogLevel,
+  MockOverride,
+  MockResult,
+  ServiceMockContext,
+} from './shared.js';
+
+// ============================================================================
+// Dioxus-Specific Types
+// ============================================================================
+
+/**
+ * Dioxus driver provider.
+ *
+ * - `'external'` — wdio-dioxus-driver subprocess (Windows only in v1; Linux
+ *   blocked pending an upstream Dioxus PR per spike/FINDINGS.md).
+ * - `'embedded'` — wdio-dioxus-embedded-driver in-process WebDriver server
+ *   (works on all platforms; recommended default).
+ *
+ * Per Phase -1 spike findings, the launcher throws `SevereServiceError` on
+ * Linux when `'external'` is selected.
+ */
+export type DioxusDriverProvider = 'external' | 'embedded';
+
+/**
+ * Bridge-installed APIs available inside the Dioxus app's webview. Mirrors
+ * the surface `wdio-dioxus-bridge`'s guest-js bundle exposes on
+ * `window.__WDIO_DIOXUS__`.
+ */
+export interface DioxusAPIs {
+  /** Invoke a Rust command via the bridge's `wdio://` custom protocol. */
+  invoke: (command: string, args?: unknown) => Promise<unknown>;
+  /** Optional log helpers — present when the bridge's log_bridge.rs is wired. */
+  log?: {
+    trace?: (msg: string) => Promise<void>;
+    debug?: (msg: string) => Promise<void>;
+    info?: (msg: string) => Promise<void>;
+    warn?: (msg: string) => Promise<void>;
+    error?: (msg: string) => Promise<void>;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Per-call overrides for `browser.dioxus.execute()`. Use `withExecuteOptions()`
+ * from `@wdio/dioxus-service` to construct properly-typed instances.
+ */
+export interface DioxusExecuteOptions {
+  /** Window label to target (overrides the session default). */
+  windowLabel?: string;
+  /** Sentinel field used to disambiguate options from positional args. */
+  __wdioOptions__: true;
+}
+
+interface DioxusMockContext extends ServiceMockContext {
+  results: MockResult[];
+}
+
+export interface DioxusMockInstance extends Omit<Mock, MockOverride> {
+  mockImplementation(fn: AbstractFn): Promise<DioxusMock>;
+  mockImplementationOnce(fn: AbstractFn): Promise<DioxusMock>;
+  mockReturnValue(obj: unknown): Promise<DioxusMock>;
+  mockReturnValueOnce(obj: unknown): Promise<DioxusMock>;
+  mockResolvedValue(obj: unknown): Promise<DioxusMock>;
+  mockResolvedValueOnce(obj: unknown): Promise<DioxusMock>;
+  mockRejectedValue(obj: unknown): Promise<DioxusMock>;
+  mockRejectedValueOnce(obj: unknown): Promise<DioxusMock>;
+  mockClear(): Promise<DioxusMock>;
+  mockReset(): Promise<DioxusMock>;
+  mockRestore(): Promise<DioxusMock>;
+  mockReturnThis(): Promise<DioxusMock>;
+  mockName(name: string): DioxusMock;
+  getMockName(): string;
+  getMockImplementation(): AbstractFn;
+  update(): Promise<DioxusMock>;
+  __isDioxusMock: boolean;
+  mock: DioxusMockContext;
+}
+
+export interface DioxusMock<TArgs extends unknown[] = unknown[], TReturns = unknown> extends DioxusMockInstance {
+  new (...args: TArgs): TReturns;
+  (...args: TArgs): TReturns;
+}
+
+/**
+ * Public `browser.dioxus.*` surface installed by `@wdio/dioxus-service`.
+ *
+ * `emitEvent` deferred to v1.1 per spec — Dioxus has no native event bus.
+ */
+export interface DioxusServiceAPI {
+  execute<R, A extends unknown[]>(
+    script: string | ((dx: DioxusAPIs, ...a: A) => R),
+    options: DioxusExecuteOptions,
+    ...args: A
+  ): Promise<R>;
+  execute<R, A extends unknown[]>(script: string | ((dx: DioxusAPIs, ...a: A) => R), ...args: A): Promise<R>;
+
+  mock(command: string): Promise<DioxusMock>;
+  isMockFunction(commandOrFn: unknown): boolean;
+  clearAllMocks(prefix?: string): Promise<void>;
+  resetAllMocks(prefix?: string): Promise<void>;
+  restoreAllMocks(prefix?: string): Promise<void>;
+
+  triggerDeeplink(url: string): Promise<void>;
+  switchWindow(label: string): Promise<void>;
+  listWindows(): Promise<string[]>;
+}
+
+export interface DioxusServiceOptions extends BaseServiceOptions, DriverProviderConfig {
+  /** Test mode: `'native'` runs against a built Dioxus binary; `'browser'` runs the frontend against a Vite dev server in plain Chrome. */
+  mode?: 'native' | 'browser';
+  /** When `mode === 'browser'`, the URL of the running dev server. */
+  devServerUrl?: string;
+
+  driverProvider?: DioxusDriverProvider;
+  /** Base port for the wdio-dioxus-driver process. Defaults to 4444. */
+  dioxusDriverPort?: number;
+  /** Path override for wdio-dioxus-driver. */
+  dioxusDriverPath?: string;
+  /** Port for the embedded WebDriver server (when provider is 'embedded'). */
+  embeddedPort?: number;
+  /** Path to the Dioxus app binary. */
+  appBinaryPath?: string;
+  /** CLI args forwarded to the Dioxus app. */
+  appArgs?: string[];
+  /** Environment variables for the driver subprocess. */
+  env?: Record<string, string>;
+  /** Auto-install wdio-dioxus-driver via cargo if missing (defaults to true). */
+  autoInstallDioxusDriver?: boolean;
+  /** Auto-download msedgedriver on Windows (defaults to true). */
+  autoDownloadEdgeDriver?: boolean;
+  /** Default window label for execute/mock calls. */
+  windowLabel?: string;
+  /** Backend log capture toggle. */
+  captureBackendLogs?: boolean;
+  /** Frontend log capture toggle. */
+  captureFrontendLogs?: boolean;
+  /** Minimum backend log level (default 'info'). */
+  backendLogLevel?: LogLevel;
+  /** Minimum frontend log level (default 'info'). */
+  frontendLogLevel?: LogLevel;
+  /** Embedded server status-poll timeout in ms (default 2000). */
+  statusPollTimeout?: number;
+}
+
+export interface DioxusServiceGlobalOptions extends BaseServiceGlobalOptions, DriverProviderConfig {
+  mode?: 'native' | 'browser';
+  devServerUrl?: string;
+  driverProvider?: DioxusDriverProvider;
+  dioxusDriverPort?: number;
+  dioxusDriverPath?: string;
+  embeddedPort?: number;
+  autoInstallDioxusDriver?: boolean;
+  autoDownloadEdgeDriver?: boolean;
+  windowLabel?: string;
+  captureBackendLogs?: boolean;
+  captureFrontendLogs?: boolean;
+}
+
+/**
+ * Capability shape for Dioxus apps. Mirrors `'tauri:options'` /
+ * `'wdio:tauriServiceOptions'` from `@wdio/tauri-service`.
+ *
+ * Intersect with `Capabilities.RequestedStandaloneCapabilities` at the
+ * service-level when needed (see `@wdio/dioxus-service`'s session helpers).
+ */
+export interface DioxusCapabilities {
+  browserName?: 'dioxus' | 'wry' | string;
+  'dioxus:options'?: {
+    application: string;
+    args?: string[];
+    webviewOptions?: { width?: number; height?: number };
+  };
+  'wdio:dioxusServiceOptions'?: DioxusServiceOptions;
+}
+
+export interface DioxusBrowserExtension extends BrowserBase {
+  dioxus: DioxusServiceAPI;
+}
+
+declare global {
+  interface Window {
+    __WDIO_DIOXUS__?: {
+      invoke?: (cmd: string, args?: unknown) => Promise<unknown>;
+      log?: DioxusAPIs['log'];
+    };
+  }
+}

--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -2,6 +2,19 @@
 // Re-export all types from split files
 // ============================================================================
 
+// Dioxus types
+export type {
+  DioxusAPIs,
+  DioxusBrowserExtension,
+  DioxusCapabilities,
+  DioxusDriverProvider,
+  DioxusExecuteOptions,
+  DioxusMock,
+  DioxusMockInstance,
+  DioxusServiceAPI,
+  DioxusServiceGlobalOptions,
+  DioxusServiceOptions,
+} from './dioxus.js';
 // Electron types
 export type {
   ApiCommand,
@@ -90,19 +103,21 @@ export type {
 // Combined Browser Extension
 // ============================================================================
 
+import type { DioxusBrowserExtension } from './dioxus.js';
 import type { ElectronBrowserExtension } from './electron.js';
 import type { TauriBrowserExtension } from './tauri.js';
 
 /**
- * Browser extension that supports both Electron and Tauri services
+ * Browser extension that supports Electron, Tauri, and Dioxus services
  */
-export interface BrowserExtension extends ElectronBrowserExtension, TauriBrowserExtension {}
+export interface BrowserExtension extends ElectronBrowserExtension, TauriBrowserExtension, DioxusBrowserExtension {}
 
 // ============================================================================
 // Module Augmentation (WebdriverIO)
 // ============================================================================
 
 import type { fn as vitestFn } from '@wdio/native-spy';
+import type { DioxusServiceGlobalOptions, DioxusServiceOptions } from './dioxus.js';
 import type {
   ElectronInterface,
   ElectronServiceGlobalOptions,
@@ -121,14 +136,18 @@ declare global {
 
   // biome-ignore lint/style/noNamespace: This is a legitimate use of namespace for global augmentation
   namespace WebdriverIO {
-    interface Browser extends ElectronBrowserExtension, TauriBrowserExtension {}
+    interface Browser extends ElectronBrowserExtension, TauriBrowserExtension, DioxusBrowserExtension {}
     interface Element extends ElementBase {}
-    interface MultiRemoteBrowser extends ElectronBrowserExtension, TauriBrowserExtension {}
+    interface MultiRemoteBrowser extends ElectronBrowserExtension, TauriBrowserExtension, DioxusBrowserExtension {}
     interface Capabilities {
       'wdio:electronServiceOptions'?: ElectronServiceOptions;
       'wdio:tauriServiceOptions'?: TauriServiceOptions;
+      'wdio:dioxusServiceOptions'?: DioxusServiceOptions;
     }
-    interface ServiceOption extends ElectronServiceGlobalOptions, TauriServiceGlobalOptions {}
+    interface ServiceOption
+      extends ElectronServiceGlobalOptions,
+        TauriServiceGlobalOptions,
+        DioxusServiceGlobalOptions {}
   }
 
   var __name: (func: Fn) => Fn;

--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -8,7 +8,6 @@ export type {
   DioxusBrowserExtension,
   DioxusCapabilities,
   DioxusDriverProvider,
-  DioxusExecuteOptions,
   DioxusMock,
   DioxusMockInstance,
   DioxusServiceAPI,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,7 +668,31 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/dioxus-bridge:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.4)
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.7
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/dioxus-service:
     dependencies:
@@ -729,7 +753,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/electron-cdp-bridge:
     dependencies:
@@ -775,7 +799,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/electron-service:
     dependencies:
@@ -890,7 +914,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/native-core:
     dependencies:
@@ -933,7 +957,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/native-service-core:
     dependencies:
@@ -994,7 +1018,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/native-types:
     devDependencies:
@@ -1079,7 +1103,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/tauri-plugin:
     dependencies:
@@ -1113,7 +1137,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/tauri-service:
     dependencies:
@@ -1177,7 +1201,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -4625,6 +4649,10 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -6658,6 +6686,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -6680,6 +6712,10 @@ packages:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -8822,7 +8858,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/eslint-plugin@1.6.16(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
     dependencies:
@@ -8831,7 +8867,7 @@ snapshots:
       eslint: 10.2.0(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -10851,6 +10887,12 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -12797,6 +12839,36 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@15.11.7)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      happy-dom: 15.11.7
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - msw
+
   vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
@@ -12911,6 +12983,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-sources@3.3.4: {}
@@ -12949,6 +13023,8 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,6 +670,67 @@ importers:
         specifier: ^4.0.18
         version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/dioxus-service:
+    dependencies:
+      '@wdio/globals':
+        specifier: catalog:default
+        version: 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.41.0))
+      '@wdio/logger':
+        specifier: catalog:default
+        version: 9.18.0
+      '@wdio/native-core':
+        specifier: workspace:*
+        version: link:../native-core
+      '@wdio/native-spy':
+        specifier: workspace:*
+        version: link:../native-spy
+      '@wdio/native-types':
+        specifier: workspace:*
+        version: link:../native-types
+      '@wdio/native-utils':
+        specifier: workspace:*
+        version: link:../native-utils
+      '@wdio/spec-reporter':
+        specifier: catalog:default
+        version: 9.27.0
+      '@wdio/types':
+        specifier: catalog:default
+        version: 9.27.0
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3(supports-color@8.1.1)
+      get-port:
+        specifier: ^7.1.0
+        version: 7.2.0
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      webdriverio:
+        specifier: catalog:default
+        version: 9.27.0(puppeteer-core@24.41.0)
+    devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.13
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.4(vitest@4.1.4)
+      shx:
+        specifier: ^0.4.0
+        version: 0.4.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/electron-cdp-bridge:
     dependencies:
       '@wdio/native-utils':


### PR DESCRIPTION
## Summary

PR2 of the Dioxus service rollout. Stacked on \`feat/dioxus-service\` (the integration branch — see #275). Delivers the **minimum viable** \`@wdio/dioxus-service\` with the bridge IPC channel, execute command, log capture pipeline, and full mocking surface.

Bridges Phase 1, Phase 2, and Phase 3 of the plan in one PR because the pieces are tightly interdependent (bridge IPC enables execute; execute enables mocking; etc.). Splitting them post-hoc isn't a net review win.

## Test counts (all green)

| Suite | Tests |
|---|---|
| \`@wdio/dioxus-service\` | 63 |
| \`@wdio/dioxus-bridge\` (guest-js) | 10 |
| \`wdio-dioxus-bridge\` (Rust) | 13 |
| \`wdio-dioxus-driver\` (Rust) | \`cargo check\` clean |
| \`@wdio/native-spy\` | 185 (+20 DioxusAdapter) |
| \`@wdio/native-core\` | 33 (no regression) |
| \`@wdio/tauri-service\` | 627 (no regression) |
| \`@wdio/electron-service\` | 507 (no regression) |

## What this ships

**TypeScript** (\`packages/dioxus-service/\`)
- Package skeleton with launcher (extends \`BaseLauncher\` from \`@wdio/native-core\`).
- Linux + \`driverProvider: 'external'\` throws \`SevereServiceError\` per \`spike/FINDINGS.md\` (upstream Dioxus PR pending).
- \`browser.dioxus.execute(scriptOrFn, ...args)\` — wraps user functions to inject \`dx = window.__WDIO_DIOXUS__\` and forwards to \`browser.execute\`.
- \`browser.dioxus.mock(command)\` — registers an inner mock via DioxusAdapter, returns an outer mock with the full vitest-style lifecycle methods.
- \`browser.dioxus.{clearAllMocks, resetAllMocks, restoreAllMocks, isMockFunction}\` — registry-backed lifecycle helpers with optional prefix filtering.
- Log capture pipeline: \`parseLogLine\`, \`forwardLog\`, \`[Dioxus:Backend]\` / \`[Dioxus:Frontend]\` prefixes, \`[WDIO-FRONTEND]\` marker handling.

**Rust crates**
- \`wdio-dioxus-driver\` (\`packages/dioxus-driver/\`) — forked from \`tauri-driver\` 2.0.6 with ~200 LOC delta (capability namespace + env var rename).
- \`wdio-dioxus-bridge\` (\`packages/dioxus-bridge/\`) — new crate with \`automation.rs\` (env-var reader), \`invoke.rs\` (wdio:// custom-protocol command bus with built-in \`__ping\` command), \`log_bridge.rs\` (\`log_frontend\` command + \`[WDIO-FRONTEND]\` marker emission), and \`install(config)\` chaining \`Config::with_custom_protocol\` + \`Config::with_custom_head\`.

**npm guest-js** (\`@wdio/dioxus-bridge\`)
- Bundled with esbuild into \`dist-js/index.js\`, embedded by the Rust crate's \`build.rs\` and injected via \`Config::with_custom_head\`.
- Installs \`window.__WDIO_DIOXUS__.invoke\` (fetch wrapper around \`wdio://invoke\`).
- Console wrapper that forwards \`console.{log,info,warn,error,debug}\` calls through \`dx.invoke('log_frontend', ...)\`.

**Mock interceptor**
- \`DioxusAdapter\` in \`@wdio/native-spy/src/interceptor/dioxus.ts\` — mirrors \`TauriAdapter\`'s registration/call-data/setter scripts for \`window.__WDIO_DIOXUS__\`.

**CI**
- \`.github/workflows/_ci-detect-changes.reusable.yml\` extended with \`run_dioxus\` output + \`dioxus_service\` / \`e2e_dioxus\` / \`fixtures_dioxus\` filters.
- Latent gap fixed: \`shared\` filter now includes \`packages/native-spy/**\` and \`packages/native-core/**\`.
- \`_ci-build-dioxus-crates.reusable.yml\` runs \`cargo check\` + \`cargo test\` on the Dioxus Rust crates, gated on \`run_dioxus\`.

## Commits

11 commits — see the file diff. Each commit is independently green; no rebases/squashes needed.

## Out of scope

- macOS + Windows-specific verification (PR3 / Feature Complete).
- Multi-window routing + \`triggerDeeplink\` + \`switchWindow\` / \`listWindows\` (PR3).
- \`'embedded'\` provider implementation — \`wdio-dioxus-embedded-driver\` crate (PR3).
- Browser-mode special case for mocking (PR3).
- Fixture app, E2E test suite, package-test fixture, doc set (PR4 / Ship).

## Test plan

- [x] All unit suites green locally
- [x] cargo test green for bridge crate (10 tests)
- [x] cargo check clean for both Rust crates
- [x] Cross-package regression check (no Tauri/Electron breakage)
- [ ] CI green on this PR (will land once the new workflows run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)