### PR TITLE
feat(ci): add Electron Linux-ARM64 package test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,12 @@ jobs:
           - os: macos-15-intel
             display-name: macOS-Intel
             module-type: esm
+          - os: ubuntu-24.04-arm
+            display-name: Linux-ARM64
+            module-type: cjs
+          - os: ubuntu-24.04-arm
+            display-name: Linux-ARM64
+            module-type: esm
     uses: ./.github/workflows/_ci-package.reusable.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

- Adds `ubuntu-24.04-arm` (Linux ARM64) CJS and ESM matrix entries to the `package-electron-matrix` job
- Brings Electron package test platform coverage in line with the other services (Tauri already has Linux ARM64, Dioxus gaining it in the Dioxus phase branch)

## Test plan

- [ ] CI runs new ARM64 matrix legs and they pass
- [ ] Existing matrix legs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)