### PR TITLE
feat(dioxus): multi-window + deeplink (Phase 4-5)

### DIFF
--- a/packages/dioxus-bridge/src/deeplink.rs
+++ b/packages/dioxus-bridge/src/deeplink.rs
@@ -1,0 +1,64 @@
+//! Optional reference helper for registering an in-app deeplink handler.
+//!
+//! `@wdio/dioxus-service`'s `browser.dioxus.triggerDeeplink(url)` works at
+//! the OS level — it spawns `rundll32` / `open` / `gio open` so the OS
+//! routes the URL to whichever app has registered as the protocol handler.
+//! That's the most realistic test of the production code path.
+//!
+//! Apps still need to actually *handle* the deeplink when it arrives. This
+//! module is a thin convenience for that side: [`register_handler`] wraps
+//! [`dioxus_desktop::Config::with_custom_protocol`] to capture the URL and
+//! dispatch it into the running app via the user-supplied callback.
+//!
+//! Apps that already register a custom protocol handler — common, since
+//! deeplink wiring is application logic — can ignore this module entirely;
+//! it's published purely as documentation-by-example.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use wdio_dioxus_bridge::deeplink;
+//!
+//! fn main() {
+//!     let mut config = dioxus_desktop::Config::new();
+//!     config = deeplink::register_handler(config, "myapp", |url| {
+//!         tracing::info!("deeplink received: {url}");
+//!         // forward into the app's state, dispatch a signal, etc.
+//!     });
+//!     #[cfg(debug_assertions)]
+//!     {
+//!         config = wdio_dioxus_bridge::install(config);
+//!     }
+//!     dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+//! }
+//! ```
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use dioxus_desktop::wry::http::{HeaderValue, Response, StatusCode};
+use dioxus_desktop::Config;
+
+/// Register a deeplink handler for the given URI scheme. The supplied
+/// callback fires every time the OS dispatches a `<scheme>://...` URL to
+/// the app. Returns the [`Config`] for chainability.
+///
+/// The HTTP response sent back is a 200 with an empty body — Wry expects
+/// the custom-protocol handler to return *something*; we return the
+/// minimum so the OS doesn't see a navigation error.
+pub fn register_handler<F>(config: Config, scheme: impl Into<String>, on_url: F) -> Config
+where
+  F: Fn(&str) + Send + Sync + 'static,
+{
+  let cb = Arc::new(on_url);
+  config.with_custom_protocol(scheme.into(), move |_webview_id, request| {
+    let url = request.uri().to_string();
+    cb(&url);
+    let mut response = Response::new(Cow::Borrowed(b"" as &[u8]));
+    *response.status_mut() = StatusCode::OK;
+    response
+      .headers_mut()
+      .insert("content-type", HeaderValue::from_static("text/plain"));
+    response
+  })
+}

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -1,11 +1,12 @@
 //! `wdio-dioxus-bridge` — bridge crate consumed by Dioxus desktop apps that
 //! want to be testable via `@wdio/dioxus-service`.
 //!
-//! v1 ships the automation env-var reader ([`automation`]) and the
-//! `wdio://invoke` IPC channel ([`invoke`]), plus injection of the
-//! `@wdio/dioxus-bridge` guest-js bundle into the webview. Subsequent
-//! milestones will add `log_bridge.rs` (frontend/backend log forwarding),
-//! window state tracking, and the deeplink reference handler.
+//! Ships the automation env-var reader ([`automation`]), the `wdio://invoke`
+//! IPC channel ([`invoke`]), frontend/backend log forwarding
+//! ([`log_bridge`]), and a multi-window registry ([`window_state`]) that
+//! auto-labels Dioxus windows for [`@wdio/dioxus-service`]'s `switchWindow`
+//! / `listWindows` APIs. Subsequent milestones add the deeplink reference
+//! handler.
 //!
 //! # Quick start
 //!
@@ -29,12 +30,27 @@
 //!     dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
 //! }
 //! ```
+//!
+//! [`@wdio/dioxus-service`]: https://www.npmjs.com/package/@wdio/dioxus-service
+//!
+//! # Multi-window note
+//!
+//! [`install`] calls [`Config::with_on_window`] to feed each newly-built
+//! window into the window-state registry. Dioxus stores the on-window
+//! callback in an `Option` with no getter, so a subsequent
+//! `config.with_on_window(...)` call by user code would silently replace
+//! the bridge's hook and break multi-window support. **Call
+//! `wdio_dioxus_bridge::install(config)` last in your Config builder
+//! chain**, or invoke [`window_state::register_window`] from your own
+//! on-window callback.
 
 pub mod automation;
 pub mod invoke;
 pub mod log_bridge;
+pub mod window_state;
 
 use dioxus_desktop::Config;
+use serde_json::json;
 
 pub use invoke::CommandRegistry;
 pub use log_bridge::FRONTEND_MARKER;
@@ -64,6 +80,7 @@ pub fn install(config: Config) -> Config {
 pub fn install_with_registry(config: Config, registry: CommandRegistry) -> Config {
   automation::report();
   log_bridge::register(&registry);
+  register_window_commands(&registry);
 
   let registry_for_handler = registry;
   config
@@ -73,4 +90,18 @@ pub fn install_with_registry(config: Config, registry: CommandRegistry) -> Confi
     .with_custom_head(format!(
       "<script type=\"module\">{GUEST_JS_BUNDLE}</script>"
     ))
+    .with_on_window(|window, _dom| {
+      let label = window_state::register_window(&window);
+      tracing::debug!(label = %label, "wdio-dioxus-bridge: registered window");
+    })
+}
+
+fn register_window_commands(registry: &CommandRegistry) {
+  registry.register("__list_windows", |_args| Ok(json!(window_state::list_labels())));
+  registry.register("__active_window", |_args| {
+    Ok(json!(window_state::get_active_label()))
+  });
+  registry.register("__window_states", |_args| {
+    Ok(json!(window_state::get_window_states()))
+  });
 }

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -45,6 +45,7 @@
 //! on-window callback.
 
 pub mod automation;
+pub mod deeplink;
 pub mod invoke;
 pub mod log_bridge;
 pub mod window_state;

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -3,10 +3,11 @@
 //!
 //! Ships the automation env-var reader ([`automation`]), the `wdio://invoke`
 //! IPC channel ([`invoke`]), frontend/backend log forwarding
-//! ([`log_bridge`]), and a multi-window registry ([`window_state`]) that
+//! ([`log_bridge`]), a multi-window registry ([`window_state`]) that
 //! auto-labels Dioxus windows for [`@wdio/dioxus-service`]'s `switchWindow`
-//! / `listWindows` APIs. Subsequent milestones add the deeplink reference
-//! handler.
+//! / `listWindows` APIs, and an optional deeplink reference helper
+//! ([`deeplink`]) for apps that want to wire `Config::with_custom_protocol`
+//! with one line.
 //!
 //! # Quick start
 //!

--- a/packages/dioxus-bridge/src/window_state.rs
+++ b/packages/dioxus-bridge/src/window_state.rs
@@ -49,6 +49,11 @@ struct Entry {
 #[derive(Default)]
 struct Registry {
   entries: Mutex<Vec<Entry>>,
+  /// Monotonic counter: total windows ever registered. Drives labelling
+  /// so closing 'main' and opening a new window produces `window-N`,
+  /// never a recycled `main`. Independent of `entries.len()` so the
+  /// backing `Vec` can be pruned of dead entries without disturbing labels.
+  total_registered: Mutex<usize>,
 }
 
 static REGISTRY: OnceLock<Registry> = OnceLock::new();
@@ -57,19 +62,25 @@ fn registry() -> &'static Registry {
   REGISTRY.get_or_init(Registry::default)
 }
 
-/// Allocate the next label given how many entries already exist. Pulled out
-/// so the labelling rule can be unit-tested without spinning a real Window.
-pub(crate) fn allocate_label(existing_count: usize) -> String {
-  if existing_count == 0 {
+/// Allocate the next label given how many windows have **ever** been
+/// registered (live or dead). Pulled out so the labelling rule can be
+/// unit-tested without spinning a real Window.
+pub(crate) fn allocate_label(total_registered: usize) -> String {
+  if total_registered == 0 {
     "main".to_string()
   } else {
-    format!("window-{}", existing_count)
+    format!("window-{}", total_registered)
   }
 }
 
 /// Register a freshly-built window. Returns the label assigned to it.
 /// Re-registering the same [`WindowId`] is a no-op that returns the
 /// already-assigned label.
+///
+/// Each call prunes entries whose `Weak<Window>` has expired so the
+/// backing `Vec` stays proportional to the number of *live* windows in
+/// long-running test suites that churn windows repeatedly. Labels remain
+/// stable across GC because the counter is monotonic.
 pub fn register_window(window: &Arc<Window>) -> String {
   let r = registry();
   let mut entries = r.entries.lock().expect("window-state registry poisoned");
@@ -77,7 +88,10 @@ pub fn register_window(window: &Arc<Window>) -> String {
   if let Some(existing) = entries.iter().find(|e| e.id == id) {
     return existing.label.clone();
   }
-  let label = allocate_label(entries.len());
+  entries.retain(|e| e.window.upgrade().is_some());
+  let mut counter = r.total_registered.lock().expect("window-state registry poisoned");
+  let label = allocate_label(*counter);
+  *counter += 1;
   entries.push(Entry {
     id,
     label: label.clone(),
@@ -141,12 +155,14 @@ pub fn label_for_id(id: WindowId) -> Option<String> {
     .map(|e| e.label.clone())
 }
 
-/// Drop every entry from the registry. Test-only — production callers
-/// rely on `Weak::upgrade` to filter out dead windows.
+/// Reset both the entry list and the monotonic counter. Test-only —
+/// production callers rely on `Weak::upgrade` to filter out dead windows
+/// and the counter is intentionally process-lifetime.
 #[cfg(test)]
 pub(crate) fn reset_for_tests() {
   let r = registry();
   r.entries.lock().expect("window-state registry poisoned").clear();
+  *r.total_registered.lock().expect("window-state registry poisoned") = 0;
 }
 
 #[cfg(test)]
@@ -168,8 +184,9 @@ mod tests {
   #[test]
   fn should_never_reuse_a_main_label_after_closure() {
     // Three windows registered, then the first closes; the next allocation
-    // must be 'window-3', not 'main'. We model the count as the total ever
-    // pushed (entries.len()), which is exactly what register_window() uses.
+    // must be 'window-3', not 'main'. The monotonic counter passed to
+    // allocate_label is the source of truth — register_window keeps the
+    // counter independent of entries.len() so GC can prune dead entries.
     assert_eq!(allocate_label(3), "window-3");
   }
 }

--- a/packages/dioxus-bridge/src/window_state.rs
+++ b/packages/dioxus-bridge/src/window_state.rs
@@ -1,0 +1,175 @@
+//! Window-state registry for multi-window Dioxus apps.
+//!
+//! Dioxus 0.7 windows have no built-in label concept — each is identified by
+//! a [`WindowId`] from `tao`. The bridge auto-labels windows in creation
+//! order so `@wdio/dioxus-service` can route `switchWindow('main')` /
+//! `switchWindow('window-1')` calls without any user wiring:
+//!
+//! | Order | Label       |
+//! |-------|-------------|
+//! | 1st   | `main`      |
+//! | 2nd   | `window-1`  |
+//! | 3rd   | `window-2`  |
+//! | ...   | ...         |
+//!
+//! Labels are never reused: closing the `main` window and opening a new one
+//! produces `window-1`, not a recycled `main`. This keeps test code
+//! deterministic across window churn.
+//!
+//! The registry is process-global because Dioxus's `Config::with_on_window`
+//! callback has no per-`Config` context to thread state through, and only
+//! one bridge runs per process anyway. Entries hold a [`Weak<Window>`] so
+//! closed windows can be detected without keeping them alive past their
+//! natural lifetime.
+//!
+//! Focus/destroy events are **not** observed — Dioxus exposes neither in
+//! `with_on_window`. Active-window detection walks the live entries and
+//! calls [`Window::is_focused`] on each at query time.
+
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use dioxus_desktop::tao::window::{Window, WindowId};
+use serde::Serialize;
+
+/// Per-window snapshot exposed over the `wdio://` channel.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct WindowState {
+  pub label: String,
+  pub title: String,
+  pub is_visible: bool,
+  pub is_focused: bool,
+}
+
+struct Entry {
+  id: WindowId,
+  label: String,
+  window: Weak<Window>,
+}
+
+#[derive(Default)]
+struct Registry {
+  entries: Mutex<Vec<Entry>>,
+}
+
+static REGISTRY: OnceLock<Registry> = OnceLock::new();
+
+fn registry() -> &'static Registry {
+  REGISTRY.get_or_init(Registry::default)
+}
+
+/// Allocate the next label given how many entries already exist. Pulled out
+/// so the labelling rule can be unit-tested without spinning a real Window.
+pub(crate) fn allocate_label(existing_count: usize) -> String {
+  if existing_count == 0 {
+    "main".to_string()
+  } else {
+    format!("window-{}", existing_count)
+  }
+}
+
+/// Register a freshly-built window. Returns the label assigned to it.
+/// Re-registering the same [`WindowId`] is a no-op that returns the
+/// already-assigned label.
+pub fn register_window(window: &Arc<Window>) -> String {
+  let r = registry();
+  let mut entries = r.entries.lock().expect("window-state registry poisoned");
+  let id = window.id();
+  if let Some(existing) = entries.iter().find(|e| e.id == id) {
+    return existing.label.clone();
+  }
+  let label = allocate_label(entries.len());
+  entries.push(Entry {
+    id,
+    label: label.clone(),
+    window: Arc::downgrade(window),
+  });
+  label
+}
+
+/// All currently-live window labels in registration order.
+pub fn list_labels() -> Vec<String> {
+  let r = registry();
+  let entries = r.entries.lock().expect("window-state registry poisoned");
+  entries
+    .iter()
+    .filter(|e| e.window.upgrade().is_some())
+    .map(|e| e.label.clone())
+    .collect()
+}
+
+/// Label of the currently-focused window, if any. Walks the live entries
+/// looking for the first whose [`Window::is_focused`] returns true.
+pub fn get_active_label() -> Option<String> {
+  let r = registry();
+  let entries = r.entries.lock().expect("window-state registry poisoned");
+  entries.iter().find_map(|e| {
+    let w = e.window.upgrade()?;
+    if w.is_focused() {
+      Some(e.label.clone())
+    } else {
+      None
+    }
+  })
+}
+
+/// Snapshot every live window's label, title, visibility, and focus state.
+pub fn get_window_states() -> Vec<WindowState> {
+  let r = registry();
+  let entries = r.entries.lock().expect("window-state registry poisoned");
+  entries
+    .iter()
+    .filter_map(|e| {
+      let w = e.window.upgrade()?;
+      Some(WindowState {
+        label: e.label.clone(),
+        title: w.title(),
+        is_visible: w.is_visible(),
+        is_focused: w.is_focused(),
+      })
+    })
+    .collect()
+}
+
+/// Find the label for a given window id, regardless of liveness. Used by
+/// the bridge's invoke handlers to attribute incoming requests to a window.
+pub fn label_for_id(id: WindowId) -> Option<String> {
+  let r = registry();
+  let entries = r.entries.lock().expect("window-state registry poisoned");
+  entries
+    .iter()
+    .find(|e| e.id == id)
+    .map(|e| e.label.clone())
+}
+
+/// Drop every entry from the registry. Test-only — production callers
+/// rely on `Weak::upgrade` to filter out dead windows.
+#[cfg(test)]
+pub(crate) fn reset_for_tests() {
+  let r = registry();
+  r.entries.lock().expect("window-state registry poisoned").clear();
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn should_label_the_first_window_main() {
+    assert_eq!(allocate_label(0), "main");
+  }
+
+  #[test]
+  fn should_label_subsequent_windows_with_a_numeric_suffix() {
+    assert_eq!(allocate_label(1), "window-1");
+    assert_eq!(allocate_label(2), "window-2");
+    assert_eq!(allocate_label(42), "window-42");
+  }
+
+  #[test]
+  fn should_never_reuse_a_main_label_after_closure() {
+    // Three windows registered, then the first closes; the next allocation
+    // must be 'window-3', not 'main'. We model the count as the total ever
+    // pushed (entries.len()), which is exactly what register_window() uses.
+    assert_eq!(allocate_label(3), "window-3");
+  }
+}

--- a/packages/dioxus-service/src/commands/triggerDeeplink.ts
+++ b/packages/dioxus-service/src/commands/triggerDeeplink.ts
@@ -1,0 +1,43 @@
+// browser.dioxus.triggerDeeplink implementation.
+//
+// Phase 5 MVP: provider 'external' only (Windows + Linux). The deeplink is
+// triggered by spawning the OS-native protocol handler — the same path
+// the user's app would see in production. That's the most realistic test
+// of registered URI handlers and bypasses any IPC mocking.
+//
+//   - Windows: `rundll32.exe url.dll,FileProtocolHandler <url>`
+//   - macOS:   `open <url>` (Dioxus MVP does not yet support 'external'
+//              on darwin, but this stays platform-aware so a future Phase
+//              re-enables it without code changes here)
+//   - Linux:   `gio open <url>`
+//
+// Provider 'embedded' will need a different path that injects the URL via
+// `browser.execute` to bypass single-instance IPC mechanisms; that branch
+// lands in Phase 6 alongside the embedded provider itself.
+
+import { executeDeeplinkCommand, getPlatformCommand, validateDeeplinkUrl } from '@wdio/native-core';
+import { createLogger } from '@wdio/native-utils';
+
+const log = createLogger('dioxus-service', 'triggerDeeplink');
+
+/**
+ * Trigger a deeplink to the Dioxus application by spawning the OS-native
+ * protocol handler.
+ *
+ * @param url - The deeplink URL (e.g. `myapp://open?path=/test`).
+ *   Must use a custom protocol — `http`, `https`, and `file` are rejected.
+ * @throws Error when the URL is malformed or uses a disallowed protocol.
+ *
+ * @example
+ * ```ts
+ * await browser.dioxus.triggerDeeplink('myapp://open?file=test.txt');
+ * ```
+ */
+export async function triggerDeeplink(url: string): Promise<void> {
+  const validated = validateDeeplinkUrl(url);
+  log.debug(`triggering deeplink ${validated} on ${process.platform}`);
+
+  const { command, args } = getPlatformCommand(validated, process.platform);
+  await executeDeeplinkCommand(command, args);
+  log.debug(`deeplink dispatched: ${command} ${args.join(' ')}`);
+}

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -10,6 +10,7 @@ import { createLogger } from '@wdio/native-utils';
 import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from './commands/allMocks.js';
 import { execute } from './commands/execute.js';
 import { mock } from './commands/mock.js';
+import { triggerDeeplink } from './commands/triggerDeeplink.js';
 import mockStore from './mockStore.js';
 import { clearWindowState, listWindowLabels, switchWindowByLabel } from './window.js';
 
@@ -61,6 +62,7 @@ export default class DioxusWorkerService {
       isMockFunction,
       switchWindow: (label: string) => switchWindowByLabel(browser, label),
       listWindows: () => listWindowLabels(browser),
+      triggerDeeplink,
     };
     (browser as unknown as { dioxus: typeof dioxus }).dioxus = dioxus;
   }

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -11,6 +11,7 @@ import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from '.
 import { execute } from './commands/execute.js';
 import { mock } from './commands/mock.js';
 import mockStore from './mockStore.js';
+import { clearWindowState, listWindowLabels, switchWindowByLabel } from './window.js';
 
 const log = createLogger('dioxus-service', 'service');
 const interceptor = createIpcInterceptor('dioxus');
@@ -58,6 +59,8 @@ export default class DioxusWorkerService {
       resetAllMocks,
       restoreAllMocks,
       isMockFunction,
+      switchWindow: (label: string) => switchWindowByLabel(browser, label),
+      listWindows: () => listWindowLabels(browser),
     };
     (browser as unknown as { dioxus: typeof dioxus }).dioxus = dioxus;
   }
@@ -76,7 +79,11 @@ export default class DioxusWorkerService {
    * teardown anyway.
    */
   async after(): Promise<void> {
-    log.debug('DioxusWorkerService.after — clearing process-wide mockStore');
+    log.debug('DioxusWorkerService.after — clearing process-wide mockStore + window cache');
     mockStore.clear();
+    // WDIO's worker `after` runs once per spec; we don't have the browser
+    // ref here (only `before` receives it), so clear every session's cached
+    // label. Safe because each WDIO worker is its own process.
+    clearWindowState();
   }
 }

--- a/packages/dioxus-service/src/window.ts
+++ b/packages/dioxus-service/src/window.ts
@@ -1,0 +1,157 @@
+// Multi-window helpers for `@wdio/dioxus-service`.
+//
+// The Dioxus bridge auto-labels windows in creation order — first is 'main',
+// subsequent are 'window-1', 'window-2', .... This module exposes:
+//
+//   - Active-label/list helpers that call into the bridge via
+//     `dx.invoke('__list_windows')` / `dx.invoke('__active_window')`.
+//   - A per-sessionId label cache so service code can ask "what window did
+//     the user last switch to?" without re-querying the bridge.
+//   - `switchWindowByLabel` which validates the label exists, resolves it
+//     to a WebDriver handle, and updates the cache.
+//
+// Phase 4 scope: provider 'external' only (Windows/Linux msedgedriver
+// proxy). Phase 6 (embedded provider) will branch the switch path so the
+// embedded driver can switch by label directly without handle resolution.
+
+import { createLogger } from '@wdio/native-utils';
+
+import { execute } from './commands/execute.js';
+
+const log = createLogger('dioxus-service', 'window');
+
+const currentWindowLabelCache = new Map<string, string>();
+
+const DEFAULT_WINDOW_LABEL = 'main';
+
+function sessionKey(browser: WebdriverIO.Browser): string {
+  return browser.sessionId || 'default';
+}
+
+/**
+ * Default label assigned to the first window in any Dioxus app.
+ * Mirrors the bridge's `window_state::allocate_label(0)` output.
+ */
+export function getDefaultWindowLabel(): string {
+  return DEFAULT_WINDOW_LABEL;
+}
+
+/**
+ * Last label the test process explicitly switched to in this session,
+ * defaulting to 'main' when no switch has happened yet.
+ */
+export function getCurrentWindowLabel(browser: WebdriverIO.Browser): string {
+  return currentWindowLabelCache.get(sessionKey(browser)) ?? DEFAULT_WINDOW_LABEL;
+}
+
+/**
+ * Internal: update the per-session label cache after a successful switch.
+ * Exposed for tests; production code should call {@link switchWindowByLabel}.
+ */
+export function setCurrentWindowLabel(browser: WebdriverIO.Browser, label: string): void {
+  currentWindowLabelCache.set(sessionKey(browser), label);
+}
+
+/**
+ * Drop cached state for a session (or all sessions when omitted). Used in
+ * the worker service's `after()` hook to prevent label leakage across
+ * spec files in the same WDIO worker.
+ */
+export function clearWindowState(browserOrSessionId?: WebdriverIO.Browser | string): void {
+  if (!browserOrSessionId) {
+    currentWindowLabelCache.clear();
+    return;
+  }
+  const key = typeof browserOrSessionId === 'string' ? browserOrSessionId : sessionKey(browserOrSessionId);
+  currentWindowLabelCache.delete(key);
+}
+
+/**
+ * Active window label as reported by the bridge. Falls back to 'main' if
+ * the bridge isn't available (e.g. when the webview is mid-load).
+ */
+export async function getActiveWindowLabel(browser: WebdriverIO.Browser): Promise<string> {
+  try {
+    const result = await execute(browser, (dx) => dx.invoke('__active_window'));
+    return (result as string | null) ?? DEFAULT_WINDOW_LABEL;
+  } catch (error) {
+    log.warn('Failed to read active window label via bridge:', error);
+    return DEFAULT_WINDOW_LABEL;
+  }
+}
+
+/**
+ * Live windows, in registration order. The bridge filters out windows
+ * whose `Weak<Window>` has been dropped (closed).
+ */
+export async function listWindowLabels(browser: WebdriverIO.Browser): Promise<string[]> {
+  const result = await execute(browser, (dx) => dx.invoke('__list_windows'));
+  if (!Array.isArray(result)) {
+    throw new Error(`[@wdio/dioxus-service] expected __list_windows to return an array, got ${typeof result}`);
+  }
+  return result as string[];
+}
+
+/**
+ * Walk WebDriver's window handles, asking each one which Dioxus window
+ * label it corresponds to. Returns the handle string for the matching
+ * label, or throws if no handle reports that label.
+ */
+async function resolveLabelToHandle(browser: WebdriverIO.Browser, targetLabel: string): Promise<string> {
+  const handles = await browser.getWindowHandles();
+  const discovered = new Map<string, string>();
+
+  for (const handle of handles) {
+    try {
+      await browser.switchToWindow(handle);
+      const handleLabel = await execute(browser, (dx) => dx.invoke('__active_window'));
+      if (typeof handleLabel === 'string' && handleLabel.length > 0) {
+        discovered.set(handleLabel, handle);
+        if (handleLabel === targetLabel) {
+          return handle;
+        }
+      }
+    } catch {
+      log.debug(`Handle ${handle.slice(0, 8)}... unreachable, skipping`);
+    }
+  }
+
+  const labels = [...discovered.keys()].join(', ') || 'none';
+  throw new Error(
+    `[@wdio/dioxus-service] no window with label "${targetLabel}" found after checking all handles. Discovered: ${labels}`,
+  );
+}
+
+/**
+ * Switch the active WebDriver context to the window labelled `label`.
+ *
+ *   1. Validates that `label` is in the bridge's live-window list.
+ *   2. Resolves the label to a WebDriver handle by walking handles.
+ *   3. Switches WebDriver focus.
+ *   4. Updates the per-session label cache.
+ *
+ * Throws with a discoverable error message when the label doesn't exist or
+ * the underlying switch fails.
+ */
+export async function switchWindowByLabel(browser: WebdriverIO.Browser, label: string): Promise<void> {
+  const available = await listWindowLabels(browser);
+  if (!available.includes(label)) {
+    throw new Error(
+      `[@wdio/dioxus-service] window label "${label}" not found. Available: ${available.join(', ') || '(none)'}`,
+    );
+  }
+
+  const originalHandle = await browser.getWindowHandle();
+  try {
+    const handle = await resolveLabelToHandle(browser, label);
+    await browser.switchToWindow(handle);
+  } catch (switchError) {
+    await browser.switchToWindow(originalHandle).catch(() => undefined);
+    throw new Error(
+      `[@wdio/dioxus-service] failed to switch to window "${label}": ${switchError instanceof Error ? switchError.message : String(switchError)}`,
+    );
+  }
+
+  setCurrentWindowLabel(browser, label);
+  log.debug(`switched to window: ${label}`);
+}

--- a/packages/dioxus-service/src/window.ts
+++ b/packages/dioxus-service/src/window.ts
@@ -89,6 +89,14 @@ export async function listWindowLabels(browser: WebdriverIO.Browser): Promise<st
   if (!Array.isArray(result)) {
     throw new Error(`[@wdio/dioxus-service] expected __list_windows to return an array, got ${typeof result}`);
   }
+  // Validate item shape: a bridge protocol drift could return `[null]` or
+  // `[42]`, which the rest of the service would silently misinterpret
+  // (e.g. `includes()` returning false where a downstream caller expects
+  // a missing-label error). Catch the mismatch here at the boundary.
+  if (!result.every((item) => typeof item === 'string')) {
+    const types = result.map((item) => (item === null ? 'null' : typeof item)).join(', ');
+    throw new Error(`[@wdio/dioxus-service] __list_windows returned non-string items: [${types}]`);
+  }
   return result as string[];
 }
 
@@ -126,12 +134,12 @@ async function resolveLabelToHandle(browser: WebdriverIO.Browser, targetLabel: s
  * Switch the active WebDriver context to the window labelled `label`.
  *
  *   1. Validates that `label` is in the bridge's live-window list.
- *   2. Resolves the label to a WebDriver handle by walking handles.
- *   3. Switches WebDriver focus.
- *   4. Updates the per-session label cache.
+ *   2. Walks handles via `resolveLabelToHandle` (which leaves the driver
+ *      on the matching handle as a side effect).
+ *   3. Updates the per-session label cache.
  *
- * Throws with a discoverable error message when the label doesn't exist or
- * the underlying switch fails.
+ * If resolution fails, the original handle is restored before the error
+ * is propagated.
  */
 export async function switchWindowByLabel(browser: WebdriverIO.Browser, label: string): Promise<void> {
   const available = await listWindowLabels(browser);
@@ -143,13 +151,15 @@ export async function switchWindowByLabel(browser: WebdriverIO.Browser, label: s
 
   const originalHandle = await browser.getWindowHandle();
   try {
-    const handle = await resolveLabelToHandle(browser, label);
-    await browser.switchToWindow(handle);
+    // resolveLabelToHandle leaves the driver focused on the matching
+    // handle when it succeeds — no follow-up switchToWindow call needed.
+    await resolveLabelToHandle(browser, label);
   } catch (switchError) {
     await browser.switchToWindow(originalHandle).catch(() => undefined);
-    throw new Error(
-      `[@wdio/dioxus-service] failed to switch to window "${label}": ${switchError instanceof Error ? switchError.message : String(switchError)}`,
-    );
+    // Re-throw the inner error unmodified — it already carries the
+    // package prefix and discoverable context (which handles were
+    // probed, etc.). Wrapping here produced a double-prefixed string.
+    throw switchError;
   }
 
   setCurrentWindowLabel(browser, label);

--- a/packages/dioxus-service/test/commands/triggerDeeplink.spec.ts
+++ b/packages/dioxus-service/test/commands/triggerDeeplink.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wdio/native-core', async () => {
+  const actual = await vi.importActual<typeof import('@wdio/native-core')>('@wdio/native-core');
+  return {
+    ...actual,
+    executeDeeplinkCommand: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { executeDeeplinkCommand } from '@wdio/native-core';
+import { triggerDeeplink } from '../../src/commands/triggerDeeplink.js';
+
+const originalPlatform = process.platform;
+
+afterEach(() => {
+  vi.mocked(executeDeeplinkCommand).mockClear();
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+
+describe('triggerDeeplink', () => {
+  it('should spawn the macOS open command for a valid custom-protocol URL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    await triggerDeeplink('myapp://open?file=test');
+
+    expect(executeDeeplinkCommand).toHaveBeenCalledWith('open', ['myapp://open?file=test']);
+  });
+
+  it('should spawn rundll32 on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    await triggerDeeplink('myapp://open');
+
+    expect(executeDeeplinkCommand).toHaveBeenCalledWith('rundll32.exe', [
+      'url.dll,FileProtocolHandler',
+      'myapp://open',
+    ]);
+  });
+
+  it('should spawn gio open on Linux', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    await triggerDeeplink('myapp://open');
+
+    expect(executeDeeplinkCommand).toHaveBeenCalledWith('gio', ['open', 'myapp://open']);
+  });
+
+  it('should reject http URLs', async () => {
+    await expect(triggerDeeplink('http://example.com')).rejects.toThrow(/Invalid deeplink protocol: http/);
+    expect(executeDeeplinkCommand).not.toHaveBeenCalled();
+  });
+
+  it('should reject https URLs', async () => {
+    await expect(triggerDeeplink('https://example.com')).rejects.toThrow(/Invalid deeplink protocol: https/);
+    expect(executeDeeplinkCommand).not.toHaveBeenCalled();
+  });
+
+  it('should reject file URLs', async () => {
+    await expect(triggerDeeplink('file:///tmp/test')).rejects.toThrow(/Invalid deeplink protocol: file/);
+    expect(executeDeeplinkCommand).not.toHaveBeenCalled();
+  });
+
+  it('should reject malformed URLs', async () => {
+    await expect(triggerDeeplink('')).rejects.toThrow(/Invalid deeplink URL/);
+    await expect(triggerDeeplink('not a url')).rejects.toThrow(/Invalid deeplink URL/);
+  });
+
+  it('should propagate spawn failures from native-core', async () => {
+    vi.mocked(executeDeeplinkCommand).mockRejectedValueOnce(new Error('ENOENT'));
+
+    await expect(triggerDeeplink('myapp://test')).rejects.toThrow(/ENOENT/);
+  });
+});

--- a/packages/dioxus-service/test/service.spec.ts
+++ b/packages/dioxus-service/test/service.spec.ts
@@ -14,6 +14,8 @@ type Installed = {
     resetAllMocks: (prefix?: string) => Promise<void>;
     restoreAllMocks: (prefix?: string) => Promise<void>;
     isMockFunction: (x: unknown) => boolean;
+    switchWindow: (label: string) => Promise<void>;
+    listWindows: () => Promise<string[]>;
   };
 };
 
@@ -36,6 +38,8 @@ describe('DioxusWorkerService', () => {
     expect(typeof dioxus.resetAllMocks).toBe('function');
     expect(typeof dioxus.restoreAllMocks).toBe('function');
     expect(typeof dioxus.isMockFunction).toBe('function');
+    expect(typeof dioxus.switchWindow).toBe('function');
+    expect(typeof dioxus.listWindows).toBe('function');
   });
 
   it('should route browser.dioxus.execute through the underlying browser.execute', async () => {

--- a/packages/dioxus-service/test/service.spec.ts
+++ b/packages/dioxus-service/test/service.spec.ts
@@ -16,6 +16,7 @@ type Installed = {
     isMockFunction: (x: unknown) => boolean;
     switchWindow: (label: string) => Promise<void>;
     listWindows: () => Promise<string[]>;
+    triggerDeeplink: (url: string) => Promise<void>;
   };
 };
 
@@ -40,6 +41,7 @@ describe('DioxusWorkerService', () => {
     expect(typeof dioxus.isMockFunction).toBe('function');
     expect(typeof dioxus.switchWindow).toBe('function');
     expect(typeof dioxus.listWindows).toBe('function');
+    expect(typeof dioxus.triggerDeeplink).toBe('function');
   });
 
   it('should route browser.dioxus.execute through the underlying browser.execute', async () => {

--- a/packages/dioxus-service/test/window.spec.ts
+++ b/packages/dioxus-service/test/window.spec.ts
@@ -124,6 +124,13 @@ describe('window helpers', () => {
       const { browser } = makeBrowser({ executeReturns: ['not-an-array'] });
       await expect(listWindowLabels(browser)).rejects.toThrow(/expected __list_windows to return an array/);
     });
+
+    it('should throw when the array contains non-string items', async () => {
+      const { browser } = makeBrowser({ executeReturns: [['main', null, 42]] });
+      await expect(listWindowLabels(browser)).rejects.toThrow(
+        /__list_windows returned non-string items: \[string, null, number\]/,
+      );
+    });
   });
 
   describe('switchWindowByLabel', () => {
@@ -140,13 +147,10 @@ describe('window helpers', () => {
 
       await switchWindowByLabel(browser, 'window-1');
 
-      // First switchToWindow: handle iteration in resolveLabelToHandle ('h-main' then 'h-window-1');
-      // Then: final switch to the resolved handle.
-      expect(vi.mocked(browser.switchToWindow).mock.calls.map((c) => c[0])).toEqual([
-        'h-main',
-        'h-window-1',
-        'h-window-1',
-      ]);
+      // resolveLabelToHandle iterates handles ('h-main' then 'h-window-1')
+      // and the driver is already on the matching handle when it returns,
+      // so switchWindowByLabel no longer issues a redundant final switch.
+      expect(vi.mocked(browser.switchToWindow).mock.calls.map((c) => c[0])).toEqual(['h-main', 'h-window-1']);
       expect(getCurrentWindowLabel(browser)).toBe('window-1');
     });
 
@@ -169,9 +173,12 @@ describe('window helpers', () => {
         switchToWindow: vi.fn().mockResolvedValue(undefined),
       } as unknown as WebdriverIO.Browser;
 
-      await expect(switchWindowByLabel(browser, 'window-1')).rejects.toThrow(/failed to switch to window "window-1"/);
-      // resolveLabelToHandle iterated through h-main (no match), then the
-      // catch-block restored to the original handle.
+      // resolveLabelToHandle throws with the package-prefixed error; the
+      // outer catch restores the original handle and re-throws the inner
+      // error unmodified (no double prefix).
+      await expect(switchWindowByLabel(browser, 'window-1')).rejects.toThrow(
+        /no window with label "window-1" found after checking all handles/,
+      );
       const restoreCalls = vi.mocked(browser.switchToWindow).mock.calls.map((c) => c[0]);
       expect(restoreCalls).toContain('h-main');
     });

--- a/packages/dioxus-service/test/window.spec.ts
+++ b/packages/dioxus-service/test/window.spec.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearWindowState,
+  getActiveWindowLabel,
+  getCurrentWindowLabel,
+  getDefaultWindowLabel,
+  listWindowLabels,
+  setCurrentWindowLabel,
+  switchWindowByLabel,
+} from '../src/window.js';
+
+function makeBrowser(opts: { sessionId?: string; executeReturns?: unknown[]; handles?: string[] } = {}): {
+  browser: WebdriverIO.Browser;
+  executeCalls: string[];
+} {
+  const executeCalls: string[] = [];
+  const executeReturns = opts.executeReturns ?? [];
+  let executeIdx = 0;
+
+  const browser = {
+    sessionId: opts.sessionId ?? 'session-A',
+    execute: vi.fn((script: string) => {
+      executeCalls.push(script);
+      const ret = executeReturns[executeIdx++];
+      return Promise.resolve(ret);
+    }),
+    getWindowHandles: vi.fn().mockResolvedValue(opts.handles ?? ['h-main', 'h-window-1']),
+    getWindowHandle: vi.fn().mockResolvedValue('h-main'),
+    switchToWindow: vi.fn().mockResolvedValue(undefined),
+  } as unknown as WebdriverIO.Browser;
+
+  return { browser, executeCalls };
+}
+
+afterEach(() => {
+  clearWindowState();
+});
+
+describe('window helpers', () => {
+  describe('getDefaultWindowLabel', () => {
+    it("should return 'main'", () => {
+      expect(getDefaultWindowLabel()).toBe('main');
+    });
+  });
+
+  describe('getCurrentWindowLabel / setCurrentWindowLabel', () => {
+    it("should default to 'main' when nothing has been set", () => {
+      const { browser } = makeBrowser({ sessionId: 'fresh' });
+      expect(getCurrentWindowLabel(browser)).toBe('main');
+    });
+
+    it('should cache labels per sessionId', () => {
+      const { browser: a } = makeBrowser({ sessionId: 'sess-a' });
+      const { browser: b } = makeBrowser({ sessionId: 'sess-b' });
+      setCurrentWindowLabel(a, 'window-1');
+      expect(getCurrentWindowLabel(a)).toBe('window-1');
+      expect(getCurrentWindowLabel(b)).toBe('main');
+    });
+  });
+
+  describe('clearWindowState', () => {
+    beforeEach(() => {
+      const { browser: a } = makeBrowser({ sessionId: 'sess-a' });
+      const { browser: b } = makeBrowser({ sessionId: 'sess-b' });
+      setCurrentWindowLabel(a, 'window-1');
+      setCurrentWindowLabel(b, 'window-2');
+    });
+
+    it('should clear a specific session by browser ref', () => {
+      const { browser: a } = makeBrowser({ sessionId: 'sess-a' });
+      clearWindowState(a);
+      expect(getCurrentWindowLabel(a)).toBe('main');
+      const { browser: b } = makeBrowser({ sessionId: 'sess-b' });
+      expect(getCurrentWindowLabel(b)).toBe('window-2');
+    });
+
+    it('should clear a specific session by sessionId string', () => {
+      clearWindowState('sess-a');
+      const { browser: a } = makeBrowser({ sessionId: 'sess-a' });
+      expect(getCurrentWindowLabel(a)).toBe('main');
+    });
+
+    it('should clear every session when called with no args', () => {
+      clearWindowState();
+      const { browser: a } = makeBrowser({ sessionId: 'sess-a' });
+      const { browser: b } = makeBrowser({ sessionId: 'sess-b' });
+      expect(getCurrentWindowLabel(a)).toBe('main');
+      expect(getCurrentWindowLabel(b)).toBe('main');
+    });
+  });
+
+  describe('getActiveWindowLabel', () => {
+    it('should invoke __active_window and return its result', async () => {
+      const { browser, executeCalls } = makeBrowser({ executeReturns: ['window-1'] });
+      const label = await getActiveWindowLabel(browser);
+      expect(label).toBe('window-1');
+      expect(executeCalls[0]).toContain('__active_window');
+    });
+
+    it("should fall back to 'main' when the bridge returns null", async () => {
+      const { browser } = makeBrowser({ executeReturns: [null] });
+      expect(await getActiveWindowLabel(browser)).toBe('main');
+    });
+
+    it("should fall back to 'main' when the bridge throws", async () => {
+      const browser = {
+        sessionId: 'fail',
+        execute: vi.fn().mockRejectedValue(new Error('no bridge')),
+      } as unknown as WebdriverIO.Browser;
+      expect(await getActiveWindowLabel(browser)).toBe('main');
+    });
+  });
+
+  describe('listWindowLabels', () => {
+    it('should invoke __list_windows and return the array', async () => {
+      const { browser, executeCalls } = makeBrowser({ executeReturns: [['main', 'window-1']] });
+      const labels = await listWindowLabels(browser);
+      expect(labels).toEqual(['main', 'window-1']);
+      expect(executeCalls[0]).toContain('__list_windows');
+    });
+
+    it('should throw when the bridge returns a non-array', async () => {
+      const { browser } = makeBrowser({ executeReturns: ['not-an-array'] });
+      await expect(listWindowLabels(browser)).rejects.toThrow(/expected __list_windows to return an array/);
+    });
+  });
+
+  describe('switchWindowByLabel', () => {
+    it('should switch to the matching handle and update the cache', async () => {
+      // execute calls in order:
+      // 1. listWindowLabels — returns ['main', 'window-1']
+      // 2. (inside resolveLabelToHandle) per-handle __active_window queries
+      //    For handle h-main: 'main'
+      //    For handle h-window-1: 'window-1' -> match, return early
+      const { browser } = makeBrowser({
+        executeReturns: [['main', 'window-1'], 'main', 'window-1'],
+        handles: ['h-main', 'h-window-1'],
+      });
+
+      await switchWindowByLabel(browser, 'window-1');
+
+      // First switchToWindow: handle iteration in resolveLabelToHandle ('h-main' then 'h-window-1');
+      // Then: final switch to the resolved handle.
+      expect(vi.mocked(browser.switchToWindow).mock.calls.map((c) => c[0])).toEqual([
+        'h-main',
+        'h-window-1',
+        'h-window-1',
+      ]);
+      expect(getCurrentWindowLabel(browser)).toBe('window-1');
+    });
+
+    it('should throw with a discoverable message when the label is not in the bridge list', async () => {
+      const { browser } = makeBrowser({ executeReturns: [['main']] });
+      await expect(switchWindowByLabel(browser, 'nope')).rejects.toThrow(
+        /window label "nope" not found. Available: main/,
+      );
+    });
+
+    it('should restore the original handle when the switch fails', async () => {
+      const browser = {
+        sessionId: 'restore',
+        execute: vi
+          .fn()
+          .mockResolvedValueOnce(['main', 'window-1']) // listWindowLabels
+          .mockResolvedValue('main'), // every per-handle query returns the wrong label
+        getWindowHandles: vi.fn().mockResolvedValue(['h-main']),
+        getWindowHandle: vi.fn().mockResolvedValue('h-main'),
+        switchToWindow: vi.fn().mockResolvedValue(undefined),
+      } as unknown as WebdriverIO.Browser;
+
+      await expect(switchWindowByLabel(browser, 'window-1')).rejects.toThrow(/failed to switch to window "window-1"/);
+      // resolveLabelToHandle iterated through h-main (no match), then the
+      // catch-block restored to the original handle.
+      const restoreCalls = vi.mocked(browser.switchToWindow).mock.calls.map((c) => c[0]);
+      expect(restoreCalls).toContain('h-main');
+    });
+  });
+});

--- a/packages/native-types/src/dioxus.ts
+++ b/packages/native-types/src/dioxus.ts
@@ -80,10 +80,11 @@ export interface DioxusMock<TArgs extends unknown[] = unknown[], TReturns = unkn
 /**
  * Public `browser.dioxus.*` surface installed by `@wdio/dioxus-service`.
  *
- * Surface in this MVP: `execute`, `mock`, and the mock-lifecycle helpers.
- * `triggerDeeplink`, `switchWindow`, `listWindows`, and per-call execute
- * options land in PR3 alongside the bridge's `window_state` + `deeplink`
- * modules. `emitEvent` is deferred to v1.1 — Dioxus has no native event bus.
+ * Surface in PR3: `execute`, `mock`, the mock-lifecycle helpers, plus
+ * multi-window APIs (`switchWindow`, `listWindows`). `triggerDeeplink` and
+ * per-call execute options land later in PR3 alongside the bridge's
+ * `deeplink` module. `emitEvent` is deferred to v1.1 — Dioxus has no
+ * native event bus.
  */
 export interface DioxusServiceAPI {
   execute<R, A extends unknown[]>(script: string | ((dx: DioxusAPIs, ...a: A) => R), ...args: A): Promise<R>;
@@ -93,6 +94,11 @@ export interface DioxusServiceAPI {
   clearAllMocks(prefix?: string): Promise<void>;
   resetAllMocks(prefix?: string): Promise<void>;
   restoreAllMocks(prefix?: string): Promise<void>;
+
+  /** Switch the WebDriver session to the window labelled `label`. */
+  switchWindow(label: string): Promise<void>;
+  /** List all live window labels in registration order. */
+  listWindows(): Promise<string[]>;
 }
 
 export interface DioxusServiceOptions extends BaseServiceOptions, DriverProviderConfig {

--- a/packages/native-types/src/dioxus.ts
+++ b/packages/native-types/src/dioxus.ts
@@ -80,11 +80,10 @@ export interface DioxusMock<TArgs extends unknown[] = unknown[], TReturns = unkn
 /**
  * Public `browser.dioxus.*` surface installed by `@wdio/dioxus-service`.
  *
- * Surface in PR3: `execute`, `mock`, the mock-lifecycle helpers, plus
- * multi-window APIs (`switchWindow`, `listWindows`). `triggerDeeplink` and
- * per-call execute options land later in PR3 alongside the bridge's
- * `deeplink` module. `emitEvent` is deferred to v1.1 — Dioxus has no
- * native event bus.
+ * Surface in PR3: `execute`, `mock`, the mock-lifecycle helpers, multi-window
+ * APIs (`switchWindow`, `listWindows`), and `triggerDeeplink`. Per-call
+ * execute options land in a later PR. `emitEvent` is deferred to v1.1 —
+ * Dioxus has no native event bus.
  */
 export interface DioxusServiceAPI {
   execute<R, A extends unknown[]>(script: string | ((dx: DioxusAPIs, ...a: A) => R), ...args: A): Promise<R>;
@@ -99,6 +98,12 @@ export interface DioxusServiceAPI {
   switchWindow(label: string): Promise<void>;
   /** List all live window labels in registration order. */
   listWindows(): Promise<string[]>;
+  /**
+   * Trigger a deeplink (custom-protocol URL) at the OS level so the Dioxus
+   * app's registered protocol handler receives it. Use for testing the
+   * production protocol-handler code path; rejects http/https/file URLs.
+   */
+  triggerDeeplink(url: string): Promise<void>;
 }
 
 export interface DioxusServiceOptions extends BaseServiceOptions, DriverProviderConfig {


### PR DESCRIPTION
## Summary

PR3 first slice — ships **Phase 4 (multi-window)** and **Phase 5 (deeplink)** of the Dioxus service rollout. Stacks on `feat/dioxus-service`.

### Phase 4 — Multi-window

**Bridge (`packages/dioxus-bridge/`)**
- `window_state.rs` — process-global registry that auto-labels Dioxus windows in creation order: first is `main`, rest are `window-1`, `window-2`, .... Stores `Weak<Window>` so closed windows are filtered at query time. Labels are never reused.
- `install()` chains `Config::with_on_window` to feed each new window into the registry and registers three invoke commands: `__list_windows`, `__active_window`, `__window_states`.
- Doc note: `install()` must be the last builder before launch (Dioxus's `Config.on_window` is an `Option<Box<_>>` with no getter — a later user `with_on_window` would silently shadow the bridge hook).

**Service (`packages/dioxus-service/`)**
- `window.ts` — per-`sessionId` label cache + `getDefaultWindowLabel` / `getCurrentWindowLabel` / `setCurrentWindowLabel` / `clearWindowState` / `getActiveWindowLabel` / `listWindowLabels` / `switchWindowByLabel`. The switch path validates against the bridge's live list, resolves label → WebDriver handle by walking `getWindowHandles()`, and restores the original handle on failure.
- `service.before()` installs `switchWindow` + `listWindows` on `browser.dioxus`.
- `service.after()` clears the window cache alongside `mockStore`.

### Phase 5 — Deeplink

**Service**
- `commands/triggerDeeplink.ts` — validate URL via `@wdio/native-core`, spawn the platform-native protocol handler:
  - Windows: `rundll32.exe url.dll,FileProtocolHandler <url>`
  - macOS: `open <url>`
  - Linux: `gio open <url>`
- Rejects `http://` / `https://` / `file://`.

**Bridge**
- `deeplink.rs` — optional reference helper `register_handler(scheme, callback)` that wraps `Config::with_custom_protocol(scheme, ...)`. Pure convenience for app authors; not required for testing.

### Types

- `DioxusServiceAPI` restored: `switchWindow`, `listWindows`, `triggerDeeplink`.

## Test plan

- [x] Bridge: `cargo test` — 18/18 (3 new in `window_state`)
- [x] Service: `pnpm test:unit` — 93/93 (8 new for `triggerDeeplink`, 14 new for `window.ts`)
- [x] Typecheck: `pnpm typecheck` green
- [ ] CI green on `feat/dioxus-feature-complete`

## Deferred

- **E2E pipeline** — `fixtures/e2e-apps/dioxus/` doesn't exist yet; PR2 shipped without it. Window + deeplink E2E specs land in a dedicated PR that bootstraps the fixture app.
- **Phase 6** (embedded WebDriver provider + browser mode) — separate follow-up PR. Includes new `wdio-dioxus-embedded-driver` crate + platform executors + `providers/embedded.ts` + Vite dev-server branch.
- **Phase 7** (macOS support + visual regression) — depends on Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)