### PR TITLE
docs(dioxus): Phase 9 — full documentation set for @wdio/dioxus-service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 **Supported Frameworks:**
 - **Electron** - `@wdio/electron-service` (v10.x)
 - **Tauri** - `@wdio/tauri-service` (v1.x)
+- **Dioxus** - `@wdio/dioxus-service` (v1.x)
 
-**Planned:** Dioxus, React Native, Flutter, Capacitor, Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
+**Planned:** React Native, Flutter, Capacitor, Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
 
 ## Tech Stack
 
@@ -28,14 +29,18 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 
 ```
 packages/
-├── electron-service/     # Electron WDIO service
-├── tauri-service/        # Tauri WDIO service
-├── tauri-plugin/         # Tauri v2 plugin (Rust + JS)
-├── electron-cdp-bridge/  # Chrome DevTools Protocol bridge
-├── native-utils/         # Cross-platform utilities
-├── native-types/         # TypeScript type definitions
-├── native-spy/           # Spy utilities for mocking
-└── bundler/              # Build tool for packages
+├── electron-service/       # Electron WDIO service
+├── tauri-service/          # Tauri WDIO service
+├── dioxus-service/         # Dioxus WDIO service
+├── tauri-plugin/           # Tauri v2 plugin (Rust + JS)
+├── dioxus-bridge/          # Dioxus bridge crate (Rust) — IPC, mocking, log forwarding
+├── dioxus-embedded-driver/ # Dioxus in-process WebDriver server (Rust)
+├── dioxus-driver/          # Dioxus external WebDriver proxy (Rust, Windows 'external' provider)
+├── electron-cdp-bridge/    # Chrome DevTools Protocol bridge
+├── native-utils/           # Cross-platform utilities
+├── native-types/           # TypeScript type definitions
+├── native-spy/             # Spy utilities for mocking
+└── bundler/                # Build tool for packages
 
 fixtures/
 ├── e2e-apps/             # E2E test applications

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ Please be respectful and constructive in all interactions. We aim to create a we
 - pnpm 10.27.0
 - Git
 
+For Tauri and Dioxus contributions, you also need:
+
+- Rust (stable toolchain via `rustup`)
+
 ### Setup
 
 1. Fork the repository
@@ -104,6 +108,7 @@ Scope by **framework**, not package name. Most changes that touch a service, its
 # Framework-scoped (changes within one framework's ecosystem)
 git commit -m "feat(tauri): complete mocking"
 git commit -m "fix(electron): windows multiremote"
+git commit -m "fix(dioxus): embedded port conflict on linux"
 
 # No scope (cross-cutting or shared changes)
 git commit -m "refactor: extract shared diagnostics to native-utils"
@@ -281,9 +286,37 @@ When contributing to the Tauri service:
 - Ensure plugin communication works correctly
 - Test with various Tauri configuration patterns
 
-### Future Services
+### Dioxus Service
 
-When new services are added, contribution guidelines will be updated as necessary.
+When contributing to the Dioxus service or its Rust crates (`wdio-dioxus-bridge`, `wdio-dioxus-embedded-driver`, `wdio-dioxus-driver`):
+
+- Maintain backward compatibility with the `install(config)` bridge API
+- Test on Windows, macOS, and Linux (for the `'embedded'` provider)
+- Always build the Dioxus fixture app in **debug mode** — the bridge is compiled behind `#[cfg(debug_assertions)]` and will not be present in release builds
+- Build the fixture app before running E2E tests:
+  ```bash
+  cd fixtures/e2e-apps/dioxus
+  cargo build
+  ```
+- Run the Dioxus unit and integration tests:
+  ```bash
+  pnpm --filter @wdio/dioxus-service test:unit
+  pnpm --filter @wdio/dioxus-service test:integration
+  ```
+- Run the Dioxus E2E tests (requires a built fixture app):
+  ```bash
+  cd e2e
+  pnpm wdio run wdio.dioxus-embedded.conf.ts
+  ```
+- On Linux, a display server is required. Wrap E2E runs with Xvfb:
+  ```bash
+  export DISPLAY=:99
+  Xvfb :99 -screen 0 1280x800x24 &
+  pnpm wdio run wdio.dioxus-embedded.conf.ts
+  ```
+- The `'external'` provider is Windows-only in v1. Linux support is deferred to v1.1. Do not attempt to test the `'external'` provider on Linux or macOS.
+- When changing the bridge crate, also update `packages/dioxus-bridge/docs/release-notes/` as appropriate
+- See [bridge setup docs](packages/dioxus-service/docs/plugin-setup.md) for how the bridge integrates with a Dioxus application
 
 ### Shared Utilities
 
@@ -305,7 +338,7 @@ Releases are automated via GitHub Actions and triggered by PR labels.
 
 When your PR is merged to `main`, the release workflow checks for release labels:
 
-1. Add a scope label to your PR: `scope:electron`, `scope:tauri`, or `scope:shared`
+1. Add a scope label to your PR: `scope:electron`, `scope:tauri`, `scope:dioxus`, or `scope:shared`
 2. Add a version label: `bump:patch`, `bump:minor`, `bump:major`, or prerelease variants
 3. After CI passes and the PR is merged, the release workflow automatically publishes packages
 
@@ -314,6 +347,7 @@ When your PR is merged to `main`, the release workflow checks for release labels
 **Examples:**
 - `scope:electron` + `bump:major` → Electron packages at major bump
 - `scope:tauri` + `bump:minor` → Tauri packages at minor bump
+- `scope:dioxus` + `bump:patch` → Dioxus packages at patch bump
 - `scope:shared` + `bump:patch` → Shared packages at patch bump
 
 ### Manual Release
@@ -331,6 +365,7 @@ For releases without PR labels or for dry runs:
 |-------|--------|
 | `scope:electron` | Release Electron packages |
 | `scope:tauri` | Release Tauri packages |
+| `scope:dioxus` | Release Dioxus packages |
 | `scope:shared` | Release shared packages |
 | `bump:patch` | Patch bump |
 | `bump:minor` | Minor bump |
@@ -342,6 +377,7 @@ For releases without PR labels or for dry runs:
 
 For testing changes before a stable release, use the `release:prerelease` label combined with a bump label:
 - `scope:electron` + `bump:major` + `release:prerelease` → Electron packages as major prerelease (e.g., 11.0.0-next.0)
+- `scope:dioxus` + `bump:minor` + `release:prerelease` → Dioxus packages as minor prerelease (e.g., 1.1.0-next.0)
 - `scope:shared` + `bump:patch` + `release:prerelease` → Shared packages as patch prerelease (e.g., 2.0.0-next.0)
 
 ### Release Notes Policy
@@ -352,8 +388,9 @@ GitHub release notes are published per **user-installed** package — not per in
 |-----------|-----------------------------|-------------------------|
 | Electron  | `@wdio/electron-service` | `@wdio/electron-cdp-bridge`, `@wdio/native-utils`, `@wdio/native-spy`, `@wdio/native-types` |
 | Tauri     | `@wdio/tauri-service`, `tauri-plugin`, `tauri-plugin-webdriver` | — |
+| Dioxus    | `@wdio/dioxus-service` | `wdio-dioxus-bridge`, `wdio-dioxus-embedded-driver`, `wdio-dioxus-driver` |
 
-Tauri publishes three sets of release notes because `tauri-plugin` and `tauri-plugin-webdriver` are installed and configured directly by users in their Tauri app (Cargo dependency, capability/permission setup), so their breaking changes need their own changelog entries. Electron's internal packages have no equivalent direct-install surface.
+Tauri publishes three sets of release notes because `tauri-plugin` and `tauri-plugin-webdriver` are installed and configured directly by users in their Tauri app (Cargo dependency, capability/permission setup), so their breaking changes need their own changelog entries. Electron's and Dioxus's internal packages have no equivalent direct-install surface — users only wire in the bridge crate once and changes are transparent thereafter.
 
 ## Getting Help
 
@@ -370,5 +407,3 @@ Contributors will be:
 - Recognized in release notes
 
 Thank you for contributing! 🎉
-
-

--- a/README.md
+++ b/README.md
@@ -51,9 +51,18 @@
 
 [`@wdio/tauri-service`](./packages/tauri-service) - Tauri applications (Windows / macOS / Linux)
 
+<h4>
+  <div>
+    <a href="https://www.npmjs.com/package/@wdio/dioxus-service"><img src="https://img.shields.io/badge/@wdio-dioxus--service-8B5CF6?labelColor=1a1a1a&style=plastic" alt="npm package" /></a>
+    <a href="https://www.npmjs.com/package/@wdio/dioxus-service"><img src="https://img.shields.io/npm/v/@wdio/dioxus-service" alt="npm version" /></a>
+    <a href="https://www.npmjs.com/package/@wdio/dioxus-service"><img src="https://img.shields.io/npm/dw/@wdio/dioxus-service" alt="npm downloads" /></a>
+  </div>
+</h4>
+
+[`@wdio/dioxus-service`](./packages/dioxus-service) - Dioxus desktop applications (Windows / macOS / Linux)
+
 ## Planned Support
 
-- **Dioxus** - Modern cross-platform UI framework
 - **React Native** - Popular mobile and desktop framework
 - **Flutter** - Google's UI toolkit for mobile and beyond
 - **Capacitor** - Ionic's cross-platform mobile framework
@@ -64,10 +73,10 @@ See [ROADMAP.md](./ROADMAP.md) for detailed sequencing, os support, and timeline
 
 ## Features
 
-- 🎯 **Framework-specific automation** - Native integration with Electron, Tauri
+- 🎯 **Framework-specific automation** - Native integration with Electron, Tauri, Dioxus
 - 🔍 **Smart binary detection** - Automatic app discovery and configuration
 - 🎭 **API mocking & isolation** - Built-in mocking for deterministic tests
-- 🌍 **Browser-only test mode** - Run the renderer in Chrome against a dev server, no binary required. See the [Electron](./packages/electron-service/docs/browser-mode.md) and [Tauri](./packages/tauri-service/docs/browser-mode.md) guides.
+- 🌍 **Browser-only test mode** - Run the renderer in Chrome against a dev server, no binary required. See the [Electron](./packages/electron-service/docs/browser-mode.md), [Tauri](./packages/tauri-service/docs/browser-mode.md), and [Dioxus](./packages/dioxus-service/docs/browser-mode.md) guides.
 - 🌐 **Cross-platform support** - Write once, test everywhere
 - 🔧 **Consistent API** - Familiar WDIO patterns across all frameworks
 
@@ -78,12 +87,16 @@ desktop-mobile/
 ├── packages/                    # Service packages
 │   ├── electron-service/        # Electron service implementation
 │   ├── tauri-service/           # Tauri service implementation
+│   ├── dioxus-service/          # Dioxus service implementation
 │   ├── electron-cdp-bridge/     # Chrome DevTools Protocol bridge
 │   ├── native-utils/            # Cross-platform utilities
 │   ├── native-types/            # TypeScript type definitions
 │   ├── native-spy/              # Spy utilities for mocking
 │   ├── bundler/                 # Build tool for packaging
-│   └── tauri-plugin/            # Tauri plugin for backend access
+│   ├── tauri-plugin/            # Tauri plugin for backend access
+│   ├── dioxus-bridge/           # Dioxus bridge crate (Rust)
+│   ├── dioxus-embedded-driver/  # Dioxus embedded WebDriver server (Rust)
+│   └── dioxus-driver/           # Dioxus external WebDriver proxy (Rust, Windows)
 ├── fixtures/                   # Test fixtures and example apps
 │   ├── e2e-apps/               # E2E test applications
 │   ├── package-tests/          # Package integration tests
@@ -91,7 +104,8 @@ desktop-mobile/
 ├── e2e/                        # End-to-end test suites
 │   ├── test/                   # Test specifications
 │   │   ├── electron/           # Electron E2E tests
-│   │   └── tauri/              # Tauri E2E tests
+│   │   ├── tauri/              # Tauri E2E tests
+│   │   └── dioxus/             # Dioxus E2E tests
 │   └── scripts/                # Test execution scripts
 ├── docs/                       # Documentation
 └── scripts/                    # Build and utility scripts

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,11 @@ This document outlines the planned services and their development sequencing for
 **Platforms:** Windows, macOS, Linux\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/tauri-service)](https://npmjs.com/package/@wdio/tauri-service)
 
+### [@wdio/dioxus-service](./packages/dioxus-service) - v1.x
+**Status:** 🚧 Pre-release\
+**Platforms:** Windows, macOS, Linux (`'embedded'` provider); Windows only for `'external'` in v1\
+[![npm downloads](https://img.shields.io/npm/dm/@wdio/dioxus-service)](https://npmjs.com/package/@wdio/dioxus-service)
+
 ---
 
 ## Cross-cutting Capabilities
@@ -22,7 +27,7 @@ The roadmap above is scoped to *new framework support*. Capability-level feature
 
 | Capability | Status | Notes |
 |---|---|---|
-| **Visual regression testing** | ✅ Available via [`@wdio/visual-service`](https://webdriver.io/docs/visual-testing/) | See [docs/visual-testing.md](./docs/visual-testing.md) for the wiring + Tauri provider notes. |
+| **Visual regression testing** | ✅ Available via [`@wdio/visual-service`](https://webdriver.io/docs/visual-testing/) | See [docs/visual-testing.md](./docs/visual-testing.md) for the wiring + provider notes. |
 | **Video recording** | 🔍 Not yet planned | Treated as a separate track. Universally a debugging artefact rather than a regression signal in the test-frameworks we surveyed. |
 
 ---
@@ -35,10 +40,10 @@ The table below quantifies the key factors used to prioritise and sequence plann
 |---|---|---|---|---|---|---|---|
 | **Electron** *(existing)* | Desktop | ~120k | Chrome DevTools Protocol (CDP) | ✅ Proven | — | Chromium, Node.js | — |
 | **Tauri** *(existing)* | Desktop | ~100k | tauri-driver + CDP | ✅ Proven | — | Wry, Rust toolchain | — |
+| **Dioxus** *(existing)* | Desktop | ~34k | Wry webview → CDP (shared with Tauri) | ✅ Implemented | High — same Wry/CDP patterns as Tauri service | Wry maturity, Dioxus desktop stability | Low–Medium |
 | **React Native** | Mobile | ~121k | Appium (XCUITest / UiAutomator2) | ✅ Proven | Establishes mobile scaffold | Appium server stability, XCUITest / UiAutomator2 | Medium |
 | **Flutter** | Mobile | ~175k | Appium Flutter Driver | ✅ Production-ready | Reuses React Native mobile scaffold | Appium Flutter Driver maintenance, Dart VM | Medium |
 | **Ionic / Capacitor** | Mobile | ~52k / ~15k | Appium WebView context switching | ✅ Proven | Reuses mobile scaffold; pure WebView — zero new complexity | Appium server, native WebView availability | Low |
-| **Dioxus** | Desktop | ~34k | Wry webview → CDP (shared with Tauri) | 🟡 Emerging | High — same Wry/CDP patterns as Tauri service | Wry maturity, Dioxus desktop stability | Low–Medium |
 | **Electrobun** | Desktop | ~11.7k | Native CDP (port 9222 by convention) | 🟡 Emerging | Medium — CDP attach patterns from Electron service; no driver process | Bun runtime, system webviews, OOPIF (per-tab) target routing | Medium |
 | **Neutralino** | Desktop | ~7.9k | System webview → CDP (devtools endpoint) | 🟡 Emerging | Medium — similar endpoint detection to Electron service | System webview (WebView2 / WebKitGTK) | Low |
 | **Dioxus Mobile** | Mobile | *(same repo)* | Cargo Mobile 2 — experimental | 🔴 Early-stage | Reuses mobile scaffold + Dioxus desktop learnings | Cargo Mobile 2 maturity, platform bridge stability | High |
@@ -47,23 +52,6 @@ The table below quantifies the key factors used to prioritise and sequence plann
 ---
 
 ## Planned Services
-
-### Phase 1: Dioxus Desktop (Q2 2026)
-**Priority:** High - Emerging Rust ecosystem integration
-
-**Target Platforms:** Windows, macOS, Linux
-
-**Why Dioxus first:**
-- Modern Rust-based framework gaining traction
-- Similar architecture to Tauri (leverage existing patterns)
-- Desktop-first approach aligns with current offerings
-- Growing community interest
-
-**Technical approach:**
-- Wry webview automation (WebView2/WKWebView/WebKitGTK)
-- DevTools protocol via CDP sessions (standard Chromedriver)
-- Standard WDIO parallelization
-- Reuses Tauri service launch detection patterns
 
 ### Phase 2: React Native Mobile (Q3 2026)
 **Priority:** High - Mobile testing expansion

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,32 +9,37 @@ This document describes the architecture of the WebdriverIO Desktop & Mobile mon
 |                        WebdriverIO Test Runner                      |
 +---------------------------------------------------------------------+
                                  |
-                     +-----------+-----------+
-                     |                       |
-                     v                       v
-+-----------------------------+   +-----------------------------+
-|   @wdio/electron-service    |   |   @wdio/tauri-service       |
-|   (Electron Testing)        |   |   (Tauri Testing)           |
-+-----------------------------+   +-----------------------------+
-              |                              |
-              v                              v
-+-----------------------------+   +-----------------------------+
-|  @wdio/electron-cdp-bridge  |   |   @wdio/tauri-plugin        |
-|  (Chrome DevTools)          |   |   (Execute, Mock, Logs)     |
-+-----------------------------+   +-----------------------------+
-              |                              |
-              v                    +---------+---------+
-+-----------------------------+    |         |         |
-|      Chromedriver           |    v         v         v
-|      (WebDriver)            |  Embedded  Official  CrabNebula
-+-----------------------------+  (in-app)  (tauri-   (paid)
-              |                   server)   driver)
-              v                    |         |         |
-+-----------------------------+    +---------+---------+
-|   Electron Application      |              v
-+-----------------------------+   +-----------------------------+
-                                  |   Tauri Application         |
-                                  +-----------------------------+
+          +-----------+----------+-----------+
+          |           |                      |
+          v           v                      v
++------------------+ +------------------+ +------------------+
+| @wdio/electron-  | | @wdio/tauri-     | | @wdio/dioxus-    |
+| service          | | service          | | service          |
+| (Electron Tests) | | (Tauri Tests)    | | (Dioxus Tests)   |
++------------------+ +------------------+ +------------------+
+         |                    |                    |
+         v                    v                    v
++------------------+ +------------------+ +------------------+
+| @wdio/electron-  | | @wdio/tauri-     | | wdio-dioxus-     |
+| cdp-bridge       | | plugin           | | bridge           |
+| (Chrome DevTools)| | (Execute, Mock,  | | (Execute, Mock,  |
+|                  | |  Logs)           | |  Logs, Embedded  |
++------------------+ +------------------+  Driver)          |
+         |                    |            +------------------+
+         v           +--------+--------+           |
++------------------+ |        |        |           v
+|   Chromedriver   | v        v        v  +------------------+
+|   (WebDriver)    | Embedded Official CN | wdio-dioxus-     |
++------------------+ (in-app) (tauri- (paid) embedded-driver |
+         |           server) driver)   |  (in-process       |
+         v                    |        |   WebDriver server) |
++------------------+          +--------+  +------------------+
+| Electron App     |                v              |
++------------------+     +------------------+      |
+                          |   Tauri App      |      v
+                          +------------------+ +------------------+
+                                               |   Dioxus App     |
+                                               +------------------+
 ```
 
 ## Package Responsibilities
@@ -45,6 +50,7 @@ This document describes the architecture of the WebdriverIO Desktop & Mobile mon
 |---------|---------------|
 | `@wdio/electron-service` | WebdriverIO service for Electron apps |
 | `@wdio/tauri-service` | WebdriverIO service for Tauri apps |
+| `@wdio/dioxus-service` | WebdriverIO service for Dioxus desktop apps |
 
 ### Bridge/Plugin Packages
 
@@ -52,6 +58,9 @@ This document describes the architecture of the WebdriverIO Desktop & Mobile mon
 |---------|---------------|
 | `@wdio/electron-cdp-bridge` | Chrome DevTools Protocol bridge for main process access |
 | `@wdio/tauri-plugin` | Tauri v2 plugin for backend command invocation |
+| `wdio-dioxus-bridge` | Dioxus bridge crate — IPC channel, mock dispatch, log forwarding, embedded driver wiring |
+| `wdio-dioxus-embedded-driver` | In-process WebDriver HTTP server for Dioxus |
+| `wdio-dioxus-driver` | External WebDriver proxy (fork of tauri-driver); Windows `'external'` provider only |
 
 ### Shared Packages
 
@@ -80,7 +89,7 @@ Runs in the main process (no `browser` access). Responsible for:
 ### Service (`service.ts`)
 
 Runs in the worker process (receives `browser` via `before` hook). Responsible for:
-- API injection (`browser.tauri.*`, `browser.electron.*`)
+- API injection (`browser.tauri.*`, `browser.electron.*`, `browser.dioxus.*`)
 - Mock lifecycle management
 - Log forwarding setup
 - Plugin initialization
@@ -192,3 +201,58 @@ Runs in the worker process (receives `browser` via `before` hook). Responsible f
 |        browser.tauri.execute(), mock(), triggerDeeplink()           |
 +---------------------------------------------------------------------+
 ```
+
+## Dioxus-Specific Architecture
+
+### Driver Providers
+
+```
++---------------------------------------------------------------------+
+|                   @wdio/dioxus-service                              |
++-----------------------------+---------------------------------------+
+                              |
+           +------------------+------------------+
+           v                                     v
++--------------------+              +------------------------+
+|   Embedded         |              |   External             |
+|   (default,        |              |   (Windows only, v1)   |
+|    all platforms)  |              |                        |
++--------------------+              +------------------------+
+| wdio-dioxus-       |              | wdio-dioxus-driver     |
+| embedded-driver    |              | → msedgedriver.exe     |
+| HTTP server inside |              | (WebView2 automation)  |
+| app (wired via     |              |                        |
+| wdio-dioxus-bridge)|              |                        |
++--------------------+              +------------------------+
+```
+
+### Bridge Communication
+
+```
++---------------------------------------------------------------------+
+|                    Dioxus Application (debug build)                 |
++---------------------------------------------------------------------+
+|  Backend (Rust)                |     Frontend (Wry WebView)         |
+|  Rust `log` crate output       |     guest-js bundle                |
+|  captured by bridge            |     (mock interception,            |
+|                                |      console forwarding)           |
++-------------+------------------+----------------+-------------------+
+              |    wdio:// custom protocol        |
+              |<----------------------------------|
+              |                                  |
+              v                                  v
++---------------------------------------------------------------------+
+|               wdio-dioxus-bridge (install(config))                  |
+|  - embedded WebDriver server on DIOXUS_WEBVIEW_AUTOMATION_PORT      |
+|  - wdio:// IPC channel                                              |
+|  - log forwarder                                                     |
++---------------------------------------------------------------------+
+              |
+              v
++---------------------------------------------------------------------+
+|                   @wdio/dioxus-service                              |
+|        browser.dioxus.execute(), mock(), triggerDeeplink()          |
++---------------------------------------------------------------------+
+```
+
+The key architectural difference from Tauri is that Dioxus has no plugin-trait system. The bridge integrates at the `dioxus::desktop::Config` level (via the `install()` function) rather than through a registered plugin chain. The IPC channel is a Wry custom protocol (`wdio://`) rather than Tauri's IPC machinery.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -16,21 +16,27 @@ e2e/
 │   │   ├── dialog.spec.ts
 │   │   ├── mock.spec.ts
 │   │   └── ...
-│   └── tauri/              # Tauri E2E tests
+│   ├── tauri/              # Tauri E2E tests
+│   │   ├── api.spec.ts
+│   │   ├── logging.spec.ts
+│   │   └── ...
+│   └── dioxus/             # Dioxus E2E tests
 │       ├── api.spec.ts
-│       ├── logging.spec.ts
+│       ├── mock.spec.ts
 │       └── ...
 ├── lib/                    # Shared test utilities
 ├── wdio.electron.conf.ts   # Electron WDIO config
 ├── wdio.tauri.conf.ts      # Tauri WDIO config
-└── wdio.tauri-embedded.conf.ts  # Tauri embedded WDIO config
+├── wdio.tauri-embedded.conf.ts  # Tauri embedded WDIO config
+└── wdio.dioxus-embedded.conf.ts # Dioxus embedded WDIO config
 
 fixtures/e2e-apps/
 ├── electron-builder/       # Electron app (builder packaging)
 ├── electron-forge/         # Electron app (forge packaging)
 ├── electron-no-binary/     # Electron app (no binary mode)
 ├── electron-script/        # Electron app (script mode)
-└── tauri/                  # Tauri app
+├── tauri/                  # Tauri app
+└── dioxus/                 # Dioxus app
 ```
 
 ## Running E2E Tests
@@ -43,6 +49,9 @@ fixtures/e2e-apps/
    pnpm turbo build --filter electron-builder-e2e-app
    pnpm turbo build --filter electron-forge-e2e-app
    pnpm turbo build --filter tauri-e2e-app
+
+   # Build the Dioxus E2E app (Rust — no pnpm filter)
+   cd fixtures/e2e-apps/dioxus && cargo build
    ```
 
 2. **Build the services:**
@@ -53,7 +62,7 @@ fixtures/e2e-apps/
 3. **Platform-specific requirements:**
    - **Windows**: No special requirements
    - **macOS**: May need to allow app execution in Security settings
-   - **Linux**: May need to install `webkit2gtk-driver` for Tauri
+   - **Linux**: May need to install `webkit2gtk-driver` for Tauri; requires a display server (or Xvfb) for Dioxus
 
 ### Running Tests
 
@@ -74,6 +83,9 @@ pnpm --filter @repo/e2e test:e2e:tauri-basic
 pnpm --filter @repo/e2e test:e2e:tauri-basic:window
 pnpm --filter @repo/e2e test:e2e:tauri-basic:multiremote
 pnpm --filter @repo/e2e test:e2e:tauri-basic:standalone
+
+# Dioxus tests (embedded provider, all platforms)
+pnpm --filter @repo/e2e test:e2e:dioxus-embedded
 ```
 
 ## Configuration
@@ -109,6 +121,50 @@ export const config: WebdriverIO.Config = {
   // ...
 };
 ```
+
+### Dioxus Configuration (`wdio.dioxus-embedded.conf.ts`)
+
+The `'embedded'` provider is the recommended default and works on all three platforms (Windows, macOS, Linux).
+
+```typescript
+import { join } from 'node:path';
+import type { Options } from '@wdio/types';
+
+const appBinaryPath = join(
+  __dirname,
+  '../fixtures/e2e-apps/dioxus/target/debug/dioxus-e2e-app',
+);
+
+export const config: Options.Testrunner = {
+  runner: 'local',
+  framework: 'mocha',
+  services: [
+    [
+      '@wdio/dioxus-service',
+      {
+        driverProvider: 'embedded',
+        embeddedPort: 4445,
+      },
+    ],
+  ],
+  capabilities: [{
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: appBinaryPath,
+    },
+  }],
+  specs: ['test/dioxus/**/*.spec.ts'],
+};
+```
+
+#### Provider matrix
+
+| Provider | Windows | macOS | Linux | Notes |
+|---|---|---|---|---|
+| `'embedded'` (default) | ✅ | ✅ | ✅ | Recommended for all platforms |
+| `'external'` | ✅ | ❌ | ❌ (v1.1) | Windows-only in v1; Linux support deferred |
+
+For the `'external'` provider on Windows, see [edge-webdriver-windows.md](../packages/dioxus-service/docs/edge-webdriver-windows.md).
 
 ## Test Modes
 
@@ -146,6 +202,8 @@ capabilities: {
 },
 ```
 
+For Dioxus multiremote, replace `'tauri:options'` with `'dioxus:options'` and `browserName: 'dioxus'`.
+
 ### Per-Worker
 
 When `maxInstances > 1`, the service automatically spawns a separate driver per worker:
@@ -174,6 +232,7 @@ pnpm e2e:electron-builder -- --logLevel debug
 
 ```bash
 pnpm wdio wdio.tauri.conf.ts --spec test/tauri/api.spec.ts
+pnpm wdio wdio.dioxus-embedded.conf.ts --spec test/dioxus/api.spec.ts
 ```
 
 ### Common Issues
@@ -185,6 +244,7 @@ If tests hang, check for port conflicts:
 ```bash
 # Check what's using the default port
 lsof -i :4444
+lsof -i :4445  # Dioxus embedded driver default port
 
 # Kill stale processes
 kill -9 <PID>
@@ -196,6 +256,23 @@ Ensure app is built and path is correct:
 
 ```bash
 ls -la fixtures/e2e-apps/tauri/src-tauri/target/debug/
+ls -la fixtures/e2e-apps/dioxus/target/debug/
+```
+
+#### Dioxus Bridge Not Active
+
+The embedded driver only starts when the Dioxus app is built in **debug mode** — the bridge is compiled behind `#[cfg(debug_assertions)]`. Release builds will not expose the WebDriver endpoint. Always use `cargo build` (not `cargo build --release`) for E2E test apps.
+
+#### Linux: No Display
+
+Dioxus (like Tauri) requires a display server on Linux. For CI use Xvfb:
+
+```yaml
+- name: Run Dioxus E2E tests
+  run: |
+    export DISPLAY=:99
+    Xvfb :99 -screen 0 1280x800x24 &
+    pnpm --filter @repo/e2e test:e2e:dioxus-embedded
 ```
 
 #### Protocol Handler Not Registered
@@ -214,6 +291,8 @@ pnpm protocol-install:electron-builder
 
 Each app has platform-specific setup scripts in `fixtures/e2e-apps/<app>/scripts/` that detect the OS and register the protocol handler. These scripts are idempotent — running them multiple times is safe as they check if the protocol is already registered and skip if so.
 
+For Dioxus deep link testing see [deeplink-testing.md](../packages/dioxus-service/docs/deeplink-testing.md).
+
 ## CI Integration
 
 ### GitHub Actions
@@ -231,13 +310,32 @@ strategy:
         arch: arm64
 ```
 
+#### Dioxus CI example
+
+```yaml
+- name: Build Dioxus E2E app
+  run: cargo build
+  working-directory: fixtures/e2e-apps/dioxus
+
+- name: Run Dioxus E2E tests (Linux — Xvfb required)
+  if: runner.os == 'Linux'
+  run: |
+    export DISPLAY=:99
+    Xvfb :99 -screen 0 1280x800x24 &
+    pnpm --filter @repo/e2e test:e2e:dioxus-embedded
+
+- name: Run Dioxus E2E tests (Windows / macOS)
+  if: runner.os != 'Linux'
+  run: pnpm --filter @repo/e2e test:e2e:dioxus-embedded
+```
+
 ### Platform-Specific Notes
 
 | Platform | Notes |
 |----------|-------|
 | Windows | Requires `.cmd` for scripts, Edge driver for WebView2 |
 | macOS | Universal builds tested separately, may need security overrides |
-| Linux | Requires `webkit2gtk-driver` for Tauri |
+| Linux | Requires `webkit2gtk-driver` for Tauri; Xvfb for Dioxus |
 
 ## Adding New E2E Tests
 

--- a/docs/package-structure.md
+++ b/docs/package-structure.md
@@ -60,20 +60,61 @@ packages/tauri-plugin/
 └── README.md                         # Package documentation
 ```
 
+### Rust/Dioxus Bridge Packages
+
+Dioxus bridge and driver packages (Rust-only, no Tauri plugin system):
+
+```
+packages/dioxus-bridge/
+├── src/
+│   ├── lib.rs                        # Crate entry point — exports install(), automation
+│   ├── automation.rs                 # is_requested() and env-var checks
+│   ├── protocol.rs                   # wdio:// custom protocol registration
+│   └── log.rs                        # Log forwarder
+├── guest-js/                         # Frontend JavaScript bundle (injected into webview)
+│   └── index.ts                      # Mock interception, console forwarding
+├── build.rs                          # Build script (bundles guest-js)
+├── Cargo.toml                        # Rust crate manifest
+└── README.md                         # Package documentation
+
+packages/dioxus-embedded-driver/
+├── src/
+│   └── lib.rs                        # Embedded WebDriver HTTP server
+├── Cargo.toml
+└── README.md
+
+packages/dioxus-driver/
+├── src/
+│   └── main.rs                       # External WebDriver proxy (fork of tauri-driver)
+├── Cargo.toml
+└── README.md
+```
+
 ## Package Naming Conventions
 
 ### Service Packages
 
-All packages use the `@wdio/` scope:
+All npm packages use the `@wdio/` scope:
 
 - `@wdio/electron-service` - Electron WDIO service
 - `@wdio/tauri-service` - Tauri WDIO service
+- `@wdio/dioxus-service` - Dioxus WDIO service
 - `@wdio/electron-cdp-bridge` - Chrome DevTools Protocol bridge
 - `@wdio/native-utils` - Cross-platform utilities
 - `@wdio/native-types` - Shared TypeScript type definitions
 - `@wdio/native-spy` - Spy utilities for mocking
 - `@wdio/tauri-plugin` - Tauri v2 plugin (Rust + JS)
 - `@wdio/bundler` - Build tooling
+
+### Rust Crate Naming
+
+Rust crates use the `wdio-` prefix (kebab-case, matching Cargo conventions):
+
+- `wdio-dioxus-bridge` — bridge crate (not "plugin" — Dioxus has no plugin-trait system)
+- `wdio-dioxus-embedded-driver` — in-process WebDriver server
+- `wdio-dioxus-driver` — external WebDriver proxy (Windows `'external'` provider)
+
+The `wdio-` prefix is used rather than `dioxus-` to leave the `dioxus-*` namespace free for the Dioxus project itself.
 
 ## package.json Template
 
@@ -271,5 +312,3 @@ pnpm turbo release
 5. **Follow TypeScript strict mode** - Enable strict type checking
 6. **Use semantic versioning** - Follow semver for versions
 7. **Avoid breaking changes** - Maintain backward compatibility when possible
-
-

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -127,7 +127,11 @@ desktop-mobile/
 ├── packages/               # All packages
 │   ├── electron-service/       # Electron WDIO service
 │   ├── tauri-service/          # Tauri WDIO service
+│   ├── dioxus-service/         # Dioxus WDIO service
 │   ├── tauri-plugin/           # Tauri v2 plugin (Rust + JS)
+│   ├── dioxus-bridge/          # Dioxus bridge crate (Rust)
+│   ├── dioxus-embedded-driver/ # Dioxus embedded WebDriver server (Rust)
+│   ├── dioxus-driver/          # Dioxus external WebDriver proxy (Rust, Windows)
 │   ├── electron-cdp-bridge/    # Chrome DevTools Protocol bridge
 │   ├── native-utils/           # Cross-platform utilities
 │   ├── native-types/           # Shared TypeScript type definitions
@@ -136,7 +140,8 @@ desktop-mobile/
 ├── fixtures/              # Test fixtures and example apps
 │   ├── e2e-apps/         # E2E test applications
 │   │   ├── electron-*/   # Electron E2E apps
-│   │   └── tauri/        # Tauri E2E app
+│   │   ├── tauri/        # Tauri E2E app
+│   │   └── dioxus/       # Dioxus E2E app
 │   └── package-tests/     # Package test fixtures
 │       └── tauri-app/     # Tauri package test app
 ├── e2e/                  # E2E test scenarios
@@ -373,6 +378,43 @@ For working with Tauri packages and plugins:
 
 See the [Tauri Plugin README](../packages/tauri-plugin/README.md) for detailed setup instructions.
 
+### Dioxus Development
+
+For working with Dioxus packages:
+
+1. **Install Rust** (if not already installed):
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+
+2. **Install Linux system dependencies** (Linux only):
+   ```bash
+   # Debian/Ubuntu
+   sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+
+   # Fedora
+   sudo dnf install -y webkit2gtk4.1-devel gtk3-devel
+
+   # Arch Linux
+   sudo pacman -S webkit2gtk-4.1 gtk3
+   ```
+
+3. **Build the Dioxus Bridge Crate**:
+   ```bash
+   cd packages/dioxus-bridge
+   cargo build
+   ```
+
+4. **Build the Dioxus Fixture App** (for E2E tests):
+   ```bash
+   cd fixtures/e2e-apps/dioxus
+   cargo build
+   ```
+
+No Dioxus CLI (`dx`) is required for testing — the service builds and runs the app binary directly.
+
+See the [Dioxus Bridge Setup](../packages/dioxus-service/docs/plugin-setup.md) and [Quick Start](../packages/dioxus-service/docs/quick-start.md) for detailed setup instructions.
+
 ## Next Steps
 
 - Read [package-structure.md](./package-structure.md) for package conventions
@@ -380,7 +422,9 @@ See the [Tauri Plugin README](../packages/tauri-plugin/README.md) for detailed s
 - Read [AGENTS.md](../AGENTS.md) for AI assistant context and coding standards
 - Explore the Electron service implementation in `packages/electron-service/`
 - Explore the Tauri service implementation in `packages/tauri-service/`
+- Explore the Dioxus service implementation in `packages/dioxus-service/`
 - See [Tauri Plugin README](../packages/tauri-plugin/README.md) for Tauri plugin setup
+- See [Dioxus Bridge Setup](../packages/dioxus-service/docs/plugin-setup.md) for Dioxus bridge setup
 
 ## AI-Assisted Development
 
@@ -396,5 +440,3 @@ Available slash commands (Claude Code):
 - **Issues**: Report bugs or request features on [GitHub Issues](https://github.com/webdriverio/desktop-mobile/issues)
 - **Discussions**: Ask questions on [GitHub Discussions](https://github.com/webdriverio/desktop-mobile/discussions)
 - **WebdriverIO**: See [WebdriverIO documentation](https://webdriver.io/)
-
-

--- a/docs/visual-testing.md
+++ b/docs/visual-testing.md
@@ -1,6 +1,6 @@
 # Visual Regression Testing
 
-Both `@wdio/electron-service` and `@wdio/tauri-service` compose cleanly with **[`@wdio/visual-service`](https://webdriver.io/docs/visual-testing/)**, which is the recommended way to do visual regression testing (VRT) for desktop apps built on these services.
+`@wdio/electron-service`, `@wdio/tauri-service`, and `@wdio/dioxus-service` all compose cleanly with **[`@wdio/visual-service`](https://webdriver.io/docs/visual-testing/)**, which is the recommended way to do visual regression testing (VRT) for desktop apps built on these services.
 
 This document covers the small amount of glue needed to wire it in, the per-OS baseline convention, Tauri provider differences, and when to reach for the existing mock APIs instead. The visual service itself is documented upstream — start at the [official guide](https://webdriver.io/docs/visual-testing/) for the full API surface.
 
@@ -67,6 +67,36 @@ export const config: Options.Testrunner = {
 };
 ```
 
+**Dioxus** — _`wdio.visual.conf.ts`_
+
+Dioxus only has the `'embedded'` provider for VRT. The `'external'` provider is Windows-only in v1 and not recommended for visual testing.
+
+```ts
+import { join } from 'node:path';
+import type { Options, Services } from '@wdio/types';
+
+const visualService: Services.ServiceEntry = [
+  'visual',
+  {
+    baselineFolder: join(__dirname, '__visual__', process.platform, process.arch, 'baseline'),
+    screenshotPath: join(__dirname, '__visual__', process.platform, process.arch, 'actual'),
+    formatImageName: '{tag}-{width}x{height}',
+    autoSaveBaseline: !process.env.CI,
+  },
+];
+
+export const config: Options.Testrunner = {
+  // ...
+  services: [['@wdio/dioxus-service', { driverProvider: 'embedded' }], visualService],
+  capabilities: [{
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: '/path/to/your/dioxus-app',
+    },
+  }],
+};
+```
+
 > **ESM configs** — `__dirname` is not defined in ES module configs (`"type": "module"` in `package.json`, or `wdio.conf.mts`). If your config is ESM, derive it from `import.meta.url` at the top of the file:
 >
 > ```ts
@@ -120,6 +150,8 @@ The example above uses `!process.env.CI` so:
 ### Windows subpixel rendering noise (~0.5%)
 
 Consecutive WebView2 / Chromium renders on Windows produce ~0.5% pixel-level mismatch even with no UI change. macOS and Linux render deterministically. `MAX_MISMATCH_PCT = 1` is the lowest threshold that absorbs this noise reliably; real UI changes run ≥10% in practice.
+
+This applies equally to Tauri and Dioxus on Windows since both use WebView2.
 
 ### Stabilising the page before snapshotting
 
@@ -176,6 +208,27 @@ Workarounds:
 
 The first option is the simplest if you just want VRT on macOS.
 
+## Dioxus provider notes
+
+Dioxus has only one provider for VRT: `'embedded'`. This provider captures the webview content (not the native window chrome) on all three platforms.
+
+| Provider | Captures | Native chrome included? | Notes |
+|---|---|---|---|
+| `embedded` | Webview only | ❌ | Works on Windows, macOS, Linux. Recommended. |
+| `external` | Webview only | ❌ | Windows only in v1. Not recommended for VRT; use `embedded` instead. |
+
+Per-provider baselines are not needed for Dioxus in v1 since only `'embedded'` is used across platforms. A per-OS + per-arch directory is still recommended to avoid cross-platform rendering differences.
+
+### Linux headless (Xvfb)
+
+On Linux CI, Dioxus requires a display server. Wrap your visual test run with Xvfb:
+
+```bash
+export DISPLAY=:99
+Xvfb :99 -screen 0 1280x800x24 &
+pnpm wdio run wdio.visual.dioxus.conf.ts
+```
+
 ## Asserting native UI behaviour without pixels
 
 The visual service captures **webview content only** (with the noted CrabNebula exception). Native menus, tray icons, file pickers, and OS-level dialogs aren't part of the capture and aren't worth pixel-diffing — they're OS-rendered and stable. To assert *behaviour* of those surfaces, use the existing mock APIs:
@@ -192,6 +245,13 @@ The visual service captures **webview content only** (with the noted CrabNebula 
   dialogMock.mockReturnValue('/some/file');
   // … exercise the app …
   expect(dialogMock).toHaveBeenCalled();
+  ```
+- **Dioxus** — see [Usage Examples](../packages/dioxus-service/docs/usage-examples.md) and [API Reference](../packages/dioxus-service/docs/api-reference.md):
+  ```ts
+  const commandMock = await browser.dioxus.mock('my_command');
+  commandMock.mockReturnValue({ result: 'mocked' });
+  // … exercise the app …
+  expect(commandMock).toHaveBeenCalled();
   ```
 
 The combination — `@wdio/visual-service` for the in-app UI, the mock APIs for native UI surfaces — is what most desktop-app test suites actually want.

--- a/packages/dioxus-bridge/README.md
+++ b/packages/dioxus-bridge/README.md
@@ -55,10 +55,7 @@ The bridge uses Dioxus's webview configuration API, not Dioxus's plugin-trait sy
 
 ## Naming
 
-The companion npm package shipping the guest-js bundle is `@wdio/dioxus-bridge`
-(no `-js` suffix), matching the convention from `@wdio/tauri-plugin`. The Rust
-crate is named `wdio-dioxus-bridge` ("bridge" rather than "plugin" because
-Dioxus has no plugin-trait system).
+The companion npm package `@wdio/dioxus-bridge` ships the guest-js bundle (no `-js` suffix, matching the convention from `@wdio/tauri-plugin`). It is **not a separate user-installable package** — `build.rs` bundles it into the Rust crate at compile time, so adding `wdio-dioxus-bridge` to `Cargo.toml` is all that is needed. The Rust crate is named `wdio-dioxus-bridge` ("bridge" rather than "plugin" because Dioxus has no plugin-trait system).
 
 ## Platform Support
 

--- a/packages/dioxus-bridge/README.md
+++ b/packages/dioxus-bridge/README.md
@@ -4,23 +4,20 @@ Rust bridge crate that exposes a `wdio://` IPC channel and automation
 detection inside Dioxus desktop apps, consumed by
 [`@wdio/dioxus-service`](../dioxus-service/).
 
-## v1 status
+## Features
 
-This crate is being built up incrementally. The current published surface is:
+- **`install(config)`** — drop-in helper that wires the bridge into your Dioxus `desktop::Config`. Registers the `wdio://` custom protocol, starts the embedded WebDriver server, injects the guest-js bundle, and activates log forwarding — all in a single call.
+- **`automation::is_requested()`** — returns `true` when `DIOXUS_WEBVIEW_AUTOMATION=true` is set in the process environment (i.e. the app is running under `@wdio/dioxus-service`).
+- **`wdio://` custom protocol** — IPC channel between the service and the webview, used for execute, mock dispatch, and log forwarding.
+- **Mock dispatch** — guest-js bundle injected into the webview patches the invoke API and exposes `window.__wdio_mocks__` for per-command mock registration.
+- **Log forwarding** — Rust `log` crate output is captured and forwarded to the WDIO log capture pipeline. Frontend console forwarding is handled by the guest-js bundle.
+- **Embedded WebDriver server** — `wdio-dioxus-embedded-driver` is wired in automatically; no external driver process needed.
 
-- `wdio_dioxus_bridge::install(config) -> Config` — drop-in helper that wires the
-  bridge into your Dioxus `Config`.
-- `wdio_dioxus_bridge::automation::is_requested()` — true when
-  `DIOXUS_WEBVIEW_AUTOMATION=true` is set in the process env (i.e. the app is
-  running under `@wdio/dioxus-service`).
-
-The full bridge IPC (`wdio://` custom protocol + invoke command bus + log
-forwarder + guest-js bundle) lands in subsequent Phase 2 commits.
-
-## Quick start
+## Quick Start
 
 ```toml
-[dev-dependencies]
+# Cargo.toml
+[dependencies]
 wdio-dioxus-bridge = "1"
 ```
 
@@ -44,10 +41,36 @@ fn main() {
 > should not ship test plumbing. See
 > `packages/dioxus-service/docs/plugin-setup.md` for the rationale.
 
+## How It Works
+
+When `install(config)` is called:
+
+1. Checks `DIOXUS_WEBVIEW_AUTOMATION`. If not set, returns config unchanged (no-op).
+2. Registers the `wdio://` custom protocol on the Wry/Dioxus webview.
+3. Starts `wdio-dioxus-embedded-driver`'s HTTP server on `DIOXUS_WEBVIEW_AUTOMATION_PORT`.
+4. Injects the guest-js bundle into the webview.
+5. Starts the log forwarder for Rust `log` crate output.
+
+The bridge uses Dioxus's webview configuration API, not Dioxus's plugin-trait system (Dioxus has no such system). This is why it is called a "bridge" rather than a "plugin".
+
 ## Naming
 
 The companion npm package shipping the guest-js bundle is `@wdio/dioxus-bridge`
 (no `-js` suffix), matching the convention from `@wdio/tauri-plugin`. The Rust
 crate is named `wdio-dioxus-bridge` ("bridge" rather than "plugin" because
-Dioxus has no plugin-trait system — see
-`packages/native-core/src/driverProcess.ts` discussion).
+Dioxus has no plugin-trait system).
+
+## Platform Support
+
+| Platform | Status |
+|----------|--------|
+| Windows  | ✅ |
+| Linux    | ✅ |
+| macOS    | ✅ |
+
+## See Also
+
+- [Bridge Setup guide](../dioxus-service/docs/plugin-setup.md) — full integration instructions
+- [`@wdio/dioxus-service`](../dioxus-service/) — the WebdriverIO service
+- [`wdio-dioxus-embedded-driver`](../dioxus-embedded-driver/) — the embedded WebDriver server
+- [v1.0.0 Release Notes](./docs/release-notes/v1.0.0.md)

--- a/packages/dioxus-bridge/docs/release-notes/v1.0.0.md
+++ b/packages/dioxus-bridge/docs/release-notes/v1.0.0.md
@@ -1,0 +1,91 @@
+# Release Notes — wdio-dioxus-bridge v1.0.0
+
+Initial release of the `wdio-dioxus-bridge` Rust crate, the companion bridge for `@wdio/dioxus-service`.
+
+## What's Included
+
+### `install(config)` API
+
+```rust
+wdio_dioxus_bridge::install(config: dioxus::desktop::Config) -> dioxus::desktop::Config
+```
+
+Drop-in configuration helper. Call inside a `#[cfg(debug_assertions)]` block in your `main.rs`. When `DIOXUS_WEBVIEW_AUTOMATION=true` is detected, the function:
+
+1. Registers the `wdio://` custom protocol on the Dioxus webview configuration.
+2. Wires in `wdio-dioxus-embedded-driver`'s HTTP server on `DIOXUS_WEBVIEW_AUTOMATION_PORT`.
+3. Arranges for the guest-js bundle to be injected into the webview on startup.
+4. Starts the log forwarder that reads Rust `log` crate output and sends it to the WDIO log capture pipeline.
+
+If `DIOXUS_WEBVIEW_AUTOMATION` is not set, `install()` is a no-op and returns the config unchanged.
+
+### `automation::is_requested()`
+
+```rust
+wdio_dioxus_bridge::automation::is_requested() -> bool
+```
+
+Returns `true` when `DIOXUS_WEBVIEW_AUTOMATION=true` is set in the process environment. Useful for conditional setup in your app beyond the bridge itself.
+
+### `wdio://` Custom Protocol
+
+The bridge registers a `wdio://` custom protocol on the Dioxus/Wry webview. This protocol is the IPC channel between `@wdio/dioxus-service` and the webview. It is used for:
+
+- Executing JavaScript in the webview context (`browser.dioxus.execute()`)
+- Setting and clearing mock implementations
+- Forwarding log events to the service
+
+The protocol channel is separate from Dioxus's own IPC machinery — no Dioxus commands or signals are involved.
+
+### Mock Dispatch (guest-js bundle)
+
+The guest-js bundle injected into the webview:
+
+- Patches the `invoke` API used by Dioxus components to route commands through the mock registry.
+- Exposes `window.__wdio_mocks__` for command-level mock registration.
+- Serializes call arguments and return values across the bridge channel.
+
+### Log Forwarding
+
+Rust `log` crate output (from your backend and the Dioxus runtime) is intercepted and forwarded to `@wdio/dioxus-service`'s log capture pipeline when `captureBackendLogs: true` is set in the service config.
+
+Frontend console output forwarding is handled by the guest-js bundle when `captureFrontendLogs: true`.
+
+## Platform Support
+
+| Platform | Status |
+|----------|--------|
+| Windows  | ✅ |
+| Linux    | ✅ |
+| macOS    | ✅ |
+
+## Minimum Requirements
+
+- Dioxus 0.6+
+- Rust edition 2021
+- `wdio-dioxus-embedded-driver` (pulled in as a dependency automatically)
+
+## Usage
+
+```toml
+# Cargo.toml
+[dependencies]
+wdio-dioxus-bridge = "1"
+```
+
+```rust
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+    #[cfg(debug_assertions)]
+    {
+        config = wdio_dioxus_bridge::install(config);
+    }
+    dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+}
+```
+
+See [Bridge Setup](../../dioxus-service/docs/plugin-setup.md) for the full integration guide.
+
+## Known Deferred Items
+
+- **`emitEvent` support** — native-mode event emission via the `wdio://` channel. Deferred to v1.1.

--- a/packages/dioxus-embedded-driver/README.md
+++ b/packages/dioxus-embedded-driver/README.md
@@ -1,0 +1,62 @@
+# wdio-dioxus-embedded-driver
+
+In-process WebDriver server for [Dioxus](https://dioxuslabs.com/) desktop applications, wired in via [`wdio-dioxus-bridge`](../dioxus-bridge/).
+
+## What Is It?
+
+`wdio-dioxus-embedded-driver` is a Rust crate that implements a W3C WebDriver HTTP server that runs **inside your Dioxus application process**. When the bridge is installed (via `wdio_dioxus_bridge::install(config)`), this crate's server is started automatically and listens for WebDriver connections from `@wdio/dioxus-service`.
+
+This is the component that makes the `'embedded'` driver provider work. It means you do not need any external driver process (`wdio-dioxus-driver`, `webkit2gtk-driver`, or `msedgedriver`) — the WebDriver server lives inside the app itself.
+
+## How It Works
+
+1. `@wdio/dioxus-service` launches your debug Dioxus binary with environment variables:
+   - `DIOXUS_WEBVIEW_AUTOMATION=true`
+   - `DIOXUS_WEBVIEW_AUTOMATION_PORT=<port>` (default 4445, unique per worker)
+
+2. `wdio_dioxus_bridge::install(config)` checks for these variables, then starts `wdio-dioxus-embedded-driver`'s HTTP server on the specified port.
+
+3. `@wdio/dioxus-service` polls the `/status` endpoint until the server is ready, then establishes a WebDriver session.
+
+4. WebDriver commands are routed to the embedded server, which translates them to the Wry/Dioxus webview API.
+
+## Platform Support
+
+The embedded driver works on all three platforms:
+
+| Platform | Status |
+|----------|--------|
+| Windows  | ✅ |
+| Linux    | ✅ |
+| macOS    | ✅ |
+
+This is why `'embedded'` is the recommended driver provider for `@wdio/dioxus-service` — it eliminates platform-specific driver installation on all three OSes.
+
+## Direct Use
+
+This crate is **not intended for direct use**. It is a dependency of `wdio-dioxus-bridge` and is pulled in automatically when you add the bridge to your `Cargo.toml`.
+
+To enable embedded driver testing, follow the [Bridge Setup guide](../dioxus-service/docs/plugin-setup.md) in `@wdio/dioxus-service`.
+
+## Configuration
+
+Port is controlled via `@wdio/dioxus-service`:
+
+```typescript
+// wdio.conf.ts
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'embedded',
+  embeddedPort: 4445,  // Optional, defaults to 4445
+}]]
+```
+
+Or via environment variable:
+```bash
+DIOXUS_WEBVIEW_AUTOMATION_PORT=4445 npx wdio run wdio.conf.ts
+```
+
+## See Also
+
+- [`wdio-dioxus-bridge`](../dioxus-bridge/) — the bridge crate that wires the embedded driver into your app
+- [`@wdio/dioxus-service`](../dioxus-service/) — the WebdriverIO service
+- [Bridge Setup](../dioxus-service/docs/plugin-setup.md) — how to integrate the bridge into your Dioxus app

--- a/packages/dioxus-service/README.md
+++ b/packages/dioxus-service/README.md
@@ -51,7 +51,7 @@ export const config = {
     {
       browserName: 'dioxus',
       'dioxus:options': {
-        application: './target/release/my-app'
+        application: './target/debug/my-app'
       }
     }
   ]

--- a/packages/dioxus-service/README.md
+++ b/packages/dioxus-service/README.md
@@ -1,0 +1,149 @@
+# @wdio/dioxus-service
+
+[![@wdio/dioxus-service](https://img.shields.io/badge/@wdio-dioxus--service-8B5CF6?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/dioxus-service)
+[![Version](https://img.shields.io/npm/v/@wdio/dioxus-service?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@wdio/dioxus-service)
+[![Downloads](https://img.shields.io/npm/dw/@wdio/dioxus-service?color=6f42c1&labelColor=1a1a1a)](https://www.npmjs.com/package/@wdio/dioxus-service)
+
+WebdriverIO service for testing Dioxus desktop applications on Windows, Linux, and macOS.
+
+Enables cross-platform E2E testing of Dioxus apps via the extensive WebdriverIO ecosystem.
+
+## Features
+
+- 🚗 Embedded WebDriver server — no external driver required on any platform
+- 🔧 Automatic Edge WebDriver management on Windows (`'external'` provider)
+- 📦 Automatic Dioxus binary path detection
+- 🌐 Cross-platform support (Windows, Linux, macOS)
+- 🔗 Full Dioxus API access via `browser.dioxus.execute()`
+- 🧩 Mocking support for Dioxus `invoke` commands
+- 📊 Backend and frontend log capture
+- 🖥️ Multiremote testing support
+- 🏃 Per-worker driver spawning for parallel testing
+- 🌍 Browser mode — test the Dioxus frontend in plain Chrome against a dev server, no binary or driver required
+
+## Installation
+
+Install the service via npm:
+
+```bash
+npm install --save-dev @wdio/dioxus-service
+```
+
+Or with pnpm:
+
+```bash
+pnpm add -D @wdio/dioxus-service
+```
+
+## Quick Start
+
+Get started in minutes with the [Quick Start Guide](./docs/quick-start.md).
+
+### Minimal Configuration
+
+Add to your `wdio.conf.ts`:
+
+```typescript
+export const config = {
+  services: ['@wdio/dioxus-service'],
+
+  capabilities: [
+    {
+      browserName: 'dioxus',
+      'dioxus:options': {
+        application: './target/release/my-app'
+      }
+    }
+  ]
+};
+```
+
+See [Configuration Reference](./docs/configuration.md) for all options.
+
+## Documentation
+
+**Getting Started**
+- [Quick Start Guide](./docs/quick-start.md) - Set up in minutes
+- [Bridge Setup](./docs/plugin-setup.md) - Install wdio-dioxus-bridge
+
+**Reference**
+- [Configuration](./docs/configuration.md) - All service options
+- [API Reference](./docs/api-reference.md) - Complete API documentation
+- [Platform Support](./docs/platform-support.md) - Windows, Linux, macOS
+
+**Guides**
+- [Browser Mode](./docs/browser-mode.md) - Test the renderer in Chrome without a Dioxus binary
+- [Usage Examples](./docs/usage-examples.md) - Common testing patterns
+- [Log Forwarding](./docs/log-forwarding.md) - Capture app logs
+- [Edge WebDriver (Windows)](./docs/edge-webdriver-windows.md) - Windows `'external'` provider setup
+- [Deeplink Testing](./docs/deeplink-testing.md) - Test protocol handlers
+- [Coexistence](./docs/coexistence.md) - Using alongside Tauri and Electron services
+- [Visual Testing](../../docs/visual-testing.md) - Visual regression with `@wdio/visual-service`
+
+**Help & Support**
+- [Troubleshooting](./docs/troubleshooting.md) - Common issues and solutions
+- [Development](./docs/development.md) - Contributing guide
+
+## Platform Support
+
+| Platform | Supported | Driver Providers | Notes |
+|----------|-----------|------------------|-------|
+| **Windows** | ✅ Yes | `'embedded'`, `'external'` | `'embedded'` recommended; `'external'` requires `wdio-dioxus-driver` + msedgedriver |
+| **Linux** | ✅ Yes | `'embedded'` only | `'external'` blocked in v1 (upstream Dioxus PR pending) |
+| **macOS** | ✅ Yes | `'embedded'` only | `'external'` not supported |
+
+See [Platform Support](./docs/platform-support.md) for detailed information.
+
+> **Choosing a driver provider:**
+> - **`'embedded'`** (recommended) — Native support on all three platforms, no external driver needed
+> - **`'external'`** — Windows only in v1; uses `wdio-dioxus-driver` + msedgedriver
+
+## Example Projects
+
+Check out the E2E test fixtures in the [desktop-mobile repository](https://github.com/webdriverio/desktop-mobile/tree/main/fixtures/e2e-apps/dioxus) for complete working examples.
+
+## Support
+
+Having trouble? Here are some resources:
+
+1. **[Troubleshooting Guide](./docs/troubleshooting.md)** - Solutions for common issues
+2. **[Platform Support](./docs/platform-support.md)** - Platform-specific information
+3. **[GitHub Issues](https://github.com/webdriverio/desktop-mobile/issues)** - Bug reports and feature requests
+4. **[WebdriverIO Forum](https://github.com/webdriverio/webdriverio/discussions)** - General community help and discussions
+
+## Contributing
+
+We welcome contributions! Please see our [Development Guide](./docs/development.md) for:
+
+- Setting up your development environment
+- Running tests
+- Code style guidelines
+- Pull request process
+
+Quick start for contributors:
+
+```bash
+# Clone and install
+git clone https://github.com/webdriverio/desktop-mobile.git
+cd desktop-mobile
+pnpm install
+
+# Make your changes
+# ...
+
+# Run tests
+pnpm test
+
+# Submit a pull request
+```
+
+## License
+
+MIT License. See LICENSE file for details.
+
+## See Also
+
+- [WebdriverIO Documentation](https://webdriver.io)
+- [Dioxus Documentation](https://dioxuslabs.com/learn/0.6/)
+- [@wdio/tauri-service](https://github.com/webdriverio/desktop-mobile/tree/main/packages/tauri-service) - Similar service for Tauri apps
+- [@wdio/electron-service](https://github.com/webdriverio/desktop-mobile/tree/main/packages/electron-service) - Similar service for Electron apps

--- a/packages/dioxus-service/docs/api-reference.md
+++ b/packages/dioxus-service/docs/api-reference.md
@@ -387,8 +387,8 @@ console.log(result); // 'default'
 
 ### Mock Properties
 
-- `mock.calls` - Array of call arguments
-- `mock.results` - Array of call results
+- `mock.mock.calls` - Array of call arguments
+- `mock.mock.results` - Array of call results
 - `__isDioxusMock` - Boolean flag identifying Dioxus mocks
 
 ---

--- a/packages/dioxus-service/docs/api-reference.md
+++ b/packages/dioxus-service/docs/api-reference.md
@@ -1,0 +1,498 @@
+# API Reference
+
+Complete API reference for @wdio/dioxus-service.
+
+## browser.dioxus API
+
+The following methods are available on the `browser.dioxus` object when connected to a Dioxus app.
+
+### `browser.dioxus.execute(script, ...args)`
+
+Execute JavaScript code in the Dioxus webview context with access to Dioxus IPC APIs. Requires `wdio-dioxus-bridge` to be installed and configured in your app.
+
+**Parameters:**
+- `script` (Function | string) - JavaScript code to execute. If a function, receives a `DioxusAPIs` object (`dx`) as the first parameter
+- `...args` (any[]) - Additional arguments passed to the script
+
+**Returns:** `Promise<ReturnValue>`
+
+**`DioxusAPIs` (`dx`) object:**
+```typescript
+interface DioxusAPIs {
+  invoke: (command: string, args?: unknown) => Promise<unknown>;
+  log?: {
+    trace: (msg: string) => void;
+    debug: (msg: string) => void;
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+```
+
+**Example:**
+```typescript
+// Execute with destructured DioxusAPIs
+const result = await browser.dioxus.execute(({ invoke }) => {
+  return invoke('get_platform_info');
+});
+
+// Execute with full DioxusAPIs object
+const greeting = await browser.dioxus.execute(async (dx) => {
+  return dx.invoke('greet', { name: 'World' });
+});
+
+// Execute with arguments
+const result = await browser.dioxus.execute(
+  (dx, name) => dx.invoke('greet', { name }),
+  'World'
+);
+
+// Execute string of code
+const href = await browser.dioxus.execute('window.location.href');
+```
+
+**Note:** Requires `wdio-dioxus-bridge` to be installed. See [Bridge Setup](./plugin-setup.md).
+
+---
+
+### `browser.dioxus.mock(command)`
+
+Mock a specific Dioxus backend command. Returns a `DioxusMock` object for configuring the mock behavior.
+
+**Parameters:**
+- `command` (string) - Name of the Dioxus command to mock (must match what your app passes to `invoke()`)
+
+**Returns:** `Promise<DioxusMock>`
+
+**Example:**
+```typescript
+const mock = await browser.dioxus.mock('read_file');
+await mock.mockReturnValue('mocked file content');
+
+// Now calling invoke('read_file', ...) returns 'mocked file content'
+const content = await browser.dioxus.execute(({ invoke }) => invoke('read_file'));
+expect(content).toBe('mocked file content');
+```
+
+---
+
+### `browser.dioxus.isMockFunction(fn)`
+
+Check if a value is a Dioxus mock function. This is a TypeScript type guard.
+
+**Parameters:**
+- `fn` (unknown) - Value to check
+
+**Returns:** `boolean` (type narrows to `DioxusMockInstance` when true)
+
+**Example:**
+```typescript
+const mock = await browser.dioxus.mock('clipboard_read');
+if (browser.dioxus.isMockFunction(mock)) {
+  // TypeScript knows mock is DioxusMockInstance here
+  expect(mock.mock.calls).toHaveLength(1);
+}
+```
+
+---
+
+### `browser.dioxus.clearAllMocks(commandPrefix?)`
+
+Clear all mock call history and reset results, but keep the mock implementations in place.
+
+**Parameters:**
+- `commandPrefix` (string, optional) - If provided, only mocks with command names starting with this prefix will be cleared
+
+**Returns:** `Promise<void>`
+
+**Example:**
+```typescript
+// Clear all mocks
+await browser.dioxus.clearAllMocks();
+
+// Clear only clipboard-related mocks
+await browser.dioxus.clearAllMocks('clipboard');
+```
+
+---
+
+### `browser.dioxus.resetAllMocks(commandPrefix?)`
+
+Reset all mocks to their initial state (clears implementations and call history).
+
+**Parameters:**
+- `commandPrefix` (string, optional) - If provided, only mocks with matching prefix are reset
+
+**Returns:** `Promise<void>`
+
+---
+
+### `browser.dioxus.restoreAllMocks(commandPrefix?)`
+
+Remove all mocks and restore original command implementations.
+
+**Parameters:**
+- `commandPrefix` (string, optional) - If provided, only mocks with matching prefix are restored
+
+**Returns:** `Promise<void>`
+
+**Example:**
+```typescript
+await browser.dioxus.restoreAllMocks();
+// Commands now call the real Dioxus backend again
+```
+
+---
+
+### `browser.dioxus.switchWindow(label)`
+
+Switch the active Dioxus window for subsequent operations. Changes the window that `browser.dioxus.execute()` and other Dioxus-specific operations target.
+
+**Parameters:**
+- `label` (string) - The window label to switch to (e.g., `'main'`, `'settings'`)
+
+**Returns:** `Promise<void>`
+
+**Example:**
+```typescript
+// Switch to the settings window
+await browser.dioxus.switchWindow('settings');
+
+// Now executes in the settings window context
+const data = await browser.dioxus.execute(({ invoke }) => invoke('get_settings'));
+
+// Switch back to main window
+await browser.dioxus.switchWindow('main');
+```
+
+**Note:** The window label must exist in your Dioxus app. Use `browser.dioxus.listWindows()` to get available labels.
+
+---
+
+### `browser.dioxus.listWindows()`
+
+Get a list of all available Dioxus window labels in the application.
+
+**Returns:** `Promise<string[]>`
+
+**Example:**
+```typescript
+const windows = await browser.dioxus.listWindows();
+console.log(windows); // ['main', 'settings', 'dialog']
+```
+
+---
+
+### `browser.dioxus.triggerDeeplink(url)`
+
+Trigger a deeplink to the Dioxus application for testing protocol handlers. Uses platform-specific commands (`open` on macOS, `xdg-open` on Linux, `cmd /c start` on Windows).
+
+**Parameters:**
+- `url` (string) - The deeplink URL to trigger (e.g., `'myapp://open?file=test.txt'`)
+
+**Returns:** `Promise<void>`
+
+**Example:**
+```typescript
+await browser.dioxus.triggerDeeplink('myapp://open?file=test.txt');
+
+await browser.waitUntil(async () => {
+  const openedFile = await browser.dioxus.execute(() => {
+    return globalThis.lastOpenedFile;
+  });
+  return openedFile === 'test.txt';
+});
+```
+
+See [Deeplink Testing](./deeplink-testing.md) for the full usage guide.
+
+---
+
+> **Note:** `emitEvent` is deferred to v1.1.
+
+---
+
+## DioxusMock Interface
+
+When you call `browser.dioxus.mock(command)`, you receive a `DioxusMock` object with these methods:
+
+### `mockImplementation(fn)`
+
+Set a custom implementation function for the mock.
+
+**Returns:** `Promise<DioxusMock>`
+
+**Example:**
+```typescript
+const mock = await browser.dioxus.mock('calculate');
+await mock.mockImplementation(async (args) => args.x + args.y);
+
+const result = await browser.dioxus.execute(({ invoke }) => invoke('calculate', { x: 5, y: 3 }));
+// result === 8
+```
+
+---
+
+### `mockImplementationOnce(fn)`
+
+Set a custom implementation for the next call only.
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockReturnValue(value)`
+
+Set the mock to always return a specific value.
+
+**Returns:** `Promise<DioxusMock>`
+
+**Example:**
+```typescript
+const mock = await browser.dioxus.mock('get_user');
+await mock.mockReturnValue({ id: 1, name: 'John' });
+```
+
+---
+
+### `mockReturnValueOnce(value)`
+
+Set the mock to return a specific value for the next call only.
+
+**Returns:** `Promise<DioxusMock>`
+
+**Example:**
+```typescript
+const mock = await browser.dioxus.mock('counter');
+await mock.mockReturnValueOnce(1);
+await mock.mockReturnValueOnce(2);
+await mock.mockReturnValue(3); // default for subsequent calls
+```
+
+---
+
+### `mockResolvedValue(value)`
+
+Set the mock to return a promise that resolves to the given value.
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockResolvedValueOnce(value)`
+
+Set the mock to resolve to a value for the next call only.
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockRejectedValue(error)`
+
+Set the mock to return a promise that rejects with an error.
+
+**Returns:** `Promise<DioxusMock>`
+
+**Example:**
+```typescript
+const mock = await browser.dioxus.mock('risky_operation');
+await mock.mockRejectedValue(new Error('Operation failed'));
+```
+
+---
+
+### `mockRejectedValueOnce(error)`
+
+Set the mock to reject for the next call only.
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockClear()`
+
+Clear the call history of this mock without resetting its implementation.
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockReset()`
+
+Reset the mock to its initial state (clears both implementation and call history).
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockRestore()`
+
+Remove this mock and restore the original command implementation.
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockReturnThis()`
+
+Set the mock to return `this` when called.
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `mockName(name)` / `getMockName()`
+
+Set or get a display name for the mock (useful for debugging).
+
+---
+
+### `getMockImplementation()`
+
+Get the current implementation function of the mock.
+
+---
+
+### `update()`
+
+Sync mock call data from the inner mock (app context) to the outer mock (test process).
+
+**Returns:** `Promise<DioxusMock>`
+
+---
+
+### `withImplementation(implFn, callbackFn)`
+
+Temporarily use a different implementation for the duration of a callback.
+
+**Example:**
+```typescript
+const mock = await browser.dioxus.mock('my_command');
+await mock.mockReturnValue('default');
+
+await mock.withImplementation(
+  () => 'temporary',
+  async () => {
+    const result = await browser.dioxus.execute(({ invoke }) => invoke('my_command'));
+    console.log(result); // 'temporary'
+  }
+);
+
+const result = await browser.dioxus.execute(({ invoke }) => invoke('my_command'));
+console.log(result); // 'default'
+```
+
+---
+
+### Mock Properties
+
+- `mock.calls` - Array of call arguments
+- `mock.results` - Array of call results
+- `__isDioxusMock` - Boolean flag identifying Dioxus mocks
+
+---
+
+## Package Exports
+
+### `startWdioSession(capabilities, globalOptions?)`
+
+Initialize the Dioxus service in standalone mode. Use this when you want to manage the session manually outside of WebdriverIO's lifecycle.
+
+**Parameters:**
+- `capabilities` (Capabilities) - WebdriverIO capabilities with Dioxus options
+- `globalOptions?` (DioxusServiceGlobalOptions) - Global service options
+
+**Returns:** `Promise<Browser>`
+
+**Example:**
+```typescript
+import { startWdioSession } from '@wdio/dioxus-service';
+
+const browser = await startWdioSession({
+  browserName: 'dioxus',
+  'dioxus:options': {
+    application: './target/debug/my_app'
+  }
+});
+
+// Use browser...
+await browser.deleteSession();
+```
+
+---
+
+## Exported Types
+
+### `DioxusCapabilities`
+
+```typescript
+interface DioxusCapabilities extends WebdriverIO.Capabilities {
+  browserName?: 'dioxus';
+  'dioxus:options'?: {
+    application: string;
+    args?: string[];
+    webviewOptions?: {
+      width?: number;
+      height?: number;
+    };
+  };
+  'wdio:dioxusServiceOptions'?: DioxusServiceOptions;
+}
+```
+
+### `DioxusServiceOptions`
+
+```typescript
+interface DioxusServiceOptions {
+  mode?: 'native' | 'browser';
+  devServerUrl?: string;
+  driverProvider?: 'external' | 'embedded';
+  dioxusDriverPort?: number;
+  dioxusDriverPath?: string;
+  embeddedPort?: number;
+  appBinaryPath?: string;
+  appArgs?: string[];
+  env?: Record<string, string>;
+  autoInstallDioxusDriver?: boolean;
+  autoDownloadEdgeDriver?: boolean;
+  windowLabel?: string;
+  captureBackendLogs?: boolean;
+  captureFrontendLogs?: boolean;
+  backendLogLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
+  frontendLogLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
+  startTimeout?: number;
+  statusPollTimeout?: number;
+  clearMocks?: boolean;
+  clearMocksPrefix?: string;
+  resetMocks?: boolean;
+  resetMocksPrefix?: string;
+  restoreMocks?: boolean;
+  restoreMocksPrefix?: string;
+}
+```
+
+### `DioxusResult<T>`
+
+Uses the standard Result pattern:
+
+```typescript
+type DioxusResult<T = unknown> = { ok: true; value: T } | { ok: false; error: string };
+
+// Usage
+if (result.ok) {
+  console.log(result.value);
+} else {
+  console.error(result.error);
+}
+```
+
+---
+
+## Notes
+
+- All `browser.dioxus.*` methods require `wdio-dioxus-bridge` to be installed in the Dioxus app. See [Bridge Setup](./plugin-setup.md).
+- Mocking requires the bridge for invoke interception to work.
+- `triggerDeeplink` requires your app to register a custom URL scheme.
+- `emitEvent` is deferred to v1.1.
+- For detailed configuration examples, see [Configuration](./configuration.md).

--- a/packages/dioxus-service/docs/browser-mode.md
+++ b/packages/dioxus-service/docs/browser-mode.md
@@ -210,7 +210,7 @@ await mock2.mockResolvedValue('content from app2');
 
 Your renderer called `invoke(command)` before a mock was registered. Call `browser.dioxus.mock(command)` before the code path that triggers the command.
 
-### Mock returns `undefined` after navigation
+### `"unmocked Dioxus command in browser mode"` error after navigation
 
 The browser-side entry was wiped by navigation. Call `mock.mockRestore()` first to delete the worker-side entry, then `browser.dioxus.mock(command)` to re-create both sides.
 

--- a/packages/dioxus-service/docs/browser-mode.md
+++ b/packages/dioxus-service/docs/browser-mode.md
@@ -1,0 +1,219 @@
+# Browser Mode
+
+Browser mode lets you test your Dioxus frontend UI in plain Chrome against a running dev server — no Dioxus binary, no driver. The Dioxus invoke API is intercepted at the JavaScript boundary in the renderer, so you can mock individual commands and assert on call arguments just like in native mode.
+
+## Overview
+
+### What Is It?
+
+Browser mode is a **frontend-only test mode**. Your frontend code runs for real in Chrome; the Dioxus Rust backend is replaced by mocks you define per command. Same WDIO API, same frontend code path — the only thing that changes is what's on the other end of `invoke(...)`.
+
+In normal (`native`) mode the service launches your compiled Dioxus app, drives it via the configured driver provider, and communicates with the backend through the bridge. Browser mode replaces all of that with a standard Chrome session: it sets `browserName` to `'chrome'`, navigates to your dev server URL, and injects a lightweight script that patches the invoke API so your Dioxus commands can be intercepted in tests.
+
+### Why Use It?
+
+- **No build step needed** — point the service at a dev server and start testing immediately.
+- **Fast feedback** — no Dioxus startup, no Rust compilation, no driver negotiation.
+- **Standard browser devtools** — Chrome DevTools and HMR work as normal during development.
+
+### When to Use It
+
+Browser mode is the right choice when your tests are renderer-focused: asserting UI state, verifying that components call the correct Dioxus commands with the right arguments, or checking that the renderer handles mock responses correctly.
+
+It is **not** suitable when your tests need to:
+
+- Call `browser.dioxus.execute()` to run code with access to the bridge
+- Test window management with `browser.dioxus.switchWindow()` or `browser.dioxus.listWindows()`
+- Use `browser.dioxus.triggerDeeplink()`
+- Assert on real command round-trips to a running Rust backend
+
+For those scenarios use native mode (the default).
+
+## Setup
+
+### 1. Start Your Dev Server
+
+Browser mode requires a running dev server that serves your frontend code.
+
+### 2. Configure the Service
+
+Set `mode: 'browser'` and provide `devServerUrl` in your WDIO configuration. No `appBinaryPath`, `dioxus:options`, or driver config is needed.
+
+_`wdio.conf.ts`_
+
+```ts
+export const config = {
+  services: ['@wdio/dioxus-service'],
+  capabilities: [
+    {
+      browserName: 'dioxus',
+      'wdio:dioxusServiceOptions': {
+        mode: 'browser',
+        devServerUrl: 'http://localhost:8080',
+      },
+    },
+  ],
+};
+```
+
+You can also set `mode` and `devServerUrl` at the global service level:
+
+```ts
+export const config = {
+  services: [
+    [
+      '@wdio/dioxus-service',
+      {
+        mode: 'browser',
+        devServerUrl: 'http://localhost:8080',
+      },
+    ],
+  ],
+  capabilities: [
+    { browserName: 'dioxus' },
+  ],
+};
+```
+
+Capability-level options take precedence over service-level ones. All capabilities in a session must use the same mode; mixing `'native'` and `'browser'` across capabilities throws a `SevereServiceError` at startup.
+
+## IPC Mocking
+
+### How It Works
+
+When the session starts, the service injects a script into the page that:
+
+1. Creates `window.__wdio_mocks__` — a registry of per-command mock functions.
+2. Patches the Dioxus invoke API to look up `window.__wdio_mocks__[command]` and call it; throws if the command has no registered mock.
+
+The injection script runs again after every `browser.url()` navigation because a page load wipes `window` state.
+
+### Mocking a Command
+
+```ts
+const mockReadFile = await browser.dioxus.mock('read_file');
+await mockReadFile.mockResolvedValue('mocked file content');
+```
+
+### Asserting on Calls
+
+After triggering the relevant UI action, call `update()` to sync call data from the browser-side spy to the outer mock object, then assert:
+
+```ts
+await $('button#load-file').click();
+
+await mockReadFile.update();
+expect(mockReadFile).toHaveBeenCalledTimes(1);
+expect(mockReadFile.mock.calls[0]).toEqual([{ path: '/some/file' }]);
+```
+
+Element commands (`click`, `doubleClick`, `setValue`, `clearValue`) trigger `update()` automatically on all active mocks.
+
+### Setting Implementations
+
+```ts
+// Return a fixed value
+await mockReadFile.mockReturnValue('file content');
+
+// Resolve a promise (for async commands)
+await mockReadFile.mockResolvedValue('file content');
+
+// Use a function for dynamic responses
+await mockReadFile.mockImplementation((args) => {
+  return `content of ${args.path}`;
+});
+
+// Respond differently on first call, then fall back
+await mockReadFile.mockResolvedValueOnce('first call content');
+await mockReadFile.mockResolvedValue('default content');
+```
+
+### Restoring a Mock
+
+```ts
+await mockReadFile.mockRestore();
+```
+
+## Mock Lifecycle Across Tests
+
+### `mock(command)` Is Idempotent
+
+Calling `browser.dioxus.mock(command)` multiple times for the same command is safe, but the service always fully resets the existing mock (via `mockReset()`) before returning it — both call history and any previously-set implementation are cleared on every call. Set the implementation in `beforeEach` rather than relying on `beforeAll` setup persisting.
+
+```ts
+describe('File panel', () => {
+  let mockReadFile: DioxusMock;
+
+  beforeEach(async () => {
+    mockReadFile = await browser.dioxus.mock('read_file');
+    await mockReadFile.mockResolvedValue('default content');
+  });
+
+  it('displays file content', async () => {
+    await $('button#load-file').click();
+    await mockReadFile.update();
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+## Navigation
+
+`browser.url()` is patched by the service to re-run the IPC injection script after every navigation. This re-creates `window.__wdio_mocks__` (as an empty object). Existing mock handles remain valid as JS objects, but their browser-side entries are gone. To recover, call `mockRestore()` first and then `mock(command)` to re-create the browser-side entry.
+
+## Limitations
+
+| Feature | Browser Mode |
+|---------|-------------|
+| `browser.dioxus.execute()` | Throws — no Dioxus backend or bridge |
+| `browser.dioxus.triggerDeeplink()` | Throws — no Dioxus process |
+| `browser.dioxus.switchWindow()` | Throws — multi-window requires a native Dioxus app |
+| `browser.dioxus.listWindows()` | Throws — same reason as `switchWindow()` |
+| Backend log capture (`captureBackendLogs`) | Not available — no Rust process |
+| Frontend log capture (`captureFrontendLogs`) | Available — Chrome session, standard console capture |
+
+## Multiremote
+
+Each named multiremote instance gets its own isolated mock registry.
+
+```ts
+export const config = {
+  services: [['@wdio/dioxus-service', { mode: 'browser' }]],
+  capabilities: {
+    app1: {
+      capabilities: {
+        browserName: 'dioxus',
+        'wdio:dioxusServiceOptions': { devServerUrl: 'http://localhost:8080' },
+      },
+    },
+    app2: {
+      capabilities: {
+        browserName: 'dioxus',
+        'wdio:dioxusServiceOptions': { devServerUrl: 'http://localhost:8080' },
+      },
+    },
+  },
+};
+```
+
+```ts
+const mock1 = await browser.getInstance('app1').dioxus.mock('read_file');
+const mock2 = await browser.getInstance('app2').dioxus.mock('read_file');
+
+await mock1.mockResolvedValue('content from app1');
+await mock2.mockResolvedValue('content from app2');
+```
+
+## Troubleshooting
+
+### `"unmocked Dioxus command in browser mode: <command>"`
+
+Your renderer called `invoke(command)` before a mock was registered. Call `browser.dioxus.mock(command)` before the code path that triggers the command.
+
+### Mock returns `undefined` after navigation
+
+The browser-side entry was wiped by navigation. Call `mock.mockRestore()` first to delete the worker-side entry, then `browser.dioxus.mock(command)` to re-create both sides.
+
+### Dev server not running
+
+The service throws a `SevereServiceError` if `devServerUrl` is missing or not a valid URL. A connection-refused error from Chrome means the dev server is not running — start it before launching the test suite.

--- a/packages/dioxus-service/docs/coexistence.md
+++ b/packages/dioxus-service/docs/coexistence.md
@@ -187,10 +187,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: npm install
       - run: cargo build
         working-directory: apps/dioxus-app
       - name: Run tests (Linux needs a virtual display)
@@ -207,10 +211,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: npm install
       - run: cargo build
         working-directory: apps/tauri-app/src-tauri
       - name: Run tests (Linux needs a virtual display)
@@ -227,6 +235,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
       - run: npm run build:electron-app
       - name: Run tests (Linux needs a virtual display)
         if: runner.os == 'Linux'

--- a/packages/dioxus-service/docs/coexistence.md
+++ b/packages/dioxus-service/docs/coexistence.md
@@ -1,0 +1,223 @@
+# Coexistence with Other Services
+
+This guide explains how to run `@wdio/dioxus-service` alongside `@wdio/tauri-service` and `@wdio/electron-service` in the same monorepo.
+
+## Overview
+
+Each service is designed to be independent. They share `@wdio/native-types` for TypeScript types and `@wdio/native-spy` for mock utilities, but they do not interfere with each other when configured correctly.
+
+## Capability Disambiguation
+
+Each service identifies its target app via `browserName`:
+
+| Service | `browserName` |
+|---------|---------------|
+| `@wdio/dioxus-service` | `'dioxus'` |
+| `@wdio/tauri-service` | `'tauri'` |
+| `@wdio/electron-service` | `'electron'` |
+
+When a WDIO runner starts, each service checks the `browserName` of each capability and only takes ownership of capabilities matching its framework. Unrecognized capabilities are passed through untouched.
+
+## Separate Config Files Per Service
+
+The recommended approach is to maintain a separate `wdio.conf.ts` per framework:
+
+```
+your-monorepo/
+├── apps/
+│   ├── dioxus-app/         # Dioxus app source
+│   ├── tauri-app/          # Tauri app source
+│   └── electron-app/       # Electron app source
+├── e2e/
+│   ├── test/
+│   │   ├── dioxus/         # Dioxus E2E specs
+│   │   ├── tauri/          # Tauri E2E specs
+│   │   └── electron/       # Electron E2E specs
+│   ├── wdio.dioxus.conf.ts
+│   ├── wdio.tauri.conf.ts
+│   └── wdio.electron.conf.ts
+```
+
+### `wdio.dioxus.conf.ts`
+
+```typescript
+export const config = {
+  specs: ['./test/dioxus/**/*.spec.ts'],
+  services: [['@wdio/dioxus-service', {
+    driverProvider: 'embedded',
+  }]],
+  capabilities: [{
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: '../apps/dioxus-app/target/debug/dioxus_app',
+    },
+  }],
+};
+```
+
+### `wdio.tauri.conf.ts`
+
+```typescript
+export const config = {
+  specs: ['./test/tauri/**/*.spec.ts'],
+  services: [['@wdio/tauri-service', {
+    driverProvider: 'embedded',
+  }]],
+  capabilities: [{
+    browserName: 'tauri',
+    'tauri:options': {
+      application: '../apps/tauri-app/src-tauri/target/debug/tauri_app',
+    },
+  }],
+};
+```
+
+### `wdio.electron.conf.ts`
+
+```typescript
+export const config = {
+  specs: ['./test/electron/**/*.spec.ts'],
+  services: [['@wdio/electron-service', {
+    appBinaryPath: '../apps/electron-app/dist/my-app',
+  }]],
+  capabilities: [{
+    browserName: 'electron',
+  }],
+};
+```
+
+## Running Specific Suites
+
+```bash
+# Dioxus tests only
+npx wdio run wdio.dioxus.conf.ts
+
+# Tauri tests only
+npx wdio run wdio.tauri.conf.ts
+
+# Electron tests only
+npx wdio run wdio.electron.conf.ts
+```
+
+Or with package scripts:
+
+```json
+{
+  "scripts": {
+    "test:e2e:dioxus": "wdio run wdio.dioxus.conf.ts",
+    "test:e2e:tauri": "wdio run wdio.tauri.conf.ts",
+    "test:e2e:electron": "wdio run wdio.electron.conf.ts",
+    "test:e2e": "run-p test:e2e:*"
+  }
+}
+```
+
+## Shared Types — No Conflicts
+
+All three services share `@wdio/native-types` for TypeScript type definitions. The types for each service are namespaced to avoid conflicts:
+
+| Type | Service |
+|------|---------|
+| `DioxusServiceOptions` | `@wdio/dioxus-service` |
+| `TauriServiceOptions` | `@wdio/tauri-service` |
+| `ElectronServiceOptions` | `@wdio/electron-service` |
+
+The capability extensions are also namespaced:
+
+| Capability key | Service |
+|----------------|---------|
+| `'dioxus:options'` | Dioxus |
+| `'wdio:dioxusServiceOptions'` | Dioxus |
+| `'tauri:options'` | Tauri |
+| `'wdio:tauriServiceOptions'` | Tauri |
+| `'wdio:electronServiceOptions'` | Electron |
+
+## Mixed-Service Test Session (Advanced)
+
+If you want to run Dioxus and Tauri tests in a single WDIO session (not recommended for most cases), both services can coexist in the same config:
+
+```typescript
+export const config = {
+  specs: ['./test/**/*.spec.ts'],
+  services: [
+    ['@wdio/dioxus-service', { driverProvider: 'embedded' }],
+    ['@wdio/tauri-service', { driverProvider: 'embedded' }],
+  ],
+  capabilities: [
+    {
+      browserName: 'dioxus',
+      'dioxus:options': {
+        application: './target/debug/my_dioxus_app',
+      },
+    },
+    {
+      browserName: 'tauri',
+      'tauri:options': {
+        application: './src-tauri/target/debug/my_tauri_app',
+      },
+    },
+  ],
+};
+```
+
+Each service only activates for capabilities with a matching `browserName`. The Dioxus service ignores `tauri:options` capabilities and vice versa.
+
+## Port Management
+
+If running multiple services simultaneously, ensure their embedded ports do not conflict:
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', { driverProvider: 'embedded', embeddedPort: 4445 }],
+  ['@wdio/tauri-service', { driverProvider: 'embedded', embeddedPort: 4450 }],
+],
+```
+
+## CI Matrix
+
+For CI, test each framework in parallel across OS runners:
+
+```yaml
+# .github/workflows/e2e.yml
+jobs:
+  e2e-dioxus:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build
+        working-directory: apps/dioxus-app
+      - run: npm run test:e2e:dioxus
+
+  e2e-tauri:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build
+        working-directory: apps/tauri-app/src-tauri
+      - run: npm run test:e2e:tauri
+
+  e2e-electron:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm run build:electron-app
+      - run: npm run test:e2e:electron
+```
+
+## See Also
+
+- [@wdio/tauri-service README](../../tauri-service/README.md)
+- [@wdio/electron-service README](../../electron-service/README.md)
+- [Configuration](./configuration.md)
+- [Platform Support](./platform-support.md)

--- a/packages/dioxus-service/docs/coexistence.md
+++ b/packages/dioxus-service/docs/coexistence.md
@@ -188,9 +188,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
       - run: cargo build
         working-directory: apps/dioxus-app
-      - run: npm run test:e2e:dioxus
+      - name: Run tests (Linux needs a virtual display)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:e2e:dioxus
+      - name: Run tests
+        if: runner.os != 'Linux'
+        run: npm run test:e2e:dioxus
 
   e2e-tauri:
     strategy:
@@ -200,9 +208,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
       - run: cargo build
         working-directory: apps/tauri-app/src-tauri
-      - run: npm run test:e2e:tauri
+      - name: Run tests (Linux needs a virtual display)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:e2e:tauri
+      - name: Run tests
+        if: runner.os != 'Linux'
+        run: npm run test:e2e:tauri
 
   e2e-electron:
     strategy:
@@ -212,7 +228,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm run build:electron-app
-      - run: npm run test:e2e:electron
+      - name: Run tests (Linux needs a virtual display)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:e2e:electron
+      - name: Run tests
+        if: runner.os != 'Linux'
+        run: npm run test:e2e:electron
 ```
 
 ## See Also

--- a/packages/dioxus-service/docs/configuration.md
+++ b/packages/dioxus-service/docs/configuration.md
@@ -1,0 +1,544 @@
+# Configuration Reference
+
+Complete guide to configuring @wdio/dioxus-service in your WebdriverIO setup.
+
+## Service Configuration
+
+Add the Dioxus service to your `wdio.conf.ts`:
+
+```typescript
+export const config = {
+  services: [
+    ['@wdio/dioxus-service', {
+      // Service options go here
+      driverProvider: 'embedded',
+      captureBackendLogs: true,
+      captureFrontendLogs: true,
+    }]
+  ],
+  // ... rest of config
+};
+```
+
+## Service Options
+
+### `driverProvider` ('external' | 'embedded', optional)
+
+Select which driver provider to use for WebDriver communication.
+
+- `'embedded'`: Use the embedded WebDriver server wired in via `wdio-dioxus-bridge::install()`. No external driver needed. Works on all three platforms.
+- `'external'`: Use `wdio-dioxus-driver` + msedgedriver (Windows only in v1). Linux is blocked pending an upstream Dioxus PR; macOS is not supported.
+
+**Platform × Provider matrix:**
+
+| Platform | `'embedded'` | `'external'` |
+|----------|-------------|-------------|
+| Windows  | ✅ Yes      | ✅ Yes      |
+| Linux    | ✅ Yes      | ❌ Blocked in v1 |
+| macOS    | ✅ Yes      | ❌ Not supported |
+
+**Default:** `'embedded'`
+
+**Example:**
+```typescript
+driverProvider: 'embedded'   // Recommended everywhere
+driverProvider: 'external'   // Windows only in v1
+```
+
+---
+
+### `appBinaryPath` (string, optional)
+
+Path to the compiled Dioxus application binary.
+
+**Example:**
+```typescript
+appBinaryPath: './target/debug/my_app',    // debug build (bridge active)
+appBinaryPath: './target/release/my_app',  // release build (bridge inactive)
+```
+
+**Default:** Auto-detected from `dioxus:options.application` capability if not provided.
+
+**Note:** For testing, always use a debug build (`cargo build` without `--release`) so the bridge is compiled in.
+
+---
+
+### `appArgs` (string[], optional)
+
+Command-line arguments to pass to the Dioxus application when launching. Each array element is a separate argument — no shell parsing is applied.
+
+**Example:**
+```typescript
+appArgs: ['--debug', '--log-level', 'debug']
+appArgs: ['--window-size=1920,1080']
+```
+
+**Default:** `[]`
+
+---
+
+### `autoInstallDioxusDriver` (boolean, optional)
+
+Automatically install `wdio-dioxus-driver` if not found in PATH. Only relevant when `driverProvider: 'external'`. Requires Rust toolchain (`cargo`).
+
+**Example:**
+```typescript
+autoInstallDioxusDriver: true
+```
+
+**Default:** `false`
+
+---
+
+### `autoDownloadEdgeDriver` (boolean, optional)
+
+Automatically download MSEdgeDriver on Windows if a version mismatch is detected. Only relevant when `driverProvider: 'external'` on Windows.
+
+**Example:**
+```typescript
+autoDownloadEdgeDriver: true  // Windows + external provider only
+```
+
+**Default:** `true`
+
+**Note:** Ignored on Linux and macOS. See [Edge WebDriver (Windows)](./edge-webdriver-windows.md).
+
+---
+
+### `dioxusDriverPort` (number, optional)
+
+Port for `wdio-dioxus-driver` to listen on. Only used when `driverProvider: 'external'`.
+
+**Example:**
+```typescript
+dioxusDriverPort: 4444
+```
+
+**Default:** `4444`
+
+---
+
+### `dioxusDriverPath` (string, optional)
+
+Path to the `wdio-dioxus-driver` executable if not in PATH. Only used when `driverProvider: 'external'`.
+
+**Example:**
+```typescript
+dioxusDriverPath: '/usr/local/bin/wdio-dioxus-driver'
+dioxusDriverPath: 'C:\\tools\\wdio-dioxus-driver.exe'
+```
+
+**Default:** Use `wdio-dioxus-driver` from PATH.
+
+---
+
+### `embeddedPort` (number, optional)
+
+Port for the embedded WebDriver server. Only used when `driverProvider: 'embedded'`.
+
+Each worker instance gets a unique port (basePort + workerIndex).
+
+**Example:**
+```typescript
+embeddedPort: 4445
+```
+
+**Default:** `4445`
+
+---
+
+### `statusPollTimeout` (number, optional)
+
+Timeout in milliseconds for the `/status` endpoint poll during embedded WebDriver server startup. Increase this in slow CI environments where a healthy-but-busy server may miss the default deadline.
+
+**Example:**
+```typescript
+statusPollTimeout: 5000
+```
+
+**Default:** `2000`
+
+**Note:** Only applies when `driverProvider: 'embedded'`.
+
+---
+
+### `startTimeout` (number, optional)
+
+Timeout in milliseconds for the Dioxus app to start and become ready.
+
+**Example:**
+```typescript
+startTimeout: 60000  // 60 seconds
+```
+
+**Default:** `60000` for the `'embedded'` provider; `30000` for `'external'`.
+
+---
+
+### `windowLabel` (string, optional)
+
+The default window label to target for Dioxus operations. Controls which webview window `browser.dioxus.execute()` and other Dioxus-specific operations target by default.
+
+**Example:**
+```typescript
+windowLabel: 'settings'  // Target the settings window by default
+```
+
+**Default:** `'main'`
+
+**Note:** Override at runtime with `browser.dioxus.switchWindow(label)`.
+
+---
+
+### `captureBackendLogs` (boolean, optional)
+
+Capture logs from the Dioxus backend (Rust code) and forward them to WebdriverIO's logger.
+
+**Example:**
+```typescript
+captureBackendLogs: true
+```
+
+**Default:** `false`
+
+**Note:** See [Log Forwarding](./log-forwarding.md).
+
+---
+
+### `captureFrontendLogs` (boolean, optional)
+
+Capture console logs from the frontend (JavaScript/TypeScript in the webview).
+
+**Example:**
+```typescript
+captureFrontendLogs: true
+```
+
+**Default:** `false`
+
+**Note:** See [Log Forwarding](./log-forwarding.md).
+
+---
+
+### `backendLogLevel` ('trace' | 'debug' | 'info' | 'warn' | 'error', optional)
+
+Minimum log level to capture from the Rust backend. Logs below this level are ignored.
+
+**Example:**
+```typescript
+backendLogLevel: 'debug'  // Capture debug and above
+```
+
+**Default:** `'info'`
+
+**Note:** Only has effect if `captureBackendLogs: true`.
+
+---
+
+### `frontendLogLevel` ('trace' | 'debug' | 'info' | 'warn' | 'error', optional)
+
+Minimum log level to capture from the frontend webview. Logs below this level are ignored.
+
+**Example:**
+```typescript
+frontendLogLevel: 'debug'
+```
+
+**Default:** `'info'`
+
+**Note:** Only has effect if `captureFrontendLogs: true`.
+
+---
+
+### `env` (Record<string, string>, optional)
+
+Additional environment variables to pass to the Dioxus application process.
+
+**Example:**
+```typescript
+env: {
+  RUST_LOG: 'debug',
+  MY_APP_ENV: 'test',
+}
+```
+
+**Default:** `{}`
+
+---
+
+### `mode` ('native' | 'browser', optional)
+
+Controls how the service connects to your application.
+
+- `'native'` (default) — launches your compiled Dioxus binary via the configured driver provider.
+- `'browser'` — skips all driver and binary setup; sets `browserName = 'chrome'`, navigates to `devServerUrl`, and intercepts the invoke API so Dioxus commands can be mocked without a running Rust backend.
+
+**Example:**
+```typescript
+mode: 'browser'
+```
+
+**Default:** `'native'`
+
+> All capabilities in a session must use the same mode. Mixing `'native'` and `'browser'` across capabilities throws a `SevereServiceError` at startup.
+
+See [Browser Mode](./browser-mode.md) for setup, mocking, and limitations.
+
+---
+
+### `devServerUrl` (string, required in browser mode)
+
+URL of the dev server to navigate to when `mode: 'browser'` is set. Validated with `new URL()` at startup.
+
+**Example:**
+```typescript
+devServerUrl: 'http://localhost:8080'
+```
+
+**Default:** `undefined`
+
+**Note:** Only used when `mode: 'browser'`. Has no effect in native mode. See [Browser Mode](./browser-mode.md).
+
+---
+
+### `clearMocks` (boolean, optional)
+
+If `true`, all mock call history is cleared before each test. Equivalent to calling `browser.dioxus.clearAllMocks()` in a `beforeEach`.
+
+**Default:** `false`
+
+---
+
+### `clearMocksPrefix` (string, optional)
+
+If set, only mocks whose command name starts with this prefix are cleared. Only used when `clearMocks: true`.
+
+**Default:** `undefined`
+
+---
+
+### `resetMocks` (boolean, optional)
+
+If `true`, all mocks are reset (implementation + history) before each test.
+
+**Default:** `false`
+
+---
+
+### `resetMocksPrefix` (string, optional)
+
+If set, only mocks whose command name starts with this prefix are reset. Only used when `resetMocks: true`.
+
+**Default:** `undefined`
+
+---
+
+### `restoreMocks` (boolean, optional)
+
+If `true`, all mocks are restored to their original implementations before each test.
+
+**Default:** `false`
+
+---
+
+### `restoreMocksPrefix` (string, optional)
+
+If set, only mocks whose command name starts with this prefix are restored. Only used when `restoreMocks: true`.
+
+**Default:** `undefined`
+
+---
+
+## Capabilities Configuration
+
+Configure Dioxus-specific capabilities in your `capabilities` array:
+
+### Basic Configuration
+
+```typescript
+capabilities: [{
+  browserName: 'dioxus',
+  'dioxus:options': {
+    application: './target/debug/my_app'
+  }
+}]
+```
+
+### Full Capability Configuration
+
+```typescript
+capabilities: [{
+  browserName: 'dioxus',
+  'dioxus:options': {
+    application: './target/debug/my_app',
+    args: ['--debug'],
+    webviewOptions: {
+      width: 1280,
+      height: 800,
+    },
+  },
+  'wdio:dioxusServiceOptions': {
+    windowLabel: 'main',
+    captureBackendLogs: true,
+  },
+}]
+```
+
+### `dioxus:options` Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `application` | string | Yes | Path to the Dioxus app binary |
+| `args` | string[] | No | Arguments passed to the app |
+| `webviewOptions.width` | number | No | Initial window width in pixels |
+| `webviewOptions.height` | number | No | Initial window height in pixels |
+
+### Multiremote Configuration
+
+```typescript
+capabilities: {
+  app1: {
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app'
+    }
+  },
+  app2: {
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app'
+    }
+  }
+}
+```
+
+## Complete Configuration Example
+
+```typescript
+// wdio.conf.ts
+export const config = {
+  runner: 'local',
+  specs: ['./test/specs/**/*.spec.ts'],
+  maxInstances: 1,
+
+  services: [
+    ['@wdio/dioxus-service', {
+      driverProvider: 'embedded',
+      appBinaryPath: './target/debug/my_app',
+      appArgs: [],
+      embeddedPort: 4445,
+      startTimeout: 60000,
+      statusPollTimeout: 2000,
+      captureBackendLogs: true,
+      captureFrontendLogs: true,
+      backendLogLevel: 'debug',
+      frontendLogLevel: 'debug',
+      windowLabel: 'main',
+      clearMocks: false,
+      resetMocks: false,
+      restoreMocks: false,
+    }]
+  ],
+
+  capabilities: [{
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app',
+    },
+  }],
+
+  logLevel: 'info',
+  bail: 0,
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 90000,
+  connectionRetryCount: 3,
+
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+  },
+
+  reporters: ['spec'],
+};
+```
+
+## Platform-Specific Configuration
+
+### Windows (`'embedded'` — recommended)
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', {
+    driverProvider: 'embedded',
+    appBinaryPath: './target/debug/my_app.exe',
+  }]
+]
+```
+
+### Windows (`'external'`)
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', {
+    driverProvider: 'external',
+    autoInstallDioxusDriver: true,
+    autoDownloadEdgeDriver: true,
+    appBinaryPath: './target/debug/my_app.exe',
+  }]
+]
+```
+
+### Linux (embedded only)
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', {
+    driverProvider: 'embedded',  // Only supported option on Linux
+    appBinaryPath: './target/debug/my_app',
+  }]
+]
+```
+
+### macOS (embedded only)
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', {
+    driverProvider: 'embedded',  // Only supported option on macOS
+    appBinaryPath: './target/debug/my_app',
+  }]
+]
+```
+
+## Finding Your Binary Path
+
+### Debug Build (for testing)
+
+```bash
+cargo build
+```
+
+Binary locations:
+- Windows: `target\debug\my_app.exe`
+- Linux/macOS: `target/debug/my_app`
+
+### Release Build (for production — bridge compiled out)
+
+```bash
+cargo build --release
+```
+
+Binary locations:
+- Windows: `target\release\my_app.exe`
+- Linux/macOS: `target/release/my_app`
+
+**Always use a debug build for testing** so the bridge code is present.
+
+## See Also
+
+- [Quick Start](./quick-start.md) for getting started
+- [Bridge Setup](./plugin-setup.md) for bridge configuration
+- [API Reference](./api-reference.md) for available functions
+- [Log Forwarding](./log-forwarding.md) for logging configuration
+- [Platform Support](./platform-support.md) for per-platform details

--- a/packages/dioxus-service/docs/deeplink-testing.md
+++ b/packages/dioxus-service/docs/deeplink-testing.md
@@ -1,0 +1,160 @@
+# Deeplink Testing
+
+The service provides the ability to test custom protocol handlers and deeplinks in your Dioxus application using the `browser.dioxus.triggerDeeplink()` method.
+
+## Overview
+
+### What Is Deeplink Testing?
+
+Deeplink testing allows you to verify that your Dioxus application correctly handles custom protocol URLs (e.g., `myapp://action?param=value`). This is essential when your app registers as a protocol handler and needs to respond to URLs opened from external sources.
+
+### When Should You Use It?
+
+Use `browser.dioxus.triggerDeeplink()` when you need to:
+
+- Test that your app correctly handles custom protocol URLs
+- Verify deeplink parameter parsing and routing logic
+- Test protocol handler registration and activation
+- Validate deeplink-driven workflows in your application
+
+## Prerequisites
+
+### Protocol Registration
+
+Your Dioxus app must register its custom protocol scheme with the operating system. The mechanism depends on your app's packaging setup — consult your OS or Dioxus desktop documentation for registering a URL scheme handler.
+
+## Basic Usage
+
+### Simple Example
+
+```typescript
+describe('Protocol Handler Tests', () => {
+  it('should handle custom protocol deeplinks', async () => {
+    await browser.dioxus.triggerDeeplink('myapp://open?file=test.txt');
+
+    await browser.waitUntil(async () => {
+      const openedFile = await browser.dioxus.execute(() => {
+        return globalThis.lastOpenedFile;
+      });
+      return openedFile === 'test.txt';
+    }, {
+      timeout: 5000,
+      timeoutMsg: 'App did not handle the deeplink',
+    });
+  });
+});
+```
+
+### Complex URL Parameters
+
+```typescript
+it('should preserve query parameters', async () => {
+  await browser.dioxus.triggerDeeplink(
+    'myapp://action?param1=value1&param2=value2'
+  );
+
+  const receivedParams = await browser.dioxus.execute(() => {
+    return globalThis.lastDeeplinkParams;
+  });
+
+  expect(receivedParams.param1).toBe('value1');
+  expect(receivedParams.param2).toBe('value2');
+});
+```
+
+### Error Handling
+
+```typescript
+it('should reject invalid protocols', async () => {
+  await expect(
+    browser.dioxus.triggerDeeplink('https://example.com')
+  ).rejects.toThrow('Invalid deeplink protocol');
+});
+```
+
+## Platform Behavior
+
+The service handles platform-specific differences automatically:
+
+### Windows
+
+- Uses `cmd /c start` to trigger the deeplink.
+
+### macOS
+
+- Uses `open` to trigger the deeplink.
+
+### Linux
+
+- Uses `xdg-open` to trigger the deeplink.
+
+## App Implementation
+
+Your Dioxus app needs to listen for deeplinks. The implementation depends on how you register the URL scheme. A typical pattern:
+
+```rust
+use dioxus::prelude::*;
+
+#[component]
+fn App() -> Element {
+    let deeplink = use_signal(|| String::new());
+
+    // Listen for OS deeplink events via your URL scheme handler mechanism
+    // and update the `deeplink` signal
+
+    rsx! {
+        div {
+            p { "Last deeplink: {deeplink}" }
+        }
+    }
+}
+```
+
+Store deeplink data in a globally accessible location so tests can read it via `browser.dioxus.execute()`.
+
+## Common Issues
+
+### Deeplinks Not Received in App
+
+**Symptom:** The deeplink is triggered but your app doesn't receive it.
+
+**Possible Causes:**
+
+1. **Protocol not registered** — verify your app is registered as the handler for the scheme.
+2. **Listener not set up before trigger** — ensure your deeplink listener is active before calling `triggerDeeplink()`.
+3. **Timing** — the OS may take a moment to route the deeplink to your running app.
+
+### Timing Issues
+
+**Solution:** Use `waitUntil` to wait for the app to process the deeplink:
+
+```typescript
+await browser.dioxus.triggerDeeplink('myapp://action');
+
+await browser.waitUntil(async () => {
+  const processed = await browser.dioxus.execute(() => {
+    return globalThis.deeplinkProcessed;
+  });
+  return processed === true;
+}, {
+  timeout: 5000,
+  timeoutMsg: 'App did not process the deeplink within 5 seconds',
+});
+```
+
+### Invalid Protocol Error
+
+Only use custom protocol schemes — not `https`, `http`, or `file`:
+
+```typescript
+// Correct — custom protocol
+await browser.dioxus.triggerDeeplink('myapp://action');
+
+// Incorrect — web protocol (throws)
+await browser.dioxus.triggerDeeplink('https://example.com');
+```
+
+## See Also
+
+- [API Reference](./api-reference.md) for complete method documentation
+- [Usage Examples](./usage-examples.md) for additional patterns

--- a/packages/dioxus-service/docs/development.md
+++ b/packages/dioxus-service/docs/development.md
@@ -1,0 +1,197 @@
+# Development
+
+Guide for developing and contributing to `@wdio/dioxus-service`.
+
+## Prerequisites
+
+See the [Monorepo Setup Guide](../../docs/setup.md) for Node.js, pnpm, and Git setup.
+
+**Dioxus-specific requirement — Rust Toolchain:**
+
+```bash
+rustc --version
+cargo --version
+```
+
+Install via [rustup](https://rustup.rs) if not present.
+
+## Setup
+
+Follow the [Monorepo Setup Guide](../../docs/setup.md) to clone the repo and install dependencies, then build the Dioxus service:
+
+```bash
+pnpm --filter @wdio/dioxus-service build
+```
+
+### Watch Mode
+
+```bash
+pnpm --filter @wdio/dioxus-service dev
+```
+
+## Building the Dioxus Fixture App
+
+The E2E fixture app must be built before running E2E tests:
+
+```bash
+cd fixtures/e2e-apps/dioxus
+cargo build
+```
+
+This produces a debug binary with `wdio-dioxus-bridge` active (because the build is in debug mode, `#[cfg(debug_assertions)]` is satisfied).
+
+## Testing
+
+### Unit Tests
+
+```bash
+pnpm --filter @wdio/dioxus-service test:unit
+```
+
+### Integration Tests
+
+```bash
+pnpm --filter @wdio/dioxus-service test:integration
+```
+
+### All Tests
+
+```bash
+pnpm --filter @wdio/dioxus-service test
+```
+
+### With Coverage
+
+```bash
+pnpm --filter @wdio/dioxus-service test:coverage
+```
+
+Coverage threshold: ≥ 80% statement coverage, as per [AGENTS.md](../../AGENTS.md).
+
+### Watch Mode
+
+```bash
+pnpm --filter @wdio/dioxus-service test:watch
+```
+
+## E2E Tests
+
+Run the full E2E suite against the built fixture app:
+
+```bash
+# Embedded provider (all platforms)
+cd e2e && pnpm wdio run wdio.dioxus-embedded.conf.ts
+
+# External provider (Windows only)
+cd e2e && pnpm wdio run wdio.dioxus-external.conf.ts
+```
+
+Platform-specific notes:
+- **Linux**: Run under Xvfb: `xvfb-run -a pnpm wdio run wdio.dioxus-embedded.conf.ts`
+- **Windows `'external'`**: Requires `wdio-dioxus-driver` and msedgedriver (auto-managed)
+
+## Code Quality
+
+See the [Monorepo Setup Guide](../../docs/setup.md#code-quality) for formatting and linting commands.
+
+## Key Features
+
+### Embedded Driver Provider
+
+Located in `src/providers/embedded.ts`:
+
+- Spawns the Dioxus app with `DIOXUS_WEBVIEW_AUTOMATION=true` and `DIOXUS_WEBVIEW_AUTOMATION_PORT`
+- Polls the embedded WebDriver server `/status` endpoint on startup
+- Each worker gets a unique port (basePort + workerIndex)
+
+### External Driver Provider (Windows)
+
+Located in `src/providers/external.ts`:
+
+- Spawns `wdio-dioxus-driver` which proxies to `msedgedriver.exe`
+- Auto-downloads matching msedgedriver version
+- Only active on Windows; throws `SevereServiceError` on Linux and macOS
+
+### Bridge Communication
+
+`wdio-dioxus-bridge` provides:
+
+- Script execution via the `wdio://` custom protocol
+- Command mocking via invoke interception (guest-js bundle)
+- Log forwarding via the bridge's log pipeline
+
+### Cross-Platform Support
+
+| Platform | Provider | Status |
+|----------|----------|--------|
+| Windows | `embedded` | Supported |
+| Windows | `external` | Supported |
+| Linux | `embedded` | Supported |
+| Linux | `external` | v1.1 (blocked upstream) |
+| macOS | `embedded` | Supported |
+| macOS | `external` | Not supported |
+
+## Spike Findings
+
+The `spike/FINDINGS.md` document explains why `'external'` on Linux is deferred to v1.1: the upstream Dioxus/Wry codebase does not yet expose the automation toggle that `wdio-dioxus-driver` needs to pass to enable WebView2/WebKitGTK automation mode. Once the upstream PR lands, this block will be removed.
+
+## Common Tasks
+
+### Add a New Service Option
+
+1. Add to `DioxusServiceOptions` in `packages/native-types/src/dioxus.ts`
+2. Add a default value in the service class
+3. Add validation if needed
+4. Write tests
+
+### Add a New API Function
+
+1. Implement in `src/`
+2. Export from `src/index.ts`
+3. Add TypeScript types
+4. Write tests
+
+### Fix a Platform-Specific Issue
+
+1. Identify affected platforms (`windows`, `linux`, `darwin`)
+2. Add platform detection if needed
+3. Implement the fix
+4. Test on affected platforms or add platform-specific unit tests
+
+## Debugging
+
+### Enable Debug Logging
+
+```bash
+npx wdio run wdio.conf.ts --logLevel debug
+```
+
+### Debug Tests
+
+```bash
+node --inspect-brk node_modules/vitest/vitest.mjs run
+# Then open chrome://inspect in Chrome
+```
+
+## Dependency Management
+
+Dependencies are managed via the monorepo's catalog system. See [Dependency Management](../../docs/setup.md#dependency-management) for details.
+
+## Release
+
+Releases are managed by maintainers via GitHub Actions. See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the release process.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines, commit message format, and PR process.
+
+- **Questions**: [GitHub Discussions](https://github.com/webdriverio/desktop-mobile/discussions)
+- **Bugs**: [GitHub Issues](https://github.com/webdriverio/desktop-mobile/issues)
+- **Help Wanted**: [help:wanted issues](https://github.com/webdriverio/desktop-mobile/issues?q=is%3Aissue+is%3Aopen+label%3Ahelp%3Awanted+label%3Ascope%3Adioxus)
+
+## Resources
+
+- [WebdriverIO Documentation](https://webdriver.io)
+- [Dioxus Documentation](https://dioxuslabs.com/learn/0.6/)
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/)
+- [Vitest Documentation](https://vitest.dev/)

--- a/packages/dioxus-service/docs/edge-webdriver-windows.md
+++ b/packages/dioxus-service/docs/edge-webdriver-windows.md
@@ -1,0 +1,162 @@
+# Edge WebDriver Management for Windows
+
+## Overview
+
+On Windows, Dioxus applications use Microsoft Edge WebView2, which requires `msedgedriver.exe` for WebDriver automation when using the `'external'` driver provider. The dioxus-service automatically handles Edge WebDriver version matching to prevent version mismatch errors.
+
+This document only applies to the `'external'` driver provider on Windows. The `'embedded'` provider (recommended) has no Edge WebDriver dependency.
+
+## The Problem
+
+Tests using `driverProvider: 'external'` fail on Windows when the Edge browser version doesn't match the installed msedgedriver version:
+
+```
+Error: This version of Microsoft Edge WebDriver only supports Microsoft Edge version 144.
+Current browser version is 143.0.3650.139
+```
+
+## The Solution
+
+When `driverProvider: 'external'` and `autoDownloadEdgeDriver: true`, the dioxus-service automatically:
+1. **Detects** your Edge browser (WebView2) version
+2. **Checks** if a matching msedgedriver.exe exists
+3. **Downloads** the correct version if needed
+4. **Configures** PATH to use the downloaded driver
+
+## Configuration
+
+### Auto-Download (Recommended)
+
+By default, auto-download is **enabled** for the `'external'` provider:
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', {
+    driverProvider: 'external',
+    appBinaryPath: './target/debug/my_app.exe',
+    // autoDownloadEdgeDriver: true (default)
+  }]
+]
+```
+
+### Manual Management
+
+Disable auto-download if you prefer to manage drivers yourself:
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', {
+    driverProvider: 'external',
+    appBinaryPath: './target/debug/my_app.exe',
+    autoDownloadEdgeDriver: false,
+  }]
+]
+```
+
+With auto-download disabled, you must ensure msedgedriver matches your Edge version manually.
+
+## How It Works
+
+### 1. Version Detection
+
+The service detects the WebView2/Edge version from:
+- Windows Registry: `HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}`
+
+### 2. Driver Check
+
+Checks if msedgedriver.exe in PATH matches the detected Edge version (major version comparison).
+
+### 3. Download & Install
+
+If a mismatch is detected:
+- Downloads msedgedriver from `https://msedgedriver.azureedge.net/{version}/`
+- Caches in temp directory: `%TEMP%\msedgedriver\{majorVersion}\`
+- Adds to process PATH for test execution
+
+## Troubleshooting
+
+### "Could not detect Edge version"
+
+**Cause:** Edge not installed or registry keys missing.
+
+**Solution:** Install Microsoft Edge from https://www.microsoft.com/edge
+
+### "Failed to download msedgedriver"
+
+**Causes:**
+- Network/proxy issues
+- Microsoft's CDN temporarily unavailable
+
+**Solutions:**
+1. Check internet connection and proxy settings
+2. Retry — CDN may be temporarily down
+3. Download manually from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+4. Place `msedgedriver.exe` in PATH
+
+### "Version mismatch" even after download
+
+**Cause:** Another msedgedriver.exe earlier in PATH is being used.
+
+**Solution:** Check PATH order:
+```powershell
+where msedgedriver.exe
+```
+Ensure the correct version appears first.
+
+### CI/GitHub Actions Issues
+
+GitHub Actions runners may have outdated Edge. Update if needed:
+
+```yaml
+- name: Update Edge (if needed)
+  if: runner.os == 'Windows'
+  run: choco upgrade microsoft-edge -y
+
+- name: Run tests
+  run: npm run test:e2e
+```
+
+## Manual Driver Management
+
+If you disable auto-download:
+
+### Check Edge Version
+```powershell
+reg query "HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}" /v pv
+```
+
+### Download Matching Driver
+1. Visit https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+2. Download the version matching your Edge major version
+3. Extract `msedgedriver.exe`
+4. Add to PATH or place in project directory
+
+### Verify Installation
+```powershell
+msedgedriver.exe --version
+```
+
+## Cache Location
+
+Downloaded drivers are cached at:
+```
+%TEMP%\msedgedriver\{majorVersion}\msedgedriver.exe
+```
+
+Example: `C:\Users\YourName\AppData\Local\Temp\msedgedriver\143\msedgedriver.exe`
+
+## Platform Notes
+
+- **Windows**: Edge driver management runs when `driverProvider: 'external'`
+- **Linux**: `'external'` provider is blocked in v1 — use `'embedded'`
+- **macOS**: `'external'` provider is not supported — use `'embedded'`
+
+## Recommendation
+
+Use `driverProvider: 'embedded'` for the simplest Windows setup — it works on all platforms without any external driver or Edge WebDriver management.
+
+## See Also
+
+- [Platform Support](./platform-support.md) for the full provider matrix
+- [Configuration](./configuration.md) for `autoDownloadEdgeDriver` and related options
+- [Troubleshooting](./troubleshooting.md) for common issues

--- a/packages/dioxus-service/docs/log-forwarding.md
+++ b/packages/dioxus-service/docs/log-forwarding.md
@@ -71,6 +71,8 @@ dioxus = { version = "0.6", features = ["desktop"] }
 log = "0.4"
 ```
 
+> **Note:** The `log` crate is a no-op façade until a concrete backend registers itself as the global logger. During WDIO test runs, `wdio-dioxus-bridge` installs its own subscriber automatically. For non-WDIO runs (development, production), add a backend such as `tracing-subscriber` or `env_logger` so your `log::*!()` calls produce output.
+
 The service automatically filters driver-level logs and only captures logs from your Dioxus application.
 
 ## Frontend Log Capture

--- a/packages/dioxus-service/docs/log-forwarding.md
+++ b/packages/dioxus-service/docs/log-forwarding.md
@@ -1,0 +1,166 @@
+# Log Forwarding
+
+Capture and forward logs from your Dioxus application to WebdriverIO's logger system.
+
+## Overview
+
+The Dioxus service can capture and forward logs from both the Rust backend and the frontend webview console to WebdriverIO's logger system. This allows you to see Dioxus application logs seamlessly integrated with your test output.
+
+## Enabling Log Forwarding
+
+Log forwarding is disabled by default. Enable it via service options:
+
+```typescript
+// wdio.conf.ts
+export const config = {
+  services: [
+    ['@wdio/dioxus-service', {
+      captureBackendLogs: true,      // Capture Rust logs from the app process
+      captureFrontendLogs: true,     // Capture console logs from the webview
+      backendLogLevel: 'info',       // Minimum backend log level (default: 'info')
+      frontendLogLevel: 'info',      // Minimum frontend log level (default: 'info')
+    }],
+  ],
+  capabilities: [
+    {
+      browserName: 'dioxus',
+      'dioxus:options': {
+        application: './target/debug/my_app',
+      },
+    },
+  ],
+};
+```
+
+## Log Levels
+
+Both backend and frontend log capture support the following log levels (in order of priority):
+
+- `trace` - Most verbose
+- `debug` - Debug information
+- `info` - Informational messages (default)
+- `warn` - Warning messages
+- `error` - Error messages
+
+Only logs at the configured level and above will be captured. For example, with `backendLogLevel: 'info'`, only `info`, `warn`, and `error` logs are captured.
+
+## Log Format
+
+Captured logs are formatted with context tags:
+
+- Backend logs: `[Dioxus:Backend] message`
+- Frontend logs: `[Dioxus:Frontend] message`
+- Multiremote logs: `[Dioxus:Backend:instanceId] message` / `[Dioxus:Frontend:instanceId] message`
+
+## Backend Log Capture
+
+Backend log capture reads Rust logs from the Dioxus application process. These logs are generated using the Rust `log` crate:
+
+```rust
+// In your Dioxus app (add log crate to Cargo.toml)
+log::info!("This is an info log");
+log::warn!("This is a warning");
+log::error!("This is an error");
+```
+
+Enable the `log` crate in your `Cargo.toml`:
+
+```toml
+[dependencies]
+dioxus = { version = "0.6", features = ["desktop"] }
+log = "0.4"
+```
+
+The service automatically filters driver-level logs and only captures logs from your Dioxus application.
+
+## Frontend Log Capture
+
+Frontend log capture uses the WebDriver `getLogs` API to retrieve console logs from the webview:
+
+```javascript
+// In your Dioxus frontend (JavaScript/TypeScript)
+console.info('This is an info log');
+console.warn('This is a warning');
+console.error('This is an error');
+```
+
+Frontend logs are captured periodically and before each WebDriver command.
+
+## Independent Configuration
+
+Backend and frontend log capture can be configured independently:
+
+```typescript
+services: [
+  ['@wdio/dioxus-service', {
+    captureBackendLogs: true,
+    captureFrontendLogs: false,
+    backendLogLevel: 'debug',
+  }],
+],
+```
+
+## Multiremote Support
+
+In multiremote scenarios, logs are captured per instance with instance IDs in the log context:
+
+```typescript
+capabilities: {
+  browserA: {
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app',
+    },
+  },
+  browserB: {
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app',
+    },
+  },
+},
+
+services: [
+  ['@wdio/dioxus-service', {
+    captureBackendLogs: true,
+    captureFrontendLogs: true,
+  }],
+],
+```
+
+Logs will appear as:
+- `[Dioxus:Backend:browserA] message`
+- `[Dioxus:Frontend:browserB] message`
+
+## Performance Considerations
+
+- Log capture is optional and disabled by default to avoid overhead.
+- Frontend log capture uses periodic polling (every 1 second) which has minimal performance impact.
+- Backend log parsing is efficient and non-blocking.
+- Log level filtering reduces the number of logs processed.
+
+## Troubleshooting
+
+### Logs not appearing
+
+- Ensure `captureBackendLogs` or `captureFrontendLogs` is set to `true`.
+- Check that your log level is appropriate (logs below the configured level won't appear).
+- Verify logs are being written to stdout (backend) or console (frontend).
+- For backend logs: ensure the `log` crate is properly initialized in your Rust app.
+
+### Too many logs
+
+- Increase the log level (e.g., from `debug` to `info`) to filter out verbose logs.
+- Disable log capture for one source if you only need backend or frontend logs.
+
+### Frontend logs not captured
+
+- Some WebDriver implementations may not support the `getLogs` API.
+- The service will silently fail if `getLogs` is not supported.
+- Backend logs will still work in this case.
+
+## See Also
+
+- [Configuration](./configuration.md) for all service options
+- [Usage Examples](./usage-examples.md) for logging patterns
+- [Troubleshooting](./troubleshooting.md) for common issues

--- a/packages/dioxus-service/docs/platform-support.md
+++ b/packages/dioxus-service/docs/platform-support.md
@@ -1,0 +1,255 @@
+# Platform Support
+
+Complete guide to platform-specific requirements, limitations, and driver setup for Dioxus testing.
+
+## Platform Support Overview
+
+| Platform | Supported | Driver Providers | Notes |
+|----------|-----------|-----------------|-------|
+| **Windows** | ✅ Yes | `'embedded'`, `'external'` | `'embedded'` recommended; `'external'` requires wdio-dioxus-driver + msedgedriver |
+| **Linux** | ✅ Yes | `'embedded'` only | `'external'` blocked in v1 — upstream Dioxus PR pending |
+| **macOS** | ✅ Yes | `'embedded'` only | `'external'` not supported |
+
+## Driver Providers
+
+### `'embedded'` (Recommended Everywhere)
+
+The embedded WebDriver provider uses `wdio-dioxus-embedded-driver` wired into the app via `wdio_dioxus_bridge::install(config)`. No external driver process is needed.
+
+**Works on:** Windows, Linux, macOS
+
+**Requirements:**
+- `wdio-dioxus-bridge = "1"` in `Cargo.toml`
+- `wdio_dioxus_bridge::install(config)` in `main.rs` inside `#[cfg(debug_assertions)]`
+- Debug build of the app (`cargo build`)
+
+**Configuration:**
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'embedded',  // Default, recommended
+}]]
+```
+
+### `'external'` (Windows Only in v1)
+
+The external provider uses `wdio-dioxus-driver` (a fork of `tauri-driver`) + `msedgedriver.exe`.
+
+**Works on:** Windows only in v1
+
+**Not supported on:** Linux (blocked — see below), macOS (never supported)
+
+**Requirements:**
+- `wdio-dioxus-driver` installed via `cargo install wdio-dioxus-driver`
+- `msedgedriver.exe` (auto-managed by the service with `autoDownloadEdgeDriver: true`)
+
+**Configuration:**
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'external',
+  autoInstallDioxusDriver: true,
+  autoDownloadEdgeDriver: true,
+}]]
+```
+
+## Windows
+
+### `'embedded'` Provider (Recommended)
+
+No external driver needed. Ensure the bridge is in your app and use a debug build.
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'embedded',
+  appBinaryPath: './target/debug/my_app.exe',
+}]]
+```
+
+### `'external'` Provider
+
+Uses `wdio-dioxus-driver` → `msedgedriver.exe` → Dioxus app via WebView2 automation.
+
+**Setup:**
+
+1. Build a debug binary: `cargo build`
+2. Configure the service:
+   ```typescript
+   services: [['@wdio/dioxus-service', {
+     driverProvider: 'external',
+     autoInstallDioxusDriver: true,
+     autoDownloadEdgeDriver: true,
+     appBinaryPath: './target/debug/my_app.exe',
+   }]]
+   ```
+
+The service auto-manages `msedgedriver.exe` to match the WebView2 version in your binary.
+
+See [Edge WebDriver (Windows)](./edge-webdriver-windows.md) for detailed setup.
+
+### Windows-Specific Features
+
+- ✅ Full Dioxus invoke API via `browser.dioxus.execute()`
+- ✅ Command mocking
+- ✅ Log capture (frontend and backend)
+- ✅ Screenshot capture
+- ✅ Multiremote testing
+
+### Windows Requirements
+
+- **Visual C++ Build Tools** or Visual Studio
+- **Rust toolchain**
+- **Node.js 18+**
+- For `'external'` provider: wdio-dioxus-driver + msedgedriver (auto-managed)
+
+## Linux
+
+### `'embedded'` Provider Only
+
+`'external'` is blocked in v1 due to a missing upstream Dioxus API — the automation toggle that wdio-dioxus-driver needs to pass to Wry has not yet landed in the Dioxus/Wry codebase. This is tracked and will be enabled in v1.1 once the upstream PR merges.
+
+Attempting to set `driverProvider: 'external'` on Linux throws a `SevereServiceError` at startup with an explanatory message.
+
+**Configuration:**
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'embedded',  // The only supported option on Linux
+  appBinaryPath: './target/debug/my_app',
+}]]
+```
+
+### Linux Build Requirements
+
+Install WebKitGTK libraries (required to build Dioxus desktop apps):
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+
+# Fedora
+sudo dnf install -y webkit2gtk4.1-devel gtk3-devel
+
+# Arch Linux
+sudo pacman -S webkit2gtk-4.1 gtk3
+```
+
+### Headless Testing on Linux
+
+To run tests without a display (CI/CD environments):
+
+```bash
+# With Xvfb
+sudo apt-get install -y xvfb
+xvfb-run -a npx wdio run wdio.conf.ts
+```
+
+### Linux-Specific Features
+
+- ✅ Full Dioxus invoke API
+- ✅ Command mocking
+- ✅ Log capture
+- ✅ Screenshot capture
+- ✅ Headless testing with Xvfb
+- ✅ Multiremote testing
+- ❌ `'external'` provider (v1 — v1.1 target)
+
+### Linux Distribution Support
+
+| Distribution | Status |
+|-------------|--------|
+| Debian / Ubuntu 22.04+ | ✅ Supported |
+| Fedora 40+ | ✅ Supported |
+| Arch Linux | ✅ Supported |
+| Alpine Linux | ❌ Not supported (musl incompatibility) |
+
+## macOS
+
+### `'embedded'` Provider Only
+
+`'external'` is not supported on macOS and never will be — it inherits the same WKWebView limitation as the upstream `tauri-driver` fork it is based on.
+
+**Configuration:**
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'embedded',  // Default, and the only option on macOS
+  appBinaryPath: './target/debug/my_app',
+}]]
+```
+
+### macOS-Specific Features
+
+- ✅ Full Dioxus invoke API
+- ✅ Command mocking
+- ✅ Log capture
+- ✅ Screenshot capture
+- ✅ Multiremote testing
+- ❌ `'external'` provider (not supported, no timeline)
+
+## Cross-Platform Tips
+
+### Recommended CI Matrix
+
+```yaml
+# .github/workflows/e2e.yml
+jobs:
+  e2e:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev xvfb
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm install
+      - run: cargo build
+
+      - name: Run E2E (Linux, headless)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:e2e
+
+      - name: Run E2E (Windows / macOS)
+        if: runner.os != 'Linux'
+        run: npm run test:e2e
+```
+
+### Platform-Conditional Tests
+
+```typescript
+describe('Platform-specific features', () => {
+  it('should handle Windows path format', function() {
+    if (process.platform !== 'win32') {
+      this.skip();
+    }
+    // Windows-specific test
+  });
+
+  it('should handle Linux file permissions', function() {
+    if (process.platform !== 'linux') {
+      this.skip();
+    }
+    // Linux-specific test
+  });
+});
+```
+
+## Summary
+
+| Provider | Windows | Linux | macOS |
+|----------|---------|-------|-------|
+| `'embedded'` | ✅ | ✅ | ✅ |
+| `'external'` | ✅ | ❌ (v1.1) | ❌ (never) |
+
+Use `'embedded'` everywhere for the simplest, most consistent setup.
+
+## See Also
+
+- [Quick Start](./quick-start.md) for setup instructions
+- [Edge WebDriver (Windows)](./edge-webdriver-windows.md) for Windows `'external'` details
+- [Troubleshooting](./troubleshooting.md) for common issues

--- a/packages/dioxus-service/docs/plugin-setup.md
+++ b/packages/dioxus-service/docs/plugin-setup.md
@@ -1,0 +1,197 @@
+# Bridge Setup
+
+## Overview
+
+The `wdio-dioxus-bridge` is a **required** Rust crate that enables WebdriverIO testing of Dioxus desktop applications. It provides:
+
+- **Execute API** - Run JavaScript code from tests with access to Dioxus IPC (`invoke`)
+- **Mocking Support** - Mock Dioxus backend commands for isolated testing
+- **Log Forwarding** - Capture console logs from both the frontend webview and Rust backend
+- **Invoke Interception** - Enable mocking without modifying backend command handlers
+
+Unlike Tauri's plugin system, Dioxus has no plugin-trait interface. The bridge is therefore a plain Rust crate (not a plugin) that wires itself into the Dioxus `desktop::Config` via a single `install()` call. It uses a `wdio://` custom protocol registered on the webview to communicate with the WDIO service process.
+
+No capability permission system is involved — the bridge communicates through its own protocol channel, not through Dioxus's IPC machinery.
+
+## What the Bridge Provides
+
+| Feature | Available |
+|---------|-----------|
+| `browser.dioxus.execute()` | ✅ Yes |
+| `browser.dioxus.mock()` and all mock operations | ✅ Yes |
+| `browser.dioxus.listWindows()` / `switchWindow()` | ✅ Yes |
+| Backend log capture (`captureBackendLogs`) | ✅ Yes |
+| Frontend log capture (`captureFrontendLogs`) | ✅ Yes |
+| Embedded WebDriver server | ✅ Yes (wired in automatically) |
+| `browser.dioxus.triggerDeeplink()` | ✅ Yes (platform-level; no bridge needed) |
+
+## Installation
+
+### Step 1: Add the Bridge Crate
+
+Add `wdio-dioxus-bridge` to your `Cargo.toml`. The recommended placement is under `[dependencies]` (not `[dev-dependencies]`) because the `#[cfg(debug_assertions)]` guard in your Rust code controls when the bridge code is actually compiled and linked:
+
+```toml
+[package]
+name = "my_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+dioxus = { version = "0.6", features = ["desktop"] }
+wdio-dioxus-bridge = "1"
+```
+
+> **Why `[dependencies]` and not `[dev-dependencies]`?**
+>
+> `[dev-dependencies]` are only available in test builds (`cargo test`), not in normal `cargo build` invocations. Since the bridge must be present for `cargo build` to compile the `#[cfg(debug_assertions)]`-guarded block, place it in `[dependencies]`. The guard ensures the bridge code is dead-code-eliminated from release builds (`cargo build --release`) automatically.
+
+### Step 2: Wire the Bridge in `main.rs`
+
+Call `wdio_dioxus_bridge::install(config)` inside a `#[cfg(debug_assertions)]` block:
+
+```rust
+use dioxus::prelude::*;
+
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+
+    #[cfg(debug_assertions)]
+    {
+        config = wdio_dioxus_bridge::install(config);
+    }
+
+    dioxus::LaunchBuilder::desktop()
+        .with_cfg(config)
+        .launch(App);
+}
+
+#[component]
+fn App() -> Element {
+    rsx! {
+        h1 { "Hello, Dioxus!" }
+    }
+}
+```
+
+The `#[cfg(debug_assertions)]` guard means:
+- **Debug builds** (`cargo build`): bridge is active, WDIO can connect
+- **Release builds** (`cargo build --release`): bridge code is not compiled, no test plumbing ships to users
+
+### Step 3: Build in Debug Mode
+
+For testing, always use a debug build:
+
+```bash
+cargo build
+# Binary: target/debug/my_app (or my_app.exe on Windows)
+```
+
+The service's `appBinaryPath` or `dioxus:options.application` should point to the debug binary.
+
+### Step 4: Verify
+
+Build should complete without errors. The bridge registers itself on the Dioxus `Config` and the embedded WebDriver server is wired automatically — no further Rust code is needed.
+
+## What the Bridge Does Internally
+
+When `wdio_dioxus_bridge::install(config)` is called:
+
+1. **Checks `DIOXUS_WEBVIEW_AUTOMATION`** via `wdio_dioxus_bridge::automation::is_requested()`. If the environment variable is not set, the bridge is a no-op.
+2. **Registers a `wdio://` custom protocol** on the webview. This protocol is the IPC channel between the WDIO service process and the app's webview.
+3. **Wires the embedded WebDriver server** (`wdio-dioxus-embedded-driver`) that listens on the port specified by `DIOXUS_WEBVIEW_AUTOMATION_PORT` (set by the service).
+4. **Injects the guest-js bundle** into the webview. This bundle patches the invoke API for mock interception and sets up console log forwarding.
+5. **Starts the log forwarder** that reads Rust `log` crate output and forwards it to the WDIO log capture pipeline.
+
+This is controlled entirely by environment variables set by `@wdio/dioxus-service` when it launches the app binary. In a normal app run (not driven by WDIO), the bridge is loaded but takes no action.
+
+## `automation::is_requested()`
+
+You can use `wdio_dioxus_bridge::automation::is_requested()` in your app code to check whether the app is running under WDIO automation:
+
+```rust
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+
+    #[cfg(debug_assertions)]
+    {
+        if wdio_dioxus_bridge::automation::is_requested() {
+            config = wdio_dioxus_bridge::install(config);
+        }
+    }
+
+    dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+}
+```
+
+`is_requested()` returns `true` when `DIOXUS_WEBVIEW_AUTOMATION=true` is set in the process environment. `@wdio/dioxus-service` sets this variable when launching your app. Calling `install(config)` without checking this first is also safe — the function checks internally and short-circuits.
+
+## Production Considerations
+
+The `#[cfg(debug_assertions)]` guard is the canonical way to ensure the bridge never ships in production:
+
+```rust
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+
+    // This entire block is removed by the compiler in release builds.
+    #[cfg(debug_assertions)]
+    {
+        config = wdio_dioxus_bridge::install(config);
+    }
+
+    dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+}
+```
+
+When you build with `cargo build --release`, the compiler strips the bridge entirely. No test plumbing is present in the binary that ships to users.
+
+If you want additional isolation, you can use a Cargo feature flag:
+
+```toml
+[features]
+wdio = ["dep:wdio-dioxus-bridge"]
+
+[dependencies]
+wdio-dioxus-bridge = { version = "1", optional = true }
+```
+
+```rust
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+
+    #[cfg(feature = "wdio")]
+    {
+        config = wdio_dioxus_bridge::install(config);
+    }
+
+    dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+}
+```
+
+Build with `cargo build --features wdio` for test builds, and `cargo build` for production.
+
+## Troubleshooting
+
+### "bridge not available" or execute always returns undefined
+
+The bridge is not wired in. Check:
+
+1. `wdio-dioxus-bridge = "1"` is in `[dependencies]` (not only `[dev-dependencies]`).
+2. `wdio_dioxus_bridge::install(config)` is called inside `#[cfg(debug_assertions)]`.
+3. You are building with `cargo build` (debug mode), not `cargo build --release`.
+4. The `'dioxus:options'.application` path points to the debug binary.
+
+### Compilation errors from `wdio-dioxus-bridge`
+
+1. Update your Rust toolchain: `rustup update`
+2. Clear Cargo cache: `cargo clean && cargo build`
+3. Check that `dioxus` version is `0.6+`
+
+## See Also
+
+- [Quick Start](./quick-start.md) for minimal test setup
+- [API Reference](./api-reference.md) for available functions
+- [Usage Examples](./usage-examples.md) for testing patterns
+- [Configuration](./configuration.md) for service options
+- [wdio-dioxus-bridge README](../../dioxus-bridge/README.md) for bridge crate details

--- a/packages/dioxus-service/docs/quick-start.md
+++ b/packages/dioxus-service/docs/quick-start.md
@@ -310,7 +310,7 @@ jobs:
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev
+        run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Install dependencies
         run: npm install
@@ -318,7 +318,12 @@ jobs:
       - name: Build Dioxus app
         run: cargo build
 
+      - name: Run tests (Linux needs a virtual display for desktop apps)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:e2e
+
       - name: Run tests
+        if: runner.os != 'Linux'
         run: npm run test:e2e
 ```
 

--- a/packages/dioxus-service/docs/quick-start.md
+++ b/packages/dioxus-service/docs/quick-start.md
@@ -61,8 +61,6 @@ edition = "2021"
 
 [dependencies]
 dioxus = { version = "0.6", features = ["desktop"] }
-
-[dependencies]
 wdio-dioxus-bridge = "1"
 ```
 

--- a/packages/dioxus-service/docs/quick-start.md
+++ b/packages/dioxus-service/docs/quick-start.md
@@ -1,0 +1,335 @@
+# Quick Start Guide
+
+Get up and running with WebdriverIO and Dioxus E2E testing in minutes.
+
+## Prerequisites
+
+### Required Software
+
+1. **Node.js 18+** - Download from [nodejs.org](https://nodejs.org)
+
+2. **Rust Toolchain** - Required for building Dioxus apps
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+
+### Platform-Specific Requirements
+
+#### Windows
+
+- **Microsoft Visual C++ Build Tools** - Download from [Microsoft Visual C++](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+- The `'embedded'` provider (recommended) requires no additional setup.
+- The `'external'` provider requires `wdio-dioxus-driver` and msedgedriver — see [Edge WebDriver (Windows)](./edge-webdriver-windows.md).
+
+#### Linux
+
+- **WebKitGTK Development Libraries** - Required to build Dioxus desktop apps:
+  ```bash
+  # Debian/Ubuntu
+  sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+
+  # Fedora
+  sudo dnf install -y webkit2gtk4.1-devel gtk3-devel
+
+  # Arch Linux
+  sudo pacman -S webkit2gtk-4.1 gtk3
+  ```
+
+The `'embedded'` provider is the only supported provider on Linux in v1. `'external'` is blocked pending an upstream Dioxus PR — see [Platform Support](./platform-support.md).
+
+#### macOS
+
+✅ **Supported** - Use the embedded WebDriver provider (`driverProvider: 'embedded'`, the default) for native macOS testing without external dependencies. `'external'` is not supported on macOS. See [Platform Support](./platform-support.md) for details.
+
+## Setting Up a Dioxus App
+
+### Create a Minimal Dioxus Desktop App
+
+```bash
+mkdir my-dioxus-app
+cd my-dioxus-app
+cargo init --name my_app
+```
+
+Edit `Cargo.toml`:
+
+```toml
+[package]
+name = "my_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+dioxus = { version = "0.6", features = ["desktop"] }
+
+[dev-dependencies]
+wdio-dioxus-bridge = "1"
+```
+
+Edit `src/main.rs`:
+
+```rust
+use dioxus::prelude::*;
+
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+
+    #[cfg(debug_assertions)]
+    {
+        config = wdio_dioxus_bridge::install(config);
+    }
+
+    dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+}
+
+#[component]
+fn App() -> Element {
+    rsx! {
+        h1 { "Hello, Dioxus!" }
+    }
+}
+```
+
+## Bridge Setup
+
+The `wdio-dioxus-bridge` crate is **required** for testing — it enables `browser.dioxus.execute()`, mocking, and log capture.
+
+The `#[cfg(debug_assertions)]` guard ensures the bridge is compiled out of release builds. See [Bridge Setup](./plugin-setup.md) for the full rationale and setup options.
+
+## Building the Dioxus App
+
+```bash
+# Build for testing (debug build, bridge is active)
+cargo build
+
+# Or release build (bridge compiled out, for production)
+cargo build --release
+```
+
+The debug binary is at:
+- `target/debug/my_app` (Linux/macOS)
+- `target\debug\my_app.exe` (Windows)
+
+## WebdriverIO Installation
+
+### 1. Install WebdriverIO
+
+```bash
+npm install --save-dev @wdio/cli @wdio/dioxus-service
+```
+
+### 2. Create Configuration
+
+Create `wdio.conf.ts`:
+
+```typescript
+export const config = {
+  runner: 'local',
+  specs: ['./test/specs/**/*.spec.ts'],
+  maxInstances: 1,
+
+  services: [['@wdio/dioxus-service', {
+    driverProvider: 'embedded',  // Recommended on all platforms
+  }]],
+
+  capabilities: [{
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app',  // Path to debug binary
+    },
+  }],
+
+  logLevel: 'info',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 90000,
+  connectionRetryCount: 3,
+
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+  },
+};
+```
+
+### 3. Create a Test
+
+Create `test/specs/example.spec.ts`:
+
+```typescript
+describe('My Dioxus App', () => {
+  it('should display hello world', async () => {
+    await browser.pause(500);
+
+    const heading = await browser.$('h1');
+    expect(await heading.getText()).toBe('Hello, Dioxus!');
+  });
+
+  it('should execute Dioxus commands', async () => {
+    const result = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('get_platform_info');
+    });
+
+    console.log('Platform info:', result);
+  });
+
+  it('should mock Dioxus commands', async () => {
+    const mock = await browser.dioxus.mock('get_user');
+    await mock.mockReturnValue({ id: 1, name: 'Test User' });
+
+    const user = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('get_user');
+    });
+
+    expect(user).toEqual({ id: 1, name: 'Test User' });
+  });
+});
+```
+
+## Running Tests
+
+### Run All Tests
+
+```bash
+npx wdio run wdio.conf.ts
+```
+
+### Run Specific Test File
+
+```bash
+npx wdio run wdio.conf.ts --spec test/specs/example.spec.ts
+```
+
+### Run with Debug Logging
+
+```bash
+npx wdio run wdio.conf.ts --logLevel debug
+```
+
+## Troubleshooting
+
+### "Bridge not available" or execute returns undefined
+
+The `wdio-dioxus-bridge` crate is not wired into your app. Make sure:
+
+1. Add to `[dev-dependencies]` in `Cargo.toml`:
+   ```toml
+   wdio-dioxus-bridge = "1"
+   ```
+
+2. Call `wdio_dioxus_bridge::install(config)` in `main.rs` inside a `#[cfg(debug_assertions)]` block.
+
+3. Build in debug mode (`cargo build`, not `cargo build --release`).
+
+### "Application not found at path"
+
+The `appBinaryPath` or `dioxus:options.application` is wrong. Verify:
+
+1. You built the app: `cargo build`
+2. The path exists: `./target/debug/my_app`
+3. Update the path in `wdio.conf.ts` if needed
+
+### Tests timeout on Windows (`'external'` provider)
+
+Edge WebDriver version mismatch. See [Edge WebDriver (Windows)](./edge-webdriver-windows.md).
+
+### Linux: "external provider not supported"
+
+`'external'` is blocked on Linux in v1. Use `driverProvider: 'embedded'` instead.
+
+## Next Steps
+
+1. **Add more tests** - See [Usage Examples](./usage-examples.md) for patterns
+2. **Advanced features** - Read about [Mocking](./api-reference.md#mock-functions) and [Log Forwarding](./log-forwarding.md)
+3. **Configure the service** - See [Configuration](./configuration.md) for all options
+4. **Debug issues** - Check [Troubleshooting](./troubleshooting.md)
+
+## Common Patterns
+
+### Test Custom Dioxus Commands
+
+```typescript
+it('should call custom commands', async () => {
+  const result = await browser.dioxus.execute(({ invoke }) => {
+    return invoke('my_custom_command', { param: 'value' });
+  });
+
+  expect(result).toBeDefined();
+});
+```
+
+### Capture Logs
+
+Enable log capture in `wdio.conf.ts`:
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  captureBackendLogs: true,
+  captureFrontendLogs: true,
+  backendLogLevel: 'debug',
+  frontendLogLevel: 'debug',
+}]],
+```
+
+### Multiremote Testing
+
+Run multiple instances of your app:
+
+```typescript
+capabilities: [
+  {
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app',
+    },
+  },
+  {
+    browserName: 'dioxus',
+    'dioxus:options': {
+      application: './target/debug/my_app',
+    },
+  },
+],
+```
+
+### CI/CD Integration
+
+Example GitHub Actions workflow:
+
+```yaml
+name: E2E Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest  # or windows-latest / macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Dioxus app
+        run: cargo build
+
+      - name: Run tests
+        run: npm run test:e2e
+```
+
+## See Also
+
+- [Configuration Reference](./configuration.md)
+- [API Reference](./api-reference.md)
+- [Bridge Setup](./plugin-setup.md)
+- [Platform Support](./platform-support.md)
+- [Troubleshooting](./troubleshooting.md)
+- [WebdriverIO Documentation](https://webdriver.io/docs)
+- [Dioxus Documentation](https://dioxuslabs.com/learn/0.6/)

--- a/packages/dioxus-service/docs/quick-start.md
+++ b/packages/dioxus-service/docs/quick-start.md
@@ -62,7 +62,7 @@ edition = "2021"
 [dependencies]
 dioxus = { version = "0.6", features = ["desktop"] }
 
-[dev-dependencies]
+[dependencies]
 wdio-dioxus-bridge = "1"
 ```
 

--- a/packages/dioxus-service/docs/quick-start.md
+++ b/packages/dioxus-service/docs/quick-start.md
@@ -164,11 +164,14 @@ describe('My Dioxus App', () => {
   });
 
   it('should execute Dioxus commands', async () => {
+    const mock = await browser.dioxus.mock('get_platform_info');
+    await mock.mockReturnValue({ platform: 'linux', arch: 'x86_64' });
+
     const result = await browser.dioxus.execute(({ invoke }) => {
       return invoke('get_platform_info');
     });
 
-    console.log('Platform info:', result);
+    expect(result).toHaveProperty('platform');
   });
 
   it('should mock Dioxus commands', async () => {

--- a/packages/dioxus-service/docs/quick-start.md
+++ b/packages/dioxus-service/docs/quick-start.md
@@ -210,7 +210,7 @@ npx wdio run wdio.conf.ts --logLevel debug
 
 The `wdio-dioxus-bridge` crate is not wired into your app. Make sure:
 
-1. Add to `[dev-dependencies]` in `Cargo.toml`:
+1. Add to `[dependencies]` in `Cargo.toml`:
    ```toml
    wdio-dioxus-bridge = "1"
    ```

--- a/packages/dioxus-service/docs/release-notes/v1.0.0.md
+++ b/packages/dioxus-service/docs/release-notes/v1.0.0.md
@@ -1,0 +1,86 @@
+# Release Notes — @wdio/dioxus-service v1.0.0
+
+Initial release of `@wdio/dioxus-service`, a WebdriverIO service for automated E2E testing of Dioxus desktop applications.
+
+## What's Included
+
+### Core Service (Phase 1–3)
+
+- `@wdio/dioxus-service` npm package with launcher and worker service classes
+- `DioxusLauncher` — handles driver spawning, port allocation, binary detection
+- `DioxusService` — handles `browser.dioxus.*` API injection
+- Dual ESM/CJS build output
+
+### Driver Providers
+
+- **`'embedded'` provider** — in-app embedded WebDriver server via `wdio-dioxus-bridge::install()`. Supported on Windows, Linux, and macOS.
+- **`'external'` provider** — `wdio-dioxus-driver` + msedgedriver. Windows only in v1.
+
+### Browser API (`browser.dioxus.*`)
+
+- `execute(script, ...args)` — Execute JavaScript in the webview with access to `dx.invoke`
+- `mock(command)` — Mock a Dioxus backend command; returns a `DioxusMock` object
+- `isMockFunction(x)` — TypeScript type guard for mock instances
+- `clearAllMocks(prefix?)` — Clear mock call history
+- `resetAllMocks(prefix?)` — Reset mock implementation + history
+- `restoreAllMocks(prefix?)` — Remove all mocks
+- `switchWindow(label)` — Switch active window
+- `listWindows()` — List all open window labels
+- `triggerDeeplink(url)` — Trigger a custom protocol URL
+
+### Mock API (Phase 4)
+
+Full vitest-compatible mock interface on `DioxusMock`:
+- `mockReturnValue`, `mockReturnValueOnce`
+- `mockResolvedValue`, `mockResolvedValueOnce`
+- `mockRejectedValue`, `mockRejectedValueOnce`
+- `mockImplementation`, `mockImplementationOnce`
+- `mockClear`, `mockReset`, `mockRestore`
+- `withImplementation`
+- `update()` — sync inner → outer mock state
+- `mock.calls`, `mock.results`
+
+### Log Forwarding (Phase 5)
+
+- `captureBackendLogs` — forward Rust `log` crate output
+- `captureFrontendLogs` — forward webview console output
+- `backendLogLevel`, `frontendLogLevel` — minimum level filters
+
+### Browser Mode (Phase 6)
+
+- `mode: 'browser'` — frontend-only Chrome session against a dev server
+- IPC mock injection for testing invoke commands without a running Rust backend
+- `devServerUrl` configuration
+
+### Multiremote Support (Phase 7)
+
+- Per-instance driver spawning
+- Isolated mock registries per browser instance
+
+### Standalone Session (Phase 8)
+
+- `startWdioSession(capabilities, globalOptions?)` export
+- Use the service outside the WDIO test runner lifecycle
+
+## Platform × Provider Matrix
+
+| Platform | `'embedded'` | `'external'` |
+|----------|-------------|-------------|
+| Windows  | ✅           | ✅           |
+| Linux    | ✅           | ❌ (v1.1)   |
+| macOS    | ✅           | ❌ (never)  |
+
+## Companion Packages
+
+- `wdio-dioxus-bridge` (Rust crate) — v1.0.0
+- `wdio-dioxus-embedded-driver` (Rust crate) — v1.0.0
+- `wdio-dioxus-driver` (Rust crate, Windows `'external'` provider) — v1.0.0
+
+## Known Deferred Items
+
+- **`'external'` on Linux** — blocked pending an upstream Dioxus/Wry PR that exposes the webview automation toggle. Tracked for v1.1.
+- **`browser.dioxus.emitEvent()`** — deferred to v1.1. Native-mode event emission via the bridge IPC channel.
+
+## Breaking Changes
+
+None — this is the initial release.

--- a/packages/dioxus-service/docs/release-notes/v1.0.0.md
+++ b/packages/dioxus-service/docs/release-notes/v1.0.0.md
@@ -38,7 +38,7 @@ Full vitest-compatible mock interface on `DioxusMock`:
 - `mockClear`, `mockReset`, `mockRestore`
 - `withImplementation`
 - `update()` — sync inner → outer mock state
-- `mock.calls`, `mock.results`
+- `mock.mock.calls`, `mock.mock.results`
 
 ### Log Forwarding (Phase 5)
 

--- a/packages/dioxus-service/docs/troubleshooting.md
+++ b/packages/dioxus-service/docs/troubleshooting.md
@@ -1,0 +1,337 @@
+# Troubleshooting
+
+Solutions for common issues when testing Dioxus applications with WebdriverIO.
+
+## Bridge Issues
+
+### "Bridge not available" or execute always returns undefined
+
+The `wdio-dioxus-bridge` crate is not wired into your app.
+
+**Check 1: Bridge crate in dependencies**
+
+```toml
+# Cargo.toml
+[dependencies]
+wdio-dioxus-bridge = "1"
+```
+
+**Check 2: Bridge installed in `main.rs`**
+
+```rust
+fn main() {
+    let mut config = dioxus::desktop::Config::new();
+    #[cfg(debug_assertions)]
+    {
+        config = wdio_dioxus_bridge::install(config);
+    }
+    dioxus::LaunchBuilder::desktop().with_cfg(config).launch(App);
+}
+```
+
+**Check 3: Debug build used for testing**
+
+The bridge is only compiled in debug builds. Ensure you are using `cargo build` (not `cargo build --release`) and the binary path in your config points to `target/debug/my_app`, not `target/release/my_app`.
+
+**Check 4: Rebuild application**
+
+```bash
+cargo clean
+cargo build
+```
+
+See [Bridge Setup](./plugin-setup.md) for the complete installation guide.
+
+---
+
+## Driver Installation Issues
+
+### "wdio-dioxus-driver not found" (`'external'` provider, Windows)
+
+The service cannot find the wdio-dioxus-driver executable.
+
+**Solution 1: Enable Auto-Installation**
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'external',
+  autoInstallDioxusDriver: true,
+}]]
+```
+
+**Solution 2: Manual Installation**
+
+```bash
+cargo install wdio-dioxus-driver
+```
+
+**Solution 3: Specify Path Manually**
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'external',
+  dioxusDriverPath: '/custom/path/wdio-dioxus-driver',
+}]]
+```
+
+### "MSEdgeDriver not found" (Windows, `'external'` provider)
+
+**Solution 1: Enable Auto-Download**
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'external',
+  autoDownloadEdgeDriver: true,  // Default: true
+}]]
+```
+
+**Solution 2: Manual Download**
+
+1. Check your WebView2 version (right-click your binary → Properties → Details)
+2. Download matching MSEdgeDriver from [Microsoft Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
+3. Add to PATH
+
+See [Edge WebDriver (Windows)](./edge-webdriver-windows.md) for detailed setup.
+
+---
+
+## Provider Issues
+
+### "external provider not supported on Linux"
+
+`'external'` is blocked on Linux in v1 — an upstream Dioxus PR is pending. Use `driverProvider: 'embedded'` instead.
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'embedded',  // The only supported option on Linux
+}]]
+```
+
+### "external provider not supported on macOS"
+
+`'external'` is not supported on macOS. Use `driverProvider: 'embedded'`.
+
+### "No driverProvider configured" or service fails to start
+
+Set `driverProvider` explicitly:
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  driverProvider: 'embedded',  // Recommended everywhere
+}]]
+```
+
+---
+
+## Application Issues
+
+### "Application not found at path"
+
+The Dioxus app binary cannot be found.
+
+**Solution 1: Verify Binary Exists**
+
+```bash
+ls -la target/debug/my_app         # Linux/macOS
+dir target\debug\my_app.exe        # Windows
+```
+
+**Solution 2: Build the Application**
+
+```bash
+cargo build  # Debug build (bridge active)
+```
+
+**Solution 3: Use Correct Path**
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  appBinaryPath: './target/debug/my_app',   // Linux/macOS
+  // or
+  appBinaryPath: './target/debug/my_app.exe',  // Windows
+}]]
+```
+
+**Solution 4: Use Absolute Path**
+
+```typescript
+import path from 'path';
+
+services: [['@wdio/dioxus-service', {
+  appBinaryPath: path.resolve('./target/debug/my_app'),
+}]]
+```
+
+### Debug vs. Release Build Mismatch
+
+The bridge is only compiled into debug builds. If you point `appBinaryPath` at a release binary, the bridge will not be present and `browser.dioxus.execute()` will fail.
+
+Always use `cargo build` (without `--release`) for testing.
+
+### Commands Timing Out
+
+**Solution 1: Increase Start Timeout**
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  startTimeout: 60000,  // Allow more time for app to start
+}]]
+```
+
+**Solution 2: Increase Status Poll Timeout**
+
+For slow CI environments:
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  statusPollTimeout: 5000,  // Default: 2000
+}]]
+```
+
+**Solution 3: Wait for App to Be Ready**
+
+```typescript
+it('should wait for app', async () => {
+  await browser.pause(1000);
+  const element = await browser.$('button');
+  expect(element).toBeDefined();
+});
+```
+
+### "Port already in use"
+
+**Solution 1: Change Embedded Port**
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  embeddedPort: 4446,  // Instead of default 4445
+}]]
+```
+
+**Solution 2: Kill Process Using Port**
+
+```bash
+# Linux/macOS
+lsof -ti:4445 | xargs kill -9
+
+# Windows (PowerShell)
+Get-Process -Id (Get-NetTCPConnection -LocalPort 4445).OwningProcess | Stop-Process -Force
+```
+
+---
+
+## Mocking Issues
+
+### Mocking Doesn't Work
+
+**Check 1: Mock Set Up Before Call**
+
+```typescript
+// Correct — mock first, then call
+const mock = await browser.dioxus.mock('my_command');
+await mock.mockReturnValue('test');
+await browser.dioxus.execute(({ invoke }) => invoke('my_command'));
+
+// Wrong — calling before mocking
+await browser.dioxus.execute(({ invoke }) => invoke('my_command'));
+const mock = await browser.dioxus.mock('my_command');
+```
+
+**Check 2: Correct Command Name**
+
+```typescript
+// Command name must match exactly what your app passes to invoke()
+const mock = await browser.dioxus.mock('get_user');
+await mock.mockReturnValue({ id: 1 });
+```
+
+---
+
+## Multi-Window Issues
+
+### Window Label Not Found
+
+**Error:** `Window label "settings" not found. Available windows: main`
+
+**Solution:**
+
+```typescript
+// Debug: list available windows
+const windows = await browser.dioxus.listWindows();
+console.log('Available:', windows);
+```
+
+Verify the window label matches exactly (case-sensitive) and the window is created before your test runs.
+
+---
+
+## Linux Headless Issues
+
+### "X11 connection refused" or "Cannot open display"
+
+```bash
+# Install Xvfb
+sudo apt-get install -y xvfb
+
+# Run tests headless
+xvfb-run -a npx wdio run wdio.conf.ts
+```
+
+---
+
+## CI/CD Issues
+
+### Tests Fail in CI But Pass Locally
+
+**Common Causes:**
+
+1. **Missing Linux build dependencies**
+   ```bash
+   sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev
+   ```
+
+2. **Display server missing on Linux CI**
+   ```bash
+   xvfb-run -a npm run test:e2e
+   ```
+
+3. **Release binary used instead of debug**
+   - Ensure `cargo build` (not `cargo build --release`) is run in CI
+   - Verify the binary path in `wdio.conf.ts` points to `target/debug/`, not `target/release/`
+
+4. **Environment Variables**
+   ```bash
+   APP_BINARY="./target/debug/my_app" npm run test:e2e
+   ```
+
+---
+
+## Debug Mode
+
+### Enable Debug Logging
+
+```typescript
+services: [['@wdio/dioxus-service', {
+  captureBackendLogs: true,
+  captureFrontendLogs: true,
+}]]
+```
+
+### Verbose Test Output
+
+```bash
+npx wdio run wdio.conf.ts --logLevel debug
+```
+
+---
+
+## Getting Help
+
+If you're still stuck:
+
+1. **Check [Configuration](./configuration.md)** for all available options
+2. **Review [Usage Examples](./usage-examples.md)** for correct patterns
+3. **See [Bridge Setup](./plugin-setup.md)** for bridge requirements
+4. **Check [Platform Support](./platform-support.md)** for platform-specific issues
+5. **Enable debug logging** to see detailed output
+6. **Open a discussion** in the [GitHub Discussions](https://github.com/webdriverio/desktop-mobile/discussions)

--- a/packages/dioxus-service/docs/usage-examples.md
+++ b/packages/dioxus-service/docs/usage-examples.md
@@ -116,9 +116,9 @@ describe('Command Mocking', () => {
     const mock = await browser.dioxus.mock('save_data');
     await mock.mockReturnValue({ success: true });
 
-    await browser.dioxus.execute(({ invoke }) => {
-      invoke('save_data', { data: 'test1' });
-      invoke('save_data', { data: 'test2' });
+    await browser.dioxus.execute(async ({ invoke }) => {
+      await invoke('save_data', { data: 'test1' });
+      await invoke('save_data', { data: 'test2' });
     });
 
     await mock.update();

--- a/packages/dioxus-service/docs/usage-examples.md
+++ b/packages/dioxus-service/docs/usage-examples.md
@@ -1,0 +1,376 @@
+# Usage Examples
+
+Practical examples for testing Dioxus applications with WebdriverIO.
+
+## Basic Usage
+
+### Element Interactions
+
+Standard WebDriver element interactions work with Dioxus apps:
+
+```typescript
+describe('Dioxus App Interactions', () => {
+  it('should interact with form elements', async () => {
+    const input = await browser.$('input[name="username"]');
+    await input.setValue('test_user');
+
+    const button = await browser.$('button[type="submit"]');
+    await button.click();
+
+    const result = await browser.$('.result');
+    await result.waitForDisplayed();
+
+    const text = await result.getText();
+    expect(text).toBe('Success!');
+  });
+
+  it('should handle multiple elements', async () => {
+    const buttons = await browser.$$('button');
+    expect(buttons).toHaveLength(5);
+
+    for (const button of buttons) {
+      const text = await button.getText();
+      console.log('Button text:', text);
+    }
+  });
+});
+```
+
+## Execute API
+
+### Execute JavaScript in App Context
+
+Use `browser.dioxus.execute()` to run JavaScript with access to Dioxus IPC:
+
+```typescript
+describe('Dioxus API Access', () => {
+  it('should access Dioxus invoke API', async () => {
+    const result = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('get_config');
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('should use async operations', async () => {
+    const data = await browser.dioxus.execute(async ({ invoke }) => {
+      const user = await invoke('get_user');
+      const permissions = await invoke('get_user_permissions', { userId: (user as any).id });
+      return { user, permissions };
+    });
+
+    expect(data.user).toBeDefined();
+    expect(data.permissions).toBeInstanceOf(Array);
+  });
+
+  it('should execute with parameters', async () => {
+    const username = 'test_user';
+    const result = await browser.dioxus.execute(
+      (dx, name) => ({ received: name }),
+      username
+    );
+
+    expect(result.received).toBe('test_user');
+  });
+
+  it('should handle errors', async () => {
+    try {
+      await browser.dioxus.execute(() => {
+        throw new Error('Test error');
+      });
+    } catch (error) {
+      expect(error.message).toContain('Test error');
+    }
+  });
+});
+```
+
+## Mocking Dioxus Commands
+
+### Mock Backend Commands
+
+```typescript
+describe('Command Mocking', () => {
+  it('should mock a simple command', async () => {
+    const mock = await browser.dioxus.mock('get_app_version');
+    await mock.mockReturnValue('1.2.3');
+
+    const version = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('get_app_version');
+    });
+
+    expect(version).toBe('1.2.3');
+  });
+
+  it('should mock command with arguments', async () => {
+    const mock = await browser.dioxus.mock('get_user');
+    await mock.mockReturnValue({ id: 1, name: 'John Doe' });
+
+    const user = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('get_user', { userId: 123 });
+    });
+
+    expect(user).toEqual({ id: 1, name: 'John Doe' });
+  });
+
+  it('should track mock calls', async () => {
+    const mock = await browser.dioxus.mock('save_data');
+    await mock.mockReturnValue({ success: true });
+
+    await browser.dioxus.execute(({ invoke }) => {
+      invoke('save_data', { data: 'test1' });
+      invoke('save_data', { data: 'test2' });
+    });
+
+    await mock.update();
+    expect(mock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should handle errors in mocks', async () => {
+    const mock = await browser.dioxus.mock('risky_operation');
+    await mock.mockRejectedValue(new Error('Operation failed'));
+
+    try {
+      await browser.dioxus.execute(({ invoke }) => {
+        return invoke('risky_operation');
+      });
+    } catch (error) {
+      expect(error.message).toBe('Operation failed');
+    }
+  });
+
+  it('should restore mocks after test', async () => {
+    const mock = await browser.dioxus.mock('get_data');
+    await mock.mockReturnValue({ mocked: true });
+
+    await mock.mockRestore();
+
+    // Now calls the real command
+    const result = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('get_data');
+    });
+
+    expect(result).toBeDefined();
+  });
+});
+```
+
+## Testing Custom Commands
+
+```typescript
+describe('Custom Dioxus Commands', () => {
+  it('should call custom command with simple return', async () => {
+    const greeting = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('greet', { name: 'Dioxus' });
+    });
+
+    expect(greeting).toBe('Hello, Dioxus!');
+  });
+
+  it('should call command returning object', async () => {
+    const config = await browser.dioxus.execute(({ invoke }) => {
+      return invoke('get_config');
+    });
+
+    expect(config).toHaveProperty('version');
+    expect(config).toHaveProperty('isDev');
+  });
+});
+```
+
+## Log Capture
+
+```typescript
+describe('Log Capture', () => {
+  it('should verify console logs', async () => {
+    // Log capture enabled in wdio.conf.ts:
+    // captureBackendLogs: true
+    // captureFrontendLogs: true
+
+    const logs = await browser.getLogs('browser');
+
+    await browser.$('button').click();
+
+    const newLogs = await browser.getLogs('browser');
+    const hasExpectedLog = newLogs.some(log =>
+      log.message.includes('Button clicked')
+    );
+    expect(hasExpectedLog).toBe(true);
+  });
+});
+```
+
+## Multi-Window Testing
+
+```typescript
+describe('Multi-Window Testing', () => {
+  it('should list available windows', async () => {
+    const windows = await browser.dioxus.listWindows();
+    console.log('Available windows:', windows);
+    expect(windows).toContain('main');
+    expect(windows).toContain('settings');
+  });
+
+  it('should switch between windows', async () => {
+    const mainContent = await browser.dioxus.execute(() => {
+      return document.querySelector('h1')?.textContent;
+    });
+    expect(mainContent).toBe('Main Window');
+
+    await browser.dioxus.switchWindow('settings');
+
+    const settingsContent = await browser.dioxus.execute(() => {
+      return document.querySelector('h1')?.textContent;
+    });
+    expect(settingsContent).toBe('Settings');
+
+    await browser.dioxus.switchWindow('main');
+  });
+
+  it('should handle non-existent window gracefully', async () => {
+    await expect(browser.dioxus.switchWindow('nonexistent')).rejects.toThrow(
+      'Window label "nonexistent" not found'
+    );
+  });
+});
+```
+
+Configuration for a default window:
+
+```typescript
+// wdio.conf.ts
+capabilities: [{
+  browserName: 'dioxus',
+  'wdio:dioxusServiceOptions': {
+    windowLabel: 'settings',  // Default to settings window
+  },
+}]
+```
+
+## Deeplink Testing
+
+```typescript
+describe('Deeplink Tests', () => {
+  it('should handle custom protocol deeplinks', async () => {
+    await browser.dioxus.triggerDeeplink('myapp://open?file=test.txt');
+
+    await browser.waitUntil(async () => {
+      const openedFile = await browser.dioxus.execute(() => {
+        return globalThis.lastOpenedFile;
+      });
+      return openedFile === 'test.txt';
+    }, {
+      timeout: 5000,
+      timeoutMsg: 'App did not handle the deeplink',
+    });
+  });
+});
+```
+
+## Multiremote Testing
+
+```typescript
+describe('Multiremote — Multiple App Instances', () => {
+  it('should mock different commands per instance', async () => {
+    const mock1 = await browser.app1.dioxus.mock('get_user');
+    await mock1.mockReturnValue({ id: 1, name: 'User1' });
+
+    const mock2 = await browser.app2.dioxus.mock('get_user');
+    await mock2.mockReturnValue({ id: 2, name: 'User2' });
+
+    const user1 = await browser.app1.dioxus.execute(({ invoke }) => {
+      return invoke('get_user');
+    });
+
+    const user2 = await browser.app2.dioxus.execute(({ invoke }) => {
+      return invoke('get_user');
+    });
+
+    expect(user1.id).toBe(1);
+    expect(user2.id).toBe(2);
+  });
+});
+```
+
+## Standalone Session
+
+Use `startWdioSession` to manage a session outside of the WebdriverIO test runner:
+
+```typescript
+import { startWdioSession } from '@wdio/dioxus-service';
+
+const browser = await startWdioSession({
+  browserName: 'dioxus',
+  'dioxus:options': {
+    application: './target/debug/my_app',
+  },
+  'wdio:dioxusServiceOptions': {
+    driverProvider: 'embedded',
+  },
+});
+
+const heading = await browser.$('h1');
+console.log(await heading.getText());
+
+await browser.deleteSession();
+```
+
+## Common Testing Patterns
+
+### Wait for Async Operations
+
+```typescript
+it('should wait for async data load', async () => {
+  const loadButton = await browser.$('button[data-testid="load"]');
+  await loadButton.click();
+
+  const spinner = await browser.$('.loading-spinner');
+  await spinner.waitForDisplayed({ reverse: true, timeout: 5000 });
+
+  const data = await browser.$('.data-content');
+  expect(await data.isDisplayed()).toBe(true);
+});
+```
+
+### Test Error Handling
+
+```typescript
+it('should display error message on failure', async () => {
+  const mock = await browser.dioxus.mock('fetch_data');
+  await mock.mockRejectedValue(new Error('Network error'));
+
+  const button = await browser.$('button[data-testid="fetch"]');
+  await button.click();
+
+  const error = await browser.$('.error-message');
+  await error.waitForDisplayed();
+
+  const text = await error.getText();
+  expect(text).toContain('Network error');
+});
+```
+
+### Test State Persistence
+
+```typescript
+it('should persist state across reload', async () => {
+  await browser.dioxus.execute(async ({ invoke }) => {
+    await invoke('set_user_preference', { theme: 'dark' });
+  });
+
+  await browser.execute(() => window.location.reload());
+
+  const theme = await browser.dioxus.execute(({ invoke }) => {
+    return invoke('get_user_preference', { key: 'theme' });
+  });
+
+  expect(theme).toBe('dark');
+});
+```
+
+## See Also
+
+- [API Reference](./api-reference.md) for complete API documentation
+- [Configuration](./configuration.md) for testing setup options
+- [Log Forwarding](./log-forwarding.md) for logging patterns
+- [Bridge Setup](./plugin-setup.md) for bridge configuration
+- [Troubleshooting](./troubleshooting.md) for common issues


### PR DESCRIPTION
## Summary

- Adds complete documentation for `@wdio/dioxus-service` (14 doc files + package README)
- Adds `README.md` for `wdio-dioxus-embedded-driver`
- Updates `wdio-dioxus-bridge` README (removes placeholder v1-status text, documents full feature set)
- Adds bridge `docs/release-notes/v1.0.0.md`
- Updates all root-level docs (`README.md`, `ROADMAP.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/setup.md`, `docs/architecture.md`, `docs/package-structure.md`, `docs/e2e-testing.md`, `docs/visual-testing.md`) to include Dioxus alongside Electron and Tauri

## New docs in `packages/dioxus-service/docs/`

| File | Contents |
|------|----------|
| `quick-start.md` | Get running in minutes; build, install, first test |
| `configuration.md` | Every `DioxusServiceOptions` and `dioxus:options` field |
| `api-reference.md` | Full `browser.dioxus.*` surface with examples |
| `plugin-setup.md` | Bridge crate integration, `#[cfg(debug_assertions)]` guard |
| `platform-support.md` | Provider × platform matrix; Linux `'external'` deferred note |
| `browser-mode.md` | `mode: 'browser'` with Vite dev server |
| `edge-webdriver-windows.md` | Windows `'external'` provider setup |
| `deeplink-testing.md` | `triggerDeeplink()` + OS protocol handler |
| `log-forwarding.md` | Backend + frontend log capture options |
| `usage-examples.md` | Common patterns: execute, mock, multi-window, deeplink, CI |
| `development.md` | Contributor guide: build, test, coverage thresholds |
| `troubleshooting.md` | Common failure modes and fixes |
| `coexistence.md` | Running Dioxus + Tauri + Electron in the same monorepo |
| `release-notes/v1.0.0.md` | v1.0.0 feature list and known deferrals |

## Test plan

- [ ] All new markdown files render correctly (check headings, code blocks, tables)
- [ ] Cross-package relative links resolve (e.g. `../dioxus-service/docs/plugin-setup.md`)
- [ ] Root-level `README.md` renders with correct Dioxus badges and framework table
- [ ] `ROADMAP.md` shows Dioxus under current services
- [ ] `AGENTS.md` lists Dioxus in Supported Frameworks and Monorepo Structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)