### PR TITLE
feat(electrobun): PR1 foundation — package skeletons + native-types wiring

### DIFF
--- a/agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md
+++ b/agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md
@@ -1,0 +1,66 @@
+# Electrobun Service Research — Phase 0 Spike Findings
+
+**Date:** May 28, 2026
+**Status:** SPIKE COMPLETE — macOS leg validated
+**Goal:** Confirm a WebdriverIO CDP-attach service can drive a CEF-rendered Electrobun app, and pin down the architecture before the MVP PR.
+
+---
+
+## 🎯 Executive Summary
+
+**RECOMMENDATION: ✅ GO (macOS validated) — CDP-attach + Chromedriver `debuggerAddress` is viable.**
+
+A throwaway CEF Electrobun app was built and driven end-to-end on macOS (darwin/arm64). Every load-bearing question passed: CEF serves CDP, Chromedriver attaches via `debuggerAddress` and drives elements, multiple windows enumerate as separate page targets, attach is observation-only (no `Page.navigate`), and macOS deeplinks reach the handler. The model mirrors `@wdio/electron-service`.
+
+The two biggest items for the MVP PR are **per-worker process isolation** (CEF is single-instance per `--user-data-dir`) and **Linux/Windows CDP availability** (only macOS validated here; Linux likely needs an upstream fix).
+
+### Environment validated
+- macOS darwin/arm64 only. Bun 1.3.13, Node v24.14.0.
+- Electrobun source `1.18.4-beta.3` (npm `latest` lags at `1.18.1`); CEF/Chromium `147.0.10 / 147.0.7727.118`.
+- Chromedriver `147.0.7727.117` (Chrome for Testing, mac-arm64) — matching on **major 147** is what matters.
+
+---
+
+## 📊 The six questions
+
+### 1. Per-OS CEF availability
+- **macOS: ✅ validated.** CEF serves CDP. `nativeWrapper.mm:~5847` scans `FindAvailableRemoteDebugPort(9222,9232)` then sets `settings.remote_debugging_port`.
+- **Linux: ⚠️ likely OFF.** `linux/nativeWrapper.cpp:~2386` has `settings.remote_debugging_port` **commented out** → a stock Linux CEF build may serve no `/json`. Validate in CI; likely needs an upstream patch or proof that `chromiumFlags` alone enables it.
+- **Windows: ❓ untested.**
+- The default **WebKit** renderer exposes no CDP on any OS — CEF-only. The service must require `bundleCEF: true` + `renderer: 'cef'`.
+
+### 2. Chromedriver-attach viability — ✅ YES
+Chromedriver `147.0.7727.117` opened a session with `goog:chromeOptions.debuggerAddress: localhost:9333`, reported `browserVersion 147.0.7727.118`, returned **both windows as handles**, found `#increment-button`/`#counter`, clicked 3× (counter 0→3), and read `#app-title`. Same attach shape as `@wdio/electron-service`. Exact-patch chromedriver isn't published; **match on major 147**.
+
+### 3. Port control — ✅ PINNABLE (inverts the going-in assumption)
+`mac.chromiumFlags: { "remote-debugging-port": "9333" }` pinned the port to **9333**, *overriding* the 9222–9232 auto-scan (9222 was free but unused). Mechanism: the wrapper both sets `CefSettings.remote_debugging_port` from the scan **and** appends `--remote-debugging-port` to the command line — **the command-line switch wins**. So the service CAN dictate the port, rather than only discover it.
+- ⚠️ **Concurrency caveat:** a 2nd launch of the same bundle logged `Opening in existing browser session.` and spawned **no second CEF** — CEF is **single-instance per `--user-data-dir`**. Parallel WDIO workers each need a **distinct `--user-data-dir` + distinct pinned port**.
+
+### 4. Target enumeration shape
+`/json` returned **2 targets, both `type:"page"`** — one per window (`views://mainview/index.html`, `views://secondview/index.html`). **No separate shell target**; each window/view is one content page. Discriminate by URL path under the custom `views://` scheme + title; in-page via `window.__electrobunWebviewId`/`WindowId` (main 1/1, second 2/2). Target IDs were **stable** across re-enumeration and equal to the handles Chromedriver returned. `Runtime.enable`/`evaluate`/`callFunctionOn` round-tripped **without `Page.navigate`**.
+
+### 5. In-webview IPC/RPC surface
+Every CEF webview exposes: `__electrobun` (`receiveMessageFromBun`, `receiveInternalMessageFromBun`), `__electrobunBunBridge`, `__electrobunInternalBridge`, `__electrobunEventBridge`, `__electrobunSendToHost` (fn), `__electrobun_encrypt`/`_decrypt` (fns), `__electrobunWebviewId`, `__electrobunWindowId`, `__electrobunRpcSocketPort` (50000), `__electrobunSecretKeyBytes`.
+- The **Bun backend bus IS reachable** from the webview via the host RPC WebSocket (`ws://localhost:<__electrobunRpcSocketPort>/socket?webviewId=<id>`), but payloads are **AES-encrypted** with the secret key.
+- **Tractable mock seam:** wrap `window.__electrobun.*` / `__electrobunSendToHost` before app code runs, via CDP `Page.addScriptToEvaluateOnNewDocument`. This surface differs materially from Electron's `ipcRenderer`/`contextBridge`.
+
+### 6. Deeplink — ✅ YES (macOS, warm start)
+`open electrobun-playground://test/path?foo=bar` reached the handler with the full URL. Scheme registered in `Info.plist` `CFBundleURLTypes`. Handler API: `app.on("open-url", …)` (**named export** `import { app } from "electrobun/bun"`) or `Electrobun.events.on("open-url", …)`. Only warm-start exercised; cold-start + Linux/Windows untested.
+
+---
+
+## 🚧 Blockers / must-handle for the MVP PR
+
+1. **Concurrent instances** *(biggest architectural item)* — one bundle = one CEF session per `--user-data-dir`; a 2nd launch folds into the 1st. Parallel/multiremote workers need a **per-worker `--user-data-dir` + distinct pinned `--remote-debugging-port`**. Confirm the port/user-data-dir can be passed at **launch time** (CLI/env), not only via build-time `electrobun.config.ts`.
+2. **Linux CDP off by default** (`remote_debugging_port` commented out) and **Windows unverified** — validate both in CI; Linux likely needs an upstream patch or a confirmed `chromiumFlags` path. Until then, macOS + Windows lead, Linux is a documented follow-up.
+3. **`1.18.4-beta.3` ships two defects** the spike had to patch around (pin a known-good release; don't rely on `file:` source linking):
+   - **B1:** dev `dist/` fallback only copies `main.js`, then `ENOENT dist/preload-full.js`.
+   - **B2 (hard crash):** the bundler renames `import {join}`→`join5` for the WGPU chunk but drops `dirname`, so the Bun worker dies on boot with `ReferenceError: dirname is not defined` in `findWgpuLibraryPath`.
+4. **Version skew** — npm `electrobun` 1.18.1 lags source/CEF 1.18.4-beta.3 / Chromium 147. Pin compatible Electrobun + chromedriver (major 147) explicitly.
+
+## API gotcha worth recording
+`app` is a **named export** (`import { app } from "electrobun/bun"`), not on the default export. `Electrobun.app.on(...)` throws; the default export only carries `.events`.
+
+---
+
+*Spike artifacts (throwaway, gitignored): `spike/electrobun-spike/` — `app/`, `scripts/`, `chromedriver/`, `app-stdout.log`. All processes/ports were cleaned up.*

--- a/packages/electrobun-cdp-bridge/README.md
+++ b/packages/electrobun-cdp-bridge/README.md
@@ -1,0 +1,28 @@
+# @wdio/electrobun-cdp-bridge
+
+Multi-target Chrome DevTools Protocol (CDP) bridge for the
+[`@wdio/electrobun-service`](../electrobun-service). It attaches to the CEF
+renderer that an [Electrobun](https://electrobun.dev) app exposes and routes CDP
+commands to a specific webview target.
+
+Unlike a single-target CDP client (e.g. `@wdio/electron-cdp-bridge`), Electrobun
+apps surface **one CDP page target per webview** — a `BrowserWindow` shell and
+each `BrowserView`/OOPIF content webview. This bridge discovers all of them from
+the `/json` endpoint, classifies and labels them, and lets the service route
+`execute`/mock/log traffic to the active target — backing the standard
+`switchWindow` / `listWindows` surface.
+
+> **Status:** pre-release (`1.0.0-next.x`). Part of the staged Electrobun service
+> rollout — this PR ships the package foundation (constants + types); the
+> connection manager lands in the MVP PR.
+
+## Platform note
+
+CDP is only available when the Electrobun app is built with the **CEF renderer**
+(`bundleCEF: true` / `defaultRenderer: 'cef'`). The default WebKit webviews
+(WKWebView on macOS, WebKitGTK on Linux) do not speak CDP. See the service
+README for details.
+
+## License
+
+MIT

--- a/packages/electrobun-cdp-bridge/package.json
+++ b/packages/electrobun-cdp-bridge/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@wdio/electrobun-cdp-bridge",
+  "version": "1.0.0-next.0",
+  "description": "Multi-target CDP Bridge for WebdriverIO Electrobun Service",
+  "author": "WebdriverIO Community",
+  "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/electrobun-cdp-bridge",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": [
+      {
+        "import": {
+          "types": "./dist/esm/index.d.ts",
+          "default": "./dist/esm/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/index.d.ts",
+          "default": "./dist/cjs/index.js"
+        }
+      },
+      "./dist/cjs/index.js"
+    ]
+  },
+  "engines": {
+    "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+  },
+  "scripts": {
+    "clean": "shx rm -rf dist coverage .turbo",
+    "build": "tsx ../../scripts/build-package.ts",
+    "dev": "tsx ../../scripts/build-package.ts --watch",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run --coverage",
+    "test:unit": "vitest run --coverage",
+    "test:dev": "vitest --coverage",
+    "lint": "biome check ."
+  },
+  "dependencies": {
+    "@wdio/native-utils": "workspace:*",
+    "wait-port": "^1.1.0",
+    "ws": "^8.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "@types/ws": "^8.18.1",
+    "@vitest/coverage-v8": "^4.1.7",
+    "cross-env": "^10.1.0",
+    "devtools-protocol": "^0.0.1634055",
+    "get-port": "^7.1.0",
+    "nock": "^14.0.15",
+    "shx": "^0.4.0",
+    "tslib": "^2.8.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webdriverio/desktop-mobile.git",
+    "directory": "packages/electrobun-cdp-bridge"
+  }
+}

--- a/packages/electrobun-cdp-bridge/src/constants.ts
+++ b/packages/electrobun-cdp-bridge/src/constants.ts
@@ -2,11 +2,12 @@ export const REQUEST_TIMEOUT = 10000;
 export const DEFAULT_HOSTNAME = 'localhost';
 
 /**
- * Default CEF remote-debugging port. Electrobun's CEF renderer auto-selects a
- * free port in [DEFAULT_PORT_RANGE_START, DEFAULT_PORT_RANGE_END] at app startup
- * (`FindAvailableRemoteDebugPort(9222, 9232)` in its native wrapper), falling
- * back to 9222. The launcher therefore *discovers* which port an instance chose
- * by scanning the range rather than dictating it — see the service launcher.
+ * CEF's default remote-debugging port and the auto-scan range its renderer uses
+ * when an app pins no port (`FindAvailableRemoteDebugPort(9222, 9232)` in the
+ * native wrapper). The service launcher does NOT rely on the scan: it pins a
+ * specific port per worker by writing `chromiumFlags.remote-debugging-port` into
+ * that worker's bundle `build.json`, so the bridge connects to a known
+ * `host:port`. This constant is the connection default/fallback.
  */
 export const DEFAULT_PORT = 9222;
 export const DEFAULT_PORT_RANGE_START = 9222;

--- a/packages/electrobun-cdp-bridge/src/constants.ts
+++ b/packages/electrobun-cdp-bridge/src/constants.ts
@@ -1,0 +1,28 @@
+export const REQUEST_TIMEOUT = 10000;
+export const DEFAULT_HOSTNAME = 'localhost';
+
+/**
+ * Default CEF remote-debugging port. Electrobun's CEF renderer auto-selects a
+ * free port in [DEFAULT_PORT_RANGE_START, DEFAULT_PORT_RANGE_END] at app startup
+ * (`FindAvailableRemoteDebugPort(9222, 9232)` in its native wrapper), falling
+ * back to 9222. The launcher therefore *discovers* which port an instance chose
+ * by scanning the range rather than dictating it — see the service launcher.
+ */
+export const DEFAULT_PORT = 9222;
+export const DEFAULT_PORT_RANGE_START = 9222;
+export const DEFAULT_PORT_RANGE_END = 9232;
+
+export const DEFAULT_MAX_RETRY_COUNT = 3;
+export const DEFAULT_RETRY_INTERVAL = 100;
+
+export const ERROR_MESSAGE = {
+  TIMEOUT_CONNECTION: 'Request timeout exceeded waiting for response:',
+  TIMEOUT_WAIT_PORT: 'Timeout exceeded while waiting for debugger port to open',
+  DEBUGGER_NOT_FOUND: 'No debugger instance was detected',
+  NO_PAGE_TARGETS: 'No CDP page targets were detected at the debugger endpoint',
+  TARGET_NOT_FOUND: 'No CDP target is registered for label:',
+  NOT_CONNECTED: "WebSocket is not connected. Call 'CdpBridge.connect()' before using this method",
+  CONNECTION_CLOSED: 'WebSocket connection has been closed',
+  ERROR_PARSE_JSON: 'Failed to parse JSON response:',
+  ERROR_INTERNAL: 'Connection closed due to error:',
+} as const;

--- a/packages/electrobun-cdp-bridge/src/index.ts
+++ b/packages/electrobun-cdp-bridge/src/index.ts
@@ -1,0 +1,7 @@
+// @wdio/electrobun-cdp-bridge — multi-target CDP client for Electrobun's CEF
+// renderer. PR1 ships the constants + types; the multi-target connection
+// manager (bridge.ts, devTool.ts, connection.ts, targetRegistry.ts) lands in
+// the MVP PR.
+
+export * from './constants.js';
+export * from './types.js';

--- a/packages/electrobun-cdp-bridge/src/types.ts
+++ b/packages/electrobun-cdp-bridge/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * A single entry from the CDP `/json` discovery endpoint. Electrobun's CEF
+ * renderer exposes one entry per webview (a `BrowserWindow` shell or a
+ * `BrowserView`/OOPIF content webview), so unlike Electron we keep *all* the
+ * `type === 'page'` entries rather than just the first.
+ */
+export type Debugger = {
+  description: string;
+  devtoolsFrontendUrl: string;
+  devtoolsFrontendUrlCompat: string;
+  faviconUrl: string;
+  id: string;
+  title: string;
+  type: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+};
+
+export type Version = {
+  browser: string;
+  protocolVersion: string;
+};
+
+export type DebuggerList = Array<Debugger>;
+
+/**
+ * Classification of a discovered CDP target.
+ * - `content` — an app webview (a `BrowserWindow`/`BrowserView` rendering app
+ *   content); these are surfaced via `switchWindow`/`listWindows`.
+ * - `shell` — a host/chrome target (e.g. `about:blank`) not surfaced to users.
+ * - `other` — devtools, service workers, and anything else ignored for routing.
+ *
+ * The exact discriminator (URL scheme / path) is finalised by the Phase 0 spike.
+ */
+export type TargetClass = 'content' | 'shell' | 'other';
+
+/**
+ * A discovered CDP page target plus the bridge's derived routing metadata. The
+ * stable identity is the CEF target `id`; `label` is persisted against it so
+ * re-enumeration doesn't renumber a live target.
+ */
+export type PageTarget = {
+  id: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+  class: TargetClass;
+};
+
+/**
+ * An entry in the bridge's target registry: the discovered target plus the
+ * user-facing label (`main`, `window-1`, …) the multi-window API maps onto.
+ */
+export type TargetRegistryEntry = PageTarget & {
+  label: string;
+};

--- a/packages/electrobun-cdp-bridge/test/index.spec.ts
+++ b/packages/electrobun-cdp-bridge/test/index.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+describe('@wdio/electrobun-cdp-bridge public exports', () => {
+  it("should default the debugger port to CEF's 9222", async () => {
+    const { DEFAULT_PORT } = await import('../src/index.js');
+    expect(DEFAULT_PORT).toBe(9222);
+  });
+
+  it('should expose the CEF auto-select port range (9222-9232)', async () => {
+    const { DEFAULT_PORT_RANGE_START, DEFAULT_PORT_RANGE_END } = await import('../src/index.js');
+    expect(DEFAULT_PORT_RANGE_START).toBe(9222);
+    expect(DEFAULT_PORT_RANGE_END).toBe(9232);
+    expect(DEFAULT_PORT_RANGE_END).toBeGreaterThan(DEFAULT_PORT_RANGE_START);
+  });
+
+  it('should expose the bridge error messages', async () => {
+    const { ERROR_MESSAGE } = await import('../src/index.js');
+    expect(ERROR_MESSAGE.NO_PAGE_TARGETS).toBeTypeOf('string');
+    expect(ERROR_MESSAGE.TARGET_NOT_FOUND).toBeTypeOf('string');
+    expect(ERROR_MESSAGE.NOT_CONNECTED).toContain('CdpBridge.connect()');
+  });
+});

--- a/packages/electrobun-cdp-bridge/tsconfig.json
+++ b/packages/electrobun-cdp-bridge/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/electrobun-cdp-bridge/vitest.config.ts
+++ b/packages/electrobun-cdp-bridge/vitest.config.ts
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.spec.ts'],
+    exclude: [...configDefaults.exclude],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.d.ts', '**/types.ts', 'src/index.ts'],
+    },
+  },
+});

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -1,0 +1,46 @@
+# @wdio/electrobun-service
+
+WebdriverIO service for end-to-end testing [Electrobun](https://electrobun.dev)
+desktop applications — the TypeScript-first, Bun-powered desktop framework.
+
+It mirrors the surface of the sibling services (`@wdio/electron-service`,
+`@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
+Vitest-style mocking, multi-window `switchWindow`/`listWindows`, log capture,
+browser mode, standalone sessions, and multiremote.
+
+> **Status:** pre-release (`1.0.0-next.x`). Shipping in stages (Foundation →
+> MVP → Feature-complete → Ship). This package currently provides the
+> foundation; `execute`/mocking/etc. arrive in subsequent releases.
+
+## Platform requirement: the CEF renderer
+
+This is a **CDP-attach** service — it drives the app through the Chrome DevTools
+Protocol. Electrobun's webview engine differs per platform:
+
+| Platform | Default webview | CDP? |
+|---|---|---|
+| Windows | WebView2 (Chromium) | ✅ |
+| macOS | WKWebView (WebKit) | ❌ |
+| Linux | WebKitGTK (WebKit) | ❌ |
+
+Because the default WebKit webviews on macOS/Linux do **not** speak CDP, this
+service requires the app under test to be built with Electrobun's **CEF
+renderer** on every platform, for a single uniform Chromium target model:
+
+```ts
+// electrobun.config.ts
+export default {
+  build: {
+    mac: { bundleCEF: true, defaultRenderer: 'cef' },
+    win: { bundleCEF: true, defaultRenderer: 'cef' },
+    linux: { bundleCEF: true, defaultRenderer: 'cef' },
+  },
+};
+```
+
+Apps built with the default WebKit renderer are an explicit, documented
+unsupported configuration — the launcher fails fast with a clear error.
+
+## License
+
+MIT

--- a/packages/electrobun-service/package.json
+++ b/packages/electrobun-service/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "@wdio/electrobun-service",
+  "version": "1.0.0-next.0",
+  "description": "WebdriverIO service for testing Electrobun desktop applications",
+  "author": "WebdriverIO Community",
+  "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/electrobun-service",
+  "license": "MIT",
+  "engines": {
+    "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": [
+      {
+        "import": {
+          "types": "./dist/esm/index.d.ts",
+          "default": "./dist/esm/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/index.d.ts",
+          "default": "./dist/cjs/index.js"
+        }
+      },
+      "./dist/cjs/index.js"
+    ]
+  },
+  "files": [
+    "dist",
+    "docs",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsx ../../scripts/build-package.ts",
+    "build:watch": "tsx ../../scripts/build-package.ts --watch",
+    "clean": "shx rm -rf dist",
+    "clean:dist": "shx rm -rf dist",
+    "dev": "pnpm run build:watch",
+    "lint": "biome check --linter-enabled=true --formatter-enabled=false src/",
+    "lint:fix": "biome check --write --linter-enabled=true --formatter-enabled=false src/",
+    "test": "vitest run",
+    "test:unit": "vitest run --config vitest.config.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration:watch": "vitest --config vitest.integration.config.ts",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wdio/electrobun-cdp-bridge": "workspace:*",
+    "@wdio/globals": "catalog:default",
+    "@wdio/logger": "catalog:default",
+    "@wdio/native-core": "workspace:*",
+    "@wdio/native-spy": "workspace:*",
+    "@wdio/native-types": "workspace:*",
+    "@wdio/native-utils": "workspace:*",
+    "@wdio/spec-reporter": "catalog:default",
+    "@wdio/types": "catalog:default",
+    "debug": "^4.4.3",
+    "get-port": "^7.1.0",
+    "tslib": "^2.8.1",
+    "webdriverio": "catalog:default"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.12",
+    "@types/node": "^25.9.1",
+    "@vitest/coverage-v8": "^4.1.7",
+    "shx": "^0.4.0",
+    "tsx": "^4.22.3",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  },
+  "peerDependencies": {
+    "webdriverio": "^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "webdriverio": {
+      "optional": false
+    }
+  },
+  "keywords": [
+    "webdriverio",
+    "wdio",
+    "wdio-service",
+    "electrobun",
+    "testing",
+    "e2e",
+    "desktop"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webdriverio/desktop-mobile.git",
+    "directory": "packages/electrobun-service"
+  },
+  "bugs": {
+    "url": "https://github.com/webdriverio/desktop-mobile/issues"
+  }
+}

--- a/packages/electrobun-service/src/constants.ts
+++ b/packages/electrobun-service/src/constants.ts
@@ -5,11 +5,18 @@ export const SERVICE_NAME = 'electrobun-service';
 export const CUSTOM_CAPABILITY_NAME = 'wdio:electrobunServiceOptions';
 
 /**
- * CEF auto-selects its remote-debugging port in [9222, 9232] at app startup, so
- * the launcher discovers the port by scanning the range rather than dictating
- * it. This is the low end of that range and the documented default.
+ * CEF's documented default remote-debugging port and the floor of its auto-scan
+ * range [9222, 9232] (used only when an app pins no port). The service does not
+ * rely on this — it allocates a port and writes it into each worker's build.json.
  */
 export const DEFAULT_REMOTE_DEBUGGING_PORT = 9222;
+
+/**
+ * Anchor for ports the launcher allocates (via PortManager) and writes into each
+ * worker's bundle build.json. Kept clear of CEF's [9222, 9232] auto-scan range so
+ * an allocated port can't collide with one CEF picks for an un-pinned app.
+ */
+export const DEFAULT_DEBUG_PORT_BASE = 9333;
 
 /** Explicit-port override env var (escape hatch; normally the port is discovered). */
 export const REMOTE_DEBUGGING_PORT_ENV = 'ELECTROBUN_REMOTE_DEBUGGING_PORT';

--- a/packages/electrobun-service/src/constants.ts
+++ b/packages/electrobun-service/src/constants.ts
@@ -1,0 +1,18 @@
+/** Logger namespace for this service (`createLogger(SERVICE_NAME, '<module>')`). */
+export const SERVICE_NAME = 'electrobun-service';
+
+/** WDIO capability key carrying per-capability service options. */
+export const CUSTOM_CAPABILITY_NAME = 'wdio:electrobunServiceOptions';
+
+/**
+ * CEF auto-selects its remote-debugging port in [9222, 9232] at app startup, so
+ * the launcher discovers the port by scanning the range rather than dictating
+ * it. This is the low end of that range and the documented default.
+ */
+export const DEFAULT_REMOTE_DEBUGGING_PORT = 9222;
+
+/** Explicit-port override env var (escape hatch; normally the port is discovered). */
+export const REMOTE_DEBUGGING_PORT_ENV = 'ELECTROBUN_REMOTE_DEBUGGING_PORT';
+
+/** Default label for the first/primary content webview target. */
+export const DEFAULT_WINDOW_LABEL = 'main';

--- a/packages/electrobun-service/src/errors.ts
+++ b/packages/electrobun-service/src/errors.ts
@@ -1,0 +1,41 @@
+// Error helpers for the Electrobun service.
+//
+// `SevereServiceError` (re-exported from webdriverio) tells the WDIO runner the
+// failure is non-recoverable and the run should abort — used when a config
+// fundamentally can't work, e.g. the app wasn't built with the CEF renderer so
+// no CDP endpoint exists to attach to.
+
+import { SevereServiceError } from 'webdriverio';
+
+export { SevereServiceError };
+
+/**
+ * Thrown by the launcher when the Electrobun app under test was not built with
+ * the CEF renderer. The default WebKit webviews (WKWebView on macOS, WebKitGTK
+ * on Linux) expose no Chrome DevTools Protocol endpoint, so a CDP-attach service
+ * cannot drive them — the app must build with `defaultRenderer: 'cef'` /
+ * `bundleCEF: true` in `electrobun.config.ts`.
+ */
+export function cefRendererRequired(platform: NodeJS.Platform = process.platform): Error {
+  return new SevereServiceError(
+    '@wdio/electrobun-service requires the Electrobun app to be built with the CEF renderer ' +
+      "(set defaultRenderer: 'cef' / bundleCEF: true for the target OS in electrobun.config.ts). " +
+      `The default system webview on ${platform} does not expose a Chrome DevTools Protocol ` +
+      'endpoint, so the app cannot be automated over CDP. See the @wdio/electrobun-service README ' +
+      'for the renderer requirement and the supported-platform matrix.',
+  );
+}
+
+/**
+ * Returned (rejected) by `triggerDeeplink` on platforms where Electrobun does
+ * not yet support custom URL schemes. v1 supports macOS only (schemes are
+ * registered via the generated `Info.plist`); Windows/Linux are a documented
+ * gap pending upstream support.
+ */
+export function deeplinkUnsupportedOnPlatform(platform: NodeJS.Platform = process.platform): Error {
+  return new Error(
+    `triggerDeeplink is only supported on macOS in this release (current platform: ${platform}). ` +
+      'Electrobun custom URL schemes are registered via Info.plist on macOS; Windows/Linux deeplink ' +
+      'support is pending upstream and is tracked as a known gap.',
+  );
+}

--- a/packages/electrobun-service/src/index.ts
+++ b/packages/electrobun-service/src/index.ts
@@ -1,0 +1,20 @@
+// @wdio/electrobun-service entry point.
+//
+// - Default export: the worker-side service (registered automatically by the
+//   WDIO test runner via `services: ['@wdio/electrobun-service']`).
+// - Named `launcher` export: the main-process launch service (auto-detected by
+//   the runner using the standard service convention).
+//
+// The bare import pulls in @wdio/native-types' ambient module augmentation so
+// `browser.electrobun.*` and `wdio:electrobunServiceOptions` are typed for
+// consumers.
+import '@wdio/native-types';
+
+import ElectrobunLaunchService from './launcher.js';
+import ElectrobunWorkerService from './service.js';
+
+export { ElectrobunLaunchService as launcher };
+export default ElectrobunWorkerService;
+
+export { cefRendererRequired, deeplinkUnsupportedOnPlatform, SevereServiceError } from './errors.js';
+export type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './types.js';

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -1,0 +1,91 @@
+import { BaseLauncher, closeLogWriter, isLogWriterInitialized } from '@wdio/native-core';
+import { createLogger } from '@wdio/native-utils';
+import type { Options } from '@wdio/types';
+
+import { DEFAULT_REMOTE_DEBUGGING_PORT, SERVICE_NAME } from './constants.js';
+import { SevereServiceError } from './errors.js';
+import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
+import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions } from './types.js';
+
+const log = createLogger(SERVICE_NAME, 'launcher');
+
+/**
+ * Main-process launcher for `@wdio/electrobun-service`.
+ *
+ * Electrobun is a CDP-attach framework: the launcher spawns the app binary and
+ * the worker attaches over CDP through Chromedriver (`debuggerAddress`). It
+ * extends `BaseLauncher` to reuse `@wdio/native-core`'s port/process/log infra —
+ * the spawned app process plays the role the driver process does in the
+ * Wry-based services.
+ *
+ * Native-mode launch (CEF verification, binary resolution, spawn + CEF debug
+ * port discovery in 9222–9232) lands in the MVP PR. This foundation handles
+ * service wiring and browser mode.
+ */
+export default class ElectrobunLaunchService extends BaseLauncher {
+  constructor(
+    private options: ElectrobunServiceGlobalOptions,
+    capabilities: ElectrobunCapabilities,
+    config: Options.Testrunner,
+  ) {
+    super({
+      basePort: options.remoteDebuggingPort ?? DEFAULT_REMOTE_DEBUGGING_PORT,
+      baseNativePort: (options.remoteDebuggingPort ?? DEFAULT_REMOTE_DEBUGGING_PORT) + 1,
+    });
+    log.debug('ElectrobunLaunchService initialised');
+    log.debug('Capabilities:', JSON.stringify(capabilities, null, 2));
+    log.debug('Config:', JSON.stringify(config, null, 2));
+  }
+
+  async onPrepare(
+    _config: Options.Testrunner,
+    capabilities: ElectrobunCapabilities[] | Record<string, { capabilities: ElectrobunCapabilities }>,
+  ): Promise<void> {
+    const capsList = normaliseCaps(capabilities);
+    // Detect browser mode even when set on a non-first capability.
+    const primaryCap =
+      capsList.find(
+        (cap) => mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap)).mode === 'browser',
+      ) ?? capsList[0];
+    const mergedOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(primaryCap));
+
+    // Browser mode: skip all binary/CDP setup — the frontend runs against a dev
+    // server in a plain Chrome session.
+    if (mergedOptions.mode === 'browser') {
+      const { devServerUrl } = mergedOptions;
+      if (!devServerUrl) {
+        throw new SevereServiceError('devServerUrl is required when mode is "browser"');
+      }
+      try {
+        new URL(devServerUrl);
+      } catch {
+        throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+      }
+      for (const cap of capsList) {
+        (cap as { browserName?: string }).browserName = 'chrome';
+      }
+      log.info('Browser mode enabled — skipping Electrobun binary/CDP setup');
+      return;
+    }
+
+    // Native mode: CEF-renderer verification, binary resolution, app spawn, and
+    // CEF debug-port discovery land in the MVP PR.
+    log.warn('Native-mode Electrobun launch is not yet implemented in this pre-release.');
+  }
+
+  async onComplete(): Promise<void> {
+    await this.stopAllDrivers();
+    if (isLogWriterInitialized(SERVICE_NAME)) {
+      await closeLogWriter(SERVICE_NAME);
+    }
+  }
+}
+
+function normaliseCaps(
+  capabilities: ElectrobunCapabilities[] | Record<string, { capabilities: ElectrobunCapabilities }>,
+): ElectrobunCapabilities[] {
+  if (Array.isArray(capabilities)) {
+    return capabilities;
+  }
+  return Object.values(capabilities).map((entry) => entry.capabilities);
+}

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -2,7 +2,7 @@ import { BaseLauncher, closeLogWriter, isLogWriterInitialized } from '@wdio/nati
 import { createLogger } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
 
-import { DEFAULT_REMOTE_DEBUGGING_PORT, SERVICE_NAME } from './constants.js';
+import { DEFAULT_DEBUG_PORT_BASE, SERVICE_NAME } from './constants.js';
 import { SevereServiceError } from './errors.js';
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
 import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions } from './types.js';
@@ -25,16 +25,21 @@ const log = createLogger(SERVICE_NAME, 'launcher');
 export default class ElectrobunLaunchService extends BaseLauncher {
   constructor(
     private options: ElectrobunServiceGlobalOptions,
-    capabilities: ElectrobunCapabilities,
-    config: Options.Testrunner,
+    _capabilities: ElectrobunCapabilities,
+    _config: Options.Testrunner,
   ) {
+    const basePort = options.remoteDebuggingPort ?? DEFAULT_DEBUG_PORT_BASE;
     super({
-      basePort: options.remoteDebuggingPort ?? DEFAULT_REMOTE_DEBUGGING_PORT,
-      baseNativePort: (options.remoteDebuggingPort ?? DEFAULT_REMOTE_DEBUGGING_PORT) + 1,
+      basePort,
+      // Electrobun is CDP-attach: there is no separate native driver process, so
+      // baseNativePort is nominal. Anchored alongside basePort, clear of CEF's
+      // [9222, 9232] auto-scan range so PortManager never hands out a port CEF
+      // might grab for an un-pinned app.
+      baseNativePort: basePort + 1,
     });
+    // Don't serialise the full testrunner config/capabilities — they can carry
+    // credentials (reporter tokens, cloud keys) that shouldn't land in debug logs.
     log.debug('ElectrobunLaunchService initialised');
-    log.debug('Capabilities:', JSON.stringify(capabilities, null, 2));
-    log.debug('Config:', JSON.stringify(config, null, 2));
   }
 
   async onPrepare(

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -1,0 +1,39 @@
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from './constants.js';
+import type { ElectrobunServiceOptions } from './types.js';
+
+const log = createLogger(SERVICE_NAME, 'service');
+
+/**
+ * Worker-process service for `@wdio/electrobun-service`. Installs the
+ * `browser.electrobun.*` surface and drives it over the multi-target CDP bridge.
+ *
+ * The CDP attach + `browser.electrobun.*` installation (execute, mocking,
+ * switchWindow/listWindows, log capture, triggerDeeplink) lands across the MVP
+ * and feature-complete PRs. This foundation handles construction/wiring.
+ */
+export default class ElectrobunWorkerService {
+  private browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser;
+  private devServerUrl?: string;
+
+  constructor(options: ElectrobunServiceOptions, capabilities: unknown) {
+    const capOptions = (capabilities as { 'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions })[
+      'wdio:electrobunServiceOptions'
+    ];
+    this.devServerUrl = capOptions?.devServerUrl ?? options.devServerUrl;
+    log.debug('ElectrobunWorkerService initialised');
+  }
+
+  async before(
+    _capabilities: unknown,
+    _specs: string[],
+    browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
+  ): Promise<void> {
+    this.browser = browser;
+    // browser.electrobun.* installation over the CDP bridge lands in the MVP PR.
+    log.warn('browser.electrobun.* surface is not yet installed in this pre-release.');
+    void this.browser;
+    void this.devServerUrl;
+  }
+}

--- a/packages/electrobun-service/src/serviceConfig.ts
+++ b/packages/electrobun-service/src/serviceConfig.ts
@@ -1,0 +1,25 @@
+// Option resolution shared by the launcher and worker service: merge global
+// (service-level) options with per-capability options, capability taking
+// precedence, and pull the custom-capability options off a capability object.
+
+import { CUSTOM_CAPABILITY_NAME } from './constants.js';
+import type { ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './types.js';
+
+/** Read the `wdio:electrobunServiceOptions` block off a capability, if present. */
+export function getServiceOptionsFromCapability(
+  capability: { [CUSTOM_CAPABILITY_NAME]?: ElectrobunServiceOptions } | undefined,
+): ElectrobunServiceOptions | undefined {
+  return capability?.[CUSTOM_CAPABILITY_NAME];
+}
+
+/**
+ * Merge service-level global options with per-capability options. Capability
+ * options win on conflict, matching the precedence used across the sibling
+ * services.
+ */
+export function mergeServiceOptions(
+  globalOptions: ElectrobunServiceGlobalOptions = {},
+  capabilityOptions: ElectrobunServiceOptions | undefined,
+): ElectrobunServiceOptions {
+  return { ...globalOptions, ...capabilityOptions };
+}

--- a/packages/electrobun-service/src/types.ts
+++ b/packages/electrobun-service/src/types.ts
@@ -1,0 +1,11 @@
+// Extended service options for `@wdio/electrobun-service`. Builds on the shared
+// types in @wdio/native-types with any implementation-specific fields the
+// launcher / service need. Kept as a thin alias for now — diverge here only
+// when the implementation requires a field that doesn't belong in the public
+// @wdio/native-types surface.
+
+import type { ElectrobunServiceOptions as BaseElectrobunServiceOptions } from '@wdio/native-types';
+
+export type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions } from '@wdio/native-types';
+
+export type ElectrobunServiceOptions = BaseElectrobunServiceOptions;

--- a/packages/electrobun-service/test/errors.spec.ts
+++ b/packages/electrobun-service/test/errors.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { SevereServiceError } from 'webdriverio';
+
+import { cefRendererRequired, deeplinkUnsupportedOnPlatform } from '../src/errors.js';
+
+describe('cefRendererRequired', () => {
+  it('should be a SevereServiceError so the runner aborts', () => {
+    const err = cefRendererRequired('darwin');
+    expect(err).toBeInstanceOf(SevereServiceError);
+  });
+
+  it('should explain the CEF renderer requirement', () => {
+    const err = cefRendererRequired('darwin');
+    expect(err.message).toContain('CEF renderer');
+    expect(err.message).toContain('electrobun.config.ts');
+  });
+
+  it('should name the current platform in the message', () => {
+    expect(cefRendererRequired('linux').message).toContain('linux');
+    expect(cefRendererRequired('win32').message).toContain('win32');
+  });
+});
+
+describe('deeplinkUnsupportedOnPlatform', () => {
+  it('should be a plain Error (a recoverable command rejection, not severe)', () => {
+    const err = deeplinkUnsupportedOnPlatform('win32');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(SevereServiceError);
+  });
+
+  it('should state that only macOS is supported and name the platform', () => {
+    const err = deeplinkUnsupportedOnPlatform('linux');
+    expect(err.message).toContain('macOS');
+    expect(err.message).toContain('linux');
+  });
+});

--- a/packages/electrobun-service/test/index.spec.ts
+++ b/packages/electrobun-service/test/index.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+describe('@wdio/electrobun-service public exports', () => {
+  it('should expose the worker service as the default export', async () => {
+    const mod = await import('../src/index.js');
+    expect(mod.default).toBeTypeOf('function');
+    expect(mod.default.name).toBe('ElectrobunWorkerService');
+  });
+
+  it('should expose the launch service as the named "launcher" export', async () => {
+    const { launcher } = await import('../src/index.js');
+    expect(launcher).toBeTypeOf('function');
+    expect(launcher.name).toBe('ElectrobunLaunchService');
+  });
+
+  it('should re-export the cefRendererRequired helper', async () => {
+    const { cefRendererRequired } = await import('../src/index.js');
+    expect(cefRendererRequired).toBeTypeOf('function');
+    const err = cefRendererRequired('darwin');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain('CEF renderer');
+  });
+
+  it('should re-export the deeplinkUnsupportedOnPlatform helper', async () => {
+    const { deeplinkUnsupportedOnPlatform } = await import('../src/index.js');
+    expect(deeplinkUnsupportedOnPlatform).toBeTypeOf('function');
+  });
+
+  it('should re-export SevereServiceError', async () => {
+    const { SevereServiceError } = await import('../src/index.js');
+    expect(SevereServiceError).toBeTypeOf('function');
+  });
+});

--- a/packages/electrobun-service/test/integration/setup.ts
+++ b/packages/electrobun-service/test/integration/setup.ts
@@ -1,0 +1,6 @@
+// Shared setup for @wdio/electrobun-service integration tests.
+//
+// Currently a no-op — integration tests are added once the launcher actually
+// spawns the Electrobun binary (MVP PR onwards). The file exists so the
+// `setupFiles: ['test/integration/setup.ts']` reference in
+// vitest.integration.config.ts resolves cleanly before there are specs to run.

--- a/packages/electrobun-service/tsconfig.json
+++ b/packages/electrobun-service/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/electrobun-service/vitest.config.ts
+++ b/packages/electrobun-service/vitest.config.ts
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.spec.ts'],
+    exclude: [...configDefaults.exclude, 'test/integration/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.d.ts', '**/types.ts', 'src/index.ts'],
+    },
+  },
+});

--- a/packages/electrobun-service/vitest.integration.config.ts
+++ b/packages/electrobun-service/vitest.integration.config.ts
@@ -1,0 +1,19 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/integration/**/*.spec.ts'],
+    exclude: [...configDefaults.exclude],
+    // Don't fail when there are no integration tests yet — the integration
+    // suite lands once the launcher actually spawns the Electrobun binary.
+    passWithNoTests: true,
+    sequence: { concurrent: false },
+    testTimeout: 30000,
+    hookTimeout: 15000,
+    teardownTimeout: 10000,
+    fileParallelism: false,
+    setupFiles: ['test/integration/setup.ts'],
+  },
+});

--- a/packages/native-types/src/electrobun.ts
+++ b/packages/native-types/src/electrobun.ts
@@ -1,0 +1,170 @@
+import type { Mock } from '@wdio/native-spy';
+import type {
+  AbstractFn,
+  BaseServiceGlobalOptions,
+  BaseServiceOptions,
+  BrowserBase,
+  LogLevel,
+  MockOverride,
+  MockResult,
+  ServiceMockContext,
+} from './shared.js';
+
+// ============================================================================
+// Electrobun-Specific Types
+// ============================================================================
+
+/**
+ * Surface installed inside the Electrobun app's webview and injected as the
+ * first argument of `browser.electrobun.execute()` callbacks. Electrobun is a
+ * CDP-attach framework, so `execute` runs in a webview JS context via CDP
+ * `Runtime.callFunctionOn`; this is the in-page handle exposed on
+ * `window.__WDIO_ELECTROBUN__`.
+ *
+ * The concrete shape (which Electrobun RPC/bridge calls are exposed) is being
+ * finalised in the Phase 0 spike — kept intentionally open until then.
+ */
+export interface ElectrobunAPIs {
+  /** Optional log helpers, present when frontend log forwarding is wired. */
+  log?: {
+    trace?: (msg: string) => void;
+    debug?: (msg: string) => void;
+    info?: (msg: string) => void;
+    warn?: (msg: string) => void;
+    error?: (msg: string) => void;
+  };
+  [key: string]: unknown;
+}
+
+interface ElectrobunMockContext extends ServiceMockContext {
+  results: MockResult[];
+}
+
+export interface ElectrobunMockInstance extends Omit<Mock, MockOverride> {
+  mockImplementation(fn: AbstractFn): Promise<ElectrobunMock>;
+  mockImplementationOnce(fn: AbstractFn): Promise<ElectrobunMock>;
+  mockReturnValue(obj: unknown): Promise<ElectrobunMock>;
+  mockReturnValueOnce(obj: unknown): Promise<ElectrobunMock>;
+  mockResolvedValue(obj: unknown): Promise<ElectrobunMock>;
+  mockResolvedValueOnce(obj: unknown): Promise<ElectrobunMock>;
+  mockRejectedValue(obj: unknown): Promise<ElectrobunMock>;
+  mockRejectedValueOnce(obj: unknown): Promise<ElectrobunMock>;
+  mockClear(): Promise<ElectrobunMock>;
+  mockReset(): Promise<ElectrobunMock>;
+  mockRestore(): Promise<ElectrobunMock>;
+  mockReturnThis(): Promise<ElectrobunMock>;
+  mockName(name: string): ElectrobunMock;
+  getMockName(): string;
+  getMockImplementation(): AbstractFn;
+  update(): Promise<ElectrobunMock>;
+  __isElectrobunMock: boolean;
+  mock: ElectrobunMockContext;
+}
+
+export interface ElectrobunMock<TArgs extends unknown[] = unknown[], TReturns = unknown>
+  extends ElectrobunMockInstance {
+  new (...args: TArgs): TReturns;
+  (...args: TArgs): TReturns;
+}
+
+/**
+ * Public `browser.electrobun.*` surface installed by `@wdio/electrobun-service`.
+ *
+ * Matches the shared cross-service surface (see the convergence standard in
+ * AGENTS.md / the add-native-service skill). `emitEvent` is omitted in v1 —
+ * Electrobun's event bus lives in the Bun backend, which is not reachable over
+ * CDP; it ships only if the spike confirms it can be routed via the in-webview
+ * RPC. `mockAll`/class-mock are Electron-only (no enumerable main-process API).
+ */
+export interface ElectrobunServiceAPI {
+  execute<R, A extends unknown[]>(script: string | ((eb: ElectrobunAPIs, ...a: A) => R), ...args: A): Promise<R>;
+
+  mock(target: string): Promise<ElectrobunMock>;
+  isMockFunction(targetOrFn: unknown): boolean;
+  clearAllMocks(prefix?: string): Promise<void>;
+  resetAllMocks(prefix?: string): Promise<void>;
+  restoreAllMocks(prefix?: string): Promise<void>;
+
+  /** Switch the active CDP target (window/webview) to the one labelled `label`. */
+  switchWindow(label: string): Promise<void>;
+  /** List all live window/webview labels in registration order. */
+  listWindows(): Promise<string[]>;
+  /**
+   * Trigger a deeplink (custom-protocol URL) at the OS level so the Electrobun
+   * app's registered `open-url` handler receives it. Use for testing the
+   * production protocol-handler code path; rejects http/https/file URLs.
+   *
+   * macOS-only in v1 — Electrobun registers URL schemes via `Info.plist`; the
+   * Windows/Linux deeplink path is not yet supported upstream and rejects with
+   * a documented-gap error.
+   */
+  triggerDeeplink(url: string): Promise<void>;
+}
+
+/**
+ * Electrobun-specific options merged from the shared base. Electrobun is a
+ * CDP-attach framework (like Electron, unlike the Wry-based Tauri/Dioxus), so
+ * there is no driver-provider config — the launcher spawns the app binary and
+ * the worker attaches over CDP.
+ */
+export interface ElectrobunServiceOptions extends BaseServiceOptions {
+  /** Test mode: `'native'` runs against a built Electrobun binary; `'browser'` runs the frontend against a dev server in plain Chrome. */
+  mode?: 'native' | 'browser';
+  /** When `mode === 'browser'`, the URL of the running dev server. */
+  devServerUrl?: string;
+  /**
+   * Explicit CEF remote-debugging port escape hatch. By default CEF auto-selects
+   * a port in the 9222–9232 range at startup and the launcher discovers it, so
+   * this is only needed to pin a specific port.
+   */
+  remoteDebuggingPort?: number;
+  /** Per-instance CDP connection timeout in ms. @default 10000 */
+  cdpConnectionTimeout?: number;
+  /** Number of CDP connection retries before failing. @default 3 */
+  cdpConnectionRetryCount?: number;
+  /** Interval between CDP connection retries in ms. @default 100 */
+  cdpConnectionRetryInterval?: number;
+  /** Default window/target label for execute/mock calls. */
+  windowLabel?: string;
+}
+
+export interface ElectrobunServiceGlobalOptions extends BaseServiceGlobalOptions {
+  mode?: 'native' | 'browser';
+  devServerUrl?: string;
+  remoteDebuggingPort?: number;
+  cdpConnectionTimeout?: number;
+  cdpConnectionRetryCount?: number;
+  cdpConnectionRetryInterval?: number;
+  windowLabel?: string;
+  backendLogLevel?: LogLevel;
+  frontendLogLevel?: LogLevel;
+}
+
+/**
+ * Capability shape for Electrobun apps. As a CDP-attach service the launcher
+ * drives the app through Chromedriver attached to the CEF debugger port, so the
+ * effective capability is `browserName: 'chrome'` + `goog:chromeOptions`; there
+ * is no `electrobun:options` capability (CDP frameworks have no in-app plumbing).
+ *
+ * Declared as a plain interface — do NOT extend
+ * `Capabilities.RequestedStandaloneCapabilities` (Rollup's TS plugin can't
+ * extend dynamic-member interfaces). Intersect at the service level instead.
+ */
+export interface ElectrobunCapabilities {
+  browserName?: 'chrome' | 'electrobun' | string;
+  'goog:chromeOptions'?: Record<string, unknown>;
+  'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions;
+}
+
+export interface ElectrobunBrowserExtension extends BrowserBase {
+  electrobun: ElectrobunServiceAPI;
+}
+
+declare global {
+  interface Window {
+    __WDIO_ELECTROBUN__?: {
+      log?: ElectrobunAPIs['log'];
+      [key: string]: unknown;
+    };
+  }
+}

--- a/packages/native-types/src/electrobun.ts
+++ b/packages/native-types/src/electrobun.ts
@@ -113,9 +113,11 @@ export interface ElectrobunServiceOptions extends BaseServiceOptions {
   /** When `mode === 'browser'`, the URL of the running dev server. */
   devServerUrl?: string;
   /**
-   * Explicit CEF remote-debugging port escape hatch. By default CEF auto-selects
-   * a port in the 9222–9232 range at startup and the launcher discovers it, so
-   * this is only needed to pin a specific port.
+   * Force a specific CEF remote-debugging port. Normally unnecessary: the launcher
+   * allocates a free port per worker and **pins** it by writing it into that
+   * worker's bundle `build.json` (CEF reads the port from build.json, not from a
+   * launch arg). Parallel/multiremote runs each get a distinct auto-allocated,
+   * pinned port — set this only to force one instance onto a known fixed port.
    */
   remoteDebuggingPort?: number;
   /** Per-instance CDP connection timeout in ms. @default 10000 */

--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -14,6 +14,17 @@ export type {
   DioxusServiceGlobalOptions,
   DioxusServiceOptions,
 } from './dioxus.js';
+// Electrobun types
+export type {
+  ElectrobunAPIs,
+  ElectrobunBrowserExtension,
+  ElectrobunCapabilities,
+  ElectrobunMock,
+  ElectrobunMockInstance,
+  ElectrobunServiceAPI,
+  ElectrobunServiceGlobalOptions,
+  ElectrobunServiceOptions,
+} from './electrobun.js';
 // Electron types
 export type {
   ApiCommand,
@@ -103,13 +114,18 @@ export type {
 // ============================================================================
 
 import type { DioxusBrowserExtension } from './dioxus.js';
+import type { ElectrobunBrowserExtension } from './electrobun.js';
 import type { ElectronBrowserExtension } from './electron.js';
 import type { TauriBrowserExtension } from './tauri.js';
 
 /**
- * Browser extension that supports Electron, Tauri, and Dioxus services
+ * Browser extension that supports Electron, Tauri, Dioxus, and Electrobun services
  */
-export interface BrowserExtension extends ElectronBrowserExtension, TauriBrowserExtension, DioxusBrowserExtension {}
+export interface BrowserExtension
+  extends ElectronBrowserExtension,
+    TauriBrowserExtension,
+    DioxusBrowserExtension,
+    ElectrobunBrowserExtension {}
 
 // ============================================================================
 // Module Augmentation (WebdriverIO)
@@ -117,6 +133,7 @@ export interface BrowserExtension extends ElectronBrowserExtension, TauriBrowser
 
 import type { fn as vitestFn } from '@wdio/native-spy';
 import type { DioxusServiceGlobalOptions, DioxusServiceOptions } from './dioxus.js';
+import type { ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './electrobun.js';
 import type {
   ElectronInterface,
   ElectronServiceGlobalOptions,
@@ -135,18 +152,28 @@ declare global {
 
   // biome-ignore lint/style/noNamespace: This is a legitimate use of namespace for global augmentation
   namespace WebdriverIO {
-    interface Browser extends ElectronBrowserExtension, TauriBrowserExtension, DioxusBrowserExtension {}
+    interface Browser
+      extends ElectronBrowserExtension,
+        TauriBrowserExtension,
+        DioxusBrowserExtension,
+        ElectrobunBrowserExtension {}
     interface Element extends ElementBase {}
-    interface MultiRemoteBrowser extends ElectronBrowserExtension, TauriBrowserExtension, DioxusBrowserExtension {}
+    interface MultiRemoteBrowser
+      extends ElectronBrowserExtension,
+        TauriBrowserExtension,
+        DioxusBrowserExtension,
+        ElectrobunBrowserExtension {}
     interface Capabilities {
       'wdio:electronServiceOptions'?: ElectronServiceOptions;
       'wdio:tauriServiceOptions'?: TauriServiceOptions;
       'wdio:dioxusServiceOptions'?: DioxusServiceOptions;
+      'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions;
     }
     interface ServiceOption
       extends ElectronServiceGlobalOptions,
         TauriServiceGlobalOptions,
-        DioxusServiceGlobalOptions {}
+        DioxusServiceGlobalOptions,
+        ElectrobunServiceGlobalOptions {}
   }
 
   var __name: (func: Fn) => Fn;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -799,6 +799,116 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/electrobun-cdp-bridge:
+    dependencies:
+      '@wdio/native-utils':
+        specifier: workspace:*
+        version: link:../native-utils
+      wait-port:
+        specifier: ^1.1.0
+        version: 1.1.0
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      devtools-protocol:
+        specifier: ^0.0.1634055
+        version: 0.0.1634055
+      get-port:
+        specifier: ^7.1.0
+        version: 7.2.0
+      nock:
+        specifier: ^14.0.15
+        version: 14.0.15
+      shx:
+        specifier: ^0.4.0
+        version: 0.4.0
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/electrobun-service:
+    dependencies:
+      '@wdio/electrobun-cdp-bridge':
+        specifier: workspace:*
+        version: link:../electrobun-cdp-bridge
+      '@wdio/globals':
+        specifier: catalog:default
+        version: 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@25.0.4))
+      '@wdio/logger':
+        specifier: catalog:default
+        version: 9.18.0
+      '@wdio/native-core':
+        specifier: workspace:*
+        version: link:../native-core
+      '@wdio/native-spy':
+        specifier: workspace:*
+        version: link:../native-spy
+      '@wdio/native-types':
+        specifier: workspace:*
+        version: link:../native-types
+      '@wdio/native-utils':
+        specifier: workspace:*
+        version: link:../native-utils
+      '@wdio/spec-reporter':
+        specifier: catalog:default
+        version: 9.27.1
+      '@wdio/types':
+        specifier: catalog:default
+        version: 9.27.1
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3(supports-color@8.1.1)
+      get-port:
+        specifier: ^7.1.0
+        version: 7.2.0
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      webdriverio:
+        specifier: catalog:default
+        version: 9.27.1(puppeteer-core@25.0.4)
+    devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.13
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
+      shx:
+        specifier: ^0.4.0
+        version: 0.4.0
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/electron-cdp-bridge:
     dependencies:
       '@wdio/native-utils':

--- a/turbo.json
+++ b/turbo.json
@@ -257,6 +257,23 @@
         "dist/**"
       ]
     },
+    "@wdio/electrobun-cdp-bridge#build": {
+      "dependsOn": [
+        "@wdio/native-utils#build",
+        "typecheck"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
+    "@wdio/electrobun-service#build": {
+      "dependsOn": [
+        "@wdio/electrobun-cdp-bridge#build"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
     "@wdio/tauri-plugin#build": {
       "dependsOn": [
         "@wdio/tauri-plugin#build:js"


### PR DESCRIPTION
First of a **4-PR stack** (Foundation → MVP → Feature-complete → Ship) bootstrapping `@wdio/electrobun-service` per ROADMAP Phase 5. Targets the `feat/electrobun-service` integration branch; subsequent PRs stack on top.

Electrobun is a CDP-attach archetype (like Electron, unlike Wry-based Tauri/Dioxus), so this clones the Electron service pair — no Rust, no driver process.

## What's in this PR
- **`@wdio/native-types`** — new `src/electrobun.ts` (`ElectrobunServiceAPI`, options, mock, `ElectrobunCapabilities` as a plain interface, browser extension, `window.__WDIO_ELECTROBUN__`); wired into the `WebdriverIO` `Browser`/`MultiRemoteBrowser`/`Capabilities`/`ServiceOption` augmentation.
- **`@wdio/electrobun-cdp-bridge`** — skeleton for the multi-target CDP client: constants (`DEFAULT_PORT=9222` + the CEF `9222–9232` range), types (`Debugger`/`Version` + `PageTarget`/`TargetClass`/`TargetRegistryEntry`), barrel, README, export-shape test. The connection manager lands in the MVP PR.
- **`@wdio/electrobun-service`** — skeleton mirroring `@wdio/dioxus-service`: launcher extends `BaseLauncher` (handles browser mode; native-mode spawn lands in MVP), worker stub, errors (`cefRendererRequired` / `deeplinkUnsupportedOnPlatform`), constants, `serviceConfig`, unit tests.
- **`turbo.json`** — build-graph entries for both new packages.

## Key decision baked in
CDP is only available under Electrobun's **CEF renderer** (the default WebKit webviews on macOS/Linux don't speak CDP), so the service requires apps built with `defaultRenderer: 'cef'` on all three OSes; WebKit-default apps are a documented unsupported gap.

## Phase 0 spike — ✅ GO (macOS validated)
A throwaway CEF app was driven end-to-end (`agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md`): Chromedriver attaches via `debuggerAddress`, multiple windows enumerate as separate CDP page targets, attach is observation-only, macOS deeplinks reach the handler. The findings refine the MVP design (port is pinnable; CEF is single-instance per `--user-data-dir`; Linux CDP still to be validated in CI).

## Verification
- `typecheck` + unit tests green for both packages (cdp-bridge 3/3 @ 100% cov, service 10/10)
- Biome clean; service builds end-to-end
- No regressions to `@wdio/native-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)