### PR TITLE
feat(dioxus): package test fixture + script support (Phase 8)

### DIFF
--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -1,0 +1,138 @@
+name: Build Dioxus Package Test App
+
+description: 'Builds Dioxus package test application and creates shareable artifacts'
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'OS of runner'
+        required: true
+        type: string
+      build_id:
+        description: 'Build ID from the main build job'
+        type: string
+        required: false
+      artifact_size:
+        description: 'Size of the build artifact in bytes'
+        type: string
+        required: false
+      cache_key:
+        description: 'Cache key to use for downloading artifacts'
+        type: string
+        required: false
+    outputs:
+      build_id:
+        description: 'Unique identifier for this build'
+        value: ${{ jobs.build-dioxus-package-app.outputs.build_id }}
+      build_date:
+        description: 'Timestamp when the build completed'
+        value: ${{ jobs.build-dioxus-package-app.outputs.build_date }}
+      artifact_size:
+        description: 'Size of the build artifact in bytes'
+        value: ${{ jobs.build-dioxus-package-app.outputs.artifact_size }}
+      cache_key:
+        description: 'Cache key used for artifact uploads, can be passed to download actions'
+        value: ${{ jobs.build-dioxus-package-app.outputs.cache_key }}
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  build-dioxus-package-app:
+    name: Build Dioxus Package Test App
+    runs-on: ${{ inputs.os }}
+    outputs:
+      build_id: ${{ steps.build-info.outputs.build_id }}
+      build_date: ${{ steps.build-info.outputs.build_date }}
+      artifact_size: ${{ steps.upload-archive.outputs.size || '0' }}
+      cache_key: ${{ steps.upload-archive.outputs.cache_key }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: '24'
+
+      # Download the pre-built packages from the main build job
+      # This ensures workspace dependencies (e.g. @wdio/native-spy dist/) are available
+      - name: Download Package Build Artifacts
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: wdio-desktop-mobile
+          path: wdio-desktop-mobile-build
+          filename: artifact.zip
+          cache_key_prefix: wdio-desktop-build
+          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: '.'
+          cache-on-failure: true
+          cache-targets: false
+
+      - name: Fix ARM64 Package Sources (Linux)
+        if: runner.os == 'Linux' && runner.arch == 'ARM64'
+        shell: bash
+        run: |
+          echo "Fixing ARM64 package sources for Ubuntu..."
+          # Add proper arm64 sources for jammy
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+
+          # Ensure default sources only use amd64
+          sudo sed -i -e 's/^deb http/deb [arch=amd64] http/' /etc/apt/sources.list
+          sudo sed -i -e 's/^deb mirror/deb [arch=amd64] mirror/' /etc/apt/sources.list
+
+          sudo apt-get update
+
+      - name: Install Dioxus Dependencies (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "Installing Dioxus dependencies for Linux..."
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libxdo-dev \
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            pkg-config
+
+      - name: Generate Build Information
+        id: build-info
+        shell: bash
+        run: |
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+
+      - name: Build Dioxus Package Test App
+        run: pnpm exec turbo run build --filter=dioxus-app-example --only
+        shell: bash
+
+      - name: Upload Dioxus Package Test App Binary
+        id: upload-archive
+        uses: ./.github/workflows/actions/upload-archive
+        with:
+          name: dioxus-package-app-${{ runner.os }}-${{ runner.arch == 'ARM64' && 'ARM64' || 'x64' }}
+          output: dioxus-package-app-${{ runner.os }}-${{ runner.arch == 'ARM64' && 'ARM64' || 'x64' }}/artifact.zip
+          paths: fixtures/package-tests/dioxus-app/src-dioxus/target
+          cache_key_prefix: dioxus-package-app
+          retention_days: '90'

--- a/fixtures/package-tests/dioxus-app/browser/index.html
+++ b/fixtures/package-tests/dioxus-app/browser/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>WDIO Dioxus Browser Mode</title>
+  </head>
+  <body>
+    <h1 id="app-title">WDIO Dioxus Browser Mode</h1>
+    <div id="status">ready</div>
+  </body>
+</html>

--- a/fixtures/package-tests/dioxus-app/package.json
+++ b/fixtures/package-tests/dioxus-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dioxus-app-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "cargo build --manifest-path src-dioxus/Cargo.toml",
+    "test": "wdio run wdio.conf.ts",
+    "test:browser": "wdio run wdio.browser.conf.ts"
+  },
+  "devDependencies": {
+    "@wdio/cli": "^9.27.0",
+    "@wdio/dioxus-service": "workspace:*",
+    "@wdio/globals": "^9.27.0",
+    "@wdio/local-runner": "^9.27.0",
+    "@wdio/mocha-framework": "^9.27.0",
+    "@wdio/native-types": "workspace:*",
+    "@wdio/spec-reporter": "^9.27.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/fixtures/package-tests/dioxus-app/src-dioxus/Cargo.toml
+++ b/fixtures/package-tests/dioxus-app/src-dioxus/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dioxus-package-test-app"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "dioxus-package-test-app"
+path = "src/main.rs"
+
+[dependencies]
+dioxus = { version = "0.7", features = ["desktop"] }
+wdio-dioxus-embedded-driver = { path = "../../../../packages/dioxus-embedded-driver" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/fixtures/package-tests/dioxus-app/src-dioxus/src/main.rs
+++ b/fixtures/package-tests/dioxus-app/src-dioxus/src/main.rs
@@ -1,0 +1,49 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use dioxus::prelude::*;
+use serde_json::json;
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("wdio_dioxus_bridge=debug".parse().unwrap())
+                .add_directive("wdio_dioxus_embedded_driver=debug".parse().unwrap()),
+        )
+        .init();
+
+    let mut config = dioxus::desktop::Config::new();
+
+    #[cfg(debug_assertions)]
+    {
+        config = wdio_dioxus_embedded_driver::install_with_commands(config, |registry| {
+            registry.register("get_platform_info", |_args| {
+                Ok(json!({
+                    "os": std::env::consts::OS,
+                    "arch": std::env::consts::ARCH,
+                }))
+            });
+            registry.register("generate_test_logs", |_args| {
+                tracing::error!("[WDIO:Backend] pkg-test-error-log");
+                tracing::warn!("[WDIO:Backend] pkg-test-warn-log");
+                tracing::info!("[WDIO:Backend] pkg-test-info-log");
+                Ok(json!(null))
+            });
+        });
+    }
+
+    dioxus::LaunchBuilder::desktop()
+        .with_cfg(config)
+        .launch(App);
+}
+
+#[component]
+fn App() -> Element {
+    rsx! {
+        head {
+            title { "WDIO Dioxus Package Test App" }
+        }
+        h1 { id: "app-title", "WDIO Dioxus Package Test App" }
+        div { id: "status", "ready" }
+    }
+}

--- a/fixtures/package-tests/dioxus-app/test-browser/browser.spec.ts
+++ b/fixtures/package-tests/dioxus-app/test-browser/browser.spec.ts
@@ -1,0 +1,13 @@
+import { browser, expect } from '@wdio/globals';
+
+describe('Dioxus browser-mode smoke (package install)', () => {
+  it('should load the page without error', async () => {
+    const title = await browser.getTitle();
+    expect(title).toBeDefined();
+  });
+
+  it('should have dioxus service available in browser mode', async () => {
+    expect(browser.dioxus).toBeDefined();
+    expect(typeof browser.dioxus.execute).toBe('function');
+  });
+});

--- a/fixtures/package-tests/dioxus-app/test/api.spec.ts
+++ b/fixtures/package-tests/dioxus-app/test/api.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from '@wdio/globals';
+import '@wdio/native-types';
+
+describe('Dioxus service package smoke', () => {
+  it('should have dioxus service available', async () => {
+    expect(browser.dioxus).toBeDefined();
+    expect(typeof browser.dioxus.execute).toBe('function');
+    expect(typeof browser.dioxus.mock).toBe('function');
+  });
+
+  it('should execute a bridge command', async () => {
+    const result = await browser.dioxus.execute(({ invoke }) => invoke('get_platform_info'));
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('os');
+    expect(result).toHaveProperty('arch');
+  });
+
+  it('should mock a bridge command', async () => {
+    const mock = await browser.dioxus.mock('get_platform_info');
+    await mock.mockResolvedValue({ os: 'mock-os', arch: 'mock-arch' });
+    const result = await browser.dioxus.execute(({ invoke }) => invoke('get_platform_info'));
+    expect(result).toEqual({ os: 'mock-os', arch: 'mock-arch' });
+    await browser.dioxus.restoreAllMocks();
+  });
+});

--- a/fixtures/package-tests/dioxus-app/test/api.spec.ts
+++ b/fixtures/package-tests/dioxus-app/test/api.spec.ts
@@ -2,6 +2,10 @@ import { expect } from '@wdio/globals';
 import '@wdio/native-types';
 
 describe('Dioxus service package smoke', () => {
+  afterEach(async () => {
+    await browser.dioxus.restoreAllMocks();
+  });
+
   it('should have dioxus service available', async () => {
     expect(browser.dioxus).toBeDefined();
     expect(typeof browser.dioxus.execute).toBe('function');
@@ -20,6 +24,5 @@ describe('Dioxus service package smoke', () => {
     await mock.mockResolvedValue({ os: 'mock-os', arch: 'mock-arch' });
     const result = await browser.dioxus.execute(({ invoke }) => invoke('get_platform_info'));
     expect(result).toEqual({ os: 'mock-os', arch: 'mock-arch' });
-    await browser.dioxus.restoreAllMocks();
   });
 });

--- a/fixtures/package-tests/dioxus-app/test/logging.spec.ts
+++ b/fixtures/package-tests/dioxus-app/test/logging.spec.ts
@@ -18,7 +18,11 @@ function readAllLogs(): string {
 describe('Dioxus log capture (package smoke)', () => {
   it('should capture frontend console logs', async () => {
     await browser.execute(() => console.info('[WDIO:Frontend] pkg-test-frontend-log'));
-    await browser.pause(200);
+    await browser.waitUntil(async () => readAllLogs().includes('pkg-test-frontend-log'), {
+      timeout: 5000,
+      timeoutMsg: 'frontend log not captured within 5s',
+    });
+    expect(readAllLogs()).toContain('pkg-test-frontend-log');
   });
 
   it('should capture backend logs via generate_test_logs', async () => {

--- a/fixtures/package-tests/dioxus-app/test/logging.spec.ts
+++ b/fixtures/package-tests/dioxus-app/test/logging.spec.ts
@@ -1,0 +1,32 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { browser, expect } from '@wdio/globals';
+import '@wdio/native-types';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const logsDir = join(__dirname, '..', 'logs');
+
+function readAllLogs(): string {
+  if (!existsSync(logsDir)) return '';
+  return readdirSync(logsDir)
+    .filter((f) => f.endsWith('.log'))
+    .map((f) => readFileSync(join(logsDir, f), 'utf-8'))
+    .join('\n');
+}
+
+describe('Dioxus log capture (package smoke)', () => {
+  it('should capture frontend console logs', async () => {
+    await browser.execute(() => console.info('[WDIO:Frontend] pkg-test-frontend-log'));
+    await browser.pause(200);
+  });
+
+  it('should capture backend logs via generate_test_logs', async () => {
+    await browser.dioxus.execute(({ invoke }) => invoke('generate_test_logs'));
+    await browser.waitUntil(async () => readAllLogs().includes('pkg-test-info-log'), {
+      timeout: 5000,
+      timeoutMsg: 'backend log not captured within 5s',
+    });
+    expect(readAllLogs()).toContain('pkg-test-info-log');
+  });
+});

--- a/fixtures/package-tests/dioxus-app/tsconfig.json
+++ b/fixtures/package-tests/dioxus-app/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": [
+      "node",
+      "@wdio/globals"
+    ]
+  },
+  "include": [
+    "test/**/*.ts",
+    "test-browser/**/*.ts",
+    "wdio.conf.ts",
+    "wdio.browser.conf.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src-dioxus"
+  ]
+}

--- a/fixtures/package-tests/dioxus-app/wdio.browser.conf.ts
+++ b/fixtures/package-tests/dioxus-app/wdio.browser.conf.ts
@@ -26,7 +26,7 @@ export const config: Options.Testrunner = {
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
-  autoXvfb: false,
+  autoXvfb: true,
   services: [['@wdio/dioxus-service', { driverProvider: 'embedded' }]],
   framework: 'mocha',
   reporters: ['spec'],

--- a/fixtures/package-tests/dioxus-app/wdio.browser.conf.ts
+++ b/fixtures/package-tests/dioxus-app/wdio.browser.conf.ts
@@ -1,0 +1,38 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Options } from '@wdio/types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const config: Options.Testrunner = {
+  runner: 'local',
+  specs: ['./test-browser/**/*.spec.ts'],
+  exclude: [],
+  maxInstances: 1,
+  capabilities: [
+    {
+      browserName: 'dioxus',
+      'wdio:dioxusServiceOptions': {
+        mode: 'browser',
+        devServerUrl: 'http://localhost:5173',
+      },
+    },
+  ] as unknown as Options.Testrunner['capabilities'],
+  logLevel: 'info',
+  outputDir: './logs',
+  bail: 0,
+  baseUrl: '',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 3,
+  autoXvfb: false,
+  services: [['@wdio/dioxus-service', { driverProvider: 'embedded' }]],
+  framework: 'mocha',
+  reporters: ['spec'],
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+  },
+  tsConfigPath: `${__dirname}/tsconfig.json`,
+};

--- a/fixtures/package-tests/dioxus-app/wdio.conf.ts
+++ b/fixtures/package-tests/dioxus-app/wdio.conf.ts
@@ -1,0 +1,80 @@
+import { existsSync } from 'node:fs';
+import path, { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const appPath = path.resolve(__dirname);
+const targetDir = join(appPath, 'src-dioxus', 'target', 'debug');
+const binaryName = process.platform === 'win32' ? 'dioxus-package-test-app.exe' : 'dioxus-package-test-app';
+const appBinaryPath = join(targetDir, binaryName);
+
+if (!existsSync(appBinaryPath)) {
+  throw new Error(
+    `Dioxus binary not found: ${appBinaryPath}. Run 'cargo build --manifest-path src-dioxus/Cargo.toml' first.`,
+  );
+}
+
+type DioxusCapability = {
+  browserName?: 'dioxus';
+  'wdio:enforceWebDriverClassic'?: boolean;
+  'dioxus:options': { application: string; args?: string[] };
+  'wdio:dioxusServiceOptions': {
+    appBinaryPath: string;
+    appArgs: string[];
+    driverProvider: 'embedded';
+    captureBackendLogs?: boolean;
+    captureFrontendLogs?: boolean;
+    backendLogLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
+    frontendLogLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
+  };
+};
+
+const capabilities: DioxusCapability[] = [
+  {
+    browserName: 'dioxus',
+    'wdio:enforceWebDriverClassic': true,
+    'dioxus:options': { application: appBinaryPath },
+    'wdio:dioxusServiceOptions': {
+      appBinaryPath,
+      appArgs: [],
+      driverProvider: 'embedded',
+      captureBackendLogs: true,
+      captureFrontendLogs: true,
+      backendLogLevel: 'debug',
+      frontendLogLevel: 'debug',
+    },
+  },
+];
+
+export const config = {
+  runner: 'local',
+  specs: ['./test/**/*.spec.ts'],
+  exclude: [],
+  maxInstances: 1,
+  capabilities,
+  logLevel: 'info',
+  bail: 0,
+  baseUrl: '',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 3,
+  autoXvfb: false,
+  outputDir: path.join(__dirname, 'logs'),
+  services: [
+    [
+      '@wdio/dioxus-service',
+      {
+        driverProvider: 'embedded',
+      },
+    ],
+  ],
+  framework: 'mocha',
+  reporters: ['spec'],
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 120000,
+  },
+  tsConfigPath: path.join(__dirname, 'tsconfig.json'),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,33 @@ importers:
         specifier: ^7.3.1
         version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  fixtures/package-tests/dioxus-app:
+    devDependencies:
+      '@wdio/cli':
+        specifier: ^9.27.0
+        version: 9.27.0(@types/node@25.6.0)(expect-webdriverio@5.6.5)(puppeteer-core@24.41.0)
+      '@wdio/dioxus-service':
+        specifier: workspace:*
+        version: link:../../../packages/dioxus-service
+      '@wdio/globals':
+        specifier: ^9.27.0
+        version: 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.41.0))
+      '@wdio/local-runner':
+        specifier: ^9.27.0
+        version: 9.27.0(@wdio/globals@9.27.0)(webdriverio@9.27.0(puppeteer-core@24.41.0))
+      '@wdio/mocha-framework':
+        specifier: ^9.27.0
+        version: 9.27.0
+      '@wdio/native-types':
+        specifier: workspace:*
+        version: link:../../../packages/native-types
+      '@wdio/spec-reporter':
+        specifier: ^9.27.0
+        version: 9.27.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   fixtures/package-tests/electron-builder-app-cjs:
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - fixtures/package-tests/electron-script-app-cjs
   - fixtures/package-tests/electron-script-app-esm
   - fixtures/package-tests/tauri-app
+  - fixtures/package-tests/dioxus-app
 allowBuilds:
   edgedriver: false
   electron: true

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 /**
- * Script to test the wdio-electron-service and wdio-tauri-service packages in the package test apps
- * Usage: pnpx tsx scripts/test-package.ts [--package=<package-name>] [--service=<electron|tauri|both>] [--module-type=<cjs|esm|both>] [--mode=<native|browser>] [--skip-build]
+ * Script to test the wdio-electron-service, wdio-tauri-service, and wdio-dioxus-service packages in the package test apps
+ * Usage: pnpx tsx scripts/test-package.ts [--package=<package-name>] [--service=<electron|tauri|dioxus|both>] [--module-type=<cjs|esm|both>] [--mode=<native|browser>] [--skip-build]
  *
  * Examples:
  * pnpx tsx scripts/test-package.ts
@@ -10,9 +10,11 @@
  * pnpx tsx scripts/test-package.ts --service=electron --module-type=esm
  * pnpx tsx scripts/test-package.ts --service=electron --mode=browser
  * pnpx tsx scripts/test-package.ts --service=tauri
+ * pnpx tsx scripts/test-package.ts --service=dioxus
  * pnpx tsx scripts/test-package.ts --package=electron-builder-app-cjs
  * pnpx tsx scripts/test-package.ts --package=electron-builder-app-esm
  * pnpx tsx scripts/test-package.ts --package=tauri-app --skip-build
+ * pnpx tsx scripts/test-package.ts --package=dioxus-app --skip-build
  */
 
 import { execSync } from 'node:child_process';
@@ -49,7 +51,7 @@ const rootDir = normalize(join(__dirname, '..'));
 interface TestOptions {
   package?: string;
   skipBuild?: boolean;
-  service?: 'electron' | 'tauri' | 'both';
+  service?: 'electron' | 'tauri' | 'dioxus' | 'both';
   moduleType?: 'cjs' | 'esm' | 'both';
   /** 'native' runs the existing app-launch tests. 'browser' starts a static
    * HTTP server against the fixture's `browser/` directory and runs the
@@ -85,9 +87,10 @@ function execCommand(command: string, cwd: string, description: string) {
   }
 }
 
-async function buildAndPackService(service: 'electron' | 'tauri' | 'both' = 'both'): Promise<{
+async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'both' = 'both'): Promise<{
   electronServicePath?: string;
   tauriServicePath?: string;
+  dioxusServicePath?: string;
   utilsPath: string;
   spyPath: string;
   corePath: string;
@@ -100,9 +103,10 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'both' = 'bot
     // Build only the packages required for the requested service. Each
     // service depends on @wdio/native-core (extracted in the Dioxus
     // foundation work), so include it in every filter set.
-    const buildFilters: Record<'electron' | 'tauri' | 'both', string> = {
+    const buildFilters: Record<'electron' | 'tauri' | 'dioxus' | 'both', string> = {
       electron: '--filter=@wdio/electron-service --filter=@wdio/native-spy --filter=@wdio/native-core',
       tauri: '--filter=@wdio/tauri-service --filter=@wdio/native-core',
+      dioxus: '--filter=@wdio/dioxus-service --filter=@wdio/native-core',
       both: '--filter=./packages/*',
     };
     execCommand(`pnpm turbo run build ${buildFilters[service]}`, rootDir, `Building packages for ${service}`);
@@ -145,6 +149,7 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'both' = 'bot
     const result: {
       electronServicePath?: string;
       tauriServicePath?: string;
+      dioxusServicePath?: string;
       utilsPath: string;
       spyPath: string;
       corePath: string;
@@ -190,6 +195,19 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'both' = 'bot
       result.tauriServicePath = findTgzFile(tauriServiceDir, 'wdio-tauri-service-');
     }
 
+    // Pack Dioxus service if needed
+    if (service === 'dioxus' || service === 'both') {
+      const dioxusServiceDir = normalize(join(rootDir, 'packages', 'dioxus-service'));
+      if (!existsSync(dioxusServiceDir)) {
+        throw new Error(`Dioxus service directory does not exist: ${dioxusServiceDir}`);
+      }
+      const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
+      execCommand('pnpm pack', typesDir, 'Packing @wdio/native-types');
+      execCommand('pnpm pack', dioxusServiceDir, 'Packing @wdio/dioxus-service');
+      result.dioxusServicePath = findTgzFile(dioxusServiceDir, 'wdio-dioxus-service-');
+      result.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
+    }
+
     log(`📦 Packages packed:`);
     log(`   Utils: ${utilsPath}`);
     log(`   Spy: ${spyPath}`);
@@ -201,6 +219,12 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'both' = 'bot
     }
     if (result.tauriServicePath) {
       log(`   Tauri Service: ${result.tauriServicePath}`);
+      if (result.typesPath) {
+        log(`   Types: ${result.typesPath}`);
+      }
+    }
+    if (result.dioxusServicePath) {
+      log(`   Dioxus Service: ${result.dioxusServicePath}`);
       if (result.typesPath) {
         log(`   Types: ${result.typesPath}`);
       }
@@ -274,13 +298,14 @@ async function testExample(
   packages: {
     electronServicePath?: string;
     tauriServicePath?: string;
+    dioxusServicePath?: string;
     utilsPath: string;
     spyPath: string;
     corePath: string;
     typesPath?: string;
     cdpBridgePath?: string;
   },
-  service: 'electron' | 'tauri',
+  service: 'electron' | 'tauri' | 'dioxus',
   _skipBuild: boolean,
   mode: 'native' | 'browser' = 'native',
 ) {
@@ -364,6 +389,13 @@ async function testExample(
       overrides['@wdio/tauri-service'] = `file:${packages.tauriServicePath}`;
       overrides['@wdio/native-types'] = `file:${packages.typesPath}`;
       packagesToInstall.push(packages.typesPath, packages.tauriServicePath);
+    } else if (service === 'dioxus') {
+      if (!packages.dioxusServicePath || !packages.typesPath) {
+        throw new Error('Dioxus service packages not available');
+      }
+      overrides['@wdio/dioxus-service'] = `file:${packages.dioxusServicePath}`;
+      overrides['@wdio/native-types'] = `file:${packages.typesPath}`;
+      packagesToInstall.push(packages.typesPath, packages.dioxusServicePath);
     }
 
     packageJson.pnpm = {
@@ -429,6 +461,36 @@ async function testExample(
             }
           } else {
             log(`⚠️  Plugin source not found at ${pluginSourceDir}`);
+          }
+        }
+      }
+    }
+
+    // For Dioxus apps, copy the embedded driver as a Rust path dependency
+    if (service === 'dioxus') {
+      const embeddedDriverSourceDir = join(rootDir, 'packages', 'dioxus-embedded-driver');
+      const embeddedDriverDestDir = join(tempDir, 'packages', 'dioxus-embedded-driver');
+      const cargoTomlPath = join(packageDir, 'src-dioxus', 'Cargo.toml');
+
+      if (existsSync(cargoTomlPath)) {
+        let cargoToml = readFileSync(cargoTomlPath, 'utf-8');
+        if (cargoToml.includes('wdio-dioxus-embedded-driver') && cargoToml.includes('path =')) {
+          if (existsSync(embeddedDriverSourceDir)) {
+            log(`Copying embedded driver source for Rust dependency resolution...`);
+            mkdirSync(dirname(embeddedDriverDestDir), { recursive: true });
+            cpSync(embeddedDriverSourceDir, embeddedDriverDestDir, { recursive: true });
+            log(`✅ Embedded driver source copied to ${embeddedDriverDestDir}`);
+
+            const oldPathPattern =
+              /(wdio-dioxus-embedded-driver\s*=\s*\{\s*path\s*=\s*)"\.\.\/\.\.\/\.\.\/\.\.\/packages\/dioxus-embedded-driver"(\s*[,}])/;
+            if (oldPathPattern.test(cargoToml)) {
+              const absoluteDriverPath = normalize(embeddedDriverDestDir);
+              cargoToml = cargoToml.replace(oldPathPattern, `$1"${absoluteDriverPath}"$2`);
+              writeFileSync(cargoTomlPath, cargoToml);
+              log(`✅ Updated Cargo.toml path dependency to: ${absoluteDriverPath}`);
+            }
+          } else {
+            log(`⚠️  Embedded driver source not found at ${embeddedDriverSourceDir}`);
           }
         }
       }
@@ -568,7 +630,7 @@ async function testExample(
         }
       }
     } else if (packageJson.scripts?.build && mode === 'native') {
-      // Build Electron apps in isolated environment (browser mode skips the build)
+      // Build Electron and Dioxus apps in isolated environment (browser mode skips the build)
       execCommand('pnpm build', packageDir, `Building ${packageName} app`);
     }
 
@@ -686,12 +748,12 @@ async function main() {
     const serviceArg = args.find((arg) => arg.startsWith('--service='))?.split('=')[1];
 
     // Validate service argument if provided, default to 'both' if not provided
-    let service: 'electron' | 'tauri' | 'both' = 'both';
+    let service: 'electron' | 'tauri' | 'dioxus' | 'both' = 'both';
     if (serviceArg) {
-      if (serviceArg === 'electron' || serviceArg === 'tauri' || serviceArg === 'both') {
+      if (serviceArg === 'electron' || serviceArg === 'tauri' || serviceArg === 'dioxus' || serviceArg === 'both') {
         service = serviceArg;
       } else {
-        throw new Error(`Invalid service value: ${serviceArg}. Must be 'electron', 'tauri', or 'both'`);
+        throw new Error(`Invalid service value: ${serviceArg}. Must be 'electron', 'tauri', 'dioxus', or 'both'`);
       }
     }
 
@@ -727,6 +789,7 @@ async function main() {
     let packages: {
       electronServicePath?: string;
       tauriServicePath?: string;
+      dioxusServicePath?: string;
       utilsPath: string;
       spyPath: string;
       corePath: string;
@@ -769,6 +832,13 @@ async function main() {
         packages.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
       }
 
+      if (options.service === 'dioxus' || options.service === 'both') {
+        const dioxusServiceDir = normalize(join(rootDir, 'packages', 'dioxus-service'));
+        const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
+        packages.dioxusServicePath = findTgzFile(dioxusServiceDir, 'wdio-dioxus-service-');
+        packages.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
+      }
+
       log(`📦 Using existing packages:`);
       log(`   Utils: ${packages.utilsPath}`);
       log(`   Spy: ${packages.spyPath}`);
@@ -780,6 +850,9 @@ async function main() {
       }
       if (packages.tauriServicePath) {
         log(`   Tauri Service: ${packages.tauriServicePath}`);
+      }
+      if (packages.dioxusServicePath) {
+        log(`   Dioxus Service: ${packages.dioxusServicePath}`);
       }
     } else {
       packages = await buildAndPackService(options.service);
@@ -796,12 +869,14 @@ async function main() {
       .map((dirent) => dirent.name)
       .filter((name) => !name.startsWith('.'));
 
-    // Filter packages by service type (electron-* vs tauri-*)
+    // Filter packages by service type (electron-* vs tauri-* vs dioxus-*)
     let filteredDirs = packageTestDirs;
     if (options.service === 'electron') {
       filteredDirs = packageTestDirs.filter((name) => name.startsWith('electron-'));
     } else if (options.service === 'tauri') {
       filteredDirs = packageTestDirs.filter((name) => name.startsWith('tauri-'));
+    } else if (options.service === 'dioxus') {
+      filteredDirs = packageTestDirs.filter((name) => name.startsWith('dioxus-'));
     }
     // If service is 'both', don't filter
 
@@ -876,7 +951,11 @@ async function main() {
       }
 
       // Detect service type from package name (already filtered by prefix, but needed for testExample)
-      const detectedService: 'electron' | 'tauri' = packageName.startsWith('tauri-') ? 'tauri' : 'electron';
+      const detectedService: 'electron' | 'tauri' | 'dioxus' = packageName.startsWith('tauri-')
+        ? 'tauri'
+        : packageName.startsWith('dioxus-')
+          ? 'dioxus'
+          : 'electron';
 
       // Log module type for Electron packages
       if (detectedService === 'electron') {

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -205,10 +205,12 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
       if (!existsSync(typesDir)) {
         throw new Error(`Types directory does not exist: ${typesDir}`);
       }
-      execCommand('pnpm pack', typesDir, 'Packing @wdio/native-types');
+      if (!result.typesPath) {
+        execCommand('pnpm pack', typesDir, 'Packing @wdio/native-types');
+        result.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
+      }
       execCommand('pnpm pack', dioxusServiceDir, 'Packing @wdio/dioxus-service');
       result.dioxusServicePath = findTgzFile(dioxusServiceDir, 'wdio-dioxus-service-');
-      result.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
     }
 
     log(`📦 Packages packed:`);
@@ -491,6 +493,10 @@ async function testExample(
               cargoToml = cargoToml.replace(oldPathPattern, `$1"${absoluteDriverPath}"$2`);
               writeFileSync(cargoTomlPath, cargoToml);
               log(`✅ Updated Cargo.toml path dependency to: ${absoluteDriverPath}`);
+            } else {
+              log(
+                `⚠️  Could not rewrite wdio-dioxus-embedded-driver path dep — pattern did not match. Cargo build may fail if the relative path is unreachable from the isolated environment.`,
+              );
             }
           } else {
             log(`⚠️  Embedded driver source not found at ${embeddedDriverSourceDir}`);

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -459,7 +459,7 @@ async function testExample(
               /(tauri-plugin-wdio\s*=\s*\{\s*path\s*=\s*)"\.\.\/\.\.\/\.\.\/\.\.\/packages\/tauri-plugin"(\s*\})/;
             if (oldPathPattern.test(cargoToml)) {
               // Use absolute path to ensure Cargo can find it
-              const absolutePluginPath = normalize(pluginDestDir);
+              const absolutePluginPath = normalize(pluginDestDir).replace(/\\/g, '/');
               cargoToml = cargoToml.replace(oldPathPattern, `$1"${absolutePluginPath}"$2`);
               writeFileSync(cargoTomlPath, cargoToml);
               log(`✅ Updated Cargo.toml path dependency to absolute path: ${absolutePluginPath}`);
@@ -489,7 +489,7 @@ async function testExample(
             const oldPathPattern =
               /(wdio-dioxus-embedded-driver\s*=\s*\{\s*path\s*=\s*)"\.\.\/\.\.\/\.\.\/\.\.\/packages\/dioxus-embedded-driver"(\s*[,}])/;
             if (oldPathPattern.test(cargoToml)) {
-              const absoluteDriverPath = normalize(embeddedDriverDestDir);
+              const absoluteDriverPath = normalize(embeddedDriverDestDir).replace(/\\/g, '/');
               cargoToml = cargoToml.replace(oldPathPattern, `$1"${absoluteDriverPath}"$2`);
               writeFileSync(cargoTomlPath, cargoToml);
               log(`✅ Updated Cargo.toml path dependency to: ${absoluteDriverPath}`);

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -202,6 +202,9 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
         throw new Error(`Dioxus service directory does not exist: ${dioxusServiceDir}`);
       }
       const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
+      if (!existsSync(typesDir)) {
+        throw new Error(`Types directory does not exist: ${typesDir}`);
+      }
       execCommand('pnpm pack', typesDir, 'Packing @wdio/native-types');
       execCommand('pnpm pack', dioxusServiceDir, 'Packing @wdio/dioxus-service');
       result.dioxusServicePath = findTgzFile(dioxusServiceDir, 'wdio-dioxus-service-');

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -486,6 +486,18 @@ async function testExample(
             cpSync(embeddedDriverSourceDir, embeddedDriverDestDir, { recursive: true });
             log(`✅ Embedded driver source copied to ${embeddedDriverDestDir}`);
 
+            // wdio-dioxus-embedded-driver has a path dep on wdio-dioxus-bridge
+            // (path = "../dioxus-bridge"). Copy the bridge alongside the driver so
+            // Cargo can resolve it from the isolated tempDir.
+            const bridgeSourceDir = join(rootDir, 'packages', 'dioxus-bridge');
+            const bridgeDestDir = join(tempDir, 'packages', 'dioxus-bridge');
+            if (existsSync(bridgeSourceDir)) {
+              cpSync(bridgeSourceDir, bridgeDestDir, { recursive: true });
+              log(`✅ Bridge source copied to ${bridgeDestDir}`);
+            } else {
+              log(`⚠️  Bridge source not found at ${bridgeSourceDir}`);
+            }
+
             const oldPathPattern =
               /(wdio-dioxus-embedded-driver\s*=\s*\{\s*path\s*=\s*)"\.\.\/\.\.\/\.\.\/\.\.\/packages\/dioxus-embedded-driver"(\s*[,}])/;
             if (oldPathPattern.test(cargoToml)) {


### PR DESCRIPTION
## Summary

- Adds `fixtures/package-tests/dioxus-app/` — a self-contained package test fixture mirroring `fixtures/package-tests/tauri-app/`
- Extends `scripts/test-package.ts` with full `--service=dioxus` support
- Adds `.github/workflows/_ci-build-dioxus-package-app.reusable.yml` (mirrors the Tauri equivalent)
- Registers `fixtures/package-tests/dioxus-app` in `pnpm-workspace.yaml`

### Fixture contents (`fixtures/package-tests/dioxus-app/`)

- `src-dioxus/` — minimal Dioxus app with `get_platform_info` + `generate_test_logs` commands, `wdio-dioxus-embedded-driver` wired via `install_with_commands`
- `wdio.conf.ts` — native mode, embedded provider (works on all platforms)
- `wdio.browser.conf.ts` — browser mode, static dev server
- `test/api.spec.ts` — launch, `browser.dioxus.execute`, one `mock()` call, `restoreAllMocks`
- `test/logging.spec.ts` — backend + frontend log capture via `waitUntil` + file read
- `test-browser/browser.spec.ts` — browser-mode smoke (service loads, execute available)
- `browser/index.html` — minimal static page for browser mode

### `scripts/test-package.ts` changes

- `service` union: `'electron' | 'tauri' | 'dioxus' | 'both'`
- Packs `@wdio/dioxus-service` tarball; overrides the workspace dep in the isolated copy
- Copies `packages/dioxus-embedded-driver` to temp dir and rewrites the Cargo.toml path dep (same pattern as the tauri-plugin copy)
- `dioxus-*` prefix filtering; tri-value service detection from package name

### CI workflow

Mirrors `_ci-build-tauri-package-app.reusable.yml` without the ACL manifest debug step. Uploads `src-dioxus/target` as a build artifact for use in the package test jobs.

## Test plan

- [ ] `pnpx tsx scripts/test-package.ts --service=dioxus --skip-build` after a manual `cargo build` in the fixture — confirm the three specs pass
- [ ] `pnpx tsx scripts/test-package.ts --service=dioxus` — builds, packs, copies embedded driver, runs tests
- [ ] `pnpx tsx scripts/test-package.ts --service=tauri` — no regression
- [ ] `pnpx tsx scripts/test-package.ts --service=electron` — no regression

🤖 Generated with [Claude Code](https://claude.ai/claude-code)