### PR TITLE
ci: free disk space on Linux E2E runners before building Electron apps

### DIFF
--- a/.github/workflows/_ci-e2e.reusable.yml
+++ b/.github/workflows/_ci-e2e.reusable.yml
@@ -65,6 +65,29 @@ jobs:
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
+      # Reclaim disk as early as possible — before setup/install/artifact-download
+      # consume the headroom. Electron Linux E2E runs have intermittently crashed
+      # with "No space left on device", taking down the runner worker before logs
+      # could even upload (seen on #298/#301). Dependency-free: plain shell, no
+      # third-party action. Every removal is guarded so it can never fail the job.
+      - name: 🧹 Free Disk Space (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "=== Disk usage before cleanup ==="
+          df -h /
+          # Toolchains preinstalled on the runner image but unused by these
+          # Electron/web E2E tests. Each guarded so a missing path is harmless.
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/share/swift || true
+          sudo docker image prune --all --force || true
+          echo "=== Disk usage after cleanup ==="
+          df -h /
+
       # Set up Node.js and PNPM using the reusable action
       - name: 🛠️ Setup Development Environment
         uses: ./.github/workflows/actions/setup-workspace
@@ -117,29 +140,6 @@ jobs:
               }
             }
             return scenarios.map(s => `--filter=electron-${s}-e2e-app`).join(' ');
-
-      # Reclaim disk on GitHub-hosted Linux runners before building/running.
-      # Electron Linux E2E runs have intermittently crashed with
-      # "No space left on device", taking down the runner worker before logs
-      # could even upload (seen on #298/#301). Dependency-free: plain shell, no
-      # third-party action. Every removal is guarded so it can never fail the job.
-      - name: 🧹 Free Disk Space (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          echo "=== Disk usage before cleanup ==="
-          df -h /
-          # Toolchains preinstalled on the runner image but unused by these
-          # Electron/web E2E tests. Each guarded so a missing path is harmless.
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          sudo rm -rf /usr/share/swift || true
-          sudo docker image prune --all --force || true
-          echo "=== Disk usage after cleanup ==="
-          df -h /
 
       # Build the test applications using Turbo with the generated filter
       # This builds only the necessary test apps for the current test configuration

--- a/.github/workflows/_ci-e2e.reusable.yml
+++ b/.github/workflows/_ci-e2e.reusable.yml
@@ -118,6 +118,29 @@ jobs:
             }
             return scenarios.map(s => `--filter=electron-${s}-e2e-app`).join(' ');
 
+      # Reclaim disk on GitHub-hosted Linux runners before building/running.
+      # Electron Linux E2E runs have intermittently crashed with
+      # "No space left on device", taking down the runner worker before logs
+      # could even upload (seen on #298/#301). Dependency-free: plain shell, no
+      # third-party action. Every removal is guarded so it can never fail the job.
+      - name: 🧹 Free Disk Space (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "=== Disk usage before cleanup ==="
+          df -h /
+          # Toolchains preinstalled on the runner image but unused by these
+          # Electron/web E2E tests. Each guarded so a missing path is harmless.
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/share/swift || true
+          sudo docker image prune --all --force || true
+          echo "=== Disk usage after cleanup ==="
+          df -h /
+
       # Build the test applications using Turbo with the generated filter
       # This builds only the necessary test apps for the current test configuration
       - name: 🏗️ Build Test Applications


### PR DESCRIPTION
## The flake

`E2E - Electron [Linux] - script` has intermittently failed because the GitHub-hosted Linux runner **runs out of disk space mid-test**. The runner's own worker crashes with `System.IO.IOException: No space left on device`, so the test step never finishes and the job log blob is never uploaded — the failure surfaces as an opaque dead job rather than a test error.

Observed on **#298** and **#301**.

## The fix

Add an early **Linux-only** "Free Disk Space" step to the E2E reusable workflow, placed after the build filter is generated and **before "Build Test Applications"**, so the build/test phase has headroom.

- **Dependency-free**: plain shell, no third-party action (e.g. no `jlumbroso/free-disk-space`) — zero new supply-chain surface, nothing for dependabot to track.
- **Gated** to Linux via `if: runner.os == 'Linux'`.
- Prints `df -h /` before and after, then `sudo rm -rf` large preinstalled toolchains unused by these Electron/web tests (.NET, Android SDK, GHC/ghcup, CodeQL, Swift) and prunes Docker images.
- **Non-fatal**: every removal is guarded with `|| true`, so a missing path or prune failure can never fail the job.

## Scope

Only `.github/workflows/_ci-e2e.reusable.yml` is touched — the observed crashes were E2E-only. The same step could be lifted into the package/build workflows later if disk pressure shows up there.

## Validation

Locally validated as parseable YAML and passes `actionlint`. CI will exercise the step on the next Linux E2E run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)