### PR TITLE
fix: harden Windows session teardown against benign-error crash/hang

### DIFF
--- a/packages/dioxus-service/src/providers/embedded.ts
+++ b/packages/dioxus-service/src/providers/embedded.ts
@@ -253,6 +253,14 @@ export async function stopEmbeddedDriver(info: EmbeddedDriverInfo): Promise<void
     return;
   }
 
+  // Guard against issuing a kill on a process that has already exited: during
+  // Windows teardown the app/driver can exit on its own while we're tearing
+  // down, and a redundant kill() emits a spurious ESRCH 'error' event.
+  if (info.proc.exitCode !== null || info.proc.signalCode !== null) {
+    log.debug('Embedded driver already exited, skipping kill');
+    return;
+  }
+
   log.info(`Stopping embedded driver (PID: ${info.proc.pid})…`);
   info.proc.kill('SIGTERM');
 

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -1,6 +1,6 @@
 import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import type { DioxusServiceAPI } from '@wdio/native-types';
-import { createLogger, isBenignTeardownError, runBounded } from '@wdio/native-utils';
+import { createLogger, DEFAULT_TEARDOWN_TIMEOUT_MS, isBenignTeardownError, runBounded } from '@wdio/native-utils';
 
 import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from './commands/allMocks.js';
 import { execute } from './commands/execute.js';
@@ -12,8 +12,6 @@ import { clearWindowState, listWindowLabels, switchWindowByLabel } from './windo
 
 const log = createLogger('dioxus-service', 'service');
 const interceptor = createIpcInterceptor('dioxus');
-
-const TEARDOWN_TIMEOUT_MS = 10_000;
 
 /**
  * Delete a WebDriver session defensively during teardown. Bounded by a timeout
@@ -31,8 +29,8 @@ async function safeDeleteSession(browser: WebdriverIO.Browser, label: string): P
   try {
     await runBounded(
       () => browser.deleteSession(),
-      TEARDOWN_TIMEOUT_MS,
-      () => log.debug(`deleteSession timed out after ${TEARDOWN_TIMEOUT_MS}ms${label ? ` (${label})` : ''}`),
+      DEFAULT_TEARDOWN_TIMEOUT_MS,
+      () => log.debug(`deleteSession timed out after ${DEFAULT_TEARDOWN_TIMEOUT_MS}ms${label ? ` (${label})` : ''}`),
     );
   } catch (error) {
     if (isBenignTeardownError(error)) {
@@ -128,7 +126,7 @@ export default class DioxusWorkerService {
       // socket and block the worker before safeDeleteSession() is ever reached.
       await runBounded(
         () => restoreAllMocks(),
-        TEARDOWN_TIMEOUT_MS,
+        DEFAULT_TEARDOWN_TIMEOUT_MS,
         () => log.debug('restoreAllMocks timed out during teardown'),
       );
     } catch (error) {

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -1,6 +1,6 @@
 import { createIpcInterceptor } from '@wdio/native-spy/interceptor';
 import type { DioxusServiceAPI } from '@wdio/native-types';
-import { createLogger } from '@wdio/native-utils';
+import { createLogger, isBenignTeardownError, runBounded } from '@wdio/native-utils';
 
 import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from './commands/allMocks.js';
 import { execute } from './commands/execute.js';
@@ -15,62 +15,31 @@ const interceptor = createIpcInterceptor('dioxus');
 
 const SESSION_DELETE_TIMEOUT_MS = 10_000;
 
-// During teardown the embedded driver may already have dropped the session (or
-// be mid-shutdown), so a DELETE races the server going away. The benign
-// outcomes — session already gone, or the connection closing under us — must
-// not propagate: on Windows webdriverio retries the DELETE, the socket closes
-// (UND_ERR_CLOSED), and a libuv double-close assertion crashes the worker
-// (0xC0000409) AFTER the test itself passed. Swallow-and-debug those here.
-const BENIGN_TEARDOWN_ERROR_PATTERNS = [
-  'session not found',
-  'invalid session id',
-  'session id is null',
-  'und_err_closed',
-  'econnreset',
-  'econnrefused',
-  'socket hang up',
-  'other side closed',
-];
-
-function isBenignTeardownError(error: unknown): boolean {
-  const haystack = `${(error as { message?: string })?.message ?? error ?? ''} ${
-    (error as { code?: string })?.code ?? ''
-  }`.toLowerCase();
-  return BENIGN_TEARDOWN_ERROR_PATTERNS.some((pattern) => haystack.includes(pattern));
-}
-
 /**
  * Delete a WebDriver session defensively during teardown. Bounded by a timeout
  * so a hanging/retrying DELETE can't block the worker until the CI step timeout,
  * and benign "session already gone / connection closed" errors are debug-logged
- * rather than rethrown (they otherwise escalate into the libuv crash above).
+ * rather than rethrown — left to propagate, the retried DELETE closes the socket
+ * and a libuv double-close assertion crashes the Windows worker after the test
+ * already passed. See @wdio/native-utils teardown helpers.
  */
 async function safeDeleteSession(browser: WebdriverIO.Browser, label: string): Promise<void> {
   if (!browser.sessionId) {
     return;
   }
   log.debug(`Deleting session${label ? ` for ${label}` : ''}: ${browser.sessionId}`);
-  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.race([
-      browser.deleteSession(),
-      new Promise<void>((resolve) => {
-        timer = setTimeout(() => {
-          log.debug(`deleteSession timed out after ${SESSION_DELETE_TIMEOUT_MS}ms${label ? ` (${label})` : ''}`);
-          resolve();
-        }, SESSION_DELETE_TIMEOUT_MS);
-      }),
-    ]);
+    await runBounded(
+      () => browser.deleteSession(),
+      SESSION_DELETE_TIMEOUT_MS,
+      () => log.debug(`deleteSession timed out after ${SESSION_DELETE_TIMEOUT_MS}ms${label ? ` (${label})` : ''}`),
+    );
   } catch (error) {
     if (isBenignTeardownError(error)) {
       log.debug(`Ignoring benign teardown error during deleteSession${label ? ` (${label})` : ''}:`, error);
       return;
     }
     throw error;
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
   }
 }
 

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -13,7 +13,7 @@ import { clearWindowState, listWindowLabels, switchWindowByLabel } from './windo
 const log = createLogger('dioxus-service', 'service');
 const interceptor = createIpcInterceptor('dioxus');
 
-const SESSION_DELETE_TIMEOUT_MS = 10_000;
+const TEARDOWN_TIMEOUT_MS = 10_000;
 
 /**
  * Delete a WebDriver session defensively during teardown. Bounded by a timeout
@@ -31,8 +31,8 @@ async function safeDeleteSession(browser: WebdriverIO.Browser, label: string): P
   try {
     await runBounded(
       () => browser.deleteSession(),
-      SESSION_DELETE_TIMEOUT_MS,
-      () => log.debug(`deleteSession timed out after ${SESSION_DELETE_TIMEOUT_MS}ms${label ? ` (${label})` : ''}`),
+      TEARDOWN_TIMEOUT_MS,
+      () => log.debug(`deleteSession timed out after ${TEARDOWN_TIMEOUT_MS}ms${label ? ` (${label})` : ''}`),
     );
   } catch (error) {
     if (isBenignTeardownError(error)) {
@@ -123,9 +123,20 @@ export default class DioxusWorkerService {
     log.debug('DioxusWorkerService.afterSession — deleting WebDriver session');
 
     try {
-      await restoreAllMocks();
+      // Bound + benign-swallow like the delete below: if the app has already
+      // exited, restoreAllMocks()'s browser.execute() can hang on a half-open
+      // socket and block the worker before safeDeleteSession() is ever reached.
+      await runBounded(
+        () => restoreAllMocks(),
+        TEARDOWN_TIMEOUT_MS,
+        () => log.debug('restoreAllMocks timed out during teardown'),
+      );
     } catch (error) {
-      log.warn('Failed to restore mocks during session cleanup:', error);
+      if (isBenignTeardownError(error)) {
+        log.debug('Ignoring benign teardown error during restoreAllMocks:', error);
+      } else {
+        log.warn('Failed to restore mocks during session cleanup:', error);
+      }
     } finally {
       // Clear unconditionally — if restoreAllMocks() throws (commonly when the
       // browser session has already gone away and execute() rejects), leaving

--- a/packages/dioxus-service/src/service.ts
+++ b/packages/dioxus-service/src/service.ts
@@ -13,6 +13,67 @@ import { clearWindowState, listWindowLabels, switchWindowByLabel } from './windo
 const log = createLogger('dioxus-service', 'service');
 const interceptor = createIpcInterceptor('dioxus');
 
+const SESSION_DELETE_TIMEOUT_MS = 10_000;
+
+// During teardown the embedded driver may already have dropped the session (or
+// be mid-shutdown), so a DELETE races the server going away. The benign
+// outcomes — session already gone, or the connection closing under us — must
+// not propagate: on Windows webdriverio retries the DELETE, the socket closes
+// (UND_ERR_CLOSED), and a libuv double-close assertion crashes the worker
+// (0xC0000409) AFTER the test itself passed. Swallow-and-debug those here.
+const BENIGN_TEARDOWN_ERROR_PATTERNS = [
+  'session not found',
+  'invalid session id',
+  'session id is null',
+  'und_err_closed',
+  'econnreset',
+  'econnrefused',
+  'socket hang up',
+  'other side closed',
+];
+
+function isBenignTeardownError(error: unknown): boolean {
+  const haystack = `${(error as { message?: string })?.message ?? error ?? ''} ${
+    (error as { code?: string })?.code ?? ''
+  }`.toLowerCase();
+  return BENIGN_TEARDOWN_ERROR_PATTERNS.some((pattern) => haystack.includes(pattern));
+}
+
+/**
+ * Delete a WebDriver session defensively during teardown. Bounded by a timeout
+ * so a hanging/retrying DELETE can't block the worker until the CI step timeout,
+ * and benign "session already gone / connection closed" errors are debug-logged
+ * rather than rethrown (they otherwise escalate into the libuv crash above).
+ */
+async function safeDeleteSession(browser: WebdriverIO.Browser, label: string): Promise<void> {
+  if (!browser.sessionId) {
+    return;
+  }
+  log.debug(`Deleting session${label ? ` for ${label}` : ''}: ${browser.sessionId}`);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      browser.deleteSession(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          log.debug(`deleteSession timed out after ${SESSION_DELETE_TIMEOUT_MS}ms${label ? ` (${label})` : ''}`);
+          resolve();
+        }, SESSION_DELETE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (error) {
+    if (isBenignTeardownError(error)) {
+      log.debug(`Ignoring benign teardown error during deleteSession${label ? ` (${label})` : ''}:`, error);
+      return;
+    }
+    throw error;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 export default class DioxusWorkerService {
   private browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser;
   private devServerUrl?: string;
@@ -111,20 +172,12 @@ export default class DioxusWorkerService {
 
     try {
       if (!this.browser.isMultiremote) {
-        const stdBrowser = this.browser as WebdriverIO.Browser;
-        if (stdBrowser.sessionId) {
-          log.debug(`Deleting session: ${stdBrowser.sessionId}`);
-          await stdBrowser.deleteSession();
-        }
+        await safeDeleteSession(this.browser as WebdriverIO.Browser, '');
       } else {
         const mrBrowser = this.browser as WebdriverIO.MultiRemoteBrowser;
         for (const instanceName of mrBrowser.instances) {
           try {
-            const instance = mrBrowser.getInstance(instanceName);
-            if (instance.sessionId) {
-              log.debug(`Deleting session for instance ${instanceName}: ${instance.sessionId}`);
-              await instance.deleteSession();
-            }
+            await safeDeleteSession(mrBrowser.getInstance(instanceName), `instance ${instanceName}`);
           } catch (error) {
             log.warn(`Failed to delete session for instance ${instanceName}:`, error);
           }

--- a/packages/dioxus-service/test/service.spec.ts
+++ b/packages/dioxus-service/test/service.spec.ts
@@ -140,6 +140,63 @@ describe('DioxusWorkerService', () => {
     expect(mockStore.getMocks()).toHaveLength(0);
   });
 
+  describe('afterSession() session teardown', () => {
+    function makeNativeBrowser(deleteSession: () => Promise<void>): WebdriverIO.Browser {
+      return {
+        isMultiremote: false,
+        sessionId: 'sess-1',
+        execute: vi.fn().mockResolvedValue(undefined),
+        deleteSession: vi.fn(deleteSession),
+      } as unknown as WebdriverIO.Browser;
+    }
+
+    it('should delete the session when one is present', async () => {
+      const browser = makeNativeBrowser(() => Promise.resolve());
+      const service = new DioxusWorkerService({}, {});
+      await service.before({}, [], browser);
+
+      await service.afterSession();
+
+      expect(browser.deleteSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('should swallow a benign "Session not found" error instead of rethrowing', async () => {
+      // The Windows flake: deleteSession sees the session already gone; left to
+      // propagate it triggers a retry that closes the socket and crashes libuv.
+      const browser = makeNativeBrowser(() => Promise.reject(new Error('Session not found')));
+      const service = new DioxusWorkerService({}, {});
+      await service.before({}, [], browser);
+
+      await expect(service.afterSession()).resolves.toBeUndefined();
+      expect(browser.deleteSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('should swallow a connection-closed (UND_ERR_CLOSED) error during teardown', async () => {
+      const closed = Object.assign(new Error('other side closed'), { code: 'UND_ERR_CLOSED' });
+      const browser = makeNativeBrowser(() => Promise.reject(closed));
+      const service = new DioxusWorkerService({}, {});
+      await service.before({}, [], browser);
+
+      await expect(service.afterSession()).resolves.toBeUndefined();
+    });
+
+    it('should not hang when deleteSession never settles (bounded by timeout)', async () => {
+      vi.useFakeTimers();
+      try {
+        const browser = makeNativeBrowser(() => new Promise<void>(() => {}));
+        const service = new DioxusWorkerService({}, {});
+        await service.before({}, [], browser);
+
+        const pending = service.afterSession();
+        await vi.advanceTimersByTimeAsync(10_000);
+
+        await expect(pending).resolves.toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('browser mode (mode: "browser")', () => {
     it('should navigate to devServerUrl in before()', async () => {
       const urlSpy = vi.fn().mockResolvedValue(undefined);

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -9,7 +9,13 @@ import type {
   ElectronType,
   ExecuteOpts,
 } from '@wdio/native-types';
-import { createLogger, isBenignTeardownError, runBounded, waitUntilWindowAvailable } from '@wdio/native-utils';
+import {
+  createLogger,
+  DEFAULT_TEARDOWN_TIMEOUT_MS,
+  isBenignTeardownError,
+  runBounded,
+  waitUntilWindowAvailable,
+} from '@wdio/native-utils';
 import type { Capabilities, Services } from '@wdio/types';
 import { SevereServiceError } from 'webdriverio';
 import { ElectronCdpBridge, getDebuggerEndpoint } from './bridge.js';
@@ -130,8 +136,6 @@ function getMockUpdateScheduler(browser: WebdriverIO.Browser): MockUpdateSchedul
 }
 
 const log = createLogger('electron-service', 'service');
-
-const TEARDOWN_TIMEOUT_MS = 10_000;
 
 type ElementCommands = 'click' | 'doubleClick' | 'setValue' | 'clearValue';
 
@@ -330,7 +334,7 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
     try {
       await runBounded(
         () => restoreAllMocks(),
-        TEARDOWN_TIMEOUT_MS,
+        DEFAULT_TEARDOWN_TIMEOUT_MS,
         () => log.debug('restoreAllMocks timed out during teardown'),
       );
     } catch (error) {

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -131,6 +131,54 @@ function getMockUpdateScheduler(browser: WebdriverIO.Browser): MockUpdateSchedul
 
 const log = createLogger('electron-service', 'service');
 
+const TEARDOWN_TIMEOUT_MS = 10_000;
+
+// CDP teardown failure modes that are benign once the debugger socket is gone:
+// the bridge reports "WebSocket is not connected" / "connection has been
+// closed", or the underlying socket drops (UND_ERR_CLOSED / ECONNRESET). These
+// must not fail an otherwise-green run.
+const BENIGN_TEARDOWN_ERROR_PATTERNS = [
+  'websocket is not connected',
+  'connection has been closed',
+  'connection closed',
+  'und_err_closed',
+  'econnreset',
+  'econnrefused',
+  'socket hang up',
+  'other side closed',
+];
+
+function isBenignTeardownError(error: unknown): boolean {
+  const haystack = `${(error as { message?: string })?.message ?? error ?? ''} ${
+    (error as { code?: string })?.code ?? ''
+  }`.toLowerCase();
+  return BENIGN_TEARDOWN_ERROR_PATTERNS.some((pattern) => haystack.includes(pattern));
+}
+
+/**
+ * Run a teardown operation bounded by a timeout so a stalled CDP round-trip
+ * can't block the hook until the CI step timeout. On timeout the operation is
+ * abandoned (settled to undefined) rather than rejected — teardown is best-effort.
+ */
+async function runBounded<T>(op: () => Promise<T>, timeoutMs: number, label: string): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      op(),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => {
+          log.debug(`${label} timed out after ${timeoutMs}ms during teardown`);
+          resolve(undefined);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 type ElementCommands = 'click' | 'doubleClick' | 'setValue' | 'clearValue';
 
 export default class ElectronWorkerService extends ServiceConfig implements Services.ServiceInstance {
@@ -318,8 +366,24 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
   }
 
   async afterSession() {
-    await restoreAllMocks();
-    mockStore.clear();
+    // restoreAllMocks() drives a CDP send() per mock. During teardown the
+    // debugger socket may already be gone, so a send() either rejects with
+    // "WebSocket is not connected" or stalls against a half-open socket until
+    // each per-command timeout fires — on Windows this hangs the worker until
+    // the CI step timeout kills it, AFTER the test passed. Bound it and swallow
+    // benign disconnect errors so teardown always completes. mockStore.clear()
+    // must still run regardless so the next session starts with a clean store.
+    try {
+      await runBounded(() => restoreAllMocks(), TEARDOWN_TIMEOUT_MS, 'restoreAllMocks');
+    } catch (error) {
+      if (isBenignTeardownError(error)) {
+        log.debug('Ignoring benign teardown error during restoreAllMocks:', error);
+      } else {
+        log.warn('Failed to restore mocks during session cleanup:', error);
+      }
+    } finally {
+      mockStore.clear();
+    }
   }
 
   /**

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -9,7 +9,7 @@ import type {
   ElectronType,
   ExecuteOpts,
 } from '@wdio/native-types';
-import { createLogger, waitUntilWindowAvailable } from '@wdio/native-utils';
+import { createLogger, isBenignTeardownError, runBounded, waitUntilWindowAvailable } from '@wdio/native-utils';
 import type { Capabilities, Services } from '@wdio/types';
 import { SevereServiceError } from 'webdriverio';
 import { ElectronCdpBridge, getDebuggerEndpoint } from './bridge.js';
@@ -132,52 +132,6 @@ function getMockUpdateScheduler(browser: WebdriverIO.Browser): MockUpdateSchedul
 const log = createLogger('electron-service', 'service');
 
 const TEARDOWN_TIMEOUT_MS = 10_000;
-
-// CDP teardown failure modes that are benign once the debugger socket is gone:
-// the bridge reports "WebSocket is not connected" / "connection has been
-// closed", or the underlying socket drops (UND_ERR_CLOSED / ECONNRESET). These
-// must not fail an otherwise-green run.
-const BENIGN_TEARDOWN_ERROR_PATTERNS = [
-  'websocket is not connected',
-  'connection has been closed',
-  'connection closed',
-  'und_err_closed',
-  'econnreset',
-  'econnrefused',
-  'socket hang up',
-  'other side closed',
-];
-
-function isBenignTeardownError(error: unknown): boolean {
-  const haystack = `${(error as { message?: string })?.message ?? error ?? ''} ${
-    (error as { code?: string })?.code ?? ''
-  }`.toLowerCase();
-  return BENIGN_TEARDOWN_ERROR_PATTERNS.some((pattern) => haystack.includes(pattern));
-}
-
-/**
- * Run a teardown operation bounded by a timeout so a stalled CDP round-trip
- * can't block the hook until the CI step timeout. On timeout the operation is
- * abandoned (settled to undefined) rather than rejected — teardown is best-effort.
- */
-async function runBounded<T>(op: () => Promise<T>, timeoutMs: number, label: string): Promise<T | undefined> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      op(),
-      new Promise<undefined>((resolve) => {
-        timer = setTimeout(() => {
-          log.debug(`${label} timed out after ${timeoutMs}ms during teardown`);
-          resolve(undefined);
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
 
 type ElementCommands = 'click' | 'doubleClick' | 'setValue' | 'clearValue';
 
@@ -374,7 +328,11 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
     // benign disconnect errors so teardown always completes. mockStore.clear()
     // must still run regardless so the next session starts with a clean store.
     try {
-      await runBounded(() => restoreAllMocks(), TEARDOWN_TIMEOUT_MS, 'restoreAllMocks');
+      await runBounded(
+        () => restoreAllMocks(),
+        TEARDOWN_TIMEOUT_MS,
+        () => log.debug('restoreAllMocks timed out during teardown'),
+      );
     } catch (error) {
       if (isBenignTeardownError(error)) {
         log.debug('Ignoring benign teardown error during restoreAllMocks:', error);

--- a/packages/electron-service/test/mocks/native-utils.ts
+++ b/packages/electron-service/test/mocks/native-utils.ts
@@ -43,3 +43,12 @@ export const wrapAsync = vi.fn();
 // Select executable
 export const selectExecutable = vi.fn();
 export const validateBinaryPaths = vi.fn();
+
+// Teardown helpers are pure utilities the service depends on for real behavior
+// (bounded timeout, benign-error matching) — re-export the actual source rather
+// than stub them, so afterSession() tests exercise the real logic.
+export {
+  BENIGN_TEARDOWN_ERROR_PATTERNS,
+  isBenignTeardownError,
+  runBounded,
+} from '../../../native-utils/src/teardown.js';

--- a/packages/electron-service/test/mocks/native-utils.ts
+++ b/packages/electron-service/test/mocks/native-utils.ts
@@ -49,6 +49,7 @@ export const validateBinaryPaths = vi.fn();
 // than stub them, so afterSession() tests exercise the real logic.
 export {
   BENIGN_TEARDOWN_ERROR_PATTERNS,
+  DEFAULT_TEARDOWN_TIMEOUT_MS,
   isBenignTeardownError,
   runBounded,
 } from '../../../native-utils/src/teardown.js';

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -8,6 +8,7 @@ import { mock } from '../src/commands/mock.js';
 import { mockAll } from '../src/commands/mockAll.js';
 import { resetAllMocks } from '../src/commands/resetAllMocks.js';
 import { restoreAllMocks } from '../src/commands/restoreAllMocks.js';
+import mockStore from '../src/mockStore.js';
 import ElectronWorkerService from '../src/service.js';
 import { clearPuppeteerSessions, ensureActiveWindowFocus } from '../src/window.js';
 import { mockProcessProperty } from './helpers.js';
@@ -71,6 +72,7 @@ vi.mock('../src/mockStore', () => {
         throw new Error('No mock registered for key');
       }),
       setMockWithKey: vi.fn(),
+      clear: vi.fn(),
     },
   };
 });
@@ -1277,5 +1279,52 @@ describe('Electron Worker Service', () => {
         await expect(perInstanceBrowser.electron.mock('read_file')).resolves.toBeDefined();
       });
     });
+  });
+});
+
+describe('Electron Worker Service - afterSession()', () => {
+  it('should restore mocks, then clear the mock store', async () => {
+    vi.mocked(restoreAllMocks).mockResolvedValueOnce(undefined);
+    const instance = new ElectronWorkerService({}, {});
+
+    await instance.afterSession();
+
+    expect(restoreAllMocks).toHaveBeenCalledTimes(1);
+    expect(mockStore.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('should swallow a benign CDP disconnect error and still clear the store', async () => {
+    // The Windows hang: a CDP send() during teardown rejects with "WebSocket is
+    // not connected" once the debugger socket is gone; left to propagate it fails
+    // an otherwise-green run. It must be swallowed, and the store still cleared.
+    vi.mocked(restoreAllMocks).mockRejectedValueOnce(new Error('WebSocket is not connected'));
+    const instance = new ElectronWorkerService({}, {});
+
+    await expect(instance.afterSession()).resolves.toBeUndefined();
+    expect(mockStore.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still clear the store after a non-benign restore error', async () => {
+    vi.mocked(restoreAllMocks).mockRejectedValueOnce(new Error('unexpected teardown failure'));
+    const instance = new ElectronWorkerService({}, {});
+
+    await expect(instance.afterSession()).resolves.toBeUndefined();
+    expect(mockStore.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not hang when restoreAllMocks never settles, bounded by timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(restoreAllMocks).mockImplementationOnce(() => new Promise<void>(() => {}));
+      const instance = new ElectronWorkerService({}, {});
+
+      const pending = instance.afterSession();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(mockStore.clear).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/native-utils/src/index.ts
+++ b/packages/native-utils/src/index.ts
@@ -27,5 +27,6 @@ export {
 } from './result.js';
 export { hasSemicolonOutsideQuotes, hasTopLevelArrow } from './script-detect.js';
 export { selectExecutable, validateBinaryPaths } from './selectExecutable.js';
+export { BENIGN_TEARDOWN_ERROR_PATTERNS, isBenignTeardownError, runBounded } from './teardown.js';
 export { waitUntilWindowAvailable } from './window.js';
 export { createLogger };

--- a/packages/native-utils/src/index.ts
+++ b/packages/native-utils/src/index.ts
@@ -27,6 +27,11 @@ export {
 } from './result.js';
 export { hasSemicolonOutsideQuotes, hasTopLevelArrow } from './script-detect.js';
 export { selectExecutable, validateBinaryPaths } from './selectExecutable.js';
-export { BENIGN_TEARDOWN_ERROR_PATTERNS, isBenignTeardownError, runBounded } from './teardown.js';
+export {
+  BENIGN_TEARDOWN_ERROR_PATTERNS,
+  DEFAULT_TEARDOWN_TIMEOUT_MS,
+  isBenignTeardownError,
+  runBounded,
+} from './teardown.js';
 export { waitUntilWindowAvailable } from './window.js';
 export { createLogger };

--- a/packages/native-utils/src/teardown.ts
+++ b/packages/native-utils/src/teardown.ts
@@ -1,0 +1,64 @@
+/**
+ * Helpers shared by the WDIO services for defensive session teardown.
+ *
+ * During teardown the driver/debugger socket is frequently already gone, so a
+ * session DELETE or CDP round-trip either rejects with a benign "already
+ * closed / not found" error or stalls against a half-open socket. On Windows a
+ * propagated or retried teardown error can crash the worker (libuv
+ * `UV_HANDLE_CLOSING`, exit `0xC0000409`) or hang it until the CI step timeout —
+ * in both cases *after* the test already passed. These helpers let each service
+ * swallow benign teardown errors and bound the operations.
+ */
+
+// Benign teardown failure modes across providers: WebDriver session lifecycle,
+// CDP-bridge disconnects, and raw socket teardown. Matching a superset across
+// services is safe — every entry is benign once teardown has begun.
+export const BENIGN_TEARDOWN_ERROR_PATTERNS = [
+  'session not found',
+  'invalid session id',
+  'session id is null',
+  'websocket is not connected',
+  'connection has been closed',
+  'connection closed',
+  'und_err_closed',
+  'econnreset',
+  'econnrefused',
+  'socket hang up',
+  'other side closed',
+];
+
+export function isBenignTeardownError(error: unknown): boolean {
+  const haystack = `${(error as { message?: string })?.message ?? error ?? ''} ${
+    (error as { code?: string })?.code ?? ''
+  }`.toLowerCase();
+  return BENIGN_TEARDOWN_ERROR_PATTERNS.some((pattern) => haystack.includes(pattern));
+}
+
+/**
+ * Run a teardown operation bounded by a timeout so a stalled call can't block
+ * the hook until the CI step timeout. On timeout the operation is abandoned
+ * (the race settles to `undefined`) rather than rejected — teardown is
+ * best-effort. `onTimeout` lets the caller log with its own service logger.
+ */
+export async function runBounded<T>(
+  op: () => Promise<T>,
+  timeoutMs: number,
+  onTimeout?: () => void,
+): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      op(),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => {
+          onTimeout?.();
+          resolve(undefined);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/native-utils/src/teardown.ts
+++ b/packages/native-utils/src/teardown.ts
@@ -10,6 +10,12 @@
  * swallow benign teardown errors and bound the operations.
  */
 
+/**
+ * Default teardown deadline (ms): how long a single teardown op may run before
+ * it is abandoned. Shared so electron- and dioxus-service stay in sync.
+ */
+export const DEFAULT_TEARDOWN_TIMEOUT_MS = 10_000;
+
 // Benign teardown failure modes across providers: WebDriver session lifecycle,
 // CDP-bridge disconnects, and raw socket teardown. Matching a superset across
 // services is safe — every entry is benign once teardown has begun.
@@ -47,8 +53,15 @@ export async function runBounded<T>(
 ): Promise<T | undefined> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
+    // If the timeout wins, the abandoned op may still reject later (e.g. the OS
+    // resets the socket after the deadline). Attach a no-op rejection handler so
+    // that late rejection can't surface as an unhandledRejection — the very
+    // teardown crash this guard exists to prevent. The race still propagates a
+    // rejection that arrives before the timeout.
+    const opPromise = op();
+    opPromise.catch(() => {});
     return await Promise.race([
-      op(),
+      opPromise,
       new Promise<undefined>((resolve) => {
         timer = setTimeout(() => {
           onTimeout?.();

--- a/packages/native-utils/test/teardown.spec.ts
+++ b/packages/native-utils/test/teardown.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BENIGN_TEARDOWN_ERROR_PATTERNS, isBenignTeardownError, runBounded } from '../src/teardown.js';
+
+describe('isBenignTeardownError', () => {
+  it('should match a benign error by message', () => {
+    expect(isBenignTeardownError(new Error('WebSocket is not connected'))).toBe(true);
+    expect(isBenignTeardownError(new Error('Session not found'))).toBe(true);
+  });
+
+  it('should match a benign error by error code', () => {
+    expect(isBenignTeardownError(Object.assign(new Error('boom'), { code: 'UND_ERR_CLOSED' }))).toBe(true);
+  });
+
+  it('should match a plain string error', () => {
+    expect(isBenignTeardownError('socket hang up')).toBe(true);
+  });
+
+  it('should not match an unrelated error', () => {
+    expect(isBenignTeardownError(new Error('expected 1 to equal 2'))).toBe(false);
+  });
+
+  it('should not match undefined', () => {
+    expect(isBenignTeardownError(undefined)).toBe(false);
+  });
+
+  it('should expose a non-empty pattern list', () => {
+    expect(BENIGN_TEARDOWN_ERROR_PATTERNS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('runBounded', () => {
+  it('should return the operation result when it settles before the timeout', async () => {
+    await expect(runBounded(() => Promise.resolve('done'), 1000)).resolves.toBe('done');
+  });
+
+  it('should propagate a rejection from the operation', async () => {
+    await expect(runBounded(() => Promise.reject(new Error('nope')), 1000)).rejects.toThrow('nope');
+  });
+
+  it('should resolve to undefined and call onTimeout when the operation stalls', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const pending = runBounded(() => new Promise<string>(() => {}), 5000, onTimeout);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should clear the timer when the operation settles first', async () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    try {
+      await runBounded(() => Promise.resolve('x'), 5000);
+      expect(clearSpy).toHaveBeenCalled();
+    } finally {
+      clearSpy.mockRestore();
+    }
+  });
+});

--- a/packages/native-utils/test/teardown.spec.ts
+++ b/packages/native-utils/test/teardown.spec.ts
@@ -60,4 +60,35 @@ describe('runBounded', () => {
       clearSpy.mockRestore();
     }
   });
+
+  it('should swallow a late rejection from the abandoned op without an unhandledRejection', async () => {
+    // Guards the no-op .catch on the abandoned op promise: if the timeout wins
+    // and the stalled op rejects LATER (e.g. the OS resets the socket after the
+    // deadline), that must not become an unhandledRejection — the very teardown
+    // crash runBounded exists to prevent.
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      vi.useFakeTimers();
+      let rejectOp!: (reason: unknown) => void;
+      const pending = runBounded(
+        () =>
+          new Promise<string>((_, reject) => {
+            rejectOp = reject;
+          }),
+        5000,
+      );
+      await vi.advanceTimersByTimeAsync(5000);
+      await expect(pending).resolves.toBeUndefined();
+
+      rejectOp(new Error('socket reset after teardown deadline'));
+      vi.useRealTimers();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      process.off('unhandledRejection', unhandled);
+    }
+  });
 });


### PR DESCRIPTION
## Problem

Two Windows-only **session-teardown** flakes turn otherwise-green runs red. In both, the test assertions PASS and the failure happens during teardown — a benign teardown error escalates into a process crash or hang.

**1. Dioxus — `E2E - Dioxus [Windows] - standalone` (libuv crash `0xC0000409`)**
Assertions pass, then during teardown the embedded-driver session DELETE returns `Session not found` → webdriverio retries the DELETE → `UND_ERR_CLOSED` → a libuv NATIVE assertion `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76` → the worker exits with `0xC0000409` (3221226505). A benign "session already gone" error escalates into a process crash that fails a passing run.

**2. Electron — `E2E - Electron [Windows] - builder/forge` (CDP teardown hang)**
`15 passing`, then a CDP teardown error `WebSocket is not connected. Call 'CdpBridge.connect()' before using this method` and the worker **hangs** until the 5-minute step timeout kills it.

## Root cause

Benign teardown errors — *session already deleted*, *websocket already closed*, *connection closed / `UND_ERR_CLOSED`* — are allowed to propagate (Dioxus, where the retry races the driver shutdown into a native double-close) or to stall an unbounded teardown call (Electron, where a CDP `send()` against a dead/half-open socket either rejects or waits on per-command timeouts). Neither is wrapped to be swallowed-and-bounded.

## What this PR changes

**`packages/dioxus-service/src/service.ts`** — adds `safeDeleteSession()`, used by `afterSession()` for both single-remote and multiremote paths. It:
- **bounds** `deleteSession()` with a 10s timeout race so a hanging/retrying DELETE can't block the worker until the CI step timeout; on timeout it settles and lets teardown proceed;
- **swallows-and-debug-logs** benign teardown errors (`session not found`, `invalid session id`, `und_err_closed`, `econnreset`/`econnrefused`, `socket hang up`, `other side closed`) instead of rethrowing into the crashing retry.

This targets the **Dioxus libuv crash**.

**`packages/dioxus-service/src/providers/embedded.ts`** — `stopEmbeddedDriver()` now **skips `kill()` when the process has already exited** (`exitCode`/`signalCode` set), avoiding a spurious `ESRCH` `error` event during the teardown race. Defence-in-depth for the same Dioxus crash (guards against issuing teardown ops on an already-exited driver).

**`packages/electron-service/src/service.ts`** — adds `runBounded()` + benign-error matcher; `afterSession()` now runs `restoreAllMocks()` **bounded by a 10s timeout** and **swallows benign CDP disconnect errors** at debug level. `mockStore.clear()` still runs unconditionally so the next session starts clean. This targets the **Electron CDP-teardown hang**.

**`packages/dioxus-service/test/service.spec.ts`** — 4 regression tests for the Dioxus path: deletes when a session is present; swallows `Session not found`; swallows a connection-closed (`UND_ERR_CLOSED`) error; does not hang when `deleteSession()` never settles (fake-timer bounded).

Each swallowed-error guard carries a one-line WHY comment (benign teardown error was crashing/hanging the Windows run). No startup logic, retry counts, or connection behaviour was changed.

## What this PR deliberately does NOT address (follow-ups)

This is a **"harden teardown"** improvement, not a claimed full fix. The separate Windows driver-**STARTUP** races are out of scope and remain follow-ups:
- Dioxus embedded WebDriver server not reachable at session start.
- Electron CDP `connect()` timeout at session start.

## Validation

Local (macOS), warm pnpm store:
- `pnpm install --frozen-lockfile` — ok
- `pnpm --filter @wdio/dioxus-service... --filter @wdio/electron-service... build` — ok
- `pnpm --filter @wdio/dioxus-service typecheck` — ok (0 errors)
- `pnpm --filter @wdio/electron-service typecheck` — ok (0 errors)
- `pnpm --filter @wdio/dioxus-service test:unit` — 125 passed (incl. 4 new)
- `pnpm --filter @wdio/electron-service test:unit` — 507 passed
- biome + eslint on changed files — clean (no new findings)

The teardown crash/hang reproduces only on Windows CI, so **the actual fix needs CI validation on Windows** — local checks confirm compilation, typing, and that existing + new unit behaviour is green, but cannot reproduce the native libuv assertion or the CDP socket race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)