### PR TITLE
ci: harden Linux E2E against runner disk exhaustion

### DIFF
--- a/.github/workflows/_ci-e2e.reusable.yml
+++ b/.github/workflows/_ci-e2e.reusable.yml
@@ -84,6 +84,12 @@ jobs:
           sudo rm -rf /usr/local/.ghcup || true
           sudo rm -rf /opt/hostedtoolcache/CodeQL || true
           sudo rm -rf /usr/share/swift || true
+          sudo rm -rf /usr/lib/jvm || true
+          sudo rm -rf /usr/local/share/powershell || true
+          sudo rm -rf /usr/local/share/boost || true
+          sudo rm -rf /usr/local/graalvm || true
+          sudo rm -rf /opt/hostedtoolcache/Ruby /opt/hostedtoolcache/go /opt/hostedtoolcache/PyPy || true
+          sudo apt-get clean || true
           sudo docker image prune --all --force || true
           echo "=== Disk usage after cleanup ==="
           df -h /
@@ -289,3 +295,23 @@ jobs:
         if: failure()
         with:
           timeout: '300000'
+
+      # The build/install footprint can fill the runner disk by job end, which
+      # then fails the job's post-actions as they write to a full disk. Tests and
+      # log upload are done by here; reclaim that footprint. Runs last so the
+      # failure-debug steps above still see the build artifacts.
+      - name: 🧹 Reclaim disk before teardown (Linux)
+        if: always() && runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "=== Disk before teardown cleanup ==="
+          df -h /
+          rm -rf ~/.cache/electron ~/.cache/electron-builder 2>/dev/null || true
+          store="$(pnpm store path 2>/dev/null || true)"
+          if [ -n "$store" ]; then
+            rm -rf "$store" 2>/dev/null || true
+          fi
+          find "$GITHUB_WORKSPACE" -type d -name node_modules -prune -exec rm -rf {} + 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -type d \( -name dist-electron -o -name out \) -prune -exec rm -rf {} + 2>/dev/null || true
+          echo "=== Disk after teardown cleanup ==="
+          df -h /


### PR DESCRIPTION
## Problem

GitHub runners vary in starting free disk, so the Electron Linux E2E job can hit ENOSPC two ways:
- **During the test** — the runner Worker crashes (`No space left` writing its own diag log); steps from Execute-E2E onward never run.
- **At teardown** — tests + log upload pass, but the post-actions fail writing to a full disk, marking an otherwise-green job red.

#305 reduced this but doesn't fully eliminate it on tight runners.

## Fix — two layers on top of #305's free-disk step

1. **More upfront headroom** — free additional unused preinstalled toolchains (jvm, powershell, boost, graalvm, Ruby/go/PyPy tool-caches, apt cache). Node + Python are kept (the build needs them).
2. **Pre-teardown reclaim** — a final `always()` step that removes the build/install footprint (electron caches, pnpm store + node_modules, `dist-electron`/`out`) so post-actions have room. Runs after the failure-debug steps so they still see artifacts.

`df -h /` brackets both for visibility. No change to the tests themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
