### PR TITLE
chore(fixtures): align e2e + package-test app styles on shared theme

### DIFF
--- a/.claude/skills/add-native-service/SKILL.md
+++ b/.claude/skills/add-native-service/SKILL.md
@@ -146,12 +146,41 @@ See [ci-and-release.md](ci-and-release.md) → "CI gates". Add `run_<framework>`
 
 ### Phase 5 — Fixtures, E2E, docs, release
 
-- `fixtures/e2e-apps/<framework>/` — minimal app: execute + mock + multi-window.
+- `fixtures/e2e-apps/<framework>/` — minimal app exercising the service surface (execute + mock + multi-window). See **Fixture app conventions** below.
+- `fixtures/package-tests/<framework>-app/` — package-install smoke fixture. Same visual conventions; reduced functional surface (typically just `#app-title` + `#status`).
 - `e2e/test/<framework>/{api,application,execute-advanced,execute-data-types,logging,mocking,window}.spec.ts` mirroring `e2e/test/tauri/`. Also add `logging.external.spec.ts` if the service has an **external** driver provider — capturing the driver subprocess's stdout/stderr is a distinct code path from in-app frontend/backend logging and needs its own coverage.
 - `e2e/wdio.<framework>.conf.ts` (+ `wdio.<framework>-embedded.conf.ts` for a Wry embedded provider).
 - `packages/<framework>-service/README.md` + `docs/` set + per-crate READMEs.
 - Root `README.md`, `ROADMAP.md`, `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/*.md` updates.
 - Release pipeline — see [ci-and-release.md](ci-and-release.md) → "Release pipeline".
+
+#### Fixture app conventions
+
+The same convergence principle that applies to the API surface ([features.md](features.md)) applies to fixtures. Every fixture — both `fixtures/e2e-apps/<framework>/` and `fixtures/package-tests/<framework>-app/` — uses a **shared visual + functional template** so a screenshot of one is largely interchangeable with a screenshot of any other. New fixtures must adopt it.
+
+**Visual template ("big-glass"):**
+
+- Background: `linear-gradient(135deg, #667eea 0%, #764ba2 100%)` (purple). Splash screens use the same gradient.
+- `.container`: `background: rgba(255, 255, 255, 0.15)`, `backdrop-filter: blur(15px)`, `border-radius: 25px`, `padding: 50px`, `max-width: 800px`, with a `border: 1px solid rgba(255, 255, 255, 0.25)` and `box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15)`.
+- `h1`: `font-size: 3em`, `font-weight: 200`, text-shadow `0 2px 10px rgba(0, 0, 0, 0.3)`.
+- `button`: white-translucent (`rgba(255, 255, 255, 0.25)`, `border: 2px solid rgba(255, 255, 255, 0.4)`), `border-radius: 12px`, hover lifts with `translateY(-3px)`.
+- `#counter` (when present): `font-size: 4em`, `color: #61dafb` (carried over from the original Tauri theme — the only colour accent on top of the white-on-purple base).
+- `.info-section` panel for status/log output: `background: rgba(0, 0, 0, 0.25)`, `border-radius: 15px`, SF Mono / Monaco font.
+- White text throughout.
+
+**Functional content:**
+
+- When the framework can render a UI, ship an **increment / decrement / reset counter + status panel**. Stable selectors: `#app-title`, `#counter`, `#increment-button`, `#decrement-button`, `#reset-button`, `#status` (used by `visual.spec.ts` and `application.spec.ts`).
+- CDP fixtures (Electron) additionally include the window-resize / show-dialog buttons that exercise Electron's extras — these are framework-additive and live alongside the standard counter UI, not in place of it.
+- The package-test fixture is allowed to ship a reduced surface (typically just `#app-title` + `#status`) since the install-smoke spec doesn't need the counter — but the visual styling stays identical.
+
+**Canonical references:**
+
+- HTML fixtures: `fixtures/e2e-apps/electron-builder/src/renderer/index.html`.
+- rsx / Rust fixtures: `fixtures/e2e-apps/dioxus/src/main.rs` (CSS lives in a `SHARED_STYLES: &str` const fed into the rsx `style { }` block).
+- Tauri counter UI on the shared theme: `fixtures/e2e-apps/tauri/index.html`.
+
+Don't introduce a new per-framework gradient or container style — pick `.container` + counter rule from the references above and only add framework-specific *content* on top.
 
 ## Naming conventions
 

--- a/fixtures/e2e-apps/dioxus/src/main.rs
+++ b/fixtures/e2e-apps/dioxus/src/main.rs
@@ -59,25 +59,108 @@ fn App() -> Element {
     rsx! {
         head {
             title { "WDIO Dioxus E2E App" }
-            style { "body {{ font-family: sans-serif; padding: 20px; }}" }
+            style { {SHARED_STYLES} }
         }
-        h1 { id: "app-title", "WDIO Dioxus E2E Test App" }
-        div { id: "counter", "{count}" }
-        div { id: "status", "{status}" }
-        button {
-            id: "increment-button",
-            onclick: move |_| { count += 1; *status.write() = "incremented".into(); },
-            "Increment"
-        }
-        button {
-            id: "decrement-button",
-            onclick: move |_| { count -= 1; *status.write() = "decremented".into(); },
-            "Decrement"
-        }
-        button {
-            id: "reset-button",
-            onclick: move |_| { count.set(0); *status.write() = "reset".into(); },
-            "Reset"
+        div { class: "container",
+            h1 { id: "app-title", "WDIO Dioxus E2E Test App" }
+            div { class: "counter-section",
+                div { id: "counter", "{count}" }
+                button {
+                    id: "increment-button",
+                    onclick: move |_| { count += 1; *status.write() = "incremented".into(); },
+                    "Increment"
+                }
+                button {
+                    id: "decrement-button",
+                    onclick: move |_| { count -= 1; *status.write() = "decremented".into(); },
+                    "Decrement"
+                }
+                button {
+                    id: "reset-button",
+                    onclick: move |_| { count.set(0); *status.write() = "reset".into(); },
+                    "Reset"
+                }
+            }
+            div { class: "info-section",
+                div { id: "status", "{status}" }
+            }
         }
     }
 }
+
+const SHARED_STYLES: &str = r#"
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+.container {
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(15px);
+    border-radius: 25px;
+    padding: 50px;
+    text-align: center;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    max-width: 800px;
+    width: 100%;
+}
+h1 {
+    margin: 0 0 25px 0;
+    font-size: 3em;
+    font-weight: 200;
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+button {
+    background: rgba(255, 255, 255, 0.25);
+    border: 2px solid rgba(255, 255, 255, 0.4);
+    color: white;
+    padding: 15px 20px;
+    border-radius: 12px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: 500;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(5px);
+    margin: 8px;
+}
+button:hover {
+    background: rgba(255, 255, 255, 0.35);
+    transform: translateY(-3px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+}
+.counter-section {
+    margin: 2rem 0;
+}
+#counter {
+    font-size: 4em;
+    font-weight: bold;
+    margin: 1rem 0;
+    color: #61dafb;
+}
+.info-section {
+    margin-top: 40px;
+    padding: 25px;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 15px;
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    font-size: 0.95em;
+    line-height: 1.5;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+#status {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    display: inline-block;
+}
+"#;

--- a/fixtures/e2e-apps/electron-browser/index.html
+++ b/fixtures/e2e-apps/electron-browser/index.html
@@ -3,23 +3,89 @@
   <head>
     <meta charset="UTF-8" />
     <title>Electron Browser-Mode E2E Fixture</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 20px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
+        text-align: center;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
+      }
+      h1 {
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+      }
+      button {
+        background: rgba(255, 255, 255, 0.25);
+        border: 2px solid rgba(255, 255, 255, 0.4);
+        color: white;
+        padding: 15px 20px;
+        border-radius: 12px;
+        cursor: pointer;
+        font-size: 1em;
+        font-weight: 500;
+        transition: all 0.3s ease;
+        backdrop-filter: blur(5px);
+        margin: 8px;
+      }
+      button:hover {
+        background: rgba(255, 255, 255, 0.35);
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+      }
+      section {
+        margin: 20px 0;
+      }
+      pre {
+        margin-top: 12px;
+        padding: 12px 16px;
+        background: rgba(0, 0, 0, 0.25);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 10px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        min-height: 1.2em;
+        text-align: left;
+        white-space: pre-wrap;
+      }
+    </style>
   </head>
   <body>
-    <h1 data-testid="title">Electron Browser-Mode E2E</h1>
+    <div class="container">
+      <h1 data-testid="title">Electron Browser-Mode E2E</h1>
 
-    <section>
-      <button type="button" data-testid="fetch-version">Fetch version</button>
-      <pre data-testid="version-output"></pre>
-    </section>
+      <section>
+        <button type="button" data-testid="fetch-version">Fetch version</button>
+        <pre data-testid="version-output"></pre>
+      </section>
 
-    <section>
-      <button type="button" data-testid="send-action">Send action</button>
-      <pre data-testid="action-status"></pre>
-    </section>
+      <section>
+        <button type="button" data-testid="send-action">Send action</button>
+        <pre data-testid="action-status"></pre>
+      </section>
 
-    <section>
-      <pre data-testid="event-output"></pre>
-    </section>
+      <section>
+        <pre data-testid="event-output"></pre>
+      </section>
+    </div>
 
     <script>
       // Minimal contextBridge-shape surface. In a real Electron app this is

--- a/fixtures/e2e-apps/electron-forge/src/renderer/index.html
+++ b/fixtures/e2e-apps/electron-forge/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/e2e-apps/electron-script/src/renderer/index.html
+++ b/fixtures/e2e-apps/electron-script/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/e2e-apps/tauri/index.html
+++ b/fixtures/e2e-apps/tauri/index.html
@@ -6,77 +6,86 @@
     <title>Tauri E2E Test App</title>
     <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        height: 100vh;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
+        padding: 20px;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
       }
-
       .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
         text-align: center;
-        background: rgba(255, 255, 255, 0.1);
-        padding: 2rem;
-        border-radius: 1rem;
-        backdrop-filter: blur(10px);
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
       }
-
       h1 {
-        font-size: 2.5rem;
-        margin-bottom: 1rem;
-        font-weight: 300;
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
       }
-
+      button {
+        background: rgba(255, 255, 255, 0.25);
+        border: 2px solid rgba(255, 255, 255, 0.4);
+        color: white;
+        padding: 15px 20px;
+        border-radius: 12px;
+        cursor: pointer;
+        font-size: 1em;
+        font-weight: 500;
+        transition: all 0.3s ease;
+        backdrop-filter: blur(5px);
+        margin: 8px;
+      }
+      button:hover {
+        background: rgba(255, 255, 255, 0.35);
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+      }
       .counter-section {
         margin: 2rem 0;
       }
-
       #counter {
-        font-size: 4rem;
+        font-size: 4em;
         font-weight: bold;
         margin: 1rem 0;
         color: #61dafb;
       }
-
-      button {
-        padding: 12px 24px;
-        font-size: 1.1rem;
-        cursor: pointer;
-        border: none;
-        border-radius: 8px;
-        background: linear-gradient(45deg, #61dafb, #21a1f1);
-        color: white;
-        transition: all 0.3s ease;
-        margin: 0.5rem;
-        box-shadow: 0 4px 15px rgba(97, 218, 251, 0.3);
-      }
-
-      button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(97, 218, 251, 0.4);
-      }
-
-      button:active {
-        transform: translateY(0);
-      }
-
       .info-section {
-        margin-top: 2rem;
-        font-size: 0.9rem;
-        opacity: 0.8;
+        margin-top: 40px;
+        padding: 25px;
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 15px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        line-height: 1.5;
+        border: 1px solid rgba(255, 255, 255, 0.1);
       }
-
       .status {
         margin-top: 1rem;
         padding: 0.5rem;
         background: rgba(255, 255, 255, 0.1);
         border-radius: 4px;
-        font-family: monospace;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      }
+      .badge {
+        display: inline-block;
+        background: rgba(255, 255, 255, 0.2);
+        padding: 5px 12px;
+        border-radius: 20px;
+        font-size: 0.8em;
+        margin: 0 5px;
+        border: 1px solid rgba(255, 255, 255, 0.3);
       }
     </style>
   </head>

--- a/fixtures/e2e-apps/tauri/index.html
+++ b/fixtures/e2e-apps/tauri/index.html
@@ -78,15 +78,6 @@
         border-radius: 4px;
         font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
       }
-      .badge {
-        display: inline-block;
-        background: rgba(255, 255, 255, 0.2);
-        padding: 5px 12px;
-        border-radius: 20px;
-        font-size: 0.8em;
-        margin: 0 5px;
-        border: 1px solid rgba(255, 255, 255, 0.3);
-      }
     </style>
   </head>
   <body>

--- a/fixtures/package-tests/dioxus-app/src-dioxus/src/main.rs
+++ b/fixtures/package-tests/dioxus-app/src-dioxus/src/main.rs
@@ -48,8 +48,63 @@ fn App() -> Element {
     rsx! {
         head {
             title { "WDIO Dioxus Package Test App" }
+            style { {SHARED_STYLES} }
         }
-        h1 { id: "app-title", "WDIO Dioxus Package Test App" }
-        div { id: "status", "ready" }
+        div { class: "container",
+            h1 { id: "app-title", "WDIO Dioxus Package Test App" }
+            div { class: "info-section",
+                div { id: "status", "ready" }
+            }
+        }
     }
 }
+
+const SHARED_STYLES: &str = r#"
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+.container {
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(15px);
+    border-radius: 25px;
+    padding: 50px;
+    text-align: center;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    max-width: 800px;
+    width: 100%;
+}
+h1 {
+    margin: 0 0 25px 0;
+    font-size: 3em;
+    font-weight: 200;
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+.info-section {
+    margin-top: 40px;
+    padding: 25px;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 15px;
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    font-size: 0.95em;
+    line-height: 1.5;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+#status {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    display: inline-block;
+}
+"#;

--- a/fixtures/package-tests/electron-builder-app-cjs/src/renderer/index.html
+++ b/fixtures/package-tests/electron-builder-app-cjs/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/package-tests/electron-builder-app-esm/src/renderer/index.html
+++ b/fixtures/package-tests/electron-builder-app-esm/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/package-tests/electron-forge-app-cjs/src/renderer/index.html
+++ b/fixtures/package-tests/electron-forge-app-cjs/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/package-tests/electron-forge-app-esm/src/renderer/index.html
+++ b/fixtures/package-tests/electron-forge-app-esm/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/package-tests/electron-script-app-cjs/src/renderer/index.html
+++ b/fixtures/package-tests/electron-script-app-cjs/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/package-tests/electron-script-app-esm/src/renderer/index.html
+++ b/fixtures/package-tests/electron-script-app-esm/src/renderer/index.html
@@ -9,7 +9,7 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #ff6b6b 0%, #4ecdc4 100%);
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
         min-height: 100vh;
         display: flex;

--- a/fixtures/package-tests/tauri-app/index.html
+++ b/fixtures/package-tests/tauri-app/index.html
@@ -6,77 +6,86 @@
     <title>Tauri Basic App</title>
     <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        height: 100vh;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
         margin: 0;
+        padding: 20px;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
       }
-
       .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
         text-align: center;
-        background: rgba(255, 255, 255, 0.1);
-        padding: 2rem;
-        border-radius: 1rem;
-        backdrop-filter: blur(10px);
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
       }
-
       h1 {
-        font-size: 2.5rem;
-        margin-bottom: 1rem;
-        font-weight: 300;
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
       }
-
+      button {
+        background: rgba(255, 255, 255, 0.25);
+        border: 2px solid rgba(255, 255, 255, 0.4);
+        color: white;
+        padding: 15px 20px;
+        border-radius: 12px;
+        cursor: pointer;
+        font-size: 1em;
+        font-weight: 500;
+        transition: all 0.3s ease;
+        backdrop-filter: blur(5px);
+        margin: 8px;
+      }
+      button:hover {
+        background: rgba(255, 255, 255, 0.35);
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+      }
       .counter-section {
         margin: 2rem 0;
       }
-
       #counter {
-        font-size: 4rem;
+        font-size: 4em;
         font-weight: bold;
         margin: 1rem 0;
         color: #61dafb;
       }
-
-      button {
-        padding: 12px 24px;
-        font-size: 1.1rem;
-        cursor: pointer;
-        border: none;
-        border-radius: 8px;
-        background: linear-gradient(45deg, #61dafb, #21a1f1);
-        color: white;
-        transition: all 0.3s ease;
-        margin: 0.5rem;
-        box-shadow: 0 4px 15px rgba(97, 218, 251, 0.3);
-      }
-
-      button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(97, 218, 251, 0.4);
-      }
-
-      button:active {
-        transform: translateY(0);
-      }
-
       .info-section {
-        margin-top: 2rem;
-        font-size: 0.9rem;
-        opacity: 0.8;
+        margin-top: 40px;
+        padding: 25px;
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 15px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        line-height: 1.5;
+        border: 1px solid rgba(255, 255, 255, 0.1);
       }
-
       .status {
         margin-top: 1rem;
         padding: 0.5rem;
         background: rgba(255, 255, 255, 0.1);
         border-radius: 4px;
-        font-family: monospace;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      }
+      .badge {
+        display: inline-block;
+        background: rgba(255, 255, 255, 0.2);
+        padding: 5px 12px;
+        border-radius: 20px;
+        font-size: 0.8em;
+        margin: 0 5px;
+        border: 1px solid rgba(255, 255, 255, 0.3);
       }
     </style>
   </head>

--- a/fixtures/package-tests/tauri-app/index.html
+++ b/fixtures/package-tests/tauri-app/index.html
@@ -78,15 +78,6 @@
         border-radius: 4px;
         font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
       }
-      .badge {
-        display: inline-block;
-        background: rgba(255, 255, 255, 0.2);
-        padding: 5px 12px;
-        border-radius: 20px;
-        font-size: 0.8em;
-        margin: 0 5px;
-        border: 1px solid rgba(255, 255, 255, 0.3);
-      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary

Standardises every fixture app — across all framework variants (electron, tauri, dioxus) and both directories (`fixtures/e2e-apps/`, `fixtures/package-tests/`) — on a **single visual template**, and codifies that template in the `add-native-service` skill so future framework additions follow it:

- **Big-glass container** (already in use by the electron-* e2e apps): `rgba(255,255,255,0.15)` background, `radius=25px`, `padding=50px`, `backdrop-filter: blur(15px)`, white translucent buttons.
- **Purple gradient `#667eea → #764ba2`** everywhere (already shared by every splash screen and by `electron-builder` e2e; pink/mint/red-teal variants gone).
- **Counter rule preserved** — the `#counter { 4em #61dafb }` styling from the old Tauri theme lives on top of the shared base so the Tauri/Dioxus counter UIs keep their look.

## Commits

1. **`chore(fixtures): align e2e + package-test app styles…`** — the 13 fixture files (2 Dioxus `main.rs`, 11 HTML).
2. **`chore(fixtures): drop dead .badge rule from Tauri apps`** — Greptile-flagged cleanup; `.badge` was copied across from the Electron template but unused in the Tauri markup.
3. **`docs(skills): document fixture app conventions in add-native-service`** — adds a "Fixture app conventions" sub-section to Phase 5 of `.claude/skills/add-native-service/SKILL.md` listing the visual rules, the stable selectors (`#app-title`, `#counter`, etc.), the canonical reference fixtures, and the package-test reduced-surface allowance. Mirrors the API-convergence principle already documented in `features.md`.

## What changed (fixtures)

| Area | Before | After |
| --- | --- | --- |
| Tauri e2e + tauri-app pkg-test | "small-glass" (alpha 0.1, padding 2rem, blue-gradient pill buttons) | shared big-glass + counter |
| Dioxus e2e + dioxus-app pkg-test | unstyled (`font-family: sans-serif`) / bare HTML | shared big-glass via rsx `style { }` |
| electron-forge e2e | pink gradient `#ff9a9e→#fecfef` | purple |
| electron-script e2e | mint gradient `#a8edea→#fed6e3` | purple |
| All 6 electron pkg-test apps | red/teal gradient `#ff6b6b→#4ecdc4` | purple |
| electron-browser e2e | bare HTML | big-glass with styled `<pre>` panels |
| Splash screens | — | already aligned, untouched |

**No selector / `data-testid` changes**, no E2E test files touched, no Cargo.toml changes. Only static fixture markup + rsx styling + skill doc.

## Test plan

- [ ] CI runs all package tests + E2E suites green (the pre-push hook already ran every `pnpm test` suite locally — 19/19 passed, twice)
- [ ] Visual regression baseline for `dioxus-app-baseline` will be regenerated on first run (no existing baseline committed)
- [ ] Eyeball each fixture in dev to confirm the look matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
