### PR TITLE
feat(ci): Phase 10 — wire Dioxus CI jobs into GitHub Actions

### DIFF
--- a/.github/workflows/_ci-build-dioxus-crates.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-crates.reusable.yml
@@ -30,7 +30,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        shell: bash
+        run: rustup update stable && rustup default stable
 
       - name: Cache Cargo registry + target dirs
         uses: actions/cache@v4

--- a/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
@@ -1,5 +1,5 @@
 name: Build Dioxus E2E App
-description: 'Builds Dioxus E2E test application and creates shareable artifacts'
+# Description: Builds Dioxus E2E test application and creates shareable artifacts
 
 permissions:
   contents: read
@@ -111,8 +111,8 @@ jobs:
         id: build-info
         shell: bash
         run: |
-          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       - name: 📦 Download Package Build Artifacts
         uses: ./.github/workflows/actions/download-archive

--- a/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
@@ -63,7 +63,8 @@ jobs:
           node-version: '24'
 
       - name: 🦀 Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        shell: bash
+        run: rustup update stable && rustup default stable
 
       - name: 🦀 Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
@@ -137,8 +137,9 @@ jobs:
         shell: bash
 
       - name: 🏗️ Build Dioxus E2E App
-        run: pnpm exec turbo run build --filter=wdio-dioxus-e2e-app
+        run: cargo build
         shell: bash
+        working-directory: fixtures/e2e-apps/dioxus
 
       - name: 📦 Upload Dioxus E2E App Binary
         id: upload-archive

--- a/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
@@ -1,0 +1,151 @@
+name: Build Dioxus E2E App
+description: 'Builds Dioxus E2E test application and creates shareable artifacts'
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'OS of runner'
+        required: true
+        type: string
+      build_id:
+        description: 'Build ID from the main build job'
+        type: string
+        required: false
+      artifact_size:
+        description: 'Size of the build artifact in bytes'
+        type: string
+        required: false
+      cache_key:
+        description: 'Cache key to use for downloading artifacts'
+        type: string
+        required: false
+    outputs:
+      build_id:
+        description: 'Unique identifier for this build'
+        value: ${{ jobs.build-dioxus-e2e-app.outputs.build_id }}
+      build_date:
+        description: 'Timestamp when the build completed'
+        value: ${{ jobs.build-dioxus-e2e-app.outputs.build_date }}
+      artifact_size:
+        description: 'Size of the build artifact in bytes'
+        value: ${{ jobs.build-dioxus-e2e-app.outputs.artifact_size }}
+      cache_key:
+        description: 'Cache key used for artifact uploads, can be passed to download actions'
+        value: ${{ jobs.build-dioxus-e2e-app.outputs.cache_key }}
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  build-dioxus-e2e-app:
+    name: Build Dioxus E2E App
+    runs-on: ${{ inputs.os }}
+    outputs:
+      build_id: ${{ steps.build-info.outputs.build_id }}
+      build_date: ${{ steps.build-info.outputs.build_date }}
+      artifact_size: ${{ steps.upload-archive.outputs.size || '0' }}
+      cache_key: ${{ steps.upload-archive.outputs.cache_key }}
+    steps:
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: 🛠️ Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: '24'
+
+      - name: 🦀 Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: 🦀 Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: '.'
+          cache-on-failure: true
+          cache-targets: false
+
+      - name: 🔧 Fix ARM64 Package Sources (Linux)
+        if: runner.os == 'Linux' && runner.arch == 'ARM64'
+        shell: bash
+        run: |
+          echo "Fixing ARM64 package sources for Ubuntu..."
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+
+          sudo sed -i -e 's/^deb http/deb [arch=amd64] http/' /etc/apt/sources.list
+          sudo sed -i -e 's/^deb mirror/deb [arch=amd64] mirror/' /etc/apt/sources.list
+
+          sudo apt-get update
+
+      - name: 🦀 Install Dioxus Build Dependencies (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "Installing Dioxus build dependencies for Linux..."
+          if [ "$(uname -m)" != "aarch64" ]; then
+            echo "deb http://archive.ubuntu.com/ubuntu jammy main universe" | sudo tee -a /etc/apt/sources.list > /dev/null
+          fi
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libxdo-dev \
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            pkg-config \
+            build-essential
+
+      - name: 📊 Generate Build Information
+        id: build-info
+        shell: bash
+        run: |
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+
+      - name: 📦 Download Package Build Artifacts
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: wdio-desktop-mobile
+          path: wdio-desktop-mobile-build
+          filename: artifact.zip
+          cache_key_prefix: wdio-desktop-build
+          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
+
+      - name: 📊 Show Build Information
+        if: inputs.build_id != '' && inputs.artifact_size != ''
+        shell: bash
+        run: |
+          echo "::notice::Build artifact: ID=${{ inputs.build_id }}, Size=${{ inputs.artifact_size }} bytes"
+
+      - name: 📦 Install Dependencies
+        run: pnpm install --frozen-lockfile
+        shell: bash
+
+      - name: 🏗️ Build Dioxus Bridge Guest JS
+        run: pnpm --filter @wdio/dioxus-bridge build
+        shell: bash
+
+      - name: 🏗️ Build Dioxus E2E App
+        run: pnpm exec turbo run build --filter=wdio-dioxus-e2e-app
+        shell: bash
+
+      - name: 📦 Upload Dioxus E2E App Binary
+        id: upload-archive
+        uses: ./.github/workflows/actions/upload-archive
+        with:
+          name: dioxus-e2e-app-${{ runner.os }}-${{ runner.arch }}
+          output: dioxus-e2e-app-${{ runner.os }}-${{ runner.arch }}/artifact.zip
+          paths: fixtures/e2e-apps/dioxus/target
+          cache_key_prefix: dioxus-e2e-app
+          retention_days: '90'

--- a/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
@@ -68,7 +68,7 @@ jobs:
       - name: 🦀 Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: '.'
+          workspaces: 'fixtures/e2e-apps/dioxus'
           cache-on-failure: true
           cache-targets: false
 

--- a/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   build-dioxus-e2e-app:
-    name: Build Dioxus E2E App
+    name: Build
     runs-on: ${{ inputs.os }}
     outputs:
       build_id: ${{ steps.build-info.outputs.build_id }}

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -123,6 +123,10 @@ jobs:
           echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
+      - name: Build Dioxus Bridge Guest JS
+        run: pnpm --filter @wdio/dioxus-bridge build
+        shell: bash
+
       - name: Build Dioxus Package Test App
         run: cargo build
         shell: bash

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -124,8 +124,9 @@ jobs:
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
       - name: Build Dioxus Package Test App
-        run: pnpm exec turbo run build --filter=dioxus-app-example --only
+        run: cargo build
         shell: bash
+        working-directory: fixtures/package-tests/dioxus-app/src-dioxus
 
       - name: Upload Dioxus Package Test App Binary
         id: upload-archive

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   build-dioxus-package-app:
-    name: Build Dioxus Package Test App
+    name: Build
     runs-on: ${{ inputs.os }}
     outputs:
       build_id: ${{ steps.build-info.outputs.build_id }}

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: '.'
+          workspaces: 'fixtures/package-tests/dioxus-app/src-dioxus'
           cache-on-failure: true
           cache-targets: false
 

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -75,7 +75,8 @@ jobs:
           exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
 
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        shell: bash
+        run: rustup update stable && rustup default stable
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -1,6 +1,6 @@
 name: Build Dioxus Package Test App
 
-description: 'Builds Dioxus package test application and creates shareable artifacts'
+# Description: Builds Dioxus package test application and creates shareable artifacts
 
 permissions:
   contents: read
@@ -121,8 +121,8 @@ jobs:
         id: build-info
         shell: bash
         run: |
-          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -123,6 +123,10 @@ jobs:
           echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+        shell: bash
+
       - name: Build Dioxus Bridge Guest JS
         run: pnpm --filter @wdio/dioxus-bridge build
         shell: bash

--- a/.github/workflows/_ci-build-electron-package-apps.reusable.yml
+++ b/.github/workflows/_ci-build-electron-package-apps.reusable.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   build-electron-package-apps:
-    name: Build Electron Package Test Apps
+    name: Build
     runs-on: ${{ inputs.os }}
     outputs:
       build_id: ${{ steps.build-info.outputs.build_id }}

--- a/.github/workflows/_ci-build-electron-package-apps.reusable.yml
+++ b/.github/workflows/_ci-build-electron-package-apps.reusable.yml
@@ -1,5 +1,5 @@
 name: Build Electron Package Test Apps
-description: 'Builds Electron package test applications and creates shareable artifacts'
+# Description: Builds Electron package test applications and creates shareable artifacts
 
 permissions:
   contents: read
@@ -54,8 +54,8 @@ jobs:
         id: build-info
         shell: bash
         run: |
-          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       # Install dependencies for all Electron package test apps
       # This ensures all required packages (like @electron-forge/core) are available before building

--- a/.github/workflows/_ci-build-tauri-apps.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-apps.reusable.yml
@@ -1,5 +1,5 @@
 name: Build Tauri Apps
-description: 'Builds Tauri test applications and creates shareable artifacts for E2E testing'
+# Description: Builds Tauri test applications and creates shareable artifacts for E2E testing
 
 permissions:
   contents: read
@@ -145,8 +145,8 @@ jobs:
         id: build-info
         shell: bash
         run: |
-          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       # Build all Tauri test applications using Turbo
       # This creates the binaries in src-tauri/target/debug

--- a/.github/workflows/_ci-build-tauri-apps.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-apps.reusable.yml
@@ -62,7 +62,8 @@ jobs:
 
       # Install Rust toolchain for Tauri compilation
       - name: 🦀 Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        shell: bash
+        run: rustup update stable && rustup default stable
 
       - name: 🦀 Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/_ci-build-tauri-apps.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-apps.reusable.yml
@@ -40,7 +40,7 @@ jobs:
   # This job builds all Tauri test applications for the specified OS
   # Unlike package builds, each OS creates its own artifacts since binaries are platform-specific
   build-tauri-apps:
-    name: Build Tauri Apps
+    name: Build
     runs-on: ${{ inputs.os }}
     outputs:
       build_id: ${{ steps.build-info.outputs.build_id }}

--- a/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
@@ -1,5 +1,5 @@
 name: Build Tauri E2E App
-description: 'Builds Tauri E2E test application and creates shareable artifacts'
+# Description: Builds Tauri E2E test application and creates shareable artifacts
 
 permissions:
   contents: read
@@ -147,8 +147,8 @@ jobs:
         id: build-info
         shell: bash
         run: |
-          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       # Download the pre-built packages from the main build job
       # This ensures we use the same build artifacts and avoid rebuilding Node.js packages

--- a/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
@@ -210,7 +210,7 @@ jobs:
           echo "Checking capabilities file..."
           if [ -f "$APP_DIR/capabilities/default.json" ]; then
             echo "✅ Capabilities file exists"
-            cat "$APP_DIR/capabilities/default.json" | head -20 || echo "Failed to read capabilities file"
+            head -20 "$APP_DIR/capabilities/default.json" || echo "Failed to read capabilities file"
 
             # Check if identifier is "default"
             if grep -q '"identifier": "default"' "$APP_DIR/capabilities/default.json"; then
@@ -285,7 +285,7 @@ jobs:
             if [ -f "$ACL_MANIFEST" ]; then
               echo "✅ ACL manifest exists"
               echo "ACL manifest keys:"
-              cat "$ACL_MANIFEST" | jq 'keys' 2>/dev/null || cat "$ACL_MANIFEST" | head -50
+              jq 'keys' "$ACL_MANIFEST" 2>/dev/null || head -50 "$ACL_MANIFEST"
 
               if grep -q '"default"' "$ACL_MANIFEST" 2>/dev/null; then
                 echo "✅ 'default' capability found in ACL manifest"

--- a/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
@@ -67,7 +67,8 @@ jobs:
           node-version: '24'
 
       - name: 🦀 Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        shell: bash
+        run: rustup update stable && rustup default stable
 
       - name: 🦀 Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
@@ -48,7 +48,7 @@ env:
 
 jobs:
   build-tauri-e2e-app:
-    name: Build Tauri E2E App
+    name: Build
     runs-on: ${{ inputs.os }}
     outputs:
       build_id: ${{ steps.build-info.outputs.build_id }}

--- a/.github/workflows/_ci-build-tauri-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-package-app.reusable.yml
@@ -269,7 +269,7 @@ jobs:
             echo "Checking existing ACL manifest (if present):"
             if [ -f "$APP_DIR/gen/schemas/acl-manifests.json" ]; then
               echo "Existing ACL manifest found:"
-              cat "$APP_DIR/gen/schemas/acl-manifests.json" | jq 'keys' 2>/dev/null || cat "$APP_DIR/gen/schemas/acl-manifests.json" | head -20
+              jq 'keys' "$APP_DIR/gen/schemas/acl-manifests.json" 2>/dev/null || head -20 "$APP_DIR/gen/schemas/acl-manifests.json"
 
               if grep -q '"default"' "$APP_DIR/gen/schemas/acl-manifests.json" 2>/dev/null; then
                 echo "✅ Existing manifest has 'default' capability"
@@ -325,7 +325,7 @@ jobs:
             if [ -f "$ACL_MANIFEST" ]; then
               echo "✅ ACL manifest exists"
               echo "ACL manifest keys:"
-              cat "$ACL_MANIFEST" | jq 'keys' 2>/dev/null || cat "$ACL_MANIFEST" | head -50
+              jq 'keys' "$ACL_MANIFEST" 2>/dev/null || head -50 "$ACL_MANIFEST"
 
               if grep -q '"default"' "$ACL_MANIFEST" 2>/dev/null; then
                 echo "✅ 'default' capability found in ACL manifest"

--- a/.github/workflows/_ci-build-tauri-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-package-app.reusable.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   build-tauri-package-app:
-    name: Build Tauri Package Test App
+    name: Build
     runs-on: ${{ inputs.os }}
     outputs:
       build_id: ${{ steps.build-info.outputs.build_id }}

--- a/.github/workflows/_ci-build-tauri-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-package-app.reusable.yml
@@ -74,7 +74,8 @@ jobs:
           exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
 
       - name: 🦀 Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        shell: bash
+        run: rustup update stable && rustup default stable
 
       - name: 🦀 Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/_ci-build-tauri-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-package-app.reusable.yml
@@ -1,5 +1,5 @@
 name: Build Tauri Package Test App
-description: 'Builds Tauri package test application and creates shareable artifacts'
+# Description: Builds Tauri package test application and creates shareable artifacts
 
 permissions:
   contents: read
@@ -154,8 +154,8 @@ jobs:
         id: build-info
         shell: bash
         run: |
-          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       # Debug: Check environment before build
       - name: 🔍 Debug Tauri Package App Build Environment

--- a/.github/workflows/_ci-build.reusable.yml
+++ b/.github/workflows/_ci-build.reusable.yml
@@ -1,5 +1,5 @@
 name: Build
-description: 'Builds all packages and creates shareable artifacts for testing'
+# Description: Builds all packages and creates shareable artifacts for testing
 
 permissions:
   contents: read
@@ -62,8 +62,8 @@ jobs:
         id: build-info
         shell: bash
         run: |
-          echo "build_id=$(date +%s)-${{ github.run_id }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          echo "build_id=$(date +%s)-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       # Build all packages using Turbo
       # This creates the dist/ directories with compiled code

--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -165,12 +165,13 @@ jobs:
       - name: Determine What to Run
         id: determine
         run: |
+          # shellcheck disable=SC2129
           # If force_all is true, always run everything
           if [ "${{ inputs.force_all }}" = "true" ]; then
-            echo "run_electron=true" >> $GITHUB_OUTPUT
-            echo "run_tauri=true" >> $GITHUB_OUTPUT
-            echo "run_dioxus=true" >> $GITHUB_OUTPUT
-            echo "has_shared_changes=true" >> $GITHUB_OUTPUT
+            echo "run_electron=true" >> "$GITHUB_OUTPUT"
+            echo "run_tauri=true" >> "$GITHUB_OUTPUT"
+            echo "run_dioxus=true" >> "$GITHUB_OUTPUT"
+            echo "has_shared_changes=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Force all mode enabled - running all tests"
             exit 0
           fi
@@ -233,45 +234,47 @@ jobs:
             RUN_LINT_ONLY="true"
           fi
 
-          echo "run_electron=$RUN_ELECTRON" >> $GITHUB_OUTPUT
-          echo "run_tauri=$RUN_TAURI" >> $GITHUB_OUTPUT
-          echo "run_dioxus=$RUN_DIOXUS" >> $GITHUB_OUTPUT
-          echo "has_shared_changes=$SHARED" >> $GITHUB_OUTPUT
-          echo "run_lint_only=$RUN_LINT_ONLY" >> $GITHUB_OUTPUT
+          # shellcheck disable=SC2129
+          echo "run_electron=$RUN_ELECTRON" >> "$GITHUB_OUTPUT"
+          echo "run_tauri=$RUN_TAURI" >> "$GITHUB_OUTPUT"
+          echo "run_dioxus=$RUN_DIOXUS" >> "$GITHUB_OUTPUT"
+          echo "has_shared_changes=$SHARED" >> "$GITHUB_OUTPUT"
+          echo "run_lint_only=$RUN_LINT_ONLY" >> "$GITHUB_OUTPUT"
 
           # Create summary for GitHub Step Summary (appears in Actions Summary page)
-          echo "## Change Detection Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Category | Changed |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|---------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Documentation | $DOCS |" >> $GITHUB_STEP_SUMMARY
-          echo "| Electron service | $ELECTRON |" >> $GITHUB_STEP_SUMMARY
-          echo "| Tauri service | $TAURI |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dioxus service | $DIOXUS |" >> $GITHUB_STEP_SUMMARY
-          echo "| Shared packages | $SHARED |" >> $GITHUB_STEP_SUMMARY
-          echo "| E2E Electron | $E2E_ELECTRON |" >> $GITHUB_STEP_SUMMARY
-          echo "| E2E Tauri | $E2E_TAURI |" >> $GITHUB_STEP_SUMMARY
-          echo "| E2E Dioxus | $E2E_DIOXUS |" >> $GITHUB_STEP_SUMMARY
-          echo "| Fixtures Electron | $FIXTURES_ELECTRON |" >> $GITHUB_STEP_SUMMARY
-          echo "| Fixtures Tauri | $FIXTURES_TAURI |" >> $GITHUB_STEP_SUMMARY
-          echo "| Fixtures Dioxus | $FIXTURES_DIOXUS |" >> $GITHUB_STEP_SUMMARY
-          echo "| Infrastructure (shared) | $INFRA |" >> $GITHUB_STEP_SUMMARY
-          echo "| Infrastructure (Electron) | $INFRA_ELECTRON |" >> $GITHUB_STEP_SUMMARY
-          echo "| Infrastructure (Tauri) | $INFRA_TAURI |" >> $GITHUB_STEP_SUMMARY
-          echo "| Infrastructure (Dioxus) | $INFRA_DIOXUS |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Decisions" >> $GITHUB_STEP_SUMMARY
-          echo "- **Run Electron**: $RUN_ELECTRON" >> $GITHUB_STEP_SUMMARY
-          echo "- **Run Tauri**: $RUN_TAURI" >> $GITHUB_STEP_SUMMARY
-          echo "- **Run Dioxus**: $RUN_DIOXUS" >> $GITHUB_STEP_SUMMARY
-          echo "- **Lint only (no service changes)**: $RUN_LINT_ONLY" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Outputs" >> $GITHUB_STEP_SUMMARY
-          echo "- \`run_electron\`: $RUN_ELECTRON" >> $GITHUB_STEP_SUMMARY
-          echo "- \`run_tauri\`: $RUN_TAURI" >> $GITHUB_STEP_SUMMARY
-          echo "- \`run_dioxus\`: $RUN_DIOXUS" >> $GITHUB_STEP_SUMMARY
-          echo "- \`has_shared_changes\`: $SHARED" >> $GITHUB_STEP_SUMMARY
-          echo "- \`run_lint_only\`: $RUN_LINT_ONLY" >> $GITHUB_STEP_SUMMARY
+          # shellcheck disable=SC2129
+          echo "## Change Detection Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Category | Changed |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|---------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Documentation | $DOCS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Electron service | $ELECTRON |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tauri service | $TAURI |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Dioxus service | $DIOXUS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Shared packages | $SHARED |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| E2E Electron | $E2E_ELECTRON |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| E2E Tauri | $E2E_TAURI |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| E2E Dioxus | $E2E_DIOXUS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Fixtures Electron | $FIXTURES_ELECTRON |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Fixtures Tauri | $FIXTURES_TAURI |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Fixtures Dioxus | $FIXTURES_DIOXUS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Infrastructure (shared) | $INFRA |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Infrastructure (Electron) | $INFRA_ELECTRON |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Infrastructure (Tauri) | $INFRA_TAURI |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Infrastructure (Dioxus) | $INFRA_DIOXUS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Decisions" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Run Electron**: $RUN_ELECTRON" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Run Tauri**: $RUN_TAURI" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Run Dioxus**: $RUN_DIOXUS" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Lint only (no service changes)**: $RUN_LINT_ONLY" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Outputs" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`run_electron\`: $RUN_ELECTRON" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`run_tauri\`: $RUN_TAURI" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`run_dioxus\`: $RUN_DIOXUS" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`has_shared_changes\`: $SHARED" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`run_lint_only\`: $RUN_LINT_ONLY" >> "$GITHUB_STEP_SUMMARY"
 
           # Also print to logs for debugging
           echo "Change Detection Summary:"

--- a/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
@@ -93,14 +93,6 @@ jobs:
             libayatana-appindicator3-1 \
             libxdo3
 
-      # Rust needed for external provider (wdio-dioxus-driver auto-install on Windows)
-      # Only installed on Windows where external provider runs in v1
-      - name: 🦀 Setup Rust (for wdio-dioxus-driver auto-install)
-        if: inputs.os == 'windows-latest'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
       - name: 📦 Download Package Build Artifacts
         uses: ./.github/workflows/actions/download-archive
         with:
@@ -196,43 +188,13 @@ jobs:
             }
             const suffix = testType !== 'standard' ? `:${testType}` : '';
             core.setOutput('embedded', `test:e2e:dioxus${suffix}`);
-            // External provider has no per-test-type scripts in v1
-            core.setOutput('external', 'test:e2e:dioxus-external');
 
       # ══════════════════════════════════════════════════════════════
-      # PROVIDER 1: EXTERNAL (wdio-dioxus-driver) — Windows only in v1
+      # PROVIDER 1: EXTERNAL (wdio-dioxus-driver) — not implemented in v1
+      # The external provider requires wdio-dioxus-driver spawning in the launcher,
+      # which is deferred to v1.1. External E2E steps will be added once the
+      # launcher's external path is wired up.
       # ══════════════════════════════════════════════════════════════
-
-      - name: 🧹 Cleanup [External]
-        if: inputs.os == 'windows-latest'
-        shell: bash
-        run: |
-          echo "Cleaning up before External provider tests..."
-          powershell -Command "Get-Process -Name 'wdio-dioxus-driver','msedgedriver','wdio-dioxus-e2e-app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" || true
-
-      - name: 🧪 E2E Tests [External]
-        id: test-external
-        if: inputs.os == 'windows-latest'
-        continue-on-error: true
-        shell: pwsh
-        working-directory: e2e
-        env:
-          RUST_BACKTRACE: '1'
-          DRIVER_PROVIDER: 'external'
-        run: |
-          pnpm run ${{ steps.gen-test.outputs.external }}
-
-      - name: 🧹 Post-cleanup [External]
-        if: always() && inputs.os == 'windows-latest'
-        shell: bash
-        run: |
-          echo "Cleaning up after External provider tests..."
-          powershell -Command "Get-Process -Name 'wdio-dioxus-driver','msedgedriver','wdio-dioxus-e2e-app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" || true
-
-      - name: 🐛 Debug Information [External]
-        if: always() && inputs.os == 'windows-latest'
-        shell: bash
-        run: pnpm exec tsx e2e/scripts/show-logs.ts --provider external
 
       # ══════════════════════════════════════════════════════════════
       # PROVIDER 2: EMBEDDED (wdio-dioxus-embedded-driver) — all platforms
@@ -295,7 +257,6 @@ jobs:
           echo "| Provider | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          external="${{ steps.test-external.outcome }}"
           embedded="${{ steps.test-embedded.outcome }}"
 
           format_result() {
@@ -309,7 +270,7 @@ jobs:
             esac
           }
 
-          format_result "External (Windows only)" "$external"
+          echo "| External (v1.1) | ⏭️ Not implemented |" >> $GITHUB_STEP_SUMMARY
           format_result "Embedded" "$embedded"
 
       - name: 📦 Upload Test Logs
@@ -326,34 +287,25 @@ jobs:
         if: always()
         shell: bash
         run: |
-          external="${{ steps.test-external.outcome }}"
           embedded="${{ steps.test-embedded.outcome }}"
 
-          failed=false
-
-          check_result() {
-            local provider="$1" outcome="$2"
-            case "$outcome" in
-              success|skipped|"") ;;
-              failure)
-                echo "::error::$provider provider tests failed"
-                failed=true ;;
-              cancelled)
-                echo "::error::$provider provider tests were cancelled"
-                failed=true ;;
-              *)
-                echo "::error::$provider provider had unexpected outcome: $outcome"
-                failed=true ;;
-            esac
-          }
-
-          check_result "External" "$external"
-          check_result "Embedded" "$embedded"
-
-          if [ "$failed" = "true" ]; then
-            exit 1
-          fi
-          echo "All providers passed"
+          case "$embedded" in
+            success|skipped|"")
+              echo "Embedded provider passed"
+              ;;
+            failure)
+              echo "::error::Embedded provider tests failed"
+              exit 1
+              ;;
+            cancelled)
+              echo "::error::Embedded provider tests were cancelled"
+              exit 1
+              ;;
+            *)
+              echo "::error::Embedded provider had unexpected outcome: $embedded"
+              exit 1
+              ;;
+          esac
 
       - name: 🐛 Debug Build on Failure
         if: failure()

--- a/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
@@ -1,0 +1,360 @@
+name: Dioxus E2E Tests - All Providers
+
+description: 'Runs Dioxus E2E tests for all WebDriver providers (external, embedded) sequentially on a single runner'
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system to run tests on'
+        required: true
+        type: string
+      node-version:
+        description: 'Node.js version to use for testing'
+        required: true
+        type: string
+      test-type:
+        description: 'Test type (standard, window, multiremote, standalone, deeplink)'
+        type: string
+        default: 'standard'
+      build_id:
+        description: 'Build ID from the build job'
+        type: string
+        required: false
+      artifact_size:
+        description: 'Size of the build artifact in bytes'
+        type: string
+        required: false
+      cache_key:
+        description: 'Cache key to use for downloading package artifacts'
+        type: string
+        required: false
+      dioxus_cache_key:
+        description: 'Cache key to use for downloading Dioxus app binaries'
+        type: string
+        required: false
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  e2e-dioxus:
+    name: Dioxus E2E Tests
+    runs-on: ${{ inputs.os }}
+    steps:
+      # ══════════════════════════════════════════════════════════════
+      # SHARED SETUP (runs once, reused by all providers)
+      # ══════════════════════════════════════════════════════════════
+
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: 🛠️ Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: 🔧 Fix ARM64 Package Sources (Linux)
+        if: runner.os == 'Linux' && runner.arch == 'ARM64'
+        shell: bash
+        run: |
+          echo "Fixing ARM64 package sources for Ubuntu..."
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-jammy.list > /dev/null
+
+          sudo sed -i -e 's/^deb http/deb [arch=amd64] http/' /etc/apt/sources.list
+          sudo sed -i -e 's/^deb mirror/deb [arch=amd64] mirror/' /etc/apt/sources.list
+
+          sudo apt-get update
+
+      - name: 🦀 Install Dioxus Runtime Dependencies (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "Installing Dioxus runtime dependencies for Linux..."
+          if [ "$(uname -m)" != "aarch64" ]; then
+            echo "deb http://archive.ubuntu.com/ubuntu jammy main universe" | sudo tee -a /etc/apt/sources.list > /dev/null
+          fi
+          sudo apt-get update
+          sudo apt-get --fix-broken install -y || true
+
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-0 \
+            libgtk-3-0t64 \
+            libayatana-appindicator3-1 \
+            libxdo3
+
+      # Rust needed for external provider (wdio-dioxus-driver auto-install on Windows)
+      # Only installed on Windows where external provider runs in v1
+      - name: 🦀 Setup Rust (for wdio-dioxus-driver auto-install)
+        if: inputs.os == 'windows-latest'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: 📦 Download Package Build Artifacts
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: wdio-desktop-mobile
+          path: wdio-desktop-mobile-build
+          filename: artifact.zip
+          cache_key_prefix: wdio-desktop-build
+          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
+
+      - name: 📦 Download Dioxus E2E App Binary
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: dioxus-e2e-app-${{ runner.os }}-${{ runner.arch }}
+          path: dioxus-e2e-app-${{ runner.os }}-${{ runner.arch }}
+          filename: artifact.zip
+          cache_key_prefix: dioxus-e2e-app
+          exact_cache_key: ${{ inputs.dioxus_cache_key }}
+
+      - name: ✅ Verify Dioxus Binaries
+        shell: bash
+        run: |
+          echo "Checking for Dioxus binaries in fixtures/e2e-apps/dioxus/target/"
+
+          if [ ! -d "fixtures/e2e-apps/dioxus" ]; then
+            echo "::error::fixtures/e2e-apps/dioxus directory not found!"
+            exit 1
+          fi
+
+          TARGET_DIRS=$(find fixtures/e2e-apps/dioxus -name "target" -type d 2>/dev/null || true)
+
+          if [ -z "$TARGET_DIRS" ]; then
+            echo "::error::No target directories found! Binaries were not extracted correctly."
+            echo "Directory contents:"
+            ls -la fixtures/e2e-apps/dioxus/ || true
+            exit 1
+          fi
+
+          echo "✅ Found target directories:"
+          echo "$TARGET_DIRS"
+
+          BINARY_COUNT=0
+          for target_dir in $TARGET_DIRS; do
+            if [ "${{ runner.os }}" = "Windows" ]; then
+              if compgen -G "$target_dir/debug/*.exe" > /dev/null 2>&1; then
+                BINARY_COUNT=$((BINARY_COUNT + 1))
+                echo "  ✅ Found Windows binary in $target_dir/debug/"
+              fi
+            elif [ "${{ runner.os }}" = "macOS" ]; then
+              if find "$target_dir/debug" -maxdepth 1 -type f -perm +111 2>/dev/null | grep -q .; then
+                BINARY_COUNT=$((BINARY_COUNT + 1))
+                echo "  ✅ Found macOS binary in $target_dir/debug/"
+              fi
+            else
+              if find "$target_dir/debug" -maxdepth 1 -type f -executable 2>/dev/null | grep -q .; then
+                BINARY_COUNT=$((BINARY_COUNT + 1))
+                echo "  ✅ Found Linux binary in $target_dir/debug/"
+              fi
+            fi
+          done
+
+          if [ "$BINARY_COUNT" -eq 0 ]; then
+            echo "::error::No binaries found in target directories!"
+            echo ""
+            echo "Directory structure for debugging:"
+            for target_dir in $TARGET_DIRS; do
+              echo "=== $target_dir/debug/ ==="
+              ls -la "$target_dir/debug/" 2>/dev/null | head -20 || echo "Cannot list debug directory"
+            done
+            exit 1
+          fi
+
+          echo "✅ Verification complete: Found $BINARY_COUNT app(s) with binaries"
+
+      - name: 📊 Show Build Information
+        if: inputs.build_id != '' && inputs.artifact_size != ''
+        shell: bash
+        run: |
+          echo "::notice::Package build: ID=${{ inputs.build_id }}, Size=${{ inputs.artifact_size }} bytes"
+          echo "::notice::Dioxus binaries: Using pre-built binaries for ${{ runner.os }}"
+
+      - name: 🪄 Generate Test Commands
+        id: gen-test
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const ALLOWED = ['standard', 'window', 'multiremote', 'standalone', 'deeplink'];
+            const testType = '${{ inputs.test-type }}'.trim();
+            if (!ALLOWED.includes(testType)) {
+              core.setFailed(`Invalid test-type: "${testType}". Allowed: ${ALLOWED.join(', ')}`);
+              return;
+            }
+            const suffix = testType !== 'standard' ? `:${testType}` : '';
+            core.setOutput('embedded', `test:e2e:dioxus${suffix}`);
+            // External provider has no per-test-type scripts in v1
+            core.setOutput('external', 'test:e2e:dioxus-external');
+
+      # ══════════════════════════════════════════════════════════════
+      # PROVIDER 1: EXTERNAL (wdio-dioxus-driver) — Windows only in v1
+      # ══════════════════════════════════════════════════════════════
+
+      - name: 🧹 Cleanup [External]
+        if: inputs.os == 'windows-latest'
+        shell: bash
+        run: |
+          echo "Cleaning up before External provider tests..."
+          powershell -Command "Get-Process -Name 'wdio-dioxus-driver','msedgedriver','wdio-dioxus-e2e-app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" || true
+
+      - name: 🧪 E2E Tests [External]
+        id: test-external
+        if: inputs.os == 'windows-latest'
+        continue-on-error: true
+        shell: pwsh
+        working-directory: e2e
+        env:
+          RUST_BACKTRACE: '1'
+          DRIVER_PROVIDER: 'external'
+        run: |
+          pnpm run ${{ steps.gen-test.outputs.external }}
+
+      - name: 🧹 Post-cleanup [External]
+        if: always() && inputs.os == 'windows-latest'
+        shell: bash
+        run: |
+          echo "Cleaning up after External provider tests..."
+          powershell -Command "Get-Process -Name 'wdio-dioxus-driver','msedgedriver','wdio-dioxus-e2e-app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" || true
+
+      - name: 🐛 Debug Information [External]
+        if: always() && inputs.os == 'windows-latest'
+        shell: bash
+        run: pnpm exec tsx e2e/scripts/show-logs.ts --provider external
+
+      # ══════════════════════════════════════════════════════════════
+      # PROVIDER 2: EMBEDDED (wdio-dioxus-embedded-driver) — all platforms
+      # ══════════════════════════════════════════════════════════════
+
+      - name: 🧹 Cleanup [Embedded]
+        if: always()
+        shell: bash
+        run: |
+          echo "Cleaning up before Embedded provider tests..."
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            powershell -Command "Get-Process -Name 'wdio-dioxus-e2e-app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" || true
+          else
+            pkill -9 -f wdio-dioxus-e2e-app || true
+          fi
+
+      - name: 🧪 E2E Tests [Embedded]
+        id: test-embedded
+        continue-on-error: true
+        shell: pwsh
+        working-directory: e2e
+        env:
+          RUST_BACKTRACE: '1'
+          NO_AT_BRIDGE: '1'
+          DRIVER_PROVIDER: 'embedded'
+        run: |
+          if ($env:RUNNER_OS -eq "Linux") {
+            xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" `
+              pnpm run ${{ steps.gen-test.outputs.embedded }}
+          } else {
+            pnpm run ${{ steps.gen-test.outputs.embedded }}
+          }
+
+      - name: 🧹 Post-cleanup [Embedded]
+        if: always()
+        shell: bash
+        run: |
+          echo "Cleaning up after Embedded provider tests..."
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            powershell -Command "Get-Process -Name 'wdio-dioxus-e2e-app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" || true
+          else
+            pkill -9 -f wdio-dioxus-e2e-app || true
+          fi
+
+      - name: 🐛 Debug Information [Embedded]
+        if: always()
+        shell: bash
+        run: pnpm exec tsx e2e/scripts/show-logs.ts --provider embedded
+
+      # ══════════════════════════════════════════════════════════════
+      # REPORTING & ARTIFACTS
+      # ══════════════════════════════════════════════════════════════
+
+      - name: 📊 Provider Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "## Dioxus E2E Results — ${{ inputs.os }} / ${{ inputs.test-type }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Provider | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
+
+          external="${{ steps.test-external.outcome }}"
+          embedded="${{ steps.test-embedded.outcome }}"
+
+          format_result() {
+            local provider="$1" outcome="$2"
+            case "$outcome" in
+              success)   echo "| $provider | ✅ Passed |" >> $GITHUB_STEP_SUMMARY ;;
+              failure)   echo "| $provider | ❌ Failed |" >> $GITHUB_STEP_SUMMARY ;;
+              cancelled) echo "| $provider | ⚠️ Cancelled |" >> $GITHUB_STEP_SUMMARY ;;
+              skipped|"") echo "| $provider | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY ;;
+              *)         echo "| $provider | ❓ $outcome |" >> $GITHUB_STEP_SUMMARY ;;
+            esac
+          }
+
+          format_result "External (Windows only)" "$external"
+          format_result "Embedded" "$embedded"
+
+      - name: 📦 Upload Test Logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-dioxus-logs-${{ inputs.os }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-type }}
+          path: e2e/logs/**/*.log
+          retention-days: 90
+          if-no-files-found: warn
+
+      - name: ❌ Check Provider Results
+        if: always()
+        shell: bash
+        run: |
+          external="${{ steps.test-external.outcome }}"
+          embedded="${{ steps.test-embedded.outcome }}"
+
+          failed=false
+
+          check_result() {
+            local provider="$1" outcome="$2"
+            case "$outcome" in
+              success|skipped|"") ;;
+              failure)
+                echo "::error::$provider provider tests failed"
+                failed=true ;;
+              cancelled)
+                echo "::error::$provider provider tests were cancelled"
+                failed=true ;;
+              *)
+                echo "::error::$provider provider had unexpected outcome: $outcome"
+                failed=true ;;
+            esac
+          }
+
+          check_result "External" "$external"
+          check_result "Embedded" "$embedded"
+
+          if [ "$failed" = "true" ]; then
+            exit 1
+          fi
+          echo "All providers passed"
+
+      - name: 🐛 Debug Build on Failure
+        if: failure()
+        uses: goosewobbler/vscode-server-action@v1.5.0
+        with:
+          timeout: '300000'

--- a/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   e2e-dioxus:
-    name: Dioxus E2E Tests
+    name: Run
     runs-on: ${{ inputs.os }}
     steps:
       # ══════════════════════════════════════════════════════════════

--- a/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
@@ -1,6 +1,6 @@
 name: Dioxus E2E Tests - All Providers
 
-description: 'Runs Dioxus E2E tests for all WebDriver providers (external, embedded) sequentially on a single runner'
+# Description: Runs Dioxus E2E tests for all WebDriver providers (external, embedded) sequentially on a single runner
 
 permissions:
   contents: read
@@ -114,6 +114,7 @@ jobs:
       - name: ✅ Verify Dioxus Binaries
         shell: bash
         run: |
+          # shellcheck disable=SC2012
           echo "Checking for Dioxus binaries in fixtures/e2e-apps/dioxus/target/"
 
           if [ ! -d "fixtures/e2e-apps/dioxus" ]; then
@@ -159,6 +160,7 @@ jobs:
             echo "Directory structure for debugging:"
             for target_dir in $TARGET_DIRS; do
               echo "=== $target_dir/debug/ ==="
+              # shellcheck disable=SC2012
               ls -la "$target_dir/debug/" 2>/dev/null | head -20 || echo "Cannot list debug directory"
             done
             exit 1
@@ -252,25 +254,26 @@ jobs:
         if: always()
         shell: bash
         run: |
-          echo "## Dioxus E2E Results — ${{ inputs.os }} / ${{ inputs.test-type }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Provider | Result |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
+          # shellcheck disable=SC2129
+          echo "## Dioxus E2E Results — ${{ inputs.os }} / ${{ inputs.test-type }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Provider | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
           embedded="${{ steps.test-embedded.outcome }}"
 
           format_result() {
             local provider="$1" outcome="$2"
             case "$outcome" in
-              success)   echo "| $provider | ✅ Passed |" >> $GITHUB_STEP_SUMMARY ;;
-              failure)   echo "| $provider | ❌ Failed |" >> $GITHUB_STEP_SUMMARY ;;
-              cancelled) echo "| $provider | ⚠️ Cancelled |" >> $GITHUB_STEP_SUMMARY ;;
-              skipped|"") echo "| $provider | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY ;;
-              *)         echo "| $provider | ❓ $outcome |" >> $GITHUB_STEP_SUMMARY ;;
+              success)   echo "| $provider | ✅ Passed |" >> "$GITHUB_STEP_SUMMARY" ;;
+              failure)   echo "| $provider | ❌ Failed |" >> "$GITHUB_STEP_SUMMARY" ;;
+              cancelled) echo "| $provider | ⚠️ Cancelled |" >> "$GITHUB_STEP_SUMMARY" ;;
+              skipped|"") echo "| $provider | ⏭️ Skipped |" >> "$GITHUB_STEP_SUMMARY" ;;
+              *)         echo "| $provider | ❓ $outcome |" >> "$GITHUB_STEP_SUMMARY" ;;
             esac
           }
 
-          echo "| External (v1.1) | ⏭️ Not implemented |" >> $GITHUB_STEP_SUMMARY
+          echo "| External (v1.1) | ⏭️ Not implemented |" >> "$GITHUB_STEP_SUMMARY"
           format_result "Embedded" "$embedded"
 
       - name: 📦 Upload Test Logs

--- a/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
@@ -184,10 +184,12 @@ jobs:
       - name: 🪄 Generate Test Commands
         id: gen-test
         uses: actions/github-script@v9
+        env:
+          TEST_TYPE: ${{ inputs.test-type }}
         with:
           script: |
             const ALLOWED = ['standard', 'window', 'multiremote', 'standalone', 'deeplink'];
-            const testType = '${{ inputs.test-type }}'.trim();
+            const testType = process.env.TEST_TYPE.trim();
             if (!ALLOWED.includes(testType)) {
               core.setFailed(`Invalid test-type: "${testType}". Allowed: ${ALLOWED.join(', ')}`);
               return;

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -1,6 +1,6 @@
 name: Tauri E2E Tests - All Providers
 
-description: 'Runs Tauri E2E tests for all WebDriver providers (official, embedded, CrabNebula) sequentially on a single runner'
+# Description: Runs Tauri E2E tests for all WebDriver providers (official, embedded, CrabNebula) sequentially on a single runner
 
 permissions:
   contents: read
@@ -130,6 +130,7 @@ jobs:
       - name: ✅ Verify Tauri Binaries
         shell: bash
         run: |
+          # shellcheck disable=SC2012
           echo "Checking for Tauri binaries in fixtures/e2e-apps/tauri/src-tauri/target/"
 
           if [ ! -d "fixtures/e2e-apps/tauri" ]; then
@@ -184,9 +185,11 @@ jobs:
             echo "Directory structure for debugging:"
             for target_dir in $TARGET_DIRS; do
               echo "=== $target_dir ==="
+              # shellcheck disable=SC2012
               ls -la "$target_dir/" 2>/dev/null | head -10 || echo "Cannot list directory"
               echo ""
               echo "=== $target_dir/debug/ ==="
+              # shellcheck disable=SC2012
               ls -la "$target_dir/debug/" 2>/dev/null | head -20 || echo "Cannot list debug directory"
               if [ "${{ runner.os }}" = "macOS" ]; then
                 echo ""
@@ -272,6 +275,7 @@ jobs:
         if: runner.os != 'macOS'
         shell: bash
         run: |
+          # shellcheck disable=SC2028
           echo "=== Protocol Registration Verification ==="
 
           if [ "${{ runner.os }}" == "Linux" ]; then
@@ -293,6 +297,7 @@ jobs:
 
           elif [ "${{ runner.os }}" == "Windows" ]; then
             echo "Windows: Checking registry..."
+            # shellcheck disable=SC2028
             reg query "HKCR\testapp" 2>nul || echo "❌ Protocol NOT registered in HKCR\testapp"
             reg query "HKCR\testapp\shell\open\command" 2>nul || echo "❌ Command key NOT found"
           fi
@@ -481,10 +486,11 @@ jobs:
         if: always()
         shell: bash
         run: |
-          echo "## Tauri E2E Results — ${{ inputs.os }} / ${{ inputs.test-type }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Provider | Result |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
+          # shellcheck disable=SC2129
+          echo "## Tauri E2E Results — ${{ inputs.os }} / ${{ inputs.test-type }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Provider | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
           official="${{ steps.test-official.outcome }}"
           embedded="${{ steps.test-embedded.outcome }}"
@@ -493,11 +499,11 @@ jobs:
           format_result() {
             local provider="$1" outcome="$2"
             case "$outcome" in
-              success)   echo "| $provider | ✅ Passed |" >> $GITHUB_STEP_SUMMARY ;;
-              failure)   echo "| $provider | ❌ Failed |" >> $GITHUB_STEP_SUMMARY ;;
-              cancelled) echo "| $provider | ⚠️ Cancelled |" >> $GITHUB_STEP_SUMMARY ;;
-              skipped|"") echo "| $provider | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY ;;
-              *)         echo "| $provider | ❓ $outcome |" >> $GITHUB_STEP_SUMMARY ;;
+              success)   echo "| $provider | ✅ Passed |" >> "$GITHUB_STEP_SUMMARY" ;;
+              failure)   echo "| $provider | ❌ Failed |" >> "$GITHUB_STEP_SUMMARY" ;;
+              cancelled) echo "| $provider | ⚠️ Cancelled |" >> "$GITHUB_STEP_SUMMARY" ;;
+              skipped|"") echo "| $provider | ⏭️ Skipped |" >> "$GITHUB_STEP_SUMMARY" ;;
+              *)         echo "| $provider | ❓ $outcome |" >> "$GITHUB_STEP_SUMMARY" ;;
             esac
           }
 

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -96,9 +96,8 @@ jobs:
       # Only installed on Linux/Windows where official provider runs
       - name: 🦀 Setup Rust (for tauri-driver auto-install)
         if: inputs.os != 'macos-latest' && inputs.os != 'macos-15-intel'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+        shell: bash
+        run: rustup update stable && rustup default stable && rustup component add rustfmt
 
       # WebKitWebDriver needed for official + crabnebula providers on Linux
       - name: 🌐 Install WebKit WebDriver (Linux)

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   e2e-tauri:
-    name: Tauri E2E Tests
+    name: Run
     runs-on: ${{ inputs.os }}
     steps:
       # ══════════════════════════════════════════════════════════════

--- a/.github/workflows/_ci-e2e.reusable.yml
+++ b/.github/workflows/_ci-e2e.reusable.yml
@@ -53,7 +53,7 @@ jobs:
   # - Test scenario (builder, forge, script)
   # - E2E tests use ESM only (CJS/ESM testing is done in package tests)
   e2e:
-    name: E2E Tests
+    name: Run
     runs-on: ${{ inputs.os }}
     strategy:
       # Continue with other tests even if one fails

--- a/.github/workflows/_ci-e2e.reusable.yml
+++ b/.github/workflows/_ci-e2e.reusable.yml
@@ -1,5 +1,5 @@
 name: E2E Tests
-description: 'Runs end-to-end tests across different scenarios (ESM only)'
+# Description: Runs end-to-end tests across different scenarios (ESM only)
 
 permissions:
   contents: read
@@ -125,7 +125,10 @@ jobs:
         env:
           BUILD_CMD: ${{ inputs.build-command }}
           BUILD_FILTER: ${{ steps.gen-build.outputs.result }}
-        run: pnpm exec turbo run $BUILD_CMD $BUILD_FILTER --parallel
+        run: |
+          # BUILD_FILTER intentionally splits into multiple turbo args
+          # shellcheck disable=SC2086
+          pnpm exec turbo run $BUILD_CMD $BUILD_FILTER --parallel
 
       # Setup protocol handlers for deeplink testing
       # Required for Windows and Linux to properly handle testapp:// protocol
@@ -139,12 +142,15 @@ jobs:
           echo "Scenario: ${{ inputs.scenario }}"
           echo ""
 
-          # Determine which app(s) to set up based on scenario
+          # Determine which app(s) to set up based on scenario.
+          # Assign to a shell var first so shellcheck doesn't compare the
+          # literal templated string against the glob patterns (SC2193).
+          SCENARIO="${{ inputs.scenario }}"
           APPS=()
-          if [[ "${{ inputs.scenario }}" == *"builder"* ]]; then
+          if [[ "$SCENARIO" == *"builder"* ]]; then
             APPS+=("electron-builder")
           fi
-          if [[ "${{ inputs.scenario }}" == *"forge"* ]]; then
+          if [[ "$SCENARIO" == *"forge"* ]]; then
             APPS+=("electron-forge")
           fi
 
@@ -156,17 +162,17 @@ jobs:
 
               if [ "$APP" == "electron-builder" ]; then
                 echo "Checking if dist-electron directory exists..."
-                ls -la ./fixtures/e2e-apps/$APP/dist-electron/ || echo "dist-electron/ not found"
+                ls -la ./fixtures/e2e-apps/"$APP"/dist-electron/ || echo "dist-electron/ not found"
               else
                 echo "Checking if out directory exists..."
-                ls -la ./fixtures/e2e-apps/$APP/out/ || echo "out/ not found"
+                ls -la ./fixtures/e2e-apps/"$APP"/out/ || echo "out/ not found"
               fi
               echo ""
 
-              powershell -ExecutionPolicy Bypass -File ./fixtures/e2e-apps/$APP/scripts/setup-protocol-handler.ps1
+              powershell -ExecutionPolicy Bypass -File ./fixtures/e2e-apps/"$APP"/scripts/setup-protocol-handler.ps1
               EXIT_CODE=$?
 
-              if [ $EXIT_CODE -ne 0 ]; then
+              if [ "$EXIT_CODE" -ne 0 ]; then
                 echo "Error: Protocol handler setup failed for $APP with exit code $EXIT_CODE"
                 exit 1
               fi
@@ -176,18 +182,18 @@ jobs:
 
               if [ "$APP" == "electron-builder" ]; then
                 echo "Checking if dist-electron directory exists..."
-                ls -la ./fixtures/e2e-apps/$APP/dist-electron/ || echo "dist-electron/ not found"
+                ls -la ./fixtures/e2e-apps/"$APP"/dist-electron/ || echo "dist-electron/ not found"
               else
                 echo "Checking if out directory exists..."
-                ls -la ./fixtures/e2e-apps/$APP/out/ || echo "out/ not found"
+                ls -la ./fixtures/e2e-apps/"$APP"/out/ || echo "out/ not found"
               fi
               echo ""
 
-              chmod +x ./fixtures/e2e-apps/$APP/scripts/setup-protocol-handler.sh
-              ./fixtures/e2e-apps/$APP/scripts/setup-protocol-handler.sh
+              chmod +x ./fixtures/e2e-apps/"$APP"/scripts/setup-protocol-handler.sh
+              ./fixtures/e2e-apps/"$APP"/scripts/setup-protocol-handler.sh
               EXIT_CODE=$?
 
-              if [ $EXIT_CODE -ne 0 ]; then
+              if [ "$EXIT_CODE" -ne 0 ]; then
                 echo "Error: Protocol handler setup failed for $APP with exit code $EXIT_CODE"
                 exit 1
               fi
@@ -227,7 +233,10 @@ jobs:
         env:
           ENABLE_SPLASH_WINDOW: 'true'
           TEST_TASKS: ${{ steps.gen-test.outputs.result }}
-        run: pnpm exec turbo run $TEST_TASKS --only --log-order=stream
+        run: |
+          # TEST_TASKS intentionally splits into multiple turbo task names
+          # shellcheck disable=SC2086
+          pnpm exec turbo run $TEST_TASKS --only --log-order=stream
 
       # Show logs on failure for debugging
       # CodeQL false positive: This script cannot be poisoned by artifacts because

--- a/.github/workflows/_ci-lint.reusable.yml
+++ b/.github/workflows/_ci-lint.reusable.yml
@@ -62,7 +62,11 @@ jobs:
       # marketplace wrappers have flaky npm-based setup on newer runners.
       - name: 🔍 Run actionlint
         shell: bash
+        # Restrict to top-level workflow files. actionlint's auto-discovery
+        # also walks .github/workflows/actions/*/action.yml, but composite
+        # actions use a different schema and (incorrectly) fail the
+        # workflow-schema checks if passed in.
         run: |
           bash <(curl --silent --show-error --fail \
             https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
-          ./actionlint -color
+          ./actionlint -color .github/workflows/*.yml

--- a/.github/workflows/_ci-lint.reusable.yml
+++ b/.github/workflows/_ci-lint.reusable.yml
@@ -55,3 +55,8 @@ jobs:
       - name: 🔍 Run Format Check
         run: pnpm run format:check
         shell: bash
+
+      # Static analysis of GitHub Actions workflows. Catches schema errors,
+      # bad expressions, and shellcheck issues in `run:` scripts.
+      - name: 🔍 Run actionlint
+        uses: raven-actions/actionlint@v2

--- a/.github/workflows/_ci-lint.reusable.yml
+++ b/.github/workflows/_ci-lint.reusable.yml
@@ -1,5 +1,5 @@
 name: Lint
-description: 'Runs code quality checks across the codebase'
+# Description: Runs code quality checks across the codebase
 
 permissions:
   contents: read

--- a/.github/workflows/_ci-lint.reusable.yml
+++ b/.github/workflows/_ci-lint.reusable.yml
@@ -57,6 +57,12 @@ jobs:
         shell: bash
 
       # Static analysis of GitHub Actions workflows. Catches schema errors,
-      # bad expressions, and shellcheck issues in `run:` scripts.
+      # bad expressions, and shellcheck issues in `run:` scripts. Installs
+      # the binary via the upstream download script — the third-party
+      # marketplace wrappers have flaky npm-based setup on newer runners.
       - name: 🔍 Run actionlint
-        uses: raven-actions/actionlint@v2
+        shell: bash
+        run: |
+          bash <(curl --silent --show-error --fail \
+            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
+          ./actionlint -color

--- a/.github/workflows/_ci-package-docker.reusable.yml
+++ b/.github/workflows/_ci-package-docker.reusable.yml
@@ -1,5 +1,5 @@
 name: Package (Docker)
-description: 'Runs Tauri package tests in Docker containers across different Linux distributions'
+# Description: Runs Tauri package tests in Docker containers across different Linux distributions
 
 permissions:
   contents: read

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -1,5 +1,5 @@
 name: Package
-description: 'Runs package tests across different operating systems'
+# Description: Runs package tests across different operating systems
 
 permissions:
   contents: read

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -71,9 +71,8 @@ jobs:
       # The @wdio/tauri-service will automatically install tauri-driver via cargo if not found
       - name: 🦀 Setup Rust (for tauri-driver auto-install)
         if: inputs.service == 'tauri' || inputs.service == 'both'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+        shell: bash
+        run: rustup update stable && rustup default stable && rustup component add rustfmt
 
       # Install Dioxus GTK/WebKit runtime dependencies for Linux (required to run the desktop app)
       - name: 🦀 Install Dioxus Runtime Dependencies (Linux)

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -14,7 +14,7 @@ on:
         type: string
         required: true
       service:
-        description: 'Service to test (electron, tauri, or both)'
+        description: 'Service to test (electron, tauri, dioxus, or both)'
         type: string
         required: false
         default: 'both'
@@ -37,6 +37,10 @@ on:
         required: false
       tauri_cache_key:
         description: 'Cache key for Tauri package test app binaries'
+        type: string
+        required: false
+      dioxus_cache_key:
+        description: 'Cache key for Dioxus package test app binaries'
         type: string
         required: false
 
@@ -70,6 +74,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+
+      # Install Dioxus GTK/WebKit runtime dependencies for Linux (required to run the desktop app)
+      - name: 🦀 Install Dioxus Runtime Dependencies (Linux)
+        if: inputs.service == 'dioxus' && runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "Installing Dioxus runtime dependencies for Linux..."
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-0 \
+            libgtk-3-0t64 \
+            libayatana-appindicator3-1 \
+            libxdo3 \
+            xvfb
 
       # Install WebKit WebDriver and GTK/X11 runtime dependencies for Linux (required by tauri-driver)
       # Note: Build dependencies are handled in the build workflows, we only need runtime libs for testing
@@ -107,7 +125,18 @@ jobs:
       # Download app binaries if testing services that require pre-built apps
       # The download-archive action extracts to workspace root, preserving directory structure
       # Tauri: Archive contains fixtures/package-tests/tauri-app/src-tauri/target
+      # Dioxus: Archive contains fixtures/package-tests/dioxus-app/src-dioxus/target
       # Electron: Apps are built in isolated environments by test-package.ts script
+      - name: 📦 Download Dioxus Package Test App Binary
+        if: inputs.service == 'dioxus'
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: dioxus-package-app-${{ runner.os }}-${{ runner.arch == 'ARM64' && 'ARM64' || 'x64' }}
+          path: dioxus-package-app-${{ runner.os }}-${{ runner.arch == 'ARM64' && 'ARM64' || 'x64' }}
+          filename: artifact.zip
+          cache_key_prefix: dioxus-package-app
+          exact_cache_key: ${{ inputs.dioxus_cache_key || '' }}
+
       - name: 📦 Download Tauri Package Test App Binary
         if: inputs.service == 'tauri' || inputs.service == 'both'
         uses: ./.github/workflows/actions/download-archive
@@ -170,6 +199,13 @@ jobs:
              fi
            fi
 
+           # Pack Dioxus service if needed
+           if [ "$SERVICE" == "dioxus" ]; then
+             if [ -d "packages/dioxus-service/dist" ]; then
+               (cd packages/dioxus-service && pnpm pack)
+             fi
+           fi
+
       # Run package tests using test-package.ts script
       # All apps are built in isolated environments (Electron always, Tauri if not skipBuild)
       # Tauri uses skipBuild to copy pre-built binaries from separate build jobs
@@ -187,6 +223,16 @@ jobs:
               echo "Running Electron package tests (apps built in isolated environments)"
               echo "Module type: ${{ inputs.module-type }}"
               pnpm run test:package:electron -- --module-type=${{ inputs.module-type }}
+              ;;
+            dioxus)
+              echo "Running Dioxus package tests (using pre-built binaries from separate build job)"
+              if [[ "${{ inputs.os }}" == "ubuntu-latest" || "${{ inputs.os }}" == "ubuntu-24.04-arm" ]]; then
+                echo "Using xvfb-run to provide a DISPLAY on Linux (${{ inputs.os }})"
+                xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" \
+                  pnpm run test:package:dioxus -- --skip-build
+              else
+                pnpm run test:package:dioxus -- --skip-build
+              fi
               ;;
             tauri)
               if [ "${{ inputs.os }}" == "macos-latest" ]; then

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -226,7 +226,7 @@ jobs:
               ;;
             dioxus)
               echo "Running Dioxus package tests (using pre-built binaries from separate build job)"
-              if [[ "${{ inputs.os }}" == "ubuntu-latest" || "${{ inputs.os }}" == "ubuntu-24.04-arm" ]]; then
+              if [[ "${{ runner.os }}" == "Linux" ]]; then
                 echo "Using xvfb-run to provide a DISPLAY on Linux (${{ inputs.os }})"
                 xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" \
                   pnpm run test:package:dioxus -- --skip-build
@@ -240,7 +240,7 @@ jobs:
                 exit 0
               fi
               echo "Running Tauri package tests (using pre-built binaries from separate build job)"
-              if [[ "${{ inputs.os }}" == "ubuntu-latest" || "${{ inputs.os }}" == "ubuntu-24.04-arm" ]]; then
+              if [[ "${{ runner.os }}" == "Linux" ]]; then
                 echo "Using xvfb-run to provide a DISPLAY on Linux (${{ inputs.os }})"
                 # Use 16-bit color depth to avoid pixbuf issues with GTK/WebKit (same as E2E)
                 xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" \

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   # This job runs package tests on multiple Node.js versions and operating systems
   package:
-    name: Package Tests
+    name: Run
     runs-on: ${{ inputs.os }}
     steps:
       # Standard checkout with SSH key for private repositories

--- a/.github/workflows/_ci-unit.reusable.yml
+++ b/.github/workflows/_ci-unit.reusable.yml
@@ -1,5 +1,5 @@
 name: Unit
-description: 'Runs unit and integration tests across different operating systems'
+# Description: Runs unit and integration tests across different operating systems
 
 permissions:
   contents: read

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -78,7 +78,8 @@ jobs:
 
       - name: Setup Rust
         if: ${{ contains(inputs.scope, 'tauri') }}
-        uses: dtolnay/rust-toolchain@stable
+        shell: bash
+        run: rustup update stable && rustup default stable
 
       - name: Install GTK development libraries
         if: ${{ contains(inputs.scope, 'tauri') }}

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -103,22 +103,22 @@ jobs:
           scope="${scope#scope:}"
           case "$scope" in
             electron)
-              echo "packages=@wdio/electron-service,@wdio/electron-cdp-bridge" >> $GITHUB_OUTPUT
+              echo "packages=@wdio/electron-service,@wdio/electron-cdp-bridge" >> "$GITHUB_OUTPUT"
               ;;
             tauri)
-              echo "packages=@wdio/tauri-service,@wdio/tauri-plugin,tauri-plugin-wdio-webdriver" >> $GITHUB_OUTPUT
+              echo "packages=@wdio/tauri-service,@wdio/tauri-plugin,tauri-plugin-wdio-webdriver" >> "$GITHUB_OUTPUT"
               ;;
             utils)
-              echo "packages=@wdio/native-utils" >> $GITHUB_OUTPUT
+              echo "packages=@wdio/native-utils" >> "$GITHUB_OUTPUT"
               ;;
             types)
-              echo "packages=@wdio/native-types" >> $GITHUB_OUTPUT
+              echo "packages=@wdio/native-types" >> "$GITHUB_OUTPUT"
               ;;
             spy)
-              echo "packages=@wdio/native-spy" >> $GITHUB_OUTPUT
+              echo "packages=@wdio/native-spy" >> "$GITHUB_OUTPUT"
               ;;
             shared)
-              echo "packages=@wdio/native-utils,@wdio/native-types,@wdio/native-spy" >> $GITHUB_OUTPUT
+              echo "packages=@wdio/native-utils,@wdio/native-types,@wdio/native-spy" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unknown scope: $scope"
@@ -134,29 +134,29 @@ jobs:
 
           # If bump already starts with 'pre', it's already in releasekit format (from auto gate)
           if [[ "$bump" == pre* ]]; then
-            echo "bump=$bump" >> $GITHUB_OUTPUT
-            echo "stable=false" >> $GITHUB_OUTPUT
+            echo "bump=$bump" >> "$GITHUB_OUTPUT"
+            echo "stable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           case "$release_type" in
             stable)
               # stable release - use bump value
-              echo "bump=$bump" >> $GITHUB_OUTPUT
-              echo "stable=true" >> $GITHUB_OUTPUT
+              echo "bump=$bump" >> "$GITHUB_OUTPUT"
+              echo "stable=true" >> "$GITHUB_OUTPUT"
               ;;
             prerelease)
               # For prerelease increment, use 'prerelease'; otherwise prepend 'pre'
               if [ "$bump" = "prerelease" ]; then
-                echo "bump=prerelease" >> $GITHUB_OUTPUT
+                echo "bump=prerelease" >> "$GITHUB_OUTPUT"
               else
-                echo "bump=pre$bump" >> $GITHUB_OUTPUT
+                echo "bump=pre$bump" >> "$GITHUB_OUTPUT"
               fi
-              echo "stable=false" >> $GITHUB_OUTPUT
+              echo "stable=false" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "bump=$bump" >> $GITHUB_OUTPUT
-              echo "stable=false" >> $GITHUB_OUTPUT
+              echo "bump=$bump" >> "$GITHUB_OUTPUT"
+              echo "stable=false" >> "$GITHUB_OUTPUT"
               ;;
           esac
 
@@ -224,7 +224,7 @@ jobs:
           # Ensure we're on a branch with proper remote tracking
           if ! git symbolic-ref HEAD > /dev/null 2>&1; then
             echo "Currently in detached HEAD, checking out branch..."
-            git checkout -B ${{ inputs.branch || 'main' }} origin/${{ inputs.branch || 'main' }} 2>/dev/null || git checkout ${{ inputs.branch || 'main' }}
+            git checkout -B ${{ inputs.target_branch || 'main' }} origin/${{ inputs.target_branch || 'main' }} 2>/dev/null || git checkout ${{ inputs.target_branch || 'main' }}
           fi
 
       - name: Run ReleaseKit

--- a/.github/workflows/actions/build-verify/action.yml
+++ b/.github/workflows/actions/build-verify/action.yml
@@ -77,4 +77,4 @@ runs:
         echo "✅ All packages verified successfully"
         echo "::endgroup::"
 
-        echo "success=true" >> $GITHUB_OUTPUT
+        echo "success=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/actions/download-archive/action.yml
+++ b/.github/workflows/actions/download-archive/action.yml
@@ -45,12 +45,12 @@ runs:
         PRIMARY_KEY="${OS}-${CACHE_PREFIX}-${NAME}-${RUN_ID}${RERUN_SUFFIX}"
         FALLBACK_KEY="${CACHE_PREFIX}-${NAME}-"
 
-        echo "primary_key=${PRIMARY_KEY}" >> $GITHUB_OUTPUT
-        echo "fallback_key=${FALLBACK_KEY}" >> $GITHUB_OUTPUT
+        echo "primary_key=${PRIMARY_KEY}" >> "$GITHUB_OUTPUT"
+        echo "fallback_key=${FALLBACK_KEY}" >> "$GITHUB_OUTPUT"
 
         # Normalize path for cache operations
         NORMALIZED_PATH=$(echo "${{ inputs.path }}/${{ inputs.filename }}" | sed 's|\\|/|g')
-        echo "normalized_path=${NORMALIZED_PATH}" >> $GITHUB_OUTPUT
+        echo "normalized_path=${NORMALIZED_PATH}" >> "$GITHUB_OUTPUT"
 
         echo "Generated cache keys:"
         echo "  primary_key: ${PRIMARY_KEY}"
@@ -103,8 +103,8 @@ runs:
         # Check if gh run download extracted contents directly
         if [ -d "$NORMALIZED_PATH/packages" ] || [ -d "$NORMALIZED_PATH/fixtures" ]; then
           echo "Artifact contents extracted directly to directory"
-          echo "extracted=true" >> $GITHUB_OUTPUT
-          echo "success=true" >> $GITHUB_OUTPUT
+          echo "extracted=true" >> "$GITHUB_OUTPUT"
+          echo "success=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Successfully downloaded and extracted ${{ inputs.name }} from GitHub Artifacts"
           exit 0
         fi
@@ -113,8 +113,8 @@ runs:
         EXPECTED_PATH="$NORMALIZED_PATH/${{ inputs.filename }}"
         if [ -f "$EXPECTED_PATH" ]; then
           echo "Found artifact at expected path: $EXPECTED_PATH"
-          echo "extracted=false" >> $GITHUB_OUTPUT
-          echo "success=true" >> $GITHUB_OUTPUT
+          echo "extracted=false" >> "$GITHUB_OUTPUT"
+          echo "success=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Successfully downloaded ${{ inputs.name }} from GitHub Artifacts"
           exit 0
         fi
@@ -126,8 +126,8 @@ runs:
           if [ "$FIRST_ZIP" != "$EXPECTED_PATH" ]; then
             mv "$FIRST_ZIP" "$EXPECTED_PATH"
           fi
-          echo "extracted=false" >> $GITHUB_OUTPUT
-          echo "success=true" >> $GITHUB_OUTPUT
+          echo "extracted=false" >> "$GITHUB_OUTPUT"
+          echo "success=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Successfully downloaded ${{ inputs.name }} from GitHub Artifacts"
           exit 0
         fi
@@ -326,4 +326,4 @@ runs:
           echo "Cleaned up temporary extraction directory"
         fi
 
-        echo "success=true" >> $GITHUB_OUTPUT
+        echo "success=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/actions/upload-archive/action.yml
+++ b/.github/workflows/actions/upload-archive/action.yml
@@ -48,7 +48,7 @@ runs:
           RERUN_SUFFIX=""
         fi
 
-        echo "rerun_suffix=${RERUN_SUFFIX}" >> $GITHUB_OUTPUT
+        echo "rerun_suffix=${RERUN_SUFFIX}" >> "$GITHUB_OUTPUT"
 
     # Compress the specified directories/files into a .zip file
     - name: 🗜️ Compress Files (Unix)
@@ -73,7 +73,7 @@ runs:
         echo "::notice::Artifact ${{ inputs.name }}: created ${HUMAN_SIZE} archive with ${FILE_COUNT} files"
 
         # Export artifact size
-        echo "size=${FILE_SIZE}" >> $GITHUB_OUTPUT
+        echo "size=${FILE_SIZE}" >> "$GITHUB_OUTPUT"
 
     # Compress the specified directories/files into a .zip file (Windows)
     - name: 🗜️ Compress Files (Windows)
@@ -193,9 +193,9 @@ runs:
       shell: bash
       run: |
         if [[ "${{ runner.os }}" == "Windows" ]]; then
-          echo "size=${{ steps.compress-windows.outputs.size }}" >> $GITHUB_OUTPUT
+          echo "size=${{ steps.compress-windows.outputs.size }}" >> "$GITHUB_OUTPUT"
         else
-          echo "size=${{ steps.compress-unix.outputs.size }}" >> $GITHUB_OUTPUT
+          echo "size=${{ steps.compress-unix.outputs.size }}" >> "$GITHUB_OUTPUT"
         fi
 
     # Generate cache keys
@@ -212,15 +212,15 @@ runs:
 
         # Generate platform-specific key (no cross-platform sharing to avoid path issues)
         PLATFORM_KEY="${OS}-${CACHE_PREFIX}-${NAME}-${RUN_ID}${RERUN_SUFFIX}"
-        echo "platform_key=${PLATFORM_KEY}" >> $GITHUB_OUTPUT
+        echo "platform_key=${PLATFORM_KEY}" >> "$GITHUB_OUTPUT"
 
         # Keep standard key for backward compatibility
         STANDARD_KEY="${OS}-${CACHE_PREFIX}-${NAME}-${RUN_ID}${RERUN_SUFFIX}"
-        echo "standard_key=${STANDARD_KEY}" >> $GITHUB_OUTPUT
+        echo "standard_key=${STANDARD_KEY}" >> "$GITHUB_OUTPUT"
 
         # Generate OS-agnostic key (used across platforms)
         AGNOSTIC_KEY="${CACHE_PREFIX}-${NAME}-${RUN_ID}${RERUN_SUFFIX}"
-        echo "agnostic_key=${AGNOSTIC_KEY}" >> $GITHUB_OUTPUT
+        echo "agnostic_key=${AGNOSTIC_KEY}" >> "$GITHUB_OUTPUT"
 
     # Upload to GitHub Artifacts
     - name: 📤 Upload Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   # Run unit tests - skip when only docs changed
   unit-matrix:
-    name: Unit
+    name: Unit [${{ matrix.display-name }}]
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.run_lint_only != 'true'
     strategy:
@@ -296,7 +296,7 @@ jobs:
   # Tauri apps are built separately due to longer build times and system dependencies
   # Electron package tests are split by module type (CJS/ESM) for better error isolation
   package-electron-matrix:
-    name: Package - Electron
+    name: Package - Electron [${{ matrix.display-name }}] - ${{ matrix.module-type }}
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.run_electron == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     strategy:
@@ -387,7 +387,7 @@ jobs:
   # - CentOS Stream 9: glib 2.68 too old (Tauri requires >= 2.70)
   # - CentOS Stream 10: WebKitGTK removed by Red Hat due to 200+ CVEs and unsustainable maintenance
   package-tauri-distros:
-    name: Package - Tauri (Docker)
+    name: Package - Tauri (Docker) [${{ matrix.display-name }}]
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     strategy:
@@ -411,7 +411,7 @@ jobs:
 
   # Run build tests outside of the main Linux build job
   build-matrix:
-    name: Build
+    name: Build [${{ matrix.display-name }}]
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.run_electron == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     strategy:
@@ -435,7 +435,7 @@ jobs:
   # - E2E tests use ESM only (CJS/ESM testing is done in package tests)
   # - Optimize for GitHub Actions concurrency limits
   e2e-matrix:
-    name: E2E - Electron
+    name: E2E - Electron [${{ matrix.display-name }}] - ${{ matrix.scenario }}
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.run_electron == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     strategy:
@@ -490,7 +490,7 @@ jobs:
 
   # Electron window tests - run on Linux with splash screen enabled
   e2e-electron-window:
-    name: E2E - Electron [Linux] (window)
+    name: E2E - Electron [${{ matrix.display-name }}] (window) - ${{ matrix.scenario }}
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.run_electron == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,18 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
 
+  build-dioxus-package-app-linux-arm:
+    name: Build Dioxus Package Test App [Linux-ARM64]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-24.04-arm'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
   # Build Tauri package test apps - only if Tauri package tests will run
   build-tauri-package-app-linux:
     name: Build Tauri Package Test App [Linux]
@@ -719,6 +731,20 @@ jobs:
       cache_key: ${{ needs.build.outputs.cache_key }}
       dioxus_cache_key: ${{ needs.build-dioxus-package-app-macos-intel.outputs.cache_key }}
 
+  package-dioxus-linux-arm:
+    name: Package - Dioxus [Linux-ARM64]
+    needs: [detect-changes, build, build-dioxus-package-app-linux-arm]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-package.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-24.04-arm'
+      service: 'dioxus'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-package-app-linux-arm.outputs.cache_key }}
+
   # Universal binary verification - Electron only
   package-electron-mac-universal:
     name: Package - Electron [macOS-Universal-Verify]
@@ -834,6 +860,7 @@ jobs:
       - package-dioxus-windows
       - package-dioxus-macos-arm
       - package-dioxus-macos-intel
+      - package-dioxus-linux-arm
       - build-matrix
       - package-electron-mac-universal
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,80 @@ jobs:
     with:
       os: 'ubuntu-latest'
 
+  # Build Dioxus E2E app binaries - only if Dioxus tests will run
+  build-dioxus-e2e-app-linux:
+    name: Build Dioxus E2E App [Linux]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  build-dioxus-e2e-app-windows:
+    name: Build Dioxus E2E App [Windows]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'windows-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  build-dioxus-e2e-app-macos-arm:
+    name: Build Dioxus E2E App [macOS-ARM]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  build-dioxus-e2e-app-macos-intel:
+    name: Build Dioxus E2E App [macOS-Intel]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-15-intel'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  # Build Dioxus package test apps - only if Dioxus package tests will run (Linux + Windows only)
+  build-dioxus-package-app-linux:
+    name: Build Dioxus Package Test App [Linux]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  build-dioxus-package-app-windows:
+    name: Build Dioxus Package Test App [Windows]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'windows-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
   # Build Tauri package test apps - only if Tauri package tests will run
   build-tauri-package-app-linux:
     name: Build Tauri Package Test App [Linux]
@@ -486,6 +560,113 @@ jobs:
       cache_key: ${{ needs.build.outputs.cache_key }}
       tauri_cache_key: ${{ needs.build-tauri-e2e-app-macos-intel.outputs.cache_key }}
 
+  # Dioxus E2E tests - embedded provider (all platforms) + external provider (Windows only in v1)
+  # All providers run sequentially per runner; external provider auto-skips on Linux/macOS
+  e2e-dioxus-linux:
+    name: E2E - Dioxus [Linux] - ${{ matrix.test-type }}
+    needs: [detect-changes, build, build-dioxus-e2e-app-linux]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: ['standard', 'window', 'multiremote', 'standalone', 'deeplink']
+    uses: ./.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
+      node-version: '24'
+      test-type: ${{ matrix.test-type }}
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-e2e-app-linux.outputs.cache_key }}
+
+  e2e-dioxus-windows:
+    name: E2E - Dioxus [Windows] - ${{ matrix.test-type }}
+    needs: [detect-changes, build, build-dioxus-e2e-app-windows]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: ['standard', 'window', 'multiremote', 'standalone', 'deeplink']
+    uses: ./.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+    secrets: inherit
+    with:
+      os: 'windows-latest'
+      node-version: '24'
+      test-type: ${{ matrix.test-type }}
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-e2e-app-windows.outputs.cache_key }}
+
+  e2e-dioxus-macos-arm:
+    name: E2E - Dioxus [macOS-ARM] - ${{ matrix.test-type }}
+    needs: [detect-changes, build, build-dioxus-e2e-app-macos-arm]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: ['standard', 'window', 'multiremote', 'standalone', 'deeplink']
+    uses: ./.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      node-version: '24'
+      test-type: ${{ matrix.test-type }}
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-e2e-app-macos-arm.outputs.cache_key }}
+
+  e2e-dioxus-macos-intel:
+    name: E2E - Dioxus [macOS-Intel] - ${{ matrix.test-type }}
+    needs: [detect-changes, build, build-dioxus-e2e-app-macos-intel]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: ['standard', 'window', 'multiremote', 'standalone', 'deeplink']
+    uses: ./.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-15-intel'
+      node-version: '24'
+      test-type: ${{ matrix.test-type }}
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-e2e-app-macos-intel.outputs.cache_key }}
+
+  # Dioxus package tests - Linux and Windows (macOS uses embedded provider, added in v1.1)
+  package-dioxus-linux:
+    name: Package - Dioxus [Linux]
+    needs: [detect-changes, build, build-dioxus-package-app-linux]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-package.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
+      service: 'dioxus'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-package-app-linux.outputs.cache_key }}
+
+  package-dioxus-windows:
+    name: Package - Dioxus [Windows]
+    needs: [detect-changes, build, build-dioxus-package-app-windows]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-package.reusable.yml
+    secrets: inherit
+    with:
+      os: 'windows-latest'
+      service: 'dioxus'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-package-app-windows.outputs.cache_key }}
+
   # Universal binary verification - Electron only
   package-electron-mac-universal:
     name: Package - Electron [macOS-Universal-Verify]
@@ -588,11 +769,17 @@ jobs:
       - e2e-tauri-windows
       - e2e-tauri-macos-arm
       - e2e-tauri-macos-intel
+      - e2e-dioxus-linux
+      - e2e-dioxus-windows
+      - e2e-dioxus-macos-arm
+      - e2e-dioxus-macos-intel
       - package-electron-matrix
       - package-tauri-linux
       - package-tauri-windows
       - package-tauri-linux-arm
       - package-tauri-distros
+      - package-dioxus-linux
+      - package-dioxus-windows
       - build-matrix
       - package-electron-mac-universal
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
 
-  # Build Dioxus package test apps - only if Dioxus package tests will run (Linux + Windows only)
+  # Build Dioxus package test apps - only if Dioxus package tests will run
   build-dioxus-package-app-linux:
     name: Build Dioxus Package Test App [Linux]
     needs: [detect-changes, build]
@@ -213,6 +213,30 @@ jobs:
     secrets: inherit
     with:
       os: 'windows-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  build-dioxus-package-app-macos-arm:
+    name: Build Dioxus Package Test App [macOS-ARM]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  build-dioxus-package-app-macos-intel:
+    name: Build Dioxus Package Test App [macOS-Intel]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-15-intel'
       build_id: ${{ needs.build.outputs.build_id }}
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
@@ -638,7 +662,7 @@ jobs:
       cache_key: ${{ needs.build.outputs.cache_key }}
       dioxus_cache_key: ${{ needs.build-dioxus-e2e-app-macos-intel.outputs.cache_key }}
 
-  # Dioxus package tests - Linux and Windows (macOS uses embedded provider, added in v1.1)
+  # Dioxus package tests - all platforms (mirrors E2E coverage)
   package-dioxus-linux:
     name: Package - Dioxus [Linux]
     needs: [detect-changes, build, build-dioxus-package-app-linux]
@@ -666,6 +690,34 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
       dioxus_cache_key: ${{ needs.build-dioxus-package-app-windows.outputs.cache_key }}
+
+  package-dioxus-macos-arm:
+    name: Package - Dioxus [macOS-ARM]
+    needs: [detect-changes, build, build-dioxus-package-app-macos-arm]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-package.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      service: 'dioxus'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-package-app-macos-arm.outputs.cache_key }}
+
+  package-dioxus-macos-intel:
+    name: Package - Dioxus [macOS-Intel]
+    needs: [detect-changes, build, build-dioxus-package-app-macos-intel]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-package.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-15-intel'
+      service: 'dioxus'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+      dioxus_cache_key: ${{ needs.build-dioxus-package-app-macos-intel.outputs.cache_key }}
 
   # Universal binary verification - Electron only
   package-electron-mac-universal:
@@ -780,6 +832,8 @@ jobs:
       - package-tauri-distros
       - package-dioxus-linux
       - package-dioxus-windows
+      - package-dioxus-macos-arm
+      - package-dioxus-macos-intel
       - build-matrix
       - package-electron-mac-universal
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -862,6 +862,7 @@ jobs:
       - package-dioxus-macos-intel
       - package-dioxus-linux-arm
       - build-matrix
+      - build-dioxus-crates-linux
       - package-electron-mac-universal
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -863,6 +863,22 @@ jobs:
       - package-dioxus-linux-arm
       - build-matrix
       - build-dioxus-crates-linux
+      - build-tauri-e2e-app-linux
+      - build-tauri-e2e-app-windows
+      - build-tauri-e2e-app-macos-arm
+      - build-tauri-e2e-app-macos-intel
+      - build-tauri-package-app-linux
+      - build-tauri-package-app-windows
+      - build-tauri-package-app-linux-arm
+      - build-dioxus-e2e-app-linux
+      - build-dioxus-e2e-app-windows
+      - build-dioxus-e2e-app-macos-arm
+      - build-dioxus-e2e-app-macos-intel
+      - build-dioxus-package-app-linux
+      - build-dioxus-package-app-windows
+      - build-dioxus-package-app-macos-arm
+      - build-dioxus-package-app-macos-intel
+      - build-dioxus-package-app-linux-arm
       - package-electron-mac-universal
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/expense.yml
+++ b/.github/workflows/expense.yml
@@ -14,7 +14,6 @@ on:
         description: 'The expense amount you like to grant for the contribution in $'
         required: true
         type: choice
-        default: 'patch'
         options:
           - 15
           - 25

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -58,6 +58,7 @@
     "@wdio/mocha-framework": "catalog:default",
     "@wdio/native-utils": "workspace:*",
     "@wdio/tauri-service": "link:../packages/tauri-service",
+    "@wdio/visual-service": "^9.2.2",
     "@wdio/xvfb": "catalog:default",
     "electron": "catalog:default",
     "tsx": "^4.21.0",

--- a/e2e/test/dioxus/mocking.spec.ts
+++ b/e2e/test/dioxus/mocking.spec.ts
@@ -35,8 +35,10 @@ describe('Dioxus mocking', () => {
     const mock = await browser.dioxus.mock('get_platform_info');
     await mock.mockReturnValue({ os: 'overridden' });
     await browser.dioxus.resetAllMocks();
-    // After reset, the command should use its real implementation
+    // After reset the mock function has no implementation (vitest mockReset
+    // semantics) — the proxy still intercepts calls but returns undefined/null.
     const result = await browser.dioxus.execute(({ invoke }) => invoke('get_platform_info'));
-    expect((result as { os: string }).os).not.toBe('overridden');
+    const r = result as { os: string } | null | undefined;
+    expect(r?.os).not.toBe('overridden');
   });
 });

--- a/e2e/wdio.dioxus-embedded.conf.ts
+++ b/e2e/wdio.dioxus-embedded.conf.ts
@@ -42,7 +42,7 @@ switch (testType) {
   default:
     specs = ['./test/dioxus/*.spec.ts'];
     maxInstances = 1;
-    exclude = ['./test/dioxus/window.spec.ts', './test/dioxus/deeplink.spec.ts'];
+    exclude = ['./test/dioxus/window.spec.ts', './test/dioxus/deeplink.spec.ts', './test/dioxus/visual.spec.ts'];
     break;
 }
 

--- a/e2e/wdio.dioxus-embedded.conf.ts
+++ b/e2e/wdio.dioxus-embedded.conf.ts
@@ -42,7 +42,7 @@ switch (testType) {
   default:
     specs = ['./test/dioxus/*.spec.ts'];
     maxInstances = 1;
-    exclude = ['./test/dioxus/window.spec.ts', './test/dioxus/deeplink.spec.ts', './test/dioxus/visual.spec.ts'];
+    exclude = ['./test/dioxus/window.spec.ts', './test/dioxus/deeplink.spec.ts'];
     break;
 }
 
@@ -172,6 +172,7 @@ export const config = {
         driverProvider: 'embedded',
       },
     ],
+    '@wdio/visual-service',
   ],
   framework: 'mocha',
   reporters: ['spec'],

--- a/fixtures/e2e-apps/dioxus/Cargo.toml
+++ b/fixtures/e2e-apps/dioxus/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 dioxus = { version = "0.7", features = ["desktop"] }
-wdio-dioxus-embedded-driver = { path = "../../packages/dioxus-embedded-driver" }
+wdio-dioxus-embedded-driver = { path = "../../../packages/dioxus-embedded-driver" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/fixtures/e2e-apps/dioxus/src/main.rs
+++ b/fixtures/e2e-apps/dioxus/src/main.rs
@@ -7,6 +7,7 @@ fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into())
                 .add_directive("wdio_dioxus_bridge=debug".parse().unwrap())
                 .add_directive("wdio_dioxus_embedded_driver=debug".parse().unwrap()),
         )

--- a/fixtures/package-tests/dioxus-app/src-dioxus/src/main.rs
+++ b/fixtures/package-tests/dioxus-app/src-dioxus/src/main.rs
@@ -7,6 +7,7 @@ fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into())
                 .add_directive("wdio_dioxus_bridge=debug".parse().unwrap())
                 .add_directive("wdio_dioxus_embedded_driver=debug".parse().unwrap()),
         )

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "test:package:electron:browser": "pnpx cross-env DEBUG=@wdio/electron-service tsx ./scripts/test-package.ts --service=electron --mode=browser",
     "test:package:tauri": "pnpx tsx ./scripts/test-package.ts --service=tauri",
     "test:package:tauri:browser": "pnpx cross-env DEBUG=@wdio/tauri-service tsx ./scripts/test-package.ts --service=tauri --mode=browser",
+    "test:package:dioxus": "pnpx tsx ./scripts/test-package.ts --service=dioxus",
+    "test:package:dioxus:browser": "pnpx tsx ./scripts/test-package.ts --service=dioxus --mode=browser",
     "test:unit": "turbo run test:unit",
     "typecheck": "turbo run typecheck",
     "update:dependencies": "pnpm catalog:update --default && pnpm catalog:update --next && pnpm up -iLr",

--- a/packages/dioxus-bridge/build.rs
+++ b/packages/dioxus-bridge/build.rs
@@ -12,16 +12,27 @@ fn main() {
   let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR is set by cargo");
   let out_path = PathBuf::from(&out_dir).join("guest_js_bundle.js");
 
-  let src = PathBuf::from("guest-js/dist-js/index.js");
+  // Try the npm-package output path first (dist-js/index.js, written by
+  // `pnpm --filter @wdio/dioxus-bridge build`). Fall back to the legacy
+  // guest-js/dist-js path for backwards-compat with any existing local
+  // builds, then emit a no-op placeholder so the crate still compiles
+  // when neither has been built yet.
+  let candidates = [
+    PathBuf::from("dist-js/index.js"),
+    PathBuf::from("guest-js/dist-js/index.js"),
+  ];
 
-  let bundle = if src.exists() {
-    fs::read_to_string(&src).expect("read guest-js bundle")
-  } else {
-    String::from("/* @wdio/dioxus-bridge guest-js not built yet; run `pnpm --filter @wdio/dioxus-bridge build` */")
-  };
+  let bundle = candidates
+    .iter()
+    .find(|p| p.exists())
+    .map(|p| fs::read_to_string(p).expect("read guest-js bundle"))
+    .unwrap_or_else(|| {
+      String::from("/* @wdio/dioxus-bridge guest-js not built yet; run `pnpm --filter @wdio/dioxus-bridge build` */")
+    });
 
   fs::write(&out_path, bundle).expect("write OUT_DIR/guest_js_bundle.js");
 
+  println!("cargo:rerun-if-changed=dist-js/index.js");
   println!("cargo:rerun-if-changed=guest-js/dist-js/index.js");
   println!("cargo:rerun-if-changed=guest-js/index.ts");
   println!("cargo:rerun-if-changed=build.rs");

--- a/packages/dioxus-bridge/guest-js/__tests__/index.spec.ts
+++ b/packages/dioxus-bridge/guest-js/__tests__/index.spec.ts
@@ -40,7 +40,6 @@ describe('@wdio/dioxus-bridge guest-js', () => {
       'wdio://invoke',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ command: '__ping', args: { foo: 'bar' } }),
       }),
     );

--- a/packages/dioxus-bridge/guest-js/index.ts
+++ b/packages/dioxus-bridge/guest-js/index.ts
@@ -116,6 +116,12 @@ declare global {
 if (typeof window.__WDIO_EMBEDDED_PORT === 'number' && !window.__WDIO_EMBEDDED_RUNNING__) {
   window.__WDIO_EMBEDDED_RUNNING__ = true;
 
+  // TEMPORARY DIAGNOSTIC — beacon proving the polling-loop branch was taken.
+  // To be removed alongside the bridge invoke.rs diag logs.
+  void fetch('wdio://beacon/polling-loop-start').catch(() => {
+    // ignore — diagnostic only
+  });
+
   void (async function embeddedDriverLoop() {
     while (true) {
       try {

--- a/packages/dioxus-bridge/guest-js/index.ts
+++ b/packages/dioxus-bridge/guest-js/index.ts
@@ -36,9 +36,11 @@ interface InvokeResponse {
  * `error` string on failure.
  */
 export async function invoke(command: string, args?: unknown): Promise<unknown> {
+  // Omit Content-Type so the browser sends text/plain — a CORS "simple"
+  // request that skips the OPTIONS preflight. The Rust handler parses the
+  // body as JSON regardless of Content-Type.
   const response = await fetch('wdio://invoke', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ command, args: args ?? null }),
   });
   const body = (await response.json()) as InvokeResponse;

--- a/packages/dioxus-bridge/guest-js/index.ts
+++ b/packages/dioxus-bridge/guest-js/index.ts
@@ -21,6 +21,13 @@ declare global {
     __WDIO_DIOXUS__?: {
       invoke?: (cmd: string, args?: unknown) => Promise<unknown>;
     };
+    /**
+     * Platform-correct URL for the `wdio://invoke` endpoint. Injected by
+     * the Rust bridge so guest-js doesn't have to know that on Windows
+     * wry rewrites `wdio://` to `http://wdio.*`. Falls back to the native
+     * scheme when missing (macOS/Linux dev/test).
+     */
+    __WDIO_BRIDGE_URL__?: string;
   }
 }
 
@@ -39,7 +46,8 @@ export async function invoke(command: string, args?: unknown): Promise<unknown> 
   // Omit Content-Type so the browser sends text/plain — a CORS "simple"
   // request that skips the OPTIONS preflight. The Rust handler parses the
   // body as JSON regardless of Content-Type.
-  const response = await fetch('wdio://invoke', {
+  const url = window.__WDIO_BRIDGE_URL__ ?? 'wdio://invoke';
+  const response = await fetch(url, {
     method: 'POST',
     body: JSON.stringify({ command, args: args ?? null }),
   });
@@ -115,12 +123,6 @@ declare global {
 
 if (typeof window.__WDIO_EMBEDDED_PORT === 'number' && !window.__WDIO_EMBEDDED_RUNNING__) {
   window.__WDIO_EMBEDDED_RUNNING__ = true;
-
-  // TEMPORARY DIAGNOSTIC — beacon proving the polling-loop branch was taken.
-  // To be removed alongside the bridge invoke.rs diag logs.
-  void fetch('wdio://beacon/polling-loop-start').catch(() => {
-    // ignore — diagnostic only
-  });
 
   void (async function embeddedDriverLoop() {
     while (true) {

--- a/packages/dioxus-bridge/src/invoke.rs
+++ b/packages/dioxus-bridge/src/invoke.rs
@@ -114,20 +114,6 @@ pub fn handle_invoke_request(
   registry: &CommandRegistry,
   request: &Request<Vec<u8>>,
 ) -> Response<Cow<'static, [u8]>> {
-  // TEMPORARY DIAGNOSTIC — Windows WebView2 custom-protocol POST body investigation.
-  // Logs method + URI + body length + first 80 chars of body so we can confirm
-  // whether the body survives the WebView2 -> Rust handoff on Windows.
-  let body_bytes = request.body();
-  let body_preview: String = body_bytes.iter().take(80).map(|b| *b as char).collect();
-  tracing::info!(
-    target: "wdio_dioxus_bridge::diag",
-    method = %request.method(),
-    uri = %request.uri(),
-    body_len = body_bytes.len(),
-    body_preview = %body_preview,
-    "wdio:// request received"
-  );
-
   // CORS preflight — WKWebView and WebView2 enforce cross-origin policy even
   // for custom schemes. The guest-js bundle fetches wdio://invoke from the
   // dioxus://localhost/ origin (different scheme = different origin), so both
@@ -140,18 +126,6 @@ pub fn handle_invoke_request(
   }
 
   let parsed: Result<InvokeRequestBody, _> = serde_json::from_slice(request.body());
-  match &parsed {
-    Ok(req) => tracing::info!(
-      target: "wdio_dioxus_bridge::diag",
-      command = %req.command,
-      "wdio:// request parsed"
-    ),
-    Err(err) => tracing::warn!(
-      target: "wdio_dioxus_bridge::diag",
-      error = %err,
-      "wdio:// request parse FAILED"
-    ),
-  }
   let body = match parsed {
     Ok(req) => registry.dispatch(&req.command, req.args),
     Err(err) => InvokeResponseBody::malformed(format!("invalid JSON request: {err}")),

--- a/packages/dioxus-bridge/src/invoke.rs
+++ b/packages/dioxus-bridge/src/invoke.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use dioxus_desktop::wry::http::{HeaderValue, Request, Response, StatusCode};
+use dioxus_desktop::wry::http::{HeaderMap, HeaderValue, Method, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -103,11 +103,28 @@ impl InvokeResponseBody {
   }
 }
 
+fn cors_headers(headers: &mut HeaderMap) {
+  headers.insert("access-control-allow-origin", HeaderValue::from_static("*"));
+  headers.insert("access-control-allow-methods", HeaderValue::from_static("POST, OPTIONS"));
+  headers.insert("access-control-allow-headers", HeaderValue::from_static("content-type"));
+}
+
 /// Handle a single `wdio://` request. Pure function — easy to unit-test.
 pub fn handle_invoke_request(
   registry: &CommandRegistry,
   request: &Request<Vec<u8>>,
 ) -> Response<Cow<'static, [u8]>> {
+  // CORS preflight — WKWebView and WebView2 enforce cross-origin policy even
+  // for custom schemes. The guest-js bundle fetches wdio://invoke from the
+  // dioxus://localhost/ origin (different scheme = different origin), so both
+  // the preflight OPTIONS and the actual POST need CORS headers.
+  if request.method() == Method::OPTIONS {
+    let mut response = Response::new(Cow::Borrowed(b"" as &'static [u8]));
+    *response.status_mut() = StatusCode::OK;
+    cors_headers(response.headers_mut());
+    return response;
+  }
+
   let parsed: Result<InvokeRequestBody, _> = serde_json::from_slice(request.body());
   let body = match parsed {
     Ok(req) => registry.dispatch(&req.command, req.args),
@@ -115,24 +132,13 @@ pub fn handle_invoke_request(
   };
 
   let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| {
-    // Should never happen — serde_json::to_vec on our own types is infallible.
     br#"{"ok":false,"error":"failed to serialise response"}"#.to_vec()
   });
 
-  let status = match body {
-    InvokeResponseBody::Ok { .. } => StatusCode::OK,
-    InvokeResponseBody::Err { .. } => StatusCode::OK,
-    // wdio:// responses always use 200; failure is communicated in the JSON.
-    // Reserving non-200 for genuine HTTP-layer errors keeps the JS-side
-    // unwrap simpler.
-  };
-
   let mut response = Response::new(Cow::Owned(bytes));
-  *response.status_mut() = status;
-  response.headers_mut().insert(
-    "content-type",
-    HeaderValue::from_static("application/json"),
-  );
+  *response.status_mut() = StatusCode::OK;
+  response.headers_mut().insert("content-type", HeaderValue::from_static("application/json"));
+  cors_headers(response.headers_mut());
   response
 }
 
@@ -222,5 +228,32 @@ mod tests {
     let response = handle_invoke_request(&registry, &req(r#"{"command":"greet"}"#));
     let body = parse_body(&response);
     assert_eq!(body["value"], "hello again");
+  }
+
+  #[test]
+  fn should_include_cors_origin_header_on_post_responses() {
+    let registry = CommandRegistry::new();
+    let response = handle_invoke_request(&registry, &req(r#"{"command":"__ping"}"#));
+    assert_eq!(
+      response.headers().get("access-control-allow-origin").map(|v| v.to_str().unwrap()),
+      Some("*"),
+    );
+  }
+
+  #[test]
+  fn should_respond_to_options_preflight_with_cors_headers() {
+    let registry = CommandRegistry::new();
+    let options_req = Request::builder()
+      .method("OPTIONS")
+      .uri("wdio://invoke")
+      .body(vec![])
+      .unwrap();
+    let response = handle_invoke_request(&registry, &options_req);
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+      response.headers().get("access-control-allow-origin").map(|v| v.to_str().unwrap()),
+      Some("*"),
+    );
+    assert!(response.body().is_empty());
   }
 }

--- a/packages/dioxus-bridge/src/invoke.rs
+++ b/packages/dioxus-bridge/src/invoke.rs
@@ -114,6 +114,20 @@ pub fn handle_invoke_request(
   registry: &CommandRegistry,
   request: &Request<Vec<u8>>,
 ) -> Response<Cow<'static, [u8]>> {
+  // TEMPORARY DIAGNOSTIC — Windows WebView2 custom-protocol POST body investigation.
+  // Logs method + URI + body length + first 80 chars of body so we can confirm
+  // whether the body survives the WebView2 -> Rust handoff on Windows.
+  let body_bytes = request.body();
+  let body_preview: String = body_bytes.iter().take(80).map(|b| *b as char).collect();
+  tracing::info!(
+    target: "wdio_dioxus_bridge::diag",
+    method = %request.method(),
+    uri = %request.uri(),
+    body_len = body_bytes.len(),
+    body_preview = %body_preview,
+    "wdio:// request received"
+  );
+
   // CORS preflight — WKWebView and WebView2 enforce cross-origin policy even
   // for custom schemes. The guest-js bundle fetches wdio://invoke from the
   // dioxus://localhost/ origin (different scheme = different origin), so both
@@ -126,6 +140,18 @@ pub fn handle_invoke_request(
   }
 
   let parsed: Result<InvokeRequestBody, _> = serde_json::from_slice(request.body());
+  match &parsed {
+    Ok(req) => tracing::info!(
+      target: "wdio_dioxus_bridge::diag",
+      command = %req.command,
+      "wdio:// request parsed"
+    ),
+    Err(err) => tracing::warn!(
+      target: "wdio_dioxus_bridge::diag",
+      error = %err,
+      "wdio:// request parse FAILED"
+    ),
+  }
   let body = match parsed {
     Ok(req) => registry.dispatch(&req.command, req.args),
     Err(err) => InvokeResponseBody::malformed(format!("invalid JSON request: {err}")),

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -117,9 +117,15 @@ fn install_with_registry_and_config(
 
   // If the embedded driver is active, inject the port signal before the
   // module script so the polling loop starts up automatically.
+  //
+  // TEMPORARY DIAGNOSTIC — fires beacon fetches at three checkpoints so we
+  // can see, in the wdio:// handler logs, exactly how far page-load got on
+  // Windows: (1) inline-script ran, (2) module entered, (3) module reached
+  // the polling loop. Each beacon uses its own URL path so they're trivial
+  // to identify in the diag output. To be removed alongside the diag logs.
   let head = match embedded_port {
     Some(port) => format!(
-      "<script>window.__WDIO_EMBEDDED_PORT={};</script><script type=\"module\">{GUEST_JS_BUNDLE}</script>",
+      "<script>window.__WDIO_EMBEDDED_PORT={};fetch('wdio://beacon/inline-script').catch(()=>{{}});</script><script type=\"module\">fetch('wdio://beacon/module-entry').catch(()=>{{}});{GUEST_JS_BUNDLE}</script>",
       port
     ),
     None => format!("<script type=\"module\">{GUEST_JS_BUNDLE}</script>"),

--- a/packages/dioxus-bridge/src/lib.rs
+++ b/packages/dioxus-bridge/src/lib.rs
@@ -115,20 +115,28 @@ fn install_with_registry_and_config(
 
   let registry_for_handler = registry;
 
+  // Compute the `wdio://invoke` URL for the current platform. wry doesn't
+  // register arbitrary custom schemes with WebView2 on Windows; instead it
+  // intercepts `http://{scheme}.*` (see wry::custom_protocol_workaround).
+  // From a page's perspective the scheme `wdio://` is unknown on Windows
+  // and `fetch('wdio://invoke')` is rejected at the network layer before
+  // ever reaching our handler — so we expose the platform-correct URL via
+  // `window.__WDIO_BRIDGE_URL__` and let guest-js use it.
+  let bridge_url = if cfg!(target_os = "windows") {
+    "http://wdio.invoke/"
+  } else {
+    "wdio://invoke"
+  };
+
   // If the embedded driver is active, inject the port signal before the
   // module script so the polling loop starts up automatically.
-  //
-  // TEMPORARY DIAGNOSTIC — fires beacon fetches at three checkpoints so we
-  // can see, in the wdio:// handler logs, exactly how far page-load got on
-  // Windows: (1) inline-script ran, (2) module entered, (3) module reached
-  // the polling loop. Each beacon uses its own URL path so they're trivial
-  // to identify in the diag output. To be removed alongside the diag logs.
   let head = match embedded_port {
     Some(port) => format!(
-      "<script>window.__WDIO_EMBEDDED_PORT={};fetch('wdio://beacon/inline-script').catch(()=>{{}});</script><script type=\"module\">fetch('wdio://beacon/module-entry').catch(()=>{{}});{GUEST_JS_BUNDLE}</script>",
-      port
+      "<script>window.__WDIO_BRIDGE_URL__={bridge_url:?};window.__WDIO_EMBEDDED_PORT={port};</script><script type=\"module\">{GUEST_JS_BUNDLE}</script>"
     ),
-    None => format!("<script type=\"module\">{GUEST_JS_BUNDLE}</script>"),
+    None => format!(
+      "<script>window.__WDIO_BRIDGE_URL__={bridge_url:?};</script><script type=\"module\">{GUEST_JS_BUNDLE}</script>"
+    ),
   };
 
   config

--- a/packages/dioxus-embedded-driver/src/lib.rs
+++ b/packages/dioxus-embedded-driver/src/lib.rs
@@ -49,6 +49,11 @@ pub fn install(config: Config) -> Config {
     .and_then(|s| s.parse::<u16>().ok())
     .unwrap_or(DEFAULT_PORT);
 
+  // Use a port-scoped temp directory so concurrent instances (multiremote)
+  // each get their own WebView2/WebKit user data folder and don't conflict.
+  let data_dir = std::env::temp_dir().join(format!("wdio-dioxus-{port}"));
+  let config = config.with_data_directory(data_dir);
+
   // Install bridge + register embedded commands + inject port into guest-js.
   let config = wdio_dioxus_bridge::install_with_embedded_port(config, port);
 
@@ -77,6 +82,12 @@ pub fn install_with_commands<F: FnOnce(&wdio_dioxus_bridge::CommandRegistry)>(
     .ok()
     .and_then(|s| s.parse::<u16>().ok())
     .unwrap_or(DEFAULT_PORT);
+
+  // Use a port-scoped temp directory so concurrent instances (multiremote)
+  // each get their own WebView2/WebKit user data folder and don't conflict.
+  let data_dir = std::env::temp_dir().join(format!("wdio-dioxus-{port}"));
+  let config = config.with_data_directory(data_dir);
+
   let registry = wdio_dioxus_bridge::CommandRegistry::new();
   register(&registry);
   let config = wdio_dioxus_bridge::install_with_embedded_port_and_registry(config, registry, port);

--- a/packages/dioxus-embedded-driver/src/server/handlers/script.rs
+++ b/packages/dioxus-embedded-driver/src/server/handlers/script.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use crate::server::response::{WebDriverErrorResponse, WebDriverResponse, WebDriverResult};
 use crate::server::AppState;
 use crate::webdriver::element::ELEMENT_KEY;
+use crate::webdriver::session::Session;
 
 #[derive(Debug, Deserialize)]
 pub struct ExecuteScriptRequest {
@@ -43,6 +44,36 @@ async fn run_script(
   }
 }
 
+/// Resolve a request's WebDriver args into (call-site expressions, pass-through values).
+///
+/// Each element reference (`{"element-6066-…": id}`) becomes a `window[var]`
+/// expression inserted directly into the JS call site, so the receiving
+/// script gets an actual DOM node. Non-element args become `__argN` slots
+/// and are pushed into `pass_through` for delivery via the embedded queue.
+/// Stale element refs resolve to `null`.
+fn resolve_call_args(session: &Session, args: &[Value]) -> (Vec<String>, Vec<Value>) {
+  let mut call_args: Vec<String> = Vec::new();
+  let mut pass_through: Vec<Value> = Vec::new();
+  let mut pass_idx: usize = 0;
+
+  for arg in args {
+    if let Some(elem_id) = arg.get(ELEMENT_KEY).and_then(|v| v.as_str()) {
+      let js_expr = if let Some(var_name) = session.elements.get(elem_id) {
+        format!("window[{}]", serde_json::to_string(var_name).unwrap_or_else(|_| "null".into()))
+      } else {
+        "null".into()
+      };
+      call_args.push(js_expr);
+    } else {
+      call_args.push(format!("__arg{pass_idx}"));
+      pass_through.push(arg.clone());
+      pass_idx += 1;
+    }
+  }
+
+  (call_args, pass_through)
+}
+
 /// POST `/session/{session_id}/execute/sync`
 ///
 /// Wraps the script body in a function and passes `args` as positional
@@ -57,31 +88,10 @@ pub async fn execute_sync(
   Path(session_id): Path<String>,
   Json(request): Json<ExecuteScriptRequest>,
 ) -> WebDriverResult {
-  let (timeout_ms, call_expr) = {
+  let (timeout_ms, call_expr, pass_through) = {
     let sessions = state.sessions.read().await;
     let session = sessions.get(&session_id)?;
-
-    // Build the argument list for the IIFE call, resolving WebDriver element
-    // references to `window['var_name']` expressions so the receiving script
-    // gets an actual DOM node instead of a plain JSON object.
-    let mut call_args: Vec<String> = Vec::new();
-    let mut pass_through: Vec<Value> = Vec::new();
-    let mut pass_idx: usize = 0;
-
-    for arg in &request.args {
-      if let Some(elem_id) = arg.get(ELEMENT_KEY).and_then(|v| v.as_str()) {
-        let js_expr = if let Some(var_name) = session.elements.get(elem_id) {
-          format!("window[{}]", serde_json::to_string(var_name).unwrap_or_else(|_| "null".into()))
-        } else {
-          "null".into() // stale reference
-        };
-        call_args.push(js_expr);
-      } else {
-        call_args.push(format!("__arg{pass_idx}"));
-        pass_through.push(arg.clone());
-        pass_idx += 1;
-      }
-    }
+    let (call_args, pass_through) = resolve_call_args(session, &request.args);
 
     let param_names: Vec<String> = (0..pass_through.len()).map(|i| format!("__arg{i}")).collect();
     let param_list = param_names.join(", ");
@@ -92,50 +102,61 @@ pub async fn execute_sync(
       format!("return (function({param_list}) {{ {} }})({call_list})", request.script)
     };
 
-    (session.timeouts.script_ms, (call_expr, pass_through))
+    (session.timeouts.script_ms, call_expr, pass_through)
   };
 
-  run_script(&call_expr.0, &call_expr.1, timeout_ms).await
+  run_script(&call_expr, &pass_through, timeout_ms).await
 }
 
 /// POST `/session/{session_id}/execute/async`
 ///
 /// Async scripts receive an extra `done` callback as the last argument.
 /// The script must call it (optionally with a result value) to resolve.
+///
+/// Element references are resolved the same way as in `execute_sync` so
+/// `browser.executeAsync(fn, element)` and WDIO atoms that take elements
+/// receive an actual DOM node rather than a plain JSON object.
 pub async fn execute_async(
   State(state): State<Arc<AppState>>,
   Path(session_id): Path<String>,
   Json(request): Json<ExecuteScriptRequest>,
 ) -> WebDriverResult {
-  let timeout_ms = {
+  let (timeout_ms, wrapped, pass_through) = {
     let sessions = state.sessions.read().await;
     let session = sessions.get(&session_id)?;
-    session.timeouts.script_ms
+    let (call_args, pass_through) = resolve_call_args(session, &request.args);
+
+    // Inner-function params name each non-element pass-through plus `__done`.
+    // Call site preserves original arg order — resolved element exprs and
+    // `__argN` slots — and appends `__done` so it lands as the last argument,
+    // matching the W3C async-script contract.
+    let param_names: Vec<String> = (0..pass_through.len()).map(|i| format!("__arg{i}")).collect();
+    let param_list = if param_names.is_empty() {
+      "__done".to_string()
+    } else {
+      format!("{}, __done", param_names.join(", "))
+    };
+    let call_list = if call_args.is_empty() {
+      "__done".to_string()
+    } else {
+      format!("{}, __done", call_args.join(", "))
+    };
+
+    let wrapped = format!(
+      r#"return (function() {{
+        return new Promise(function(resolve, reject) {{
+          var __done = function(result) {{ resolve(result); }};
+          try {{ (function({param_list}) {{ {script} }})({call_list}); }}
+          catch (e) {{ reject(e); }}
+        }});
+      }})()"#,
+      param_list = param_list,
+      call_list = call_list,
+      script = request.script,
+    );
+
+    (session.timeouts.script_ms, wrapped, pass_through)
   };
 
-  // Async script: add a `done` callback as the last argument and wrap in a
-  // Promise so the polling loop can await it.
-  let arg_names: Vec<String> = (0..request.args.len()).map(|i| format!("__arg{i}")).collect();
-  let arg_list = if arg_names.is_empty() {
-    "__done".to_string()
-  } else {
-    format!("{}, __done", arg_names.join(", "))
-  };
-  let wrapped = format!(
-    r#"return (function() {{
-      return new Promise(function(resolve, reject) {{
-        var __done = function(result) {{ resolve(result); }};
-        try {{ (function({arg_list}) {{ {script} }})({args}__done); }}
-        catch (e) {{ reject(e); }}
-      }});
-    }})()"#,
-    arg_list = arg_list,
-    script = request.script,
-    args = if arg_names.is_empty() {
-      String::new()
-    } else {
-      format!("{}, ", arg_names.join(", "))
-    },
-  );
-  run_script(&wrapped, &request.args, timeout_ms).await
+  run_script(&wrapped, &pass_through, timeout_ms).await
 }

--- a/packages/dioxus-embedded-driver/src/server/handlers/script.rs
+++ b/packages/dioxus-embedded-driver/src/server/handlers/script.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::server::response::{WebDriverErrorResponse, WebDriverResponse, WebDriverResult};
 use crate::server::AppState;
+use crate::webdriver::element::ELEMENT_KEY;
 
 #[derive(Debug, Deserialize)]
 pub struct ExecuteScriptRequest {
@@ -46,27 +47,55 @@ async fn run_script(
 ///
 /// Wraps the script body in a function and passes `args` as positional
 /// parameters, matching the W3C WebDriver script execution semantics.
+///
+/// WebDriver element references (`{"element-6066-11e4-a52e-4f735466cecf": id}`)
+/// are resolved to `window[varName]` inline so the script receives an actual
+/// DOM node rather than a plain JSON object. This is required for WDIO's
+/// `isDisplayed()` atom and other element-aware scripts.
 pub async fn execute_sync(
   State(state): State<Arc<AppState>>,
   Path(session_id): Path<String>,
   Json(request): Json<ExecuteScriptRequest>,
 ) -> WebDriverResult {
-  let timeout_ms = {
+  let (timeout_ms, call_expr) = {
     let sessions = state.sessions.read().await;
     let session = sessions.get(&session_id)?;
-    session.timeouts.script_ms
+
+    // Build the argument list for the IIFE call, resolving WebDriver element
+    // references to `window['var_name']` expressions so the receiving script
+    // gets an actual DOM node instead of a plain JSON object.
+    let mut call_args: Vec<String> = Vec::new();
+    let mut pass_through: Vec<Value> = Vec::new();
+    let mut pass_idx: usize = 0;
+
+    for arg in &request.args {
+      if let Some(elem_id) = arg.get(ELEMENT_KEY).and_then(|v| v.as_str()) {
+        let js_expr = if let Some(var_name) = session.elements.get(elem_id) {
+          format!("window[{}]", serde_json::to_string(var_name).unwrap_or_else(|_| "null".into()))
+        } else {
+          "null".into() // stale reference
+        };
+        call_args.push(js_expr);
+      } else {
+        call_args.push(format!("__arg{pass_idx}"));
+        pass_through.push(arg.clone());
+        pass_idx += 1;
+      }
+    }
+
+    let param_names: Vec<String> = (0..pass_through.len()).map(|i| format!("__arg{i}")).collect();
+    let param_list = param_names.join(", ");
+    let call_list = call_args.join(", ");
+    let call_expr = if call_list.is_empty() {
+      format!("return (function() {{ {} }})()", request.script)
+    } else {
+      format!("return (function({param_list}) {{ {} }})({call_list})", request.script)
+    };
+
+    (session.timeouts.script_ms, (call_expr, pass_through))
   };
 
-  // Wrap in an IIFE, forwarding args so `arguments[N]` is accessible inside
-  // the script body per the W3C WebDriver spec.
-  let arg_names: Vec<String> = (0..request.args.len()).map(|i| format!("__arg{i}")).collect();
-  let arg_list = arg_names.join(", ");
-  let wrapped = if arg_list.is_empty() {
-    format!("return (function() {{ {} }})()", request.script)
-  } else {
-    format!("return (function({arg_list}) {{ {} }})({arg_list})", request.script)
-  };
-  run_script(&wrapped, &request.args, timeout_ms).await
+  run_script(&call_expr.0, &call_expr.1, timeout_ms).await
 }
 
 /// POST `/session/{session_id}/execute/async`

--- a/packages/dioxus-service/src/launcher.ts
+++ b/packages/dioxus-service/src/launcher.ts
@@ -72,7 +72,12 @@ export default class DioxusLaunchService extends BaseLauncher {
     log.info(`Dioxus service onPrepare — provider: ${provider}, platform: ${process.platform}`);
 
     if (provider === 'embedded') {
-      await this.prepareEmbedded(capsList);
+      const isMultiremote = !Array.isArray(capabilities);
+      if (isMultiremote) {
+        await this.prepareEmbeddedMultiremote(capabilities as Record<string, { capabilities: DioxusCapabilities }>);
+      } else {
+        await this.prepareEmbedded(capabilities as DioxusCapabilities[]);
+      }
     }
     // provider === 'external': wdio-dioxus-driver spawning wired in a follow-on commit
   }
@@ -107,9 +112,52 @@ export default class DioxusLaunchService extends BaseLauncher {
         );
       }
 
+      // Set on the capability itself — wdio run strips these before the W3C session request;
+      // standalone session.ts removes them from the cloned capabilities before remote().
       (cap as { port?: number; hostname?: string }).port = embeddedPort;
       (cap as { port?: number; hostname?: string }).hostname = hostname;
       log.info(`Embedded WebDriver connection set on capabilities[${i}]: ${hostname}:${embeddedPort}`);
+    }
+  }
+
+  private async prepareEmbeddedMultiremote(
+    capabilities: Record<string, { capabilities: DioxusCapabilities }>,
+  ): Promise<void> {
+    const hostname = '127.0.0.1';
+    const entries = Object.entries(capabilities);
+
+    for (let i = 0; i < entries.length; i++) {
+      const [key, instanceConfig] = entries[i];
+      const cap = instanceConfig.capabilities;
+      const instanceOptions = mergeOptions(this.options, cap['wdio:dioxusServiceOptions']);
+      const capPort = cap['wdio:dioxusServiceOptions']?.embeddedPort;
+      const embeddedPort = capPort != null ? capPort : getEmbeddedPort(instanceOptions) + i;
+      const appBinaryPath = cap['dioxus:options']?.application ?? instanceOptions.appBinaryPath;
+
+      if (!appBinaryPath) {
+        throw new SevereServiceError(
+          `Dioxus application path not specified for multiremote instance "${key}". ` +
+            "Set 'dioxus:options'.application or appBinaryPath in wdio:dioxusServiceOptions.",
+        );
+      }
+
+      log.info(`Starting embedded WebDriver for multiremote instance "${key}" on port ${embeddedPort}`);
+
+      try {
+        const driverInfo = await startEmbeddedDriver(appBinaryPath, embeddedPort, instanceOptions, key);
+        this.embeddedProcesses.set(key, driverInfo);
+      } catch (error) {
+        await this.stopAllEmbedded();
+        throw new SevereServiceError(
+          `Failed to start embedded WebDriver for multiremote instance "${key}": ${(error as Error).message}`,
+        );
+      }
+
+      // For multiremote, port/hostname must be on the outer instance config so WDIO
+      // reads them as connection parameters, not as W3C capability keys.
+      (instanceConfig as { port?: number; hostname?: string }).port = embeddedPort;
+      (instanceConfig as { port?: number; hostname?: string }).hostname = hostname;
+      log.info(`Embedded WebDriver connection set for "${key}": ${hostname}:${embeddedPort}`);
     }
   }
 

--- a/packages/dioxus-service/src/launcher.ts
+++ b/packages/dioxus-service/src/launcher.ts
@@ -1,4 +1,6 @@
-import { BaseLauncher } from '@wdio/native-core';
+import { join } from 'node:path';
+
+import { BaseLauncher, getLogWriter, isLogWriterInitialized } from '@wdio/native-core';
 import { createLogger } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
 import { SevereServiceError } from 'webdriverio';
@@ -80,6 +82,14 @@ export default class DioxusLaunchService extends BaseLauncher {
       }
     }
     // provider === 'external': wdio-dioxus-driver spawning wired in a follow-on commit
+
+    if (mergedOptions.captureBackendLogs || mergedOptions.captureFrontendLogs) {
+      if (!isLogWriterInitialized('dioxus-service')) {
+        const logDir = _config.outputDir ?? join(process.cwd(), 'logs');
+        getLogWriter('dioxus-service').initialize(logDir);
+        log.info(`Log capture initialized: ${logDir}`);
+      }
+    }
   }
 
   private async prepareEmbedded(capsList: DioxusCapabilities[]): Promise<void> {

--- a/packages/dioxus-service/src/providers/embedded.ts
+++ b/packages/dioxus-service/src/providers/embedded.ts
@@ -184,7 +184,12 @@ export async function startEmbeddedDriver(
     child.once('exit', exitHandler);
   });
 
-  const readyPromise = pollWebDriverStatus(port, startTimeout);
+  const readyPromise = pollWebDriverStatus(port, startTimeout).then(async () => {
+    // On Windows, add a small delay after ready to allow WebView2 to fully stabilize
+    if (process.platform === 'win32') {
+      await sleep(500);
+    }
+  });
 
   try {
     await Promise.race([readyPromise, spawnErrorPromise, earlyExitPromise]);

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -66,7 +66,17 @@ export default class DioxusWorkerService {
       clearAllMocks,
       resetAllMocks,
       restoreAllMocks,
-      isMockFunction,
+      isMockFunction: (commandOrFn: unknown) => {
+        if (typeof commandOrFn === 'string') {
+          try {
+            mockStore.getMock(`dioxus.${commandOrFn}`);
+            return true;
+          } catch {
+            return false;
+          }
+        }
+        return isMockFunction(commandOrFn);
+      },
       switchWindow: (label: string) => switchWindowByLabel(browser, label),
       listWindows: () => listWindowLabels(browser),
       triggerDeeplink,

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -1,4 +1,5 @@
 import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
+import type { DioxusServiceAPI } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 
 import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from './commands/allMocks.js';
@@ -23,19 +24,42 @@ export default class DioxusWorkerService {
     log.debug('DioxusWorkerService initialised');
   }
 
-  async before(_capabilities: unknown, _specs: string[], browser: WebdriverIO.Browser): Promise<void> {
+  async before(
+    _capabilities: unknown,
+    _specs: string[],
+    browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
+  ): Promise<void> {
     log.debug('DioxusWorkerService.before — installing browser.dioxus');
 
     if (this.devServerUrl) {
-      await this.initBrowserMode(browser);
-    } else {
-      await this.injectSpy(browser);
+      await this.initBrowserMode(browser as WebdriverIO.Browser);
+      return;
     }
 
-    // biome-ignore lint/suspicious/noExplicitAny: WebdriverIO.Browser augmentation
-    // happens via @wdio/native-types module augmentation; the cast is a transient
-    // accommodation for the in-progress migration.
-    const dioxus: any = {
+    if (browser.isMultiremote) {
+      const mrBrowser = browser as WebdriverIO.MultiRemoteBrowser;
+      log.info(`Initializing ${mrBrowser.instances.length} multiremote instances`);
+      this.addDioxusApi(browser as unknown as WebdriverIO.Browser);
+      for (const instanceName of mrBrowser.instances) {
+        const mrInstance = mrBrowser.getInstance(instanceName);
+        log.debug(`Injecting spy + installing dioxus API on instance: ${instanceName}`);
+        await this.injectSpy(mrInstance);
+        this.addDioxusApi(mrInstance);
+      }
+    } else {
+      await this.injectSpy(browser as WebdriverIO.Browser);
+      this.addDioxusApi(browser as WebdriverIO.Browser);
+    }
+  }
+
+  async after(): Promise<void> {
+    log.debug('DioxusWorkerService.after — clearing process-wide mockStore + window cache');
+    mockStore.clear();
+    clearWindowState();
+  }
+
+  private addDioxusApi(browser: WebdriverIO.Browser): void {
+    const dioxus: DioxusServiceAPI = {
       execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>
         execute<R, A>(browser, script, ...args),
       mock: (command: string) => mock(command, browser),
@@ -47,13 +71,7 @@ export default class DioxusWorkerService {
       listWindows: () => listWindowLabels(browser),
       triggerDeeplink,
     };
-    (browser as unknown as { dioxus: typeof dioxus }).dioxus = dioxus;
-  }
-
-  async after(): Promise<void> {
-    log.debug('DioxusWorkerService.after — clearing process-wide mockStore + window cache');
-    mockStore.clear();
-    clearWindowState();
+    (browser as unknown as { dioxus: DioxusServiceAPI }).dioxus = dioxus;
   }
 
   private async initBrowserMode(browser: WebdriverIO.Browser): Promise<void> {
@@ -66,8 +84,7 @@ export default class DioxusWorkerService {
     // survives page loads within the same test session.
     const originalUrl = (browser.url as unknown as (u?: string) => Promise<unknown>).bind(browser);
     const injectSpy = this.injectSpy.bind(this);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (browser as any).url = async (url?: string) => {
+    (browser as unknown as { url: (u?: string) => Promise<unknown> }).url = async (url?: string) => {
       const result = url !== undefined ? await originalUrl(url) : await originalUrl();
       if (url !== undefined) {
         await injectSpy(browser).catch((err) => {
@@ -76,6 +93,8 @@ export default class DioxusWorkerService {
       }
       return result;
     };
+
+    this.addDioxusApi(browser);
   }
 
   private async injectSpy(browser: WebdriverIO.Browser): Promise<void> {

--- a/packages/dioxus-service/src/session.ts
+++ b/packages/dioxus-service/src/session.ts
@@ -45,10 +45,18 @@ export async function init(
   const serviceOptions = capabilities['wdio:dioxusServiceOptions'];
   const startTimeout = serviceOptions?.startTimeout ?? 60_000;
 
+  // Strip non-W3C props that the launcher sets for its own connection bookkeeping.
+  // webdriverio's remote() validates capabilities against the W3C spec and rejects
+  // unknown keys like "port" and "hostname".
+  const driverCapabilities = structuredClone(capabilities);
+  delete (driverCapabilities as { port?: number }).port;
+  delete (driverCapabilities as { hostname?: string }).hostname;
+  delete (driverCapabilities as { browserName?: string }).browserName;
+
   const browser = await remote({
     hostname,
     port,
-    capabilities,
+    capabilities: driverCapabilities,
     connectionRetryTimeout: startTimeout * 4,
     connectionRetryCount: 10,
   }).catch(async (error: Error) => {

--- a/packages/dioxus-service/src/window.ts
+++ b/packages/dioxus-service/src/window.ts
@@ -107,6 +107,15 @@ export async function listWindowLabels(browser: WebdriverIO.Browser): Promise<st
  */
 async function resolveLabelToHandle(browser: WebdriverIO.Browser, targetLabel: string): Promise<string> {
   const handles = await browser.getWindowHandles();
+
+  // The embedded driver returns labels as handles (not opaque WebDriver handle IDs).
+  // When targetLabel appears directly in the handles list, no switchToWindow call is
+  // needed — the embedded driver has a single shared IPC channel and rejects window
+  // switching with an "unsupported operation" error regardless.
+  if (handles.includes(targetLabel)) {
+    return targetLabel;
+  }
+
   const discovered = new Map<string, string>();
 
   for (const handle of handles) {

--- a/packages/native-utils/package.json
+++ b/packages/native-utils/package.json
@@ -54,8 +54,15 @@
     "find-up-simple": "^1.0.1",
     "json5": "^2.2.3",
     "smol-toml": "^1.6.0",
-    "tsx": "^4.21.0",
     "yaml": "^2.8.2"
+  },
+  "peerDependencies": {
+    "tsx": "^4.21.0"
+  },
+  "peerDependenciesMeta": {
+    "tsx": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
@@ -63,6 +70,7 @@
     "@vitest/coverage-v8": "^4.1.0",
     "@wdio/native-types": "workspace:*",
     "shx": "^0.4.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },

--- a/packages/native-utils/src/config/read.ts
+++ b/packages/native-utils/src/config/read.ts
@@ -74,7 +74,9 @@ async function handleTypeScriptFile(
   configFilePathUrl: string,
   ext: string,
 ): Promise<Record<string, unknown> | undefined> {
-  // For .ts and .mts files, try tsx first
+  // For .ts and .mts files, try tsx first. tsx is an optional peer
+  // dependency (see @wdio/native-utils package.json) so consumers can
+  // skip installing it when they only ship JS/JSON configs.
   if (ext === '.ts' || ext === '.mts') {
     try {
       // @ts-ignore - tsx/esm/api is a runtime import
@@ -82,8 +84,15 @@ async function handleTypeScriptFile(
         tsImport: (url: string, parentURL: string) => Promise<Record<string, unknown>>;
       };
       return await tsxApi.tsImport(configFilePathUrl, import.meta.url);
-    } catch (_error) {
-      // If tsx fails, return undefined to trigger fallback to native import
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+        throw new Error(
+          `Reading a TypeScript config (${configFilePath}) requires the optional peer dependency 'tsx'. ` +
+            `Install it as a devDependency in your project: \`npm install -D tsx\`.`,
+        );
+      }
+      // Any other failure — let the caller fall back to native import.
       return undefined;
     }
   }

--- a/packages/native-utils/src/config/read.ts
+++ b/packages/native-utils/src/config/read.ts
@@ -78,12 +78,14 @@ async function handleTypeScriptFile(
   // dependency (see @wdio/native-utils package.json) so consumers can
   // skip installing it when they only ship JS/JSON configs.
   if (ext === '.ts' || ext === '.mts') {
+    // Split try blocks so an ERR_MODULE_NOT_FOUND from inside the user's
+    // config isn't misdiagnosed as the tsx loader itself being missing.
+    let tsxApi: { tsImport: (url: string, parentURL: string) => Promise<Record<string, unknown>> };
     try {
       // @ts-ignore - tsx/esm/api is a runtime import
-      const tsxApi = (await import('tsx/esm/api')) as unknown as {
+      tsxApi = (await import('tsx/esm/api')) as unknown as {
         tsImport: (url: string, parentURL: string) => Promise<Record<string, unknown>>;
       };
-      return await tsxApi.tsImport(configFilePathUrl, import.meta.url);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;
       if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
@@ -92,7 +94,12 @@ async function handleTypeScriptFile(
             `Install it as a devDependency in your project: \`npm install -D tsx\`.`,
         );
       }
-      // Any other failure — let the caller fall back to native import.
+      return undefined;
+    }
+
+    try {
+      return await tsxApi.tsImport(configFilePathUrl, import.meta.url);
+    } catch (_error) {
       return undefined;
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,9 +1068,6 @@ importers:
       smol-toml:
         specifier: ^1.6.0
         version: 1.6.1
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       yaml:
         specifier: ^2.8.2
         version: 2.8.3
@@ -1090,6 +1087,9 @@ importers:
       shx:
         specifier: ^0.4.0
         version: 0.4.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@wdio/tauri-service':
         specifier: link:../packages/tauri-service
         version: link:../packages/tauri-service
+      '@wdio/visual-service':
+        specifier: ^9.2.2
+        version: 9.2.2(webdriverio@9.27.0(puppeteer-core@24.41.0))
       '@wdio/xvfb':
         specifier: catalog:default
         version: 9.27.0
@@ -174,6 +177,8 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+
+  fixtures/e2e-apps/dioxus: {}
 
   fixtures/e2e-apps/electron-builder:
     devDependencies:
@@ -1359,6 +1364,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -2366,6 +2374,118 @@ packages:
     resolution: {integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jimp/core@1.6.1':
+    resolution: {integrity: sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==}
+    engines: {node: '>=18'}
+
+  '@jimp/diff@1.6.1':
+    resolution: {integrity: sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/file-ops@1.6.1':
+    resolution: {integrity: sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-bmp@1.6.1':
+    resolution: {integrity: sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-gif@1.6.1':
+    resolution: {integrity: sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-jpeg@1.6.1':
+    resolution: {integrity: sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-png@1.6.1':
+    resolution: {integrity: sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-tiff@1.6.1':
+    resolution: {integrity: sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blit@1.6.1':
+    resolution: {integrity: sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blur@1.6.1':
+    resolution: {integrity: sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-circle@1.6.1':
+    resolution: {integrity: sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-color@1.6.1':
+    resolution: {integrity: sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-contain@1.6.1':
+    resolution: {integrity: sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-cover@1.6.1':
+    resolution: {integrity: sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-crop@1.6.1':
+    resolution: {integrity: sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-displace@1.6.1':
+    resolution: {integrity: sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-dither@1.6.1':
+    resolution: {integrity: sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-fisheye@1.6.1':
+    resolution: {integrity: sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-flip@1.6.1':
+    resolution: {integrity: sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-hash@1.6.1':
+    resolution: {integrity: sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-mask@1.6.1':
+    resolution: {integrity: sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-print@1.6.1':
+    resolution: {integrity: sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-quantize@1.6.1':
+    resolution: {integrity: sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-resize@1.6.1':
+    resolution: {integrity: sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-rotate@1.6.1':
+    resolution: {integrity: sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-threshold@1.6.1':
+    resolution: {integrity: sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==}
+    engines: {node: '>=18'}
+
+  '@jimp/types@1.6.1':
+    resolution: {integrity: sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==}
+    engines: {node: '>=18'}
+
+  '@jimp/utils@1.6.1':
+    resolution: {integrity: sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==}
+    engines: {node: '>=18'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2840,6 +2960,13 @@ packages:
   '@tauri-apps/plugin-log@2.8.0':
     resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -2936,6 +3063,9 @@ packages:
 
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+
+  '@types/node@16.9.1':
+    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
@@ -3118,6 +3248,9 @@ packages:
       expect-webdriverio: ^5.6.5
       webdriverio: ^9.0.0
 
+  '@wdio/image-comparison-core@1.2.2':
+    resolution: {integrity: sha512-AFPMHVcnFxy6inOVLlY94/JYxDogUYVZ8C8LSDWjXVBB2YN3mjIFOeIkSNmzMRZybfYrev3TV9l82Yc4jrNtvw==}
+
   '@wdio/local-runner@9.27.0':
     resolution: {integrity: sha512-0AqAbz1UhZ9e72ebqH4/B9/qOy0LVm3iOOYp16Rz2zkE5DOudLPPn3DpakafqW22Z7Q+Wb/23KRttPMrq0rOxw==}
     engines: {node: '>=18.20.0'}
@@ -3159,6 +3292,9 @@ packages:
   '@wdio/utils@9.27.0':
     resolution: {integrity: sha512-fUasd5OKJTy2seJfWnYZ9xlxTtY0p/Kyeuh7Tbb8kcofBqmBi2fTvM3sfZlo1tGQX9yCh+IS2N7hlfyFMmuZ+w==}
     engines: {node: '>=18.20.0'}
+
+  '@wdio/visual-service@9.2.2':
+    resolution: {integrity: sha512-K1M/Ukw1dhpmZT71z73cM84p7W1DlKiUBn9drm6UeApzI3oTXfUTzMLafwDekhHg/ENPImPlEPHAisk1xqYYqg==}
 
   '@wdio/xvfb@9.27.0':
     resolution: {integrity: sha512-sumk8m5wzOPMs8TizfQkWG0MTqe0p1yfu77ouz+xy1hNW+gaSf99uiU3lvz4rSghloM1esKfqRCFQibJI4+d/w==}
@@ -3326,6 +3462,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-base@1.1.0:
+    resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -3398,6 +3537,10 @@ packages:
   author-regex@1.0.0:
     resolution: {integrity: sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==}
     engines: {node: '>=0.8'}
+
+  await-to-js@3.0.0:
+    resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
+    engines: {node: '>=6.0.0'}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -3482,6 +3625,9 @@ packages:
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
+  bmp-ts@1.0.9:
+    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -4270,6 +4416,9 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  exif-parser@0.1.12:
+    resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
+
   exit-hook@4.0.0:
     resolution: {integrity: sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==}
     engines: {node: '>=18'}
@@ -4377,6 +4526,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
@@ -4562,6 +4715,9 @@ packages:
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  gifwrap@0.10.1:
+    resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
 
   git-semver-tags@8.0.1:
     resolution: {integrity: sha512-zMbamckSNdlT4U48IMFa2Cn6FTzM+2yF6/gEmStPJI8PiLxd/bT6dw10+mc6u5Qe4fhrc/y9nU290FWjQhAV7g==}
@@ -4753,6 +4909,9 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  image-q@4.0.0:
+    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -4960,12 +5119,19 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
+  jimp@1.6.1:
+    resolution: {integrity: sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==}
+    engines: {node: '>=18'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -5248,6 +5414,11 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -5489,6 +5660,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  omggif@1.0.10:
+    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -5617,6 +5791,15 @@ packages:
     resolution: {integrity: sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==}
     engines: {node: '>=0.10.0'}
 
+  parse-bmfont-ascii@1.0.6:
+    resolution: {integrity: sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==}
+
+  parse-bmfont-binary@1.0.6:
+    resolution: {integrity: sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==}
+
+  parse-bmfont-xml@1.1.6:
+    resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
+
   parse-json@2.2.0:
     resolution: {integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==}
     engines: {node: '>=0.10.0'}
@@ -5720,9 +5903,21 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pixelmatch@5.3.0:
+    resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
+    hasBin: true
+
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -6088,6 +6283,10 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  simple-xml-to-json@1.2.7:
+    resolution: {integrity: sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==}
+    engines: {node: '>=20.12.2'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -6254,6 +6453,10 @@ packages:
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -6346,6 +6549,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -6387,6 +6593,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -6473,6 +6683,10 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -6543,6 +6757,9 @@ packages:
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
+  utif2@4.1.0:
+    resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6787,6 +7004,17 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-parse-from-string@1.0.1:
+    resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
+
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -7041,6 +7269,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.12':
     optional: true
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -8169,6 +8399,229 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
+  '@jimp/core@1.6.1':
+    dependencies:
+      '@jimp/file-ops': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      await-to-js: 3.0.0
+      exif-parser: 0.1.12
+      file-type: 21.3.4
+      mime: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/diff@1.6.1':
+    dependencies:
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      pixelmatch: 5.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/file-ops@1.6.1': {}
+
+  '@jimp/js-bmp@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      bmp-ts: 1.0.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-gif@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      gifwrap: 0.10.1
+      omggif: 1.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-jpeg@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      jpeg-js: 0.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-png@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      pngjs: 7.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/js-tiff@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      utif2: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-blit@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-blur@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/utils': 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-circle@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-color@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      tinycolor2: 1.6.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-contain@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-cover@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-crop@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-displace@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-dither@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+
+  '@jimp/plugin-fisheye@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-flip@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-hash@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/js-bmp': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/js-tiff': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      any-base: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-mask@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+
+  '@jimp/plugin-print@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/types': 1.6.1
+      parse-bmfont-ascii: 1.0.6
+      parse-bmfont-binary: 1.0.6
+      parse-bmfont-xml: 1.1.6
+      simple-xml-to-json: 1.2.7
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-quantize@1.6.1':
+    dependencies:
+      image-q: 4.0.0
+      zod: 3.25.76
+
+  '@jimp/plugin-resize@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/types': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-rotate@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/plugin-threshold@1.6.1':
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-hash': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jimp/types@1.6.1':
+    dependencies:
+      zod: 3.25.76
+
+  '@jimp/utils@1.6.1':
+    dependencies:
+      '@jimp/types': 1.6.1
+      tinycolor2: 1.6.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8624,6 +9077,15 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tootallnate/once@2.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
@@ -8711,6 +9173,8 @@ snapshots:
   '@types/mute-stream@0.0.4':
     dependencies:
       '@types/node': 25.6.0
+
+  '@types/node@16.9.1': {}
 
   '@types/node@20.19.39':
     dependencies:
@@ -8970,6 +9434,14 @@ snapshots:
       expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.41.0))
       webdriverio: 9.27.0(puppeteer-core@24.41.0)
 
+  '@wdio/image-comparison-core@1.2.2':
+    dependencies:
+      '@wdio/logger': 9.18.0
+      '@wdio/types': 9.27.0
+      jimp: 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@wdio/local-runner@9.27.0(@wdio/globals@9.27.0)(webdriverio@9.27.0(puppeteer-core@24.41.0))':
     dependencies:
       '@types/node': 20.19.39
@@ -9082,6 +9554,17 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@wdio/visual-service@9.2.2(webdriverio@9.27.0(puppeteer-core@24.41.0))':
+    dependencies:
+      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.41.0))
+      '@wdio/image-comparison-core': 1.2.2
+      '@wdio/logger': 9.18.0
+      '@wdio/types': 9.27.0
+      expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.41.0))
+    transitivePeerDependencies:
+      - supports-color
+      - webdriverio
 
   '@wdio/xvfb@9.27.0':
     dependencies:
@@ -9259,6 +9742,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-base@1.1.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -9371,6 +9856,8 @@ snapshots:
 
   author-regex@1.0.0: {}
 
+  await-to-js@3.0.0: {}
+
   b4a@1.8.0: {}
 
   balanced-match@1.0.2: {}
@@ -9430,6 +9917,8 @@ snapshots:
       readable-stream: 3.6.2
 
   bluebird@3.7.2: {}
+
+  bmp-ts@1.0.9: {}
 
   boolbase@1.0.0: {}
 
@@ -10422,6 +10911,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  exif-parser@0.1.12: {}
+
   exit-hook@4.0.0: {}
 
   expect-type@1.3.0: {}
@@ -10534,6 +11025,15 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   filelist@1.0.6:
     dependencies:
@@ -10757,6 +11257,11 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  gifwrap@0.10.1:
+    dependencies:
+      image-q: 4.0.0
+      omggif: 1.0.10
 
   git-semver-tags@8.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0):
     dependencies:
@@ -11001,6 +11506,10 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  image-q@4.0.0:
+    dependencies:
+      '@types/node': 16.9.1
+
   immediate@3.0.6: {}
 
   import-meta-resolve@4.2.0: {}
@@ -11178,9 +11687,43 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  jimp@1.6.1:
+    dependencies:
+      '@jimp/core': 1.6.1
+      '@jimp/diff': 1.6.1
+      '@jimp/js-bmp': 1.6.1
+      '@jimp/js-gif': 1.6.1
+      '@jimp/js-jpeg': 1.6.1
+      '@jimp/js-png': 1.6.1
+      '@jimp/js-tiff': 1.6.1
+      '@jimp/plugin-blit': 1.6.1
+      '@jimp/plugin-blur': 1.6.1
+      '@jimp/plugin-circle': 1.6.1
+      '@jimp/plugin-color': 1.6.1
+      '@jimp/plugin-contain': 1.6.1
+      '@jimp/plugin-cover': 1.6.1
+      '@jimp/plugin-crop': 1.6.1
+      '@jimp/plugin-displace': 1.6.1
+      '@jimp/plugin-dither': 1.6.1
+      '@jimp/plugin-fisheye': 1.6.1
+      '@jimp/plugin-flip': 1.6.1
+      '@jimp/plugin-hash': 1.6.1
+      '@jimp/plugin-mask': 1.6.1
+      '@jimp/plugin-print': 1.6.1
+      '@jimp/plugin-quantize': 1.6.1
+      '@jimp/plugin-resize': 1.6.1
+      '@jimp/plugin-rotate': 1.6.1
+      '@jimp/plugin-threshold': 1.6.1
+      '@jimp/types': 1.6.1
+      '@jimp/utils': 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
   jiti@2.6.1: {}
 
   jju@1.4.0: {}
+
+  jpeg-js@0.4.4: {}
 
   js-tokens@10.0.0: {}
 
@@ -11505,6 +12048,8 @@ snapshots:
 
   mime@2.6.0: {}
 
+  mime@3.0.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
@@ -11740,6 +12285,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  omggif@1.0.10: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -11871,6 +12418,15 @@ snapshots:
     dependencies:
       author-regex: 1.0.0
 
+  parse-bmfont-ascii@1.0.6: {}
+
+  parse-bmfont-binary@1.0.6: {}
+
+  parse-bmfont-xml@1.1.6:
+    dependencies:
+      xml-parse-from-string: 1.0.1
+      xml2js: 0.5.0
+
   parse-json@2.2.0:
     dependencies:
       error-ex: 1.3.4
@@ -11952,11 +12508,19 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pixelmatch@5.3.0:
+    dependencies:
+      pngjs: 6.0.0
+
   plist@3.1.0:
     dependencies:
       '@xmldom/xmldom': 0.8.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  pngjs@6.0.0: {}
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.10:
     dependencies:
@@ -12354,6 +12918,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  simple-xml-to-json@1.2.7: {}
+
   slash@3.0.0: {}
 
   slice-ansi@3.0.0:
@@ -12521,6 +13087,10 @@ snapshots:
 
   strnum@2.2.3: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -12640,6 +13210,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinycolor2@1.6.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
@@ -12672,6 +13244,12 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tough-cookie@6.0.1:
     dependencies:
@@ -12741,6 +13319,8 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
+  uint8array-extras@1.5.0: {}
+
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
@@ -12795,6 +13375,10 @@ snapshots:
       mem: 4.3.0
 
   utf8-byte-length@1.0.5: {}
+
+  utif2@4.1.0:
+    dependencies:
+      pako: 1.0.11
 
   util-deprecate@1.0.2: {}
 
@@ -13057,6 +13641,15 @@ snapshots:
   ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-parse-from-string@1.0.1: {}
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - fixtures/e2e-apps/electron-forge
   - fixtures/e2e-apps/electron-script
   - fixtures/e2e-apps/tauri
+  - fixtures/e2e-apps/dioxus
   - fixtures/package-tests/electron-builder-app-cjs
   - fixtures/package-tests/electron-builder-app-esm
   - fixtures/package-tests/electron-forge-app-cjs

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -654,7 +654,13 @@ async function testExample(
       // Dioxus: use pre-built binary when skipBuild=true (CI downloads it as a separate artifact)
       const sourceTargetDir = join(rootDir, 'fixtures', 'package-tests', 'dioxus-app', 'src-dioxus', 'target');
       const destTargetDir = join(packageDir, 'src-dioxus', 'target');
-      if (skipBuild && existsSync(sourceTargetDir)) {
+      if (skipBuild) {
+        if (!existsSync(sourceTargetDir)) {
+          throw new Error(
+            `Pre-built Dioxus binary not found at ${sourceTargetDir}. ` +
+              'Was the build artifact downloaded and extracted correctly?',
+          );
+        }
         log(`Copying pre-built Dioxus binary from ${sourceTargetDir}...`);
         mkdirSync(destTargetDir, { recursive: true });
         cpSync(sourceTargetDir, destTargetDir, { recursive: true });

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -311,7 +311,7 @@ async function testExample(
     cdpBridgePath?: string;
   },
   service: 'electron' | 'tauri' | 'dioxus',
-  _skipBuild: boolean,
+  skipBuild: boolean,
   mode: 'native' | 'browser' = 'native',
 ) {
   const packageName = packagePath.split(/[/\\]/).pop();
@@ -650,8 +650,20 @@ async function testExample(
           }
         }
       }
+    } else if (service === 'dioxus' && mode === 'native') {
+      // Dioxus: use pre-built binary when skipBuild=true (CI downloads it as a separate artifact)
+      const sourceTargetDir = join(rootDir, 'fixtures', 'package-tests', 'dioxus-app', 'src-dioxus', 'target');
+      const destTargetDir = join(packageDir, 'src-dioxus', 'target');
+      if (skipBuild && existsSync(sourceTargetDir)) {
+        log(`Copying pre-built Dioxus binary from ${sourceTargetDir}...`);
+        mkdirSync(destTargetDir, { recursive: true });
+        cpSync(sourceTargetDir, destTargetDir, { recursive: true });
+        log(`✅ Pre-built Dioxus binary copied successfully`);
+      } else if (packageJson.scripts?.build) {
+        execCommand('pnpm build', packageDir, `Building ${packageName} app`);
+      }
     } else if (packageJson.scripts?.build && mode === 'native') {
-      // Build Electron and Dioxus apps in isolated environment (browser mode skips the build)
+      // Build other apps (e.g. Electron) in isolated environment
       execCommand('pnpm build', packageDir, `Building ${packageName} app`);
     }
 


### PR DESCRIPTION
## Summary

- Adds `_ci-build-dioxus-e2e-app.reusable.yml` — builds the Dioxus E2E fixture app on Linux, Windows, macOS-ARM, macOS-Intel and uploads the binary as a shareable artifact
- Adds `_ci-e2e-dioxus-all-providers.reusable.yml` — runs Dioxus E2E tests for both providers sequentially per runner: `external` (Windows only in v1) and `embedded` (all platforms), with `xvfb-run` wrapping Linux runs
- Extends `_ci-package.reusable.yml` with `dioxus` service: Dioxus runtime deps, binary artifact download, service packing, and `test:package:dioxus -- --skip-build` execution (xvfb-run on Linux)
- Adds to `ci.yml`: 4 E2E app build jobs, 2 package app build jobs, 4 E2E test jobs (each with a 5-type matrix = 20 runners total), and 2 package test jobs — all gated on `run_dioxus`; all added to the `ci-status` gate
- Adds `test:package:dioxus` and `test:package:dioxus:browser` root scripts to `package.json`
- Adds `fixtures/e2e-apps/dioxus` to `pnpm-workspace.yaml` so turbo can resolve the `wdio-dioxus-e2e-app` filter

## Test plan

- [ ] All new `build-dioxus-*` jobs run and produce artifacts when `run_dioxus == 'true'`
- [ ] `e2e-dioxus-{linux,windows,macos-arm,macos-intel}` jobs run all 5 test types via `_ci-e2e-dioxus-all-providers.reusable.yml`
- [ ] `external` provider step auto-skips on Linux/macOS (only runs on `windows-latest`)
- [ ] `embedded` provider runs with `xvfb-run` on Linux, bare on Windows/macOS
- [ ] `package-dioxus-{linux,windows}` jobs download pre-built binaries and run `test:package:dioxus`
- [ ] PRs touching only non-Dioxus paths skip all `e2e-dioxus-*` and `package-dioxus-*` jobs
- [ ] `ci-status` gate passes when all Dioxus jobs succeed or are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)