### PR TITLE
feat(electrobun): PR2 MVP — multi-target CDP bridge, native launcher, execute

### DIFF
--- a/agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md
+++ b/agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md
@@ -62,28 +62,42 @@ Every CEF webview exposes: `__electrobun` (`receiveMessageFromBun`, `receiveInte
 
 Followed up on blocker 1 by reading the macOS native wrapper + `chromium_flags.h`:
 
-- **Port — launch-overridable ✅.** `startEventLoop`/`CefMainArgs` is built from the process's own
-  `[NSProcessInfo arguments]` (`nativeWrapper.mm:5824–5832`), so `--remote-debugging-port=N` passed to
-  the app binary at launch reaches CEF's global command line. `chromiumFlags` from `build.json` are
-  applied *separately* in `OnBeforeCommandLineProcessing`. The command-line switch wins over
-  `settings.remote_debugging_port` (the 9222–9232 scan). **Plan: build the app WITHOUT pinning the
-  port in `chromiumFlags`; the launcher passes a distinct allocated `--remote-debugging-port` per
-  spawn.** (No need to scan/discover.)
-- **Cache / user-data isolation — NOT launch-overridable ❌.** `settings.root_cache_path` =
-  `buildAppDataPath(appSupport, g_electrobunIdentifier, g_electrobunChannel, "CEF")`
-  (`nativeWrapper.mm:5895–5908`). `identifier`/`channel` are set via FFI in
-  `startEventLoop(identifier, name, channel)` (`:6794`) from the Bun process's `_carrotContext`
-  (`bun/index.ts:51,205`) — i.e. the app's build/launch context, not a CLI flag or env var. Because
-  `root_cache_path` is set explicitly, CEF ignores a `--user-data-dir` switch. A bundle-copy doesn't
-  help (the identifier isn't read from `build.json`). **Consequence: two instances of the same app
-  share the cache root → CEF folds the 2nd into the 1st (the spike's single-instance finding).**
+- **Port — per-bundle, NOT a launch arg ⚠️ (source-inference corrected by empirical test).** The
+  source path suggested `CefMainArgs(argc, argv)` (`nativeWrapper.mm:5832`) would let a launch-time
+  `--remote-debugging-port` reach CEF — **but the shipped launcher disproves this.** The built
+  `Contents/Resources/main.js` only forwards identifier/name/channel into the native run-main-thread
+  entry; it never propagates process argv to CEF, and the port is read **exclusively** from
+  `Contents/Resources/build.json` `chromiumFlags.remote-debugging-port` by `libNativeWrapper.dylib`
+  at runtime (pinned 9333 + `--remote-debugging-port=9351` arg → CEF stayed on 9333; emptied config +
+  arg → fell back to 9222). **So the port is fixed per bundle.** To vary it per worker, give each
+  worker its own bundle copy (`cp -c`, APFS clone ≈ instant) with the port written into that copy's
+  `build.json` (no full rebuild — the dylib re-reads `build.json` at runtime).
+- **Cache / user-data isolation — `CFFIXED_USER_HOME` works ✅.** `settings.root_cache_path` =
+  `buildAppDataPath(appSupport, identifier, channel, "CEF")` (`nativeWrapper.mm:5895–5908`), and
+  `NSApplicationSupportDirectory` resolves via `CFCopyHomeDirectoryURL()` which honors
+  **`CFFIXED_USER_HOME`**. Setting a distinct `CFFIXED_USER_HOME` per launch redirects each instance's
+  CEF cache to its own root (verified: real home stayed clean; `HOME` not required, harmless to also
+  set). This defeats CEF's single-instance-per-cache-root folding.
 
-**Implication for multiremote / per-worker parallelism:** there is **no local mechanism** to give
-concurrent same-app instances distinct cache roots. True parallelism is **blocked pending an upstream
-Electrobun change** (expose a cache-root / channel / `--user-data-dir` override at launch) — the same
-shape as Dioxus's Linux-external provider being blocked on an upstream Wry PR. **Recommendation:**
-ship single-instance MVP + feature surface now; document multiremote/parallel as a known limitation
-with an upstream tracking issue.
+**Implication for multiremote / per-worker parallelism — ACHIEVABLE on macOS, no upstream change.**
+Empirically confirmed: with per-instance `CFFIXED_USER_HOME` + per-instance `build.json` port, two
+concurrent same-app instances both served CDP and were independently driveable (`Runtime.evaluate`
+`1+1`→`2` on both ports, 2 process trees, 2 distinct caches, zero "Opening in existing browser
+session"). **Mechanism the launcher must implement:** per worker → clone the `.app` (APFS `cp -c`),
+write a distinct allocated `remote-debugging-port` into the clone's `Contents/Resources/build.json`,
+launch with a distinct `CFFIXED_USER_HOME` temp dir. Single-instance (MVP) is the same path with N=1.
+(Linux/Windows isolation still unverified — CI.)
+
+### CFFIXED_USER_HOME workaround test (decisive evidence)
+- Control (no home override): only 1 of 2 ports served CDP; instance B logged `Opening in existing
+  browser session`; both resolved the same `~/Library/Application Support/<id>/dev/CEF`.
+- Workaround (`CFFIXED_USER_HOME=/tmp/eb-home-N` per instance): both `:9361/json/version` and
+  `:9362/json/version` live simultaneously, 2 CEF trees, caches under each redirected home, both WS-
+  driveable. `CFFIXED_USER_HOME` alone is sufficient.
+- Launch-arg port override: **does not work** (see above) → per-worker bundle copy required.
+- Caveats: benign `Cannot create profile at path .../partitions/default` + transient
+  `blink.mojom.Widget` warnings appear in ALL runs (incl. baseline), not caused by the redirect;
+  bundled resources render fine under a redirected home; startup time unaffected.
 
 ## API gotcha worth recording
 `app` is a **named export** (`import { app } from "electrobun/bun"`), not on the default export. `Electrobun.app.on(...)` throws; the default export only carries `.events`.

--- a/agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md
+++ b/agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md
@@ -58,6 +58,33 @@ Every CEF webview exposes: `__electrobun` (`receiveMessageFromBun`, `receiveInte
    - **B2 (hard crash):** the bundler renames `import {join}`→`join5` for the WGPU chunk but drops `dirname`, so the Bun worker dies on boot with `ReferenceError: dirname is not defined` in `findWgpuLibraryPath`.
 4. **Version skew** — npm `electrobun` 1.18.1 lags source/CEF 1.18.4-beta.3 / Chromium 147. Pin compatible Electrobun + chromedriver (major 147) explicitly.
 
+## Launch-time control mechanism (PR2 source investigation)
+
+Followed up on blocker 1 by reading the macOS native wrapper + `chromium_flags.h`:
+
+- **Port — launch-overridable ✅.** `startEventLoop`/`CefMainArgs` is built from the process's own
+  `[NSProcessInfo arguments]` (`nativeWrapper.mm:5824–5832`), so `--remote-debugging-port=N` passed to
+  the app binary at launch reaches CEF's global command line. `chromiumFlags` from `build.json` are
+  applied *separately* in `OnBeforeCommandLineProcessing`. The command-line switch wins over
+  `settings.remote_debugging_port` (the 9222–9232 scan). **Plan: build the app WITHOUT pinning the
+  port in `chromiumFlags`; the launcher passes a distinct allocated `--remote-debugging-port` per
+  spawn.** (No need to scan/discover.)
+- **Cache / user-data isolation — NOT launch-overridable ❌.** `settings.root_cache_path` =
+  `buildAppDataPath(appSupport, g_electrobunIdentifier, g_electrobunChannel, "CEF")`
+  (`nativeWrapper.mm:5895–5908`). `identifier`/`channel` are set via FFI in
+  `startEventLoop(identifier, name, channel)` (`:6794`) from the Bun process's `_carrotContext`
+  (`bun/index.ts:51,205`) — i.e. the app's build/launch context, not a CLI flag or env var. Because
+  `root_cache_path` is set explicitly, CEF ignores a `--user-data-dir` switch. A bundle-copy doesn't
+  help (the identifier isn't read from `build.json`). **Consequence: two instances of the same app
+  share the cache root → CEF folds the 2nd into the 1st (the spike's single-instance finding).**
+
+**Implication for multiremote / per-worker parallelism:** there is **no local mechanism** to give
+concurrent same-app instances distinct cache roots. True parallelism is **blocked pending an upstream
+Electrobun change** (expose a cache-root / channel / `--user-data-dir` override at launch) — the same
+shape as Dioxus's Linux-external provider being blocked on an upstream Wry PR. **Recommendation:**
+ship single-instance MVP + feature surface now; document multiremote/parallel as a known limitation
+with an upstream tracking issue.
+
 ## API gotcha worth recording
 `app` is a **named export** (`import { app } from "electrobun/bun"`), not on the default export. `Electrobun.app.on(...)` throws; the default export only carries `.events`.
 

--- a/agent-os/specs/20260528-electrobun-service/UPSTREAM_ISSUE_DRAFT.md
+++ b/agent-os/specs/20260528-electrobun-service/UPSTREAM_ISSUE_DRAFT.md
@@ -1,0 +1,35 @@
+# Draft upstream issue — Electrobun multi-instance support (NOT yet filed)
+
+**Status:** drafted, **on hold** (maintainer decision to not post yet — revisit later).
+**Target repo:** `blackboardsh/electrobun`.
+
+## Why
+`@wdio/electrobun-service` multiremote/parallel test execution needs to run multiple
+concurrent instances of the same app. Today that requires a workaround (per-worker
+`.app` clone + `build.json` port edit + distinct `CFFIXED_USER_HOME`). A launch-time
+override would make it first-class. See RESEARCH_FINDINGS.md for the mechanism.
+
+## Existing adjacent issues (searched — none covers this exact need)
+- **#445** Make CEF remote debugging opt-in — same `settings.remote_debugging_port` code path (security framing, not a runtime port override).
+- **#380** macOS CEF persistent partitions / custom request-context cache paths — the cache-root machinery our isolation depends on.
+- **#227** `requestSingleInstanceLock()` equivalent — the implicit single-instance folding is our root cause; that issue asks to *enforce* single-instance (inverse need).
+- **#228** Batteries-included E2E tests (`electrobun test`) — overlapping automation goals (their built-in runner).
+- (#438 already tracks the `dirname` bundler crash we hit; #424 is the no-TCP RPC transport.)
+
+## Drafted issue
+
+**Title:** Feature: opt-in multi-instance support (per-launch remote-debugging port + cache/user-data dir) for parallel automated testing
+
+**Body:**
+
+> **Context** — I'm building a WebdriverIO service (`@wdio/electrobun-service`) that drives CEF-rendered Electrobun apps over CDP (Chromedriver attaches via `goog:chromeOptions.debuggerAddress`). Single-instance automation works great on macOS — CEF serves `/json`, targets enumerate per webview, element-driving + deeplinks all work. 🎉
+>
+> **Blocker for parallel/multi-worker testing** — running two instances of the same app at once needs hacks, because:
+> 1. **Single-instance per cache root** — `settings.root_cache_path` derives from `identifier`+`channel` (`buildAppDataPath(...)`), so a 2nd launch of the same bundle folds into the 1st (`"Opening in existing browser session."`) with no 2nd CEF/debug endpoint.
+> 2. **Remote-debugging port is build-time only** — read from the bundle's `Contents/Resources/build.json` `chromiumFlags["remote-debugging-port"]`; `main.js` doesn't forward process argv to CEF, so a `--remote-debugging-port` launch arg is ignored.
+>
+> **Current workaround (works, heavy)** — per worker: `cp -c` the `.app`, rewrite the copy's `build.json` port, launch with a distinct `CFFIXED_USER_HOME` (redirects the cache root via `CFCopyHomeDirectoryURL`). macOS-only confidence; N bundle copies; relies on undocumented env behavior.
+>
+> **Request** — a documented way to run concurrent instances of one app for automated testing, ideally launch-time overrides: `ELECTROBUN_REMOTE_DEBUGGING_PORT=<n>` and `ELECTROBUN_USER_DATA_DIR=<path>` (or an "allow multiple instances" mode). Also benefits DevTools/MCP and any external harness (WDIO, Playwright).
+>
+> **Related:** #445 (remote-debugging opt-in — same code path), #380 (custom CEF cache paths), #227 (single-instance lock — inverse need / root cause), #228 (batteries-included E2E). Happy to test / contribute a PR.

--- a/packages/electrobun-cdp-bridge/src/bridge.ts
+++ b/packages/electrobun-cdp-bridge/src/bridge.ts
@@ -1,0 +1,187 @@
+import { createLogger } from '@wdio/native-utils';
+
+import type { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping.js';
+
+import { Connection } from './connection.js';
+import {
+  DEFAULT_HOSTNAME,
+  DEFAULT_MAX_RETRY_COUNT,
+  DEFAULT_PORT,
+  DEFAULT_RETRY_INTERVAL,
+  ERROR_MESSAGE,
+  REQUEST_TIMEOUT,
+} from './constants.js';
+import { DevTool, type DevToolOptions } from './devTool.js';
+import { TargetRegistry } from './targetRegistry.js';
+import type { TargetRegistryEntry } from './types.js';
+
+const log = createLogger('electrobun-cdp-bridge', 'bridge');
+
+type Methods = keyof ProtocolMapping.Commands;
+type Events = keyof ProtocolMapping.Events;
+type MethodParams<T extends Methods> = ProtocolMapping.Commands[T]['paramsType'];
+type MethodReturn<T extends Methods> = ProtocolMapping.Commands[T]['returnType'];
+type SendParams<T extends Methods> = MethodParams<T> extends [] ? [] : [MethodParams<T>[number]];
+
+export type CdpBridgeOptions = DevToolOptions & {
+  waitInterval?: number;
+  connectionRetryCount?: number;
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Multi-target CDP client for an Electrobun CEF instance. Discovers every
+ * content webview target from `/json`, labels them via {@link TargetRegistry},
+ * and routes commands to the active target — backing the service's
+ * `switchWindow`/`listWindows`. Unlike a single-target client it holds one
+ * {@link Connection} per attached target.
+ *
+ * **Invariant: never issues `Page.navigate`.** Attaching/switching only enables
+ * the Runtime domain on the live target; reloading would destroy app state.
+ */
+export class CdpBridge {
+  #options: Required<CdpBridgeOptions>;
+  #devTool: DevTool;
+  #registry = new TargetRegistry();
+  #connections = new Map<string, Connection>();
+  #targets: TargetRegistryEntry[] = [];
+  #activeLabel: string | undefined;
+
+  constructor(options?: CdpBridgeOptions) {
+    this.#options = Object.assign(
+      {
+        host: DEFAULT_HOSTNAME,
+        port: DEFAULT_PORT,
+        timeout: REQUEST_TIMEOUT,
+        waitInterval: DEFAULT_RETRY_INTERVAL,
+        connectionRetryCount: DEFAULT_MAX_RETRY_COUNT,
+      },
+      options,
+    );
+    this.#devTool = new DevTool(this.#options);
+  }
+
+  /** Discover content targets, then attach to the primary (`main`) target. */
+  async connect(): Promise<void> {
+    await this.#discover();
+    if (this.#targets.length === 0) {
+      throw new Error(ERROR_MESSAGE.NO_PAGE_TARGETS);
+    }
+    this.#activeLabel = this.#targets[0].label;
+    await this.#ensureConnection(this.#activeLabel);
+  }
+
+  /** Re-enumerate targets (e.g. after a new window opens) and prune dead connections. */
+  async refresh(): Promise<TargetRegistryEntry[]> {
+    const list = await this.#devTool.list();
+    this.#targets = this.#registry.reconcile(list);
+    const live = new Set(this.#targets.map((target) => target.label));
+    for (const [label, connection] of this.#connections) {
+      if (!live.has(label)) {
+        void connection.close();
+        this.#connections.delete(label);
+      }
+    }
+    return [...this.#targets];
+  }
+
+  /** Live content targets (registration/label order). */
+  listTargets(): TargetRegistryEntry[] {
+    return [...this.#targets];
+  }
+
+  /** Live content target labels — backs `browser.electrobun.listWindows()`. */
+  listWindows(): string[] {
+    return this.#targets.map((target) => target.label);
+  }
+
+  get activeLabel(): string | undefined {
+    return this.#activeLabel;
+  }
+
+  /** CDP `/json/version` for the instance (CEF/Chromium version, for driver matching). */
+  version() {
+    return this.#devTool.version();
+  }
+
+  /** Make `label` the active target — backs `browser.electrobun.switchWindow()`. */
+  async switchTarget(label: string): Promise<void> {
+    if (!this.#targets.some((target) => target.label === label)) {
+      throw new Error(`${ERROR_MESSAGE.TARGET_NOT_FOUND} ${label}`);
+    }
+    await this.#ensureConnection(label);
+    this.#activeLabel = label;
+  }
+
+  /** Send a CDP command to the active target. */
+  send<T extends Methods>(method: T, ...params: SendParams<T>): Promise<MethodReturn<T>> {
+    return this.#active().send(method, ...params);
+  }
+
+  /** Send a CDP command to a specific target (e.g. log capture attaching everywhere). */
+  async sendTo<T extends Methods>(label: string, method: T, ...params: SendParams<T>): Promise<MethodReturn<T>> {
+    const connection = await this.#ensureConnection(label);
+    return connection.send(method, ...params);
+  }
+
+  /** Subscribe to a CDP event on the active target. */
+  on<T extends Events>(event: T, listener: (param: ProtocolMapping.Events[T][number]) => void): this {
+    this.#active().on(event, listener);
+    return this;
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([...this.#connections.values()].map((connection) => connection.close()));
+    this.#connections.clear();
+    this.#activeLabel = undefined;
+  }
+
+  async #discover(): Promise<void> {
+    let retries = 0;
+    while (true) {
+      try {
+        const list = await this.#devTool.list();
+        this.#targets = this.#registry.reconcile(list);
+        if (this.#targets.length > 0 || retries >= this.#options.connectionRetryCount) {
+          return;
+        }
+      } catch (error) {
+        if (retries >= this.#options.connectionRetryCount) {
+          throw error;
+        }
+        log.warn(`Target discovery attempt ${retries + 1} failed: ${(error as Error).message}`);
+      }
+      retries++;
+      await delay(this.#options.waitInterval);
+    }
+  }
+
+  async #ensureConnection(label: string): Promise<Connection> {
+    const existing = this.#connections.get(label);
+    if (existing) {
+      return existing;
+    }
+    const target = this.#targets.find((entry) => entry.label === label);
+    if (!target) {
+      throw new Error(`${ERROR_MESSAGE.TARGET_NOT_FOUND} ${label}`);
+    }
+    const connection = new Connection(target.webSocketDebuggerUrl, { timeout: this.#options.timeout });
+    await connection.connect();
+    // Attach is observation-only — enable Runtime, never Page.navigate.
+    await connection.send('Runtime.enable');
+    this.#connections.set(label, connection);
+    return connection;
+  }
+
+  #active(): Connection {
+    if (!this.#activeLabel) {
+      throw new Error(ERROR_MESSAGE.NOT_CONNECTED);
+    }
+    const connection = this.#connections.get(this.#activeLabel);
+    if (!connection) {
+      throw new Error(ERROR_MESSAGE.NOT_CONNECTED);
+    }
+    return connection;
+  }
+}

--- a/packages/electrobun-cdp-bridge/src/bridge.ts
+++ b/packages/electrobun-cdp-bridge/src/bridge.ts
@@ -83,6 +83,12 @@ export class CdpBridge {
         this.#connections.delete(label);
       }
     }
+    // If the active target was pruned (its window closed), auto-advance to the
+    // first surviving target so subsequent send()/on() don't throw an opaque
+    // NOT_CONNECTED — callers can still switchTarget() explicitly.
+    if (this.#activeLabel && !live.has(this.#activeLabel)) {
+      this.#activeLabel = this.#targets[0]?.label;
+    }
     return [...this.#targets];
   }
 

--- a/packages/electrobun-cdp-bridge/src/connection.ts
+++ b/packages/electrobun-cdp-bridge/src/connection.ts
@@ -18,6 +18,7 @@ type PromiseHandlers = {
   // biome-ignore lint/suspicious/noExplicitAny: resolve callback needs flexible type
   resolve: (value?: any) => void;
   reject: (reason?: unknown) => void;
+  timer?: ReturnType<typeof setTimeout>;
 };
 
 type EventValue = {
@@ -50,6 +51,7 @@ export class Connection extends EventEmitter {
   #ws: WebSocket | null = null;
   #promises = new Map<number, PromiseHandlers>();
   #commandId = CONNECT_PROMISE_ID;
+  #closeReason: Error | undefined;
 
   constructor(webSocketDebuggerUrl: string, options?: { timeout?: number }) {
     super();
@@ -92,14 +94,14 @@ export class Connection extends EventEmitter {
         reject(new Error(ERROR_MESSAGE.NOT_CONNECTED));
         return;
       }
-      this.#promises.set(message.id, { resolve, reject });
-      this.#ws.send(JSON.stringify(message));
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         if (this.#promises.has(message.id)) {
           this.#promises.delete(message.id);
           reject(new Error(`${ERROR_MESSAGE.TIMEOUT_CONNECTION} ${message.id}`));
         }
       }, this.#timeout);
+      this.#promises.set(message.id, { resolve, reject, timer });
+      this.#ws.send(JSON.stringify(message));
     });
   }
 
@@ -127,7 +129,8 @@ export class Connection extends EventEmitter {
     });
     ws.on('close', () => {
       log.trace(ERROR_MESSAGE.CONNECTION_CLOSED);
-      this.#rejectAllPromises();
+      this.#rejectAllPromises(this.#closeReason);
+      this.#closeReason = undefined;
       this.#ws = null;
     });
   }
@@ -145,6 +148,9 @@ export class Connection extends EventEmitter {
     const handler = this.#promises.get(message.id);
     if (!handler) {
       return;
+    }
+    if (handler.timer) {
+      clearTimeout(handler.timer);
     }
     if (message.error) {
       handler.reject(new Error(message.error.message));
@@ -165,17 +171,20 @@ export class Connection extends EventEmitter {
   }
 
   #close(error?: unknown) {
-    if (error) {
-      this.#rejectAllPromises(error as Error);
-    }
     return new Promise<void>((resolve) => {
       if (this.#ws && this.#ws.readyState !== WebSocket.CLOSED) {
+        // Reject pending promises via the single 'close' handler (it fires on
+        // ws.close() below), passing the error reason through #closeReason —
+        // avoids rejecting them here AND again in the handler.
+        this.#closeReason = error as Error | undefined;
         this.#ws.once('close', () => {
           this.#ws = null;
           resolve();
         });
         this.#ws.close();
       } else {
+        // No open socket → no 'close' event coming; reject directly.
+        this.#rejectAllPromises(error as Error | undefined);
         this.#ws = null;
         resolve();
       }
@@ -186,6 +195,9 @@ export class Connection extends EventEmitter {
     const message = error ? `${ERROR_MESSAGE.ERROR_INTERNAL} ${error.message}` : ERROR_MESSAGE.CONNECTION_CLOSED;
     const reason = new Error(message);
     this.#promises.forEach((handler) => {
+      if (handler.timer) {
+        clearTimeout(handler.timer);
+      }
       handler.reject(reason);
     });
     this.#promises.clear();

--- a/packages/electrobun-cdp-bridge/src/connection.ts
+++ b/packages/electrobun-cdp-bridge/src/connection.ts
@@ -1,0 +1,201 @@
+import EventEmitter from 'node:events';
+import { createLogger } from '@wdio/native-utils';
+
+import type { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping.js';
+import WebSocket from 'ws';
+
+import { ERROR_MESSAGE, REQUEST_TIMEOUT } from './constants.js';
+
+const log = createLogger('electrobun-cdp-bridge', 'bridge');
+
+type Methods = keyof ProtocolMapping.Commands;
+type Events = keyof ProtocolMapping.Events;
+type MethodParams<T extends Methods> = ProtocolMapping.Commands[T]['paramsType'];
+type MethodReturn<T extends Methods> = ProtocolMapping.Commands[T]['returnType'];
+type SendParams<T extends Methods> = MethodParams<T> extends [] ? [] : [MethodParams<T>[number]];
+
+type PromiseHandlers = {
+  // biome-ignore lint/suspicious/noExplicitAny: resolve callback needs flexible type
+  resolve: (value?: any) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type EventValue = {
+  method: string;
+  params: unknown;
+  sessionId?: string;
+};
+
+type MethodReturnValue = {
+  id: number;
+  result?: { result: unknown };
+  error?: { message: string };
+};
+
+const CONNECT_PROMISE_ID = 0;
+
+/**
+ * A single CDP WebSocket connection to one CEF page target. Extracted from
+ * `@wdio/electron-cdp-bridge`'s `CdpBridge`, but constructed from an explicit
+ * `webSocketDebuggerUrl` (the multi-target `CdpBridge` owns target discovery).
+ *
+ * Deliberately exposes **no navigate helper** — attaching to a live Electrobun
+ * webview must be observation/input only; issuing `Page.navigate` would reload
+ * the target and destroy the app's state. Callers send arbitrary CDP methods via
+ * `send()`, but the bridge never sends `Page.navigate` on attach/switch.
+ */
+export class Connection extends EventEmitter {
+  readonly webSocketDebuggerUrl: string;
+  #timeout: number;
+  #ws: WebSocket | null = null;
+  #promises = new Map<number, PromiseHandlers>();
+  #commandId = CONNECT_PROMISE_ID;
+
+  constructor(webSocketDebuggerUrl: string, options?: { timeout?: number }) {
+    super();
+    this.webSocketDebuggerUrl = webSocketDebuggerUrl;
+    this.#timeout = options?.timeout ?? REQUEST_TIMEOUT;
+  }
+
+  get state() {
+    return !this.#ws ? undefined : this.#ws.readyState;
+  }
+
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this.#ws) {
+        resolve();
+        return;
+      }
+      log.debug(`Connecting: ${this.webSocketDebuggerUrl}`);
+      this.#ws = new WebSocket(this.webSocketDebuggerUrl, [], {
+        maxPayload: 256 * 1024 * 1024,
+        perMessageDeflate: false,
+        followRedirects: true,
+        handshakeTimeout: this.#timeout,
+      });
+      this.#promises.set(CONNECT_PROMISE_ID, { resolve, reject });
+      this.#setHandlers(this.#ws);
+    });
+  }
+
+  on<T extends Events>(event: T, listener: (param: ProtocolMapping.Events[T][number]) => void): this {
+    return super.on(event, listener);
+  }
+
+  send<T extends Methods>(method: T, ...params: SendParams<T>): Promise<MethodReturn<T>> {
+    this.#commandId = this.#commandId + 1;
+    const messageId = this.#commandId;
+    const message = { id: messageId, method, params: params[0] || {} };
+    return new Promise((resolve, reject) => {
+      if (!this.#ws || this.#ws.readyState !== WebSocket.OPEN) {
+        reject(new Error(ERROR_MESSAGE.NOT_CONNECTED));
+        return;
+      }
+      this.#promises.set(message.id, { resolve, reject });
+      this.#ws.send(JSON.stringify(message));
+      setTimeout(() => {
+        if (this.#promises.has(message.id)) {
+          this.#promises.delete(message.id);
+          reject(new Error(`${ERROR_MESSAGE.TIMEOUT_CONNECTION} ${message.id}`));
+        }
+      }, this.#timeout);
+    });
+  }
+
+  close() {
+    return this.#close();
+  }
+
+  #setHandlers(ws: WebSocket) {
+    ws.on('open', () => {
+      log.debug(`Connected to ${this.webSocketDebuggerUrl}`);
+      this.#promises.get(CONNECT_PROMISE_ID)?.resolve();
+      this.#promises.delete(CONNECT_PROMISE_ID);
+    });
+    ws.on('message', async (rawMessage) => {
+      try {
+        this.#messageHandler(rawMessage.toString());
+      } catch (error) {
+        log.error('Message handling error');
+        return await this.#errorHandler(error);
+      }
+    });
+    ws.on('error', async (error) => {
+      log.error('WebSocket error');
+      return await this.#errorHandler(error);
+    });
+    ws.on('close', () => {
+      log.trace(ERROR_MESSAGE.CONNECTION_CLOSED);
+      this.#rejectAllPromises();
+      this.#ws = null;
+    });
+  }
+
+  #messageHandler(strMessage: string) {
+    const message = parseJson(strMessage);
+    if (message.id) {
+      this.#responseHandler(message);
+    } else if (message.method) {
+      this.#eventHandler(message);
+    }
+  }
+
+  #responseHandler(message: MethodReturnValue) {
+    const handler = this.#promises.get(message.id);
+    if (!handler) {
+      return;
+    }
+    if (message.error) {
+      handler.reject(new Error(message.error.message));
+    } else {
+      handler.resolve(message.result);
+    }
+    this.#promises.delete(message.id);
+  }
+
+  #eventHandler(message: EventValue) {
+    const { method, params, sessionId } = message;
+    this.emit(method, params, sessionId);
+  }
+
+  async #errorHandler(error: unknown) {
+    log.error((error as Error).message);
+    return await this.#close(error);
+  }
+
+  #close(error?: unknown) {
+    if (error) {
+      this.#rejectAllPromises(error as Error);
+    }
+    return new Promise<void>((resolve) => {
+      if (this.#ws && this.#ws.readyState !== WebSocket.CLOSED) {
+        this.#ws.once('close', () => {
+          this.#ws = null;
+          resolve();
+        });
+        this.#ws.close();
+      } else {
+        this.#ws = null;
+        resolve();
+      }
+    });
+  }
+
+  #rejectAllPromises(error?: Error) {
+    const message = error ? `${ERROR_MESSAGE.ERROR_INTERNAL} ${error.message}` : ERROR_MESSAGE.CONNECTION_CLOSED;
+    const reason = new Error(message);
+    this.#promises.forEach((handler) => {
+      handler.reject(reason);
+    });
+    this.#promises.clear();
+  }
+}
+
+const parseJson = (strJson: string) => {
+  try {
+    return JSON.parse(strJson);
+  } catch (error) {
+    throw new Error(`${ERROR_MESSAGE.ERROR_PARSE_JSON} ${(error as Error).message}`);
+  }
+};

--- a/packages/electrobun-cdp-bridge/src/devTool.ts
+++ b/packages/electrobun-cdp-bridge/src/devTool.ts
@@ -85,10 +85,10 @@ export class DevTool {
     const resolvedOptions: RequestOptions = Object.assign({}, this.#options, options);
     log.debug('Request to the debugger', resolvedOptions);
     return new Promise((resolve, reject) => {
+      // Order matters: run the request only AFTER the port opens. A `.catch().then()`
+      // chain would still run the `.then()` after the port-wait rejected (catch
+      // resolves), firing a request at a port that never opened.
       this.#waitDebuggerPort()
-        .catch(() => {
-          reject(new Error(ERROR_MESSAGE.TIMEOUT_WAIT_PORT));
-        })
         .then(() => {
           const req = http.request(resolvedOptions, (res) => {
             let data = '';
@@ -126,6 +126,9 @@ export class DevTool {
           });
 
           req.end();
+        })
+        .catch(() => {
+          reject(new Error(ERROR_MESSAGE.TIMEOUT_WAIT_PORT));
         });
     });
   }

--- a/packages/electrobun-cdp-bridge/src/devTool.ts
+++ b/packages/electrobun-cdp-bridge/src/devTool.ts
@@ -1,0 +1,142 @@
+import http, { type ClientRequest, type RequestOptions } from 'node:http';
+import { createLogger } from '@wdio/native-utils';
+
+import waitPort from 'wait-port';
+
+import { DEFAULT_HOSTNAME, DEFAULT_PORT, ERROR_MESSAGE, REQUEST_TIMEOUT } from './constants.js';
+import type { DebuggerList, Version } from './types.js';
+
+const log = createLogger('electrobun-cdp-bridge', 'bridge');
+
+export type DevToolOptions = {
+  host?: string;
+  port?: number;
+  timeout?: number;
+};
+
+type DevToolRequestOptions = RequestOptions & {
+  path: string;
+};
+
+type VersionReturnValue = {
+  Browser: string;
+  'Protocol-Version': string;
+};
+
+type WaitOptions = Parameters<typeof waitPort>[0];
+
+const BRIDGE_RETRY_INTERVAL = 100;
+
+/**
+ * Discovers CDP targets from a CEF instance's HTTP debugger endpoint. Mirrors
+ * `@wdio/electron-cdp-bridge`'s DevTool, but the consumer keeps **every**
+ * `type: 'page'` entry `list()` returns (CEF exposes one per webview), instead
+ * of using only the first.
+ */
+export class DevTool {
+  #options: Required<DevToolOptions>;
+  #isPortOpened = false;
+
+  constructor(options?: DevToolOptions) {
+    this.#options = Object.assign(
+      {
+        host: DEFAULT_HOSTNAME,
+        port: DEFAULT_PORT,
+        timeout: REQUEST_TIMEOUT,
+      },
+      options,
+    );
+  }
+
+  list() {
+    return this.#executeRequest<DebuggerList>({ path: '/json' });
+  }
+
+  async version(): Promise<Version> {
+    const result = await this.#executeRequest<VersionReturnValue>({ path: '/json/version' });
+    log.info(`Browser: ${result.Browser}, Protocol: ${result['Protocol-Version']}`);
+    return {
+      browser: result.Browser,
+      protocolVersion: result['Protocol-Version'],
+    };
+  }
+
+  #waitDebuggerPort() {
+    return new Promise<void>((resolve, reject) => {
+      if (!this.#isPortOpened) {
+        const waitOptions: WaitOptions = {
+          ...this.#options,
+          output: 'silent',
+          interval: BRIDGE_RETRY_INTERVAL,
+        };
+        waitPort(waitOptions)
+          .then(() => {
+            this.#isPortOpened = true;
+            resolve();
+          })
+          .catch(reject);
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async #executeRequest<T>(options: DevToolRequestOptions): Promise<T> {
+    const resolvedOptions: RequestOptions = Object.assign({}, this.#options, options);
+    log.debug('Request to the debugger', resolvedOptions);
+    return new Promise((resolve, reject) => {
+      this.#waitDebuggerPort()
+        .catch(() => {
+          reject(new Error(ERROR_MESSAGE.TIMEOUT_WAIT_PORT));
+        })
+        .then(() => {
+          const req = http.request(resolvedOptions, (res) => {
+            let data = '';
+            res.on('data', (chunk) => {
+              data += chunk;
+            });
+            res.on('end', () => {
+              try {
+                if (res.statusCode === 200) {
+                  const message = JSON.parse(data);
+                  log.trace('Received response: ', message);
+                  resolve(message);
+                } else {
+                  reject(new Error(data));
+                }
+              } catch (error) {
+                reject(error);
+              }
+            });
+          });
+
+          req.setTimeout(this.#options.timeout, () => {
+            this.#timeoutHandler(reject, req);
+          });
+
+          req.on('socket', (socket) => {
+            socket.setTimeout(this.#options.timeout);
+            socket.on('timeout', () => {
+              this.#timeoutHandler(reject, req);
+            });
+          });
+
+          req.on('error', (error) => {
+            reject(new Error(`Request Error: ${error.message}`));
+          });
+
+          req.end();
+        });
+    });
+  }
+
+  #timeoutHandler(reject: (reason?: Error) => void, request: ClientRequest) {
+    request.destroy();
+    const message = `${ERROR_MESSAGE.TIMEOUT_CONNECTION} ${getReqInfo(request)}`;
+    log.trace(message);
+    reject(new Error(message));
+  }
+}
+
+const getReqInfo = (request: ClientRequest) =>
+  `${request.method} ${request.protocol}//${request.getHeader('Host')}${request.path}`;

--- a/packages/electrobun-cdp-bridge/src/index.ts
+++ b/packages/electrobun-cdp-bridge/src/index.ts
@@ -1,7 +1,11 @@
 // @wdio/electrobun-cdp-bridge — multi-target CDP client for Electrobun's CEF
-// renderer. PR1 ships the constants + types; the multi-target connection
-// manager (bridge.ts, devTool.ts, connection.ts, targetRegistry.ts) lands in
-// the MVP PR.
+// renderer: discovers every content webview target, labels them, and routes
+// commands to the active target (backing switchWindow/listWindows). Never
+// issues Page.navigate on attach.
 
+export * from './bridge.js';
+export * from './connection.js';
 export * from './constants.js';
+export * from './devTool.js';
+export * from './targetRegistry.js';
 export * from './types.js';

--- a/packages/electrobun-cdp-bridge/src/targetRegistry.ts
+++ b/packages/electrobun-cdp-bridge/src/targetRegistry.ts
@@ -1,0 +1,82 @@
+import type { Debugger, DebuggerList, PageTarget, TargetClass, TargetRegistryEntry } from './types.js';
+
+const CONTENT_SCHEME_PREFIXES = ['views://', 'http://', 'https://', 'file://'];
+const NON_CONTENT_PREFIXES = ['devtools://', 'chrome://', 'chrome-extension://', 'chrome-untrusted://'];
+
+/**
+ * Classify a discovered CDP target. Pure + unit-tested in isolation because the
+ * discriminator is the part most likely to drift across Electrobun versions.
+ *
+ * Per the Phase 0 spike, Electrobun CEF windows surface as `type: 'page'` under
+ * the custom `views://` scheme with no separate shell target; we still keep the
+ * `shell`/`other` branches for robustness and fail **open** to `content` for an
+ * unknown page scheme so a real app webview is never hidden from the user.
+ */
+export function classifyTarget(target: Pick<Debugger, 'type' | 'url'>): TargetClass {
+  if (target.type !== 'page') {
+    return 'other';
+  }
+  const url = target.url ?? '';
+  if (NON_CONTENT_PREFIXES.some((prefix) => url.startsWith(prefix))) {
+    return 'other';
+  }
+  if (url === '' || url === 'about:blank') {
+    return 'shell';
+  }
+  if (CONTENT_SCHEME_PREFIXES.some((prefix) => url.startsWith(prefix))) {
+    return 'content';
+  }
+  return 'content';
+}
+
+function toPageTarget(target: Debugger): PageTarget {
+  return {
+    id: target.id,
+    title: target.title,
+    url: target.url,
+    webSocketDebuggerUrl: target.webSocketDebuggerUrl,
+    class: classifyTarget(target),
+  };
+}
+
+function labelOrder(label: string): number {
+  return label === 'main' ? -1 : Number.parseInt(label.replace('window-', ''), 10);
+}
+
+/**
+ * Tracks the user-facing label for each content target. Labels are stable: the
+ * first content target seen becomes `main`, then `window-1`, `window-2`…, keyed
+ * on the CEF target `id` so re-enumeration never renumbers a live target. The
+ * counter is monotonic — a closed-then-reopened window gets a fresh label rather
+ * than reclaiming a stale one.
+ */
+export class TargetRegistry {
+  #labelById = new Map<string, string>();
+  #counter = 0;
+
+  /** Reconcile against a fresh `/json` listing; returns live content targets in label order. */
+  reconcile(list: DebuggerList): TargetRegistryEntry[] {
+    const content = list.map(toPageTarget).filter((target) => target.class === 'content');
+    const liveIds = new Set(content.map((target) => target.id));
+
+    for (const target of content) {
+      if (!this.#labelById.has(target.id)) {
+        this.#labelById.set(target.id, this.#counter === 0 ? 'main' : `window-${this.#counter}`);
+        this.#counter++;
+      }
+    }
+    for (const id of [...this.#labelById.keys()]) {
+      if (!liveIds.has(id)) {
+        this.#labelById.delete(id);
+      }
+    }
+
+    return content
+      .map((target) => ({ ...target, label: this.#labelById.get(target.id) as string }))
+      .sort((a, b) => labelOrder(a.label) - labelOrder(b.label));
+  }
+
+  labelFor(id: string): string | undefined {
+    return this.#labelById.get(id);
+  }
+}

--- a/packages/electrobun-cdp-bridge/test/bridge.spec.ts
+++ b/packages/electrobun-cdp-bridge/test/bridge.spec.ts
@@ -94,4 +94,27 @@ describe('CdpBridge multi-target routing', () => {
 
     await expect(bridge.connect()).rejects.toThrow();
   });
+
+  it('should auto-advance the active target when the active window is pruned on refresh', async () => {
+    h.targets = [target('A', 'views://mainview/index.html'), target('B', 'views://secondview/index.html')];
+    const bridge = new CdpBridge();
+    await bridge.connect();
+    expect(bridge.activeLabel).toBe('main');
+
+    h.targets = [target('B', 'views://secondview/index.html')]; // 'main' (A) closed
+    await bridge.refresh();
+
+    expect(bridge.activeLabel).toBe('window-1');
+  });
+
+  it('should clear the active target when all targets disappear on refresh', async () => {
+    h.targets = [target('A', 'views://mainview/index.html')];
+    const bridge = new CdpBridge();
+    await bridge.connect();
+
+    h.targets = [];
+    await bridge.refresh();
+
+    expect(bridge.activeLabel).toBeUndefined();
+  });
 });

--- a/packages/electrobun-cdp-bridge/test/bridge.spec.ts
+++ b/packages/electrobun-cdp-bridge/test/bridge.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Debugger } from '../src/types.js';
+
+// Shared mutable state for the mocked DevTool/Connection (hoisted so the
+// vi.mock factories can reference it).
+const h = vi.hoisted(() => ({ targets: [] as Debugger[], sent: [] as string[] }));
+
+vi.mock('../src/devTool.js', () => ({
+  DevTool: class {
+    list = async () => h.targets;
+    version = async () => ({ browser: 'CEF', protocolVersion: '1.3' });
+  },
+}));
+
+vi.mock('../src/connection.js', () => ({
+  Connection: class {
+    webSocketDebuggerUrl: string;
+    constructor(url: string) {
+      this.webSocketDebuggerUrl = url;
+    }
+    connect = async () => {};
+    send = async (method: string) => {
+      h.sent.push(method);
+      return {};
+    };
+    on = () => this;
+    close = async () => {};
+  },
+}));
+
+import { CdpBridge } from '../src/bridge.js';
+
+const target = (id: string, url: string): Debugger => ({
+  id,
+  url,
+  type: 'page',
+  title: `title-${id}`,
+  description: '',
+  devtoolsFrontendUrl: '',
+  devtoolsFrontendUrlCompat: '',
+  faviconUrl: '',
+  webSocketDebuggerUrl: `ws://localhost:9222/devtools/page/${id}`,
+});
+
+beforeEach(() => {
+  h.targets = [];
+  h.sent.length = 0;
+});
+
+describe('CdpBridge multi-target routing', () => {
+  it('should attach to the main target on connect and enable Runtime but never navigate', async () => {
+    h.targets = [target('A', 'views://mainview/index.html'), target('B', 'views://secondview/index.html')];
+    const bridge = new CdpBridge();
+    await bridge.connect();
+
+    expect(bridge.activeLabel).toBe('main');
+    expect(bridge.listWindows()).toEqual(['main', 'window-1']);
+    expect(h.sent).toContain('Runtime.enable');
+    expect(h.sent).not.toContain('Page.navigate');
+  });
+
+  it('should switch the active target without navigating', async () => {
+    h.targets = [target('A', 'views://mainview/index.html'), target('B', 'views://secondview/index.html')];
+    const bridge = new CdpBridge();
+    await bridge.connect();
+
+    await bridge.switchTarget('window-1');
+
+    expect(bridge.activeLabel).toBe('window-1');
+    expect(h.sent).not.toContain('Page.navigate');
+  });
+
+  it('should expose live content targets via listTargets', async () => {
+    h.targets = [target('A', 'views://mainview/index.html'), target('B', 'views://secondview/index.html')];
+    const bridge = new CdpBridge();
+    await bridge.connect();
+
+    const labels = bridge.listTargets().map((entry) => entry.label);
+    expect(labels).toEqual(['main', 'window-1']);
+  });
+
+  it('should reject switching to an unknown label', async () => {
+    h.targets = [target('A', 'views://mainview/index.html')];
+    const bridge = new CdpBridge();
+    await bridge.connect();
+
+    await expect(bridge.switchTarget('window-9')).rejects.toThrow();
+  });
+
+  it('should throw when no content targets are discovered', async () => {
+    h.targets = [target('A', 'about:blank')];
+    const bridge = new CdpBridge({ connectionRetryCount: 0 });
+
+    await expect(bridge.connect()).rejects.toThrow();
+  });
+});

--- a/packages/electrobun-cdp-bridge/test/targetRegistry.spec.ts
+++ b/packages/electrobun-cdp-bridge/test/targetRegistry.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyTarget, TargetRegistry } from '../src/targetRegistry.js';
+import type { Debugger } from '../src/types.js';
+
+const mk = (id: string, url: string, type = 'page'): Debugger => ({
+  id,
+  url,
+  type,
+  title: `title-${id}`,
+  description: '',
+  devtoolsFrontendUrl: '',
+  devtoolsFrontendUrlCompat: '',
+  faviconUrl: '',
+  webSocketDebuggerUrl: `ws://localhost:9222/devtools/page/${id}`,
+});
+
+describe('classifyTarget', () => {
+  it('should classify a views:// page as content', () => {
+    expect(classifyTarget({ type: 'page', url: 'views://mainview/index.html' })).toBe('content');
+  });
+
+  it('should classify an http(s) dev-server page as content', () => {
+    expect(classifyTarget({ type: 'page', url: 'http://localhost:5173/' })).toBe('content');
+  });
+
+  it('should classify about:blank as a shell target', () => {
+    expect(classifyTarget({ type: 'page', url: 'about:blank' })).toBe('shell');
+  });
+
+  it('should classify devtools/chrome pages as other', () => {
+    expect(classifyTarget({ type: 'page', url: 'devtools://devtools/bundled/inspector.html' })).toBe('other');
+    expect(classifyTarget({ type: 'page', url: 'chrome://gpu' })).toBe('other');
+  });
+
+  it('should classify non-page targets as other', () => {
+    expect(classifyTarget({ type: 'service_worker', url: 'views://mainview/sw.js' })).toBe('other');
+  });
+
+  it('should fail open to content for an unknown page scheme', () => {
+    expect(classifyTarget({ type: 'page', url: 'app://weird/path' })).toBe('content');
+  });
+});
+
+describe('TargetRegistry', () => {
+  it('should label the first content target main and the rest window-N', () => {
+    const registry = new TargetRegistry();
+    const entries = registry.reconcile([
+      mk('A', 'views://mainview/index.html'),
+      mk('B', 'views://secondview/index.html'),
+    ]);
+    expect(entries.map((entry) => entry.label)).toEqual(['main', 'window-1']);
+  });
+
+  it('should exclude non-content targets and still label the first content one main', () => {
+    const registry = new TargetRegistry();
+    const entries = registry.reconcile([
+      mk('A', 'about:blank'),
+      mk('B', 'views://mainview/index.html'),
+      mk('C', 'devtools://devtools/x.html'),
+    ]);
+    expect(entries.map((entry) => entry.id)).toEqual(['B']);
+    expect(entries[0].label).toBe('main');
+  });
+
+  it('should keep labels stable across re-enumeration regardless of order', () => {
+    const registry = new TargetRegistry();
+    registry.reconcile([mk('A', 'views://m'), mk('B', 'views://s')]);
+    const again = registry.reconcile([mk('B', 'views://s'), mk('A', 'views://m')]);
+    expect(again.find((entry) => entry.id === 'A')?.label).toBe('main');
+    expect(again.find((entry) => entry.id === 'B')?.label).toBe('window-1');
+  });
+
+  it('should not reclaim a stale label after a window closes', () => {
+    const registry = new TargetRegistry();
+    registry.reconcile([mk('A', 'views://m'), mk('B', 'views://s')]);
+    registry.reconcile([mk('A', 'views://m')]);
+    const reopened = registry.reconcile([mk('A', 'views://m'), mk('C', 'views://t')]);
+    expect(reopened.find((entry) => entry.id === 'A')?.label).toBe('main');
+    expect(reopened.find((entry) => entry.id === 'C')?.label).toBe('window-2');
+  });
+});

--- a/packages/electrobun-service/src/commands/execute.ts
+++ b/packages/electrobun-service/src/commands/execute.ts
@@ -1,0 +1,81 @@
+// browser.electrobun.execute implementation.
+//
+// Electrobun is CDP-attach: there is no WebDriver executeScript channel for the
+// app's webview, so we run the user's code directly in the active CEF content
+// target via the CdpBridge's `Runtime.evaluate`. A string-built IIFE is built
+// from the user's function source (no Electron-style recast machinery needed for
+// MVP), with args inlined as JSON literals. The first callback arg is the
+// in-webview surface `window.__WDIO_ELECTROBUN__` (may be `{}` for MVP).
+//
+// Invariant: this never issues Page.navigate — the bridge only enables Runtime
+// on the live target (see @wdio/electrobun-cdp-bridge).
+
+import type { CdpBridge } from '@wdio/electrobun-cdp-bridge';
+import type { ElectrobunAPIs } from '@wdio/native-types';
+
+interface RemoteObject {
+  type?: string;
+  value?: unknown;
+  description?: string;
+}
+
+interface EvaluateResponse {
+  result?: RemoteObject;
+  exceptionDetails?: {
+    text?: string;
+    exception?: { description?: string; value?: unknown };
+  };
+}
+
+function inlineArgs(args: unknown[]): string {
+  return args
+    .map((arg, index) => {
+      try {
+        return JSON.stringify(arg) ?? 'undefined';
+      } catch (err) {
+        throw new Error(
+          `browser.electrobun.execute argument at index ${index} is not JSON-serialisable ` +
+            '(args are inlined into the script source via JSON.stringify). This typically means the ' +
+            `value contains a circular reference, a BigInt, or a function. Underlying error: ${(err as Error).message}`,
+        );
+      }
+    })
+    .join(', ');
+}
+
+/**
+ * Run a user function (or raw expression string) in the active Electrobun content
+ * target and return its (JSON-serialisable) result.
+ *
+ * Function form: the source is wrapped in an async IIFE that passes
+ * `window.__WDIO_ELECTROBUN__` (defaulting to `{}`) as the first arg, then the
+ * inlined user args. String form: evaluated as-is (standard expression).
+ */
+export async function execute<ReturnValue, InnerArguments extends unknown[] = unknown[]>(
+  bridge: CdpBridge,
+  script: string | ((eb: ElectrobunAPIs, ...args: InnerArguments) => ReturnValue),
+  ...args: InnerArguments
+): Promise<ReturnValue> {
+  const expression =
+    typeof script === 'function'
+      ? `(async () => {
+          const userFn = (${script.toString()});
+          const eb = window.__WDIO_ELECTROBUN__ || {};
+          return await userFn(eb, ${inlineArgs(args)});
+        })()`
+      : script;
+
+  const response = (await bridge.send('Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  })) as EvaluateResponse;
+
+  if (response.exceptionDetails) {
+    const detail =
+      response.exceptionDetails.exception?.description ?? response.exceptionDetails.text ?? 'Unknown evaluation error';
+    throw new Error(`browser.electrobun.execute failed: ${detail}`);
+  }
+
+  return response.result?.value as ReturnValue;
+}

--- a/packages/electrobun-service/src/commands/execute.ts
+++ b/packages/electrobun-service/src/commands/execute.ts
@@ -30,6 +30,14 @@ interface EvaluateResponse {
 function inlineArgs(args: unknown[]): string {
   return args
     .map((arg, index) => {
+      // JSON.stringify(fn) / JSON.stringify(symbol) returns `undefined` rather
+      // than throwing, which would silently drop the arg — reject those up front.
+      if (typeof arg === 'function' || typeof arg === 'symbol') {
+        throw new Error(
+          `browser.electrobun.execute argument at index ${index} is not JSON-serialisable ` +
+            `(a ${typeof arg} cannot be inlined into the script source; JSON.stringify would silently drop it).`,
+        );
+      }
       try {
         return JSON.stringify(arg) ?? 'undefined';
       } catch (err) {

--- a/packages/electrobun-service/src/electrobunConfig.ts
+++ b/packages/electrobun-service/src/electrobunConfig.ts
@@ -1,0 +1,287 @@
+// Locate and verify a built CEF Electrobun app bundle, and read/write the CEF
+// remote-debugging port the launcher pins into the bundle.
+//
+// Electrobun reads the CDP port EXCLUSIVELY from the bundle's
+// `Contents/Resources/build.json` `chromiumFlags["remote-debugging-port"]` at
+// runtime (a `--remote-debugging-port` launch arg does NOT reach CEF — see the
+// Phase 0 RESEARCH_FINDINGS). So to control the port the launcher writes it into
+// build.json. CEF's [9222, 9232] auto-scan is only a fallback when unset.
+//
+// macOS is the validated platform. Windows/Linux bundle layout is unverified, so
+// resolution + the CEF check there are best-effort and guarded by existence
+// checks rather than hard-failing on a missing framework — see the per-function
+// TODOs. E2E validation on those platforms is a documented follow-up (PR3/CI).
+
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from './constants.js';
+import { cefRendererRequired, SevereServiceError } from './errors.js';
+
+const log = createLogger(SERVICE_NAME, 'config');
+
+const REMOTE_DEBUGGING_FLAG = 'remote-debugging-port';
+
+/** Parsed shape of a bundle's `build.json` (only the keys this service reads). */
+export interface BuildJson {
+  identifier?: string;
+  name?: string;
+  /** CEF/Chromium command-line flags Electrobun forwards at launch. Values are strings. */
+  chromiumFlags?: Record<string, string>;
+  /** Renderer selection, when the bundle records it (`'cef'` enables CDP). */
+  renderer?: string;
+  defaultRenderer?: string;
+  [key: string]: unknown;
+}
+
+/** Resolved locations for a built Electrobun app, derived from the binary/bundle path. */
+export interface ResolvedElectrobunApp {
+  /** The launcher executable to spawn. */
+  binaryPath: string;
+  /** The `.app` bundle dir on macOS; the binary's parent dir elsewhere. */
+  bundlePath: string;
+  /** Directory holding `build.json` (`Contents/Resources` on macOS; binary dir elsewhere). */
+  resourcesDir: string;
+  /** Absolute path to `build.json`. */
+  buildJsonPath: string;
+  /** App identifier from build.json, when present. */
+  identifier?: string;
+}
+
+function pathExists(p: string): boolean {
+  return existsSync(p);
+}
+
+function isDirectory(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the on-disk layout of a built Electrobun app from an explicit path.
+ *
+ * Requires an explicit `appBinaryPath`: this service does NOT guess/auto-detect a
+ * bundle (the wrong bundle silently attaching to the wrong CDP port is far worse
+ * than a clear "set appBinaryPath" error). On macOS the path may point at either
+ * the `<App>.app` directory or the inner `Contents/MacOS/<exe>` binary.
+ *
+ * @throws SevereServiceError when `appBinaryPath` is missing or does not exist.
+ */
+export function resolveElectrobunApp(
+  appBinaryPath: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): ResolvedElectrobunApp {
+  if (!appBinaryPath) {
+    throw new SevereServiceError(
+      '@wdio/electrobun-service requires an explicit appBinaryPath in native mode. ' +
+        'Set it in wdio:electrobunServiceOptions (or the service-level options) — point it at the ' +
+        'built app (on macOS, the `<App>.app` bundle or its inner `Contents/MacOS/<exe>` binary). ' +
+        'Auto-detection is intentionally not attempted: attaching to the wrong bundle would silently ' +
+        'drive the wrong app over CDP.',
+    );
+  }
+
+  if (!pathExists(appBinaryPath)) {
+    throw new SevereServiceError(
+      `Electrobun app path does not exist: ${appBinaryPath}. ` +
+        'Build the app first and point appBinaryPath at the resulting bundle/binary.',
+    );
+  }
+
+  if (platform === 'darwin') {
+    return resolveMacosApp(appBinaryPath);
+  }
+
+  // Windows/Linux: layout unverified. Best-effort — treat the path as the binary
+  // with a sibling build.json. TODO(PR3/CI): verify the real on-disk layout on
+  // Windows and Linux and tighten this resolution.
+  const binaryPath = appBinaryPath;
+  const bundlePath = dirname(binaryPath);
+  const resourcesDir = bundlePath;
+  const buildJsonPath = join(resourcesDir, 'build.json');
+  const identifier = readBuildJson(buildJsonPath)?.identifier;
+  return { binaryPath, bundlePath, resourcesDir, buildJsonPath, identifier };
+}
+
+function resolveMacosApp(appPath: string): ResolvedElectrobunApp {
+  const bundlePath = resolveMacosBundle(appPath);
+  const resourcesDir = join(bundlePath, 'Contents', 'Resources');
+  const buildJsonPath = join(resourcesDir, 'build.json');
+  const binaryPath = resolveMacosBinary(bundlePath, appPath);
+  const identifier = readBuildJson(buildJsonPath)?.identifier;
+
+  return { binaryPath, bundlePath, resourcesDir, buildJsonPath, identifier };
+}
+
+function resolveMacosBundle(appPath: string): string {
+  // Accept either the `.app` directory or the inner binary.
+  if (appPath.endsWith('.app') && isDirectory(appPath)) {
+    return appPath;
+  }
+  if (isDirectory(appPath) && pathExists(join(appPath, 'Contents'))) {
+    return appPath;
+  }
+
+  // Treat as the inner binary: `<App>.app/Contents/MacOS/<exe>`.
+  const macosDir = dirname(appPath);
+  const contentsDir = dirname(macosDir);
+  const bundleRoot = dirname(contentsDir);
+  if (bundleRoot.endsWith('.app')) {
+    return bundleRoot;
+  }
+  // Non-standard layout: fall back to the binary's parent so resolution still
+  // yields a build.json location for verifyCefRenderer to evaluate.
+  return dirname(appPath);
+}
+
+function resolveMacosBinary(bundlePath: string, originalPath: string): string {
+  // If the caller already handed us the inner binary, keep it.
+  if (!isDirectory(originalPath) && originalPath.includes(join('Contents', 'MacOS'))) {
+    return originalPath;
+  }
+  const macosDir = join(bundlePath, 'Contents', 'MacOS');
+  // Convention: the launcher exe is named after the bundle (`Foo.app` → `Foo`).
+  const guessedName = basename(bundlePath).replace(/\.app$/, '');
+  const guessed = join(macosDir, guessedName);
+  if (pathExists(guessed)) {
+    return guessed;
+  }
+  // Fall back to the original path (may be the binary itself or a non-standard layout).
+  return originalPath;
+}
+
+/**
+ * Confirm the app is built with the CEF renderer (the only renderer that exposes
+ * a CDP endpoint). On macOS this is true if the CEF `.framework` is bundled under
+ * `Contents/Frameworks`, OR build.json records a `cef` renderer. On other
+ * platforms it is best-effort (build.json / sibling CEF lib) and deliberately
+ * does NOT false-negative when the layout can't be inspected.
+ *
+ * @throws cefRendererRequired when CEF is positively absent on macOS.
+ */
+export function verifyCefRenderer(app: ResolvedElectrobunApp, platform: NodeJS.Platform = process.platform): void {
+  const buildJson = readBuildJson(app.buildJsonPath);
+
+  if (platform === 'darwin') {
+    const frameworkPath = join(app.bundlePath, 'Contents', 'Frameworks', 'Chromium Embedded Framework.framework');
+    if (pathExists(frameworkPath)) {
+      log.debug(`CEF framework found: ${frameworkPath}`);
+      return;
+    }
+    if (buildJsonIndicatesCef(buildJson)) {
+      log.debug('CEF renderer indicated by build.json');
+      return;
+    }
+    throw cefRendererRequired(platform);
+  }
+
+  // Windows/Linux: best-effort. Pass if build.json indicates CEF or a sibling CEF
+  // library is present; otherwise warn (don't hard-fail) since the layout is
+  // unverified. TODO(PR3/CI): confirm the real CEF marker on these platforms.
+  if (buildJsonIndicatesCef(buildJson)) {
+    return;
+  }
+  if (siblingCefLibraryExists(app, platform)) {
+    return;
+  }
+  log.warn(
+    `Could not positively confirm the CEF renderer on ${platform} (bundle layout unverified). ` +
+      'Proceeding — if CDP attach fails, ensure the app was built with the CEF renderer.',
+  );
+}
+
+function buildJsonIndicatesCef(buildJson: BuildJson | undefined): boolean {
+  if (!buildJson) {
+    return false;
+  }
+  const renderer = (buildJson.renderer ?? buildJson.defaultRenderer ?? '').toString().toLowerCase();
+  if (renderer.includes('cef')) {
+    return true;
+  }
+  // A pinned remote-debugging port is a strong CEF signal — only CEF reads it.
+  return getRemoteDebuggingPort(buildJson) !== undefined;
+}
+
+function siblingCefLibraryExists(app: ResolvedElectrobunApp, platform: NodeJS.Platform): boolean {
+  const candidates =
+    platform === 'win32' ? ['libcef.dll', 'cef.dll'] : ['libcef.so', 'libElectrobunCEF.so', 'libNativeWrapper.so'];
+  return candidates.some((name) => pathExists(join(app.resourcesDir, name)) || pathExists(join(app.bundlePath, name)));
+}
+
+/**
+ * Read and parse a bundle's `build.json`. Returns `undefined` when the file is
+ * absent or unparseable (a malformed build.json shouldn't crash resolution; the
+ * caller decides whether the missing data is fatal).
+ */
+export function readBuildJson(buildJsonPath: string): BuildJson | undefined {
+  if (!pathExists(buildJsonPath)) {
+    return undefined;
+  }
+  try {
+    const raw = readFileSync(buildJsonPath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return undefined;
+    }
+    return parsed as BuildJson;
+  } catch (error) {
+    log.warn(`Failed to parse build.json at ${buildJsonPath}: ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+/** Read the pinned CEF remote-debugging port from a parsed build.json, if any. */
+export function getRemoteDebuggingPort(buildJson: BuildJson | undefined): number | undefined {
+  const raw = buildJson?.chromiumFlags?.[REMOTE_DEBUGGING_FLAG];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(String(raw), 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Pin a CEF remote-debugging port into a bundle's `build.json`, writing it as a
+ * string under `chromiumFlags["remote-debugging-port"]` and preserving every
+ * other key. The launcher calls this so CEF binds the allocated port at startup.
+ *
+ * @throws SevereServiceError when build.json is missing/unwritable — without it
+ *   the port can't be pinned and the worker's CDP attach has no fixed endpoint.
+ */
+export function writeRemoteDebuggingPort(buildJsonPath: string, port: number): void {
+  const existing = readBuildJson(buildJsonPath);
+  if (!existing) {
+    if (!pathExists(buildJsonPath)) {
+      throw new SevereServiceError(
+        `Cannot pin the CEF remote-debugging port: build.json not found at ${buildJsonPath}. ` +
+          'The Electrobun bundle is missing its Contents/Resources/build.json.',
+      );
+    }
+    // File present but unparseable — refuse to clobber it.
+    throw new SevereServiceError(
+      `Cannot pin the CEF remote-debugging port: build.json at ${buildJsonPath} is not valid JSON.`,
+    );
+  }
+
+  const next: BuildJson = {
+    ...existing,
+    chromiumFlags: {
+      ...existing.chromiumFlags,
+      [REMOTE_DEBUGGING_FLAG]: String(port),
+    },
+  };
+
+  try {
+    writeFileSync(buildJsonPath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+    log.debug(`Pinned remote-debugging-port=${port} into ${buildJsonPath}`);
+  } catch (error) {
+    throw new SevereServiceError(
+      `Failed to write the CEF remote-debugging port into ${buildJsonPath}: ${(error as Error).message}`,
+    );
+  }
+}

--- a/packages/electrobun-service/src/index.ts
+++ b/packages/electrobun-service/src/index.ts
@@ -17,4 +17,9 @@ export { ElectrobunLaunchService as launcher };
 export default ElectrobunWorkerService;
 
 export { cefRendererRequired, deeplinkUnsupportedOnPlatform, SevereServiceError } from './errors.js';
+export {
+  cleanup as cleanupWdioSession,
+  createElectrobunCapabilities,
+  init as startWdioSession,
+} from './session.js';
 export type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './types.js';

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -3,9 +3,16 @@ import { createLogger } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
 
 import { DEFAULT_DEBUG_PORT_BASE, SERVICE_NAME } from './constants.js';
+import {
+  type ResolvedElectrobunApp,
+  resolveElectrobunApp,
+  verifyCefRenderer,
+  writeRemoteDebuggingPort,
+} from './electrobunConfig.js';
 import { SevereServiceError } from './errors.js';
+import { type ElectrobunAppProcess, spawnElectrobunApp, stopElectrobunApp } from './nativeMode.js';
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
-import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions } from './types.js';
+import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './types.js';
 
 const log = createLogger(SERVICE_NAME, 'launcher');
 
@@ -14,15 +21,20 @@ const log = createLogger(SERVICE_NAME, 'launcher');
  *
  * Electrobun is a CDP-attach framework: the launcher spawns the app binary and
  * the worker attaches over CDP through Chromedriver (`debuggerAddress`). It
- * extends `BaseLauncher` to reuse `@wdio/native-core`'s port/process/log infra —
- * the spawned app process plays the role the driver process does in the
- * Wry-based services.
+ * extends `BaseLauncher` to reuse `@wdio/native-core`'s port/process/log infra.
  *
- * Native-mode launch (CEF verification, binary resolution, spawn + CEF debug
- * port discovery in 9222–9232) lands in the MVP PR. This foundation handles
- * service wiring and browser mode.
+ * Native-mode flow (MVP, single-instance):
+ *  - `onPrepare`: resolve + CEF-verify each app bundle, force `browserName: 'chrome'`.
+ *  - `onWorkerStart`: allocate a port, pin it into the bundle's build.json, spawn
+ *    the app with a per-run CFFIXED_USER_HOME, and set `goog:chromeOptions.debuggerAddress`.
+ *  - `onComplete`: kill spawned apps + clean temp dirs.
  */
 export default class ElectrobunLaunchService extends BaseLauncher {
+  private browserMode = false;
+  /** Resolved app bundle per capability index, set in onPrepare for onWorkerStart. */
+  private resolvedApps: ResolvedElectrobunApp[] = [];
+  private spawnedApps: ElectrobunAppProcess[] = [];
+
   constructor(
     private options: ElectrobunServiceGlobalOptions,
     _capabilities: ElectrobunCapabilities,
@@ -69,16 +81,97 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       for (const cap of capsList) {
         (cap as { browserName?: string }).browserName = 'chrome';
       }
+      this.browserMode = true;
       log.info('Browser mode enabled — skipping Electrobun binary/CDP setup');
       return;
     }
 
-    // Native mode: CEF-renderer verification, binary resolution, app spawn, and
-    // CEF debug-port discovery land in the MVP PR.
-    log.warn('Native-mode Electrobun launch is not yet implemented in this pre-release.');
+    // Native mode (MVP single-instance): resolve + CEF-verify each bundle, force
+    // chrome capability. The app spawn + port pinning happen in onWorkerStart so
+    // each worker gets a freshly allocated port.
+    this.resolvedApps = [];
+    for (const cap of capsList) {
+      const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
+      const app = resolveElectrobunApp(instanceOptions.appBinaryPath);
+      verifyCefRenderer(app);
+      this.resolvedApps.push(app);
+      (cap as { browserName?: string }).browserName = 'chrome';
+    }
+    log.info(`Native mode prepared ${this.resolvedApps.length} Electrobun app(s)`);
+  }
+
+  async onWorkerStart(
+    cid: string,
+    capabilities: ElectrobunCapabilities | ElectrobunCapabilities[] | undefined,
+  ): Promise<void> {
+    if (this.browserMode) {
+      log.debug(`Worker ${cid}: browser mode — skipping app spawn`);
+      return;
+    }
+    if (!capabilities) {
+      log.warn(`Worker ${cid}: no capabilities provided, skipping spawn`);
+      return;
+    }
+
+    const capsList = Array.isArray(capabilities) ? capabilities : [capabilities];
+
+    for (let i = 0; i < capsList.length; i++) {
+      const cap = capsList[i];
+      // MVP single-instance: one resolved app drives all workers. PR3 clones the
+      // bundle per worker; until then app[0] is the canonical bundle.
+      const app = this.resolvedApps[i] ?? this.resolvedApps[0];
+      if (!app) {
+        throw new SevereServiceError(
+          `Worker ${cid}: no resolved Electrobun app for capability ${i}. ` +
+            'onPrepare must run before onWorkerStart in native mode.',
+        );
+      }
+
+      const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
+      const port = await this.portManager.allocatePort(this.options.remoteDebuggingPort ?? DEFAULT_DEBUG_PORT_BASE);
+
+      // Pin the allocated port into the bundle's build.json — the CEF port is
+      // fixed per bundle (a launch arg does NOT work, see RESEARCH_FINDINGS).
+      // TODO(PR3): clone the bundle per worker and pin into the clone instead of
+      // mutating the shared bundle in place (mutation is acceptable single-instance).
+      writeRemoteDebuggingPort(app.buildJsonPath, port);
+
+      const spawned = this.spawnApp(app, port, instanceOptions, cid);
+      this.spawnedApps.push(spawned);
+
+      const existingChromeOptions = (cap['goog:chromeOptions'] ?? {}) as Record<string, unknown>;
+      cap['goog:chromeOptions'] = {
+        ...existingChromeOptions,
+        debuggerAddress: `localhost:${port}`,
+      };
+      log.info(`Worker ${cid}: Electrobun app on CDP port ${port} (debuggerAddress set)`);
+    }
+  }
+
+  // Seam for unit tests to assert spawn wiring without launching a real process.
+  protected spawnApp(
+    app: ResolvedElectrobunApp,
+    port: number,
+    options: ElectrobunServiceOptions,
+    instanceId?: string,
+  ): ElectrobunAppProcess {
+    return spawnElectrobunApp({
+      binaryPath: app.binaryPath,
+      appArgs: options.appArgs ?? [],
+      port,
+      options,
+      instanceId,
+    });
   }
 
   async onComplete(): Promise<void> {
+    for (const app of this.spawnedApps) {
+      await stopElectrobunApp(app).catch((error: Error) => {
+        log.warn(`Failed to stop Electrobun app: ${error.message}`);
+      });
+    }
+    this.spawnedApps = [];
+
     await this.stopAllDrivers();
     if (isLogWriterInitialized(SERVICE_NAME)) {
       await closeLogWriter(SERVICE_NAME);

--- a/packages/electrobun-service/src/nativeMode.ts
+++ b/packages/electrobun-service/src/nativeMode.ts
@@ -1,0 +1,150 @@
+// Native-mode process management for the Electrobun launcher.
+//
+// Electrobun is CDP-attach: the launcher spawns the built app binary, CEF binds
+// the port pinned in build.json, and the worker's CdpBridge attaches over CDP.
+// This module owns the spawn + per-run CFFIXED_USER_HOME temp dir + backend log
+// capture, and the teardown that kills the process and removes the temp dir.
+//
+// MVP is single-instance. A per-run CFFIXED_USER_HOME gives each run a clean,
+// isolated CEF cache root (RESEARCH_FINDINGS: NSApplicationSupportDirectory
+// honours CFFIXED_USER_HOME, defeating CEF's single-instance-per-cache-root
+// folding). PR3 will clone the bundle per worker for true multi-worker
+// parallelism; this module is the N=1 path of that mechanism.
+//
+// E2E-validation gap: spawn/teardown can only be exercised against a real built
+// CEF bundle (none in unit tests). Unit tests mock node:child_process / node:fs
+// at the @wdio/native-core + node boundary; the live path is covered by E2E.
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Interface as ReadlineInterface } from 'node:readline';
+
+import { createLogCapture } from '@wdio/native-core';
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from './constants.js';
+import type { ElectrobunServiceOptions } from './types.js';
+
+const log = createLogger(SERVICE_NAME, 'launcher');
+
+const SIGKILL_GRACE_MS = 5_000;
+
+export interface ElectrobunAppProcess {
+  proc: ChildProcess;
+  /** Per-run CFFIXED_USER_HOME temp dir to remove on teardown. */
+  userHomeDir: string;
+  /** Allocated CEF remote-debugging port (pinned into the bundle's build.json). */
+  port: number;
+  logHandlers: ReadlineInterface[];
+}
+
+export interface SpawnElectrobunAppParams {
+  binaryPath: string;
+  appArgs: string[];
+  port: number;
+  options: ElectrobunServiceOptions;
+  instanceId?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Spawn a built Electrobun app for native-mode CDP attach.
+ *
+ * Creates a per-run `CFFIXED_USER_HOME` temp dir for an isolated CEF cache root,
+ * spawns the binary, and (when log capture is enabled) wires stdout/stderr
+ * through `createLogCapture`. Returns the process handle plus the temp dir so the
+ * launcher can tear both down.
+ *
+ * The caller MUST have already pinned `port` into the bundle's build.json — the
+ * port is fixed per bundle, not a launch arg.
+ */
+export function spawnElectrobunApp(params: SpawnElectrobunAppParams): ElectrobunAppProcess {
+  const { binaryPath, appArgs, port, options, instanceId } = params;
+
+  const userHomeDir = mkdtempSync(join(tmpdir(), 'wdio-electrobun-home-'));
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...options.env,
+    // Redirect CEF's cache root to a per-run dir so a stale cache can't fold this
+    // launch into an existing browser session (RESEARCH_FINDINGS §CFFIXED_USER_HOME).
+    CFFIXED_USER_HOME: userHomeDir,
+  };
+
+  log.info(`Spawning Electrobun app: ${binaryPath} ${appArgs.join(' ')} (CDP port ${port})`);
+  const proc = spawn(binaryPath, appArgs, {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
+  log.info(`Electrobun app spawned (PID: ${proc.pid})`);
+
+  const logHandlers: ReadlineInterface[] = [];
+  if (options.captureBackendLogs) {
+    const identifier = `electrobun-${port}`;
+    const onLine = (line: string): void => {
+      log.info(`[backend] ${line}`);
+    };
+    const stdoutHandler = createLogCapture({ stream: proc.stdout, identifier, instanceId, onLine });
+    if (stdoutHandler) {
+      logHandlers.push(stdoutHandler);
+    }
+    const stderrHandler = createLogCapture({ stream: proc.stderr, identifier, instanceId, onLine });
+    if (stderrHandler) {
+      logHandlers.push(stderrHandler);
+    }
+  }
+
+  // A post-spawn 'error' (e.g. ENOENT for a bad binary path) would otherwise be
+  // an uncaught exception. Surface it; the worker's CDP attach failing is the
+  // real signal that the app didn't come up.
+  proc.on('error', (err) => {
+    log.error(`Electrobun app process error: ${err.message}`);
+  });
+
+  return { proc, userHomeDir, port, logHandlers };
+}
+
+/**
+ * Stop a spawned Electrobun app: close log handlers, SIGTERM (SIGKILL after a
+ * grace period), then remove the per-run CFFIXED_USER_HOME temp dir. Tolerant of
+ * an already-dead process and a missing temp dir.
+ */
+export async function stopElectrobunApp(app: ElectrobunAppProcess): Promise<void> {
+  for (const handler of app.logHandlers) {
+    try {
+      handler.close();
+    } catch {
+      // ignore
+    }
+  }
+
+  const { proc } = app;
+  if (proc.pid && proc.exitCode === null && proc.signalCode === null) {
+    log.info(`Stopping Electrobun app (PID: ${proc.pid})…`);
+    proc.kill('SIGTERM');
+
+    const deadline = Date.now() + SIGKILL_GRACE_MS;
+    while (Date.now() < deadline) {
+      if (proc.exitCode !== null || proc.signalCode !== null) {
+        break;
+      }
+      await sleep(100);
+    }
+    if (proc.exitCode === null && proc.signalCode === null) {
+      log.warn('Electrobun app did not exit gracefully, sending SIGKILL');
+      proc.kill('SIGKILL');
+    }
+  }
+
+  try {
+    rmSync(app.userHomeDir, { recursive: true, force: true });
+  } catch (error) {
+    log.warn(`Failed to remove CFFIXED_USER_HOME temp dir ${app.userHomeDir}: ${(error as Error).message}`);
+  }
+}

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -1,39 +1,156 @@
+import { CdpBridge } from '@wdio/electrobun-cdp-bridge';
+import type { ElectrobunServiceAPI } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 
-import { SERVICE_NAME } from './constants.js';
+import { execute } from './commands/execute.js';
+import { DEFAULT_REMOTE_DEBUGGING_PORT, SERVICE_NAME } from './constants.js';
+import { deeplinkUnsupportedOnPlatform } from './errors.js';
 import type { ElectrobunServiceOptions } from './types.js';
 
 const log = createLogger(SERVICE_NAME, 'service');
 
+const NOT_IMPLEMENTED_SUFFIX = 'is not implemented yet (lands in @wdio/electrobun-service feature-complete release)';
+
+function notImplemented(name: string): Error {
+  return new Error(`${name} ${NOT_IMPLEMENTED_SUFFIX}`);
+}
+
+/** Parse a `host:port` debuggerAddress into its parts. Defaults the host to localhost. */
+function parseDebuggerAddress(address: string): { host: string; port: number } {
+  const lastColon = address.lastIndexOf(':');
+  if (lastColon === -1) {
+    return { host: 'localhost', port: DEFAULT_REMOTE_DEBUGGING_PORT };
+  }
+  const host = address.slice(0, lastColon) || 'localhost';
+  const port = Number.parseInt(address.slice(lastColon + 1), 10);
+  return { host, port: Number.isNaN(port) ? DEFAULT_REMOTE_DEBUGGING_PORT : port };
+}
+
 /**
- * Worker-process service for `@wdio/electrobun-service`. Installs the
- * `browser.electrobun.*` surface and drives it over the multi-target CDP bridge.
+ * Worker-process service for `@wdio/electrobun-service`. Attaches a CdpBridge to
+ * the CEF debugger endpoint (`goog:chromeOptions.debuggerAddress`, set by the
+ * launcher) and installs the `browser.electrobun.*` surface.
  *
- * The CDP attach + `browser.electrobun.*` installation (execute, mocking,
- * switchWindow/listWindows, log capture, triggerDeeplink) lands across the MVP
- * and feature-complete PRs. This foundation handles construction/wiring.
+ * MVP scope: `execute` + `switchWindow`/`listWindows` are real (over the bridge);
+ * mocking + `triggerDeeplink` are stubs that throw a clear not-implemented error.
  */
 export default class ElectrobunWorkerService {
-  private browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser;
   private devServerUrl?: string;
+  private options: ElectrobunServiceOptions;
+  private bridges: CdpBridge[] = [];
 
   constructor(options: ElectrobunServiceOptions, capabilities: unknown) {
     const capOptions = (capabilities as { 'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions })[
       'wdio:electrobunServiceOptions'
     ];
     this.devServerUrl = capOptions?.devServerUrl ?? options.devServerUrl;
+    this.options = { ...options, ...capOptions };
     log.debug('ElectrobunWorkerService initialised');
   }
 
   async before(
-    _capabilities: unknown,
+    capabilities: unknown,
     _specs: string[],
     browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
   ): Promise<void> {
-    this.browser = browser;
-    // browser.electrobun.* installation over the CDP bridge lands in the MVP PR.
-    log.warn('browser.electrobun.* surface is not yet installed in this pre-release.');
-    void this.browser;
-    void this.devServerUrl;
+    // Browser mode: the frontend runs in a plain Chrome session against a dev
+    // server — no CEF, no CDP side-channel. The electrobun surface is not
+    // installed (execute/mock have no in-app target to drive).
+    if (this.devServerUrl) {
+      log.info('Browser mode — skipping CDP bridge attach');
+      return;
+    }
+
+    if (browser.isMultiremote) {
+      const mrBrowser = browser as WebdriverIO.MultiRemoteBrowser;
+      for (const instanceName of mrBrowser.instances) {
+        const instance = mrBrowser.getInstance(instanceName);
+        await this.attachInstance(instance, capabilityFor(capabilities, instanceName));
+      }
+      return;
+    }
+
+    await this.attachInstance(browser as WebdriverIO.Browser, capabilities);
   }
+
+  private async attachInstance(browser: WebdriverIO.Browser, capabilities: unknown): Promise<void> {
+    const chromeOptions = (capabilities as { 'goog:chromeOptions'?: { debuggerAddress?: string } } | undefined)?.[
+      'goog:chromeOptions'
+    ];
+    const debuggerAddress = chromeOptions?.debuggerAddress;
+
+    if (!debuggerAddress) {
+      log.warn(
+        'No goog:chromeOptions.debuggerAddress on the capability — cannot attach the CDP bridge. ' +
+          'browser.electrobun.* will be unavailable. Was the launcher (native mode) run?',
+      );
+      return;
+    }
+
+    const { host, port } = parseDebuggerAddress(debuggerAddress);
+    log.info(`Attaching CDP bridge to ${host}:${port}`);
+
+    const bridge = new CdpBridge({
+      host,
+      port,
+      timeout: this.options.cdpConnectionTimeout,
+      waitInterval: this.options.cdpConnectionRetryInterval,
+      connectionRetryCount: this.options.cdpConnectionRetryCount,
+    });
+    await bridge.connect();
+    this.bridges.push(bridge);
+
+    installApi(browser, bridge);
+  }
+
+  async after(): Promise<void> {
+    await this.closeBridges();
+  }
+
+  async afterSession(): Promise<void> {
+    await this.closeBridges();
+  }
+
+  private async closeBridges(): Promise<void> {
+    for (const bridge of this.bridges) {
+      await bridge.close().catch((error: Error) => {
+        log.warn(`Failed to close CDP bridge: ${error.message}`);
+      });
+    }
+    this.bridges = [];
+  }
+}
+
+/** Resolve the per-instance capability from a multiremote capabilities map. */
+function capabilityFor(capabilities: unknown, instanceName: string): unknown {
+  if (capabilities && typeof capabilities === 'object' && instanceName in (capabilities as Record<string, unknown>)) {
+    const entry = (capabilities as Record<string, { capabilities?: unknown }>)[instanceName];
+    return entry?.capabilities ?? entry ?? capabilities;
+  }
+  return capabilities;
+}
+
+/** Build and install the `browser.electrobun.*` surface backed by `bridge`. */
+function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge): void {
+  const electrobun: ElectrobunServiceAPI = {
+    execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>
+      execute<R, A>(bridge, script, ...args),
+    switchWindow: (label: string) => bridge.switchTarget(label),
+    listWindows: async () => bridge.listWindows(),
+    mock: () => Promise.reject(notImplemented('mock')),
+    isMockFunction: () => {
+      throw notImplemented('isMockFunction');
+    },
+    clearAllMocks: () => Promise.reject(notImplemented('clearAllMocks')),
+    resetAllMocks: () => Promise.reject(notImplemented('resetAllMocks')),
+    restoreAllMocks: () => Promise.reject(notImplemented('restoreAllMocks')),
+    triggerDeeplink: () => {
+      if (process.platform !== 'darwin') {
+        return Promise.reject(deeplinkUnsupportedOnPlatform());
+      }
+      return Promise.reject(notImplemented('triggerDeeplink'));
+    },
+  };
+  (browser as unknown as { electrobun: ElectrobunServiceAPI }).electrobun = electrobun;
+  log.debug('Installed browser.electrobun.*');
 }

--- a/packages/electrobun-service/src/session.ts
+++ b/packages/electrobun-service/src/session.ts
@@ -1,0 +1,130 @@
+// Standalone (`remote()`) session helpers for `@wdio/electrobun-service`.
+//
+// Mirrors the dioxus session API shape (createCapabilities / init / cleanup) but
+// follows the CDP-attach flow (like @wdio/electron-service): WDIO's `remote()`
+// only runs worker-level hooks, so init() manually drives the launcher's
+// onPrepare + onWorkerStart to resolve+spawn the app and set
+// `goog:chromeOptions.debuggerAddress` before opening the Chromedriver session.
+
+import type {
+  ElectrobunCapabilities,
+  ElectrobunServiceGlobalOptions,
+  ElectrobunServiceOptions,
+} from '@wdio/native-types';
+import { createLogger } from '@wdio/native-utils';
+import type { Options } from '@wdio/types';
+import { remote } from 'webdriverio';
+
+import { CUSTOM_CAPABILITY_NAME } from './constants.js';
+import ElectrobunLaunchService from './launcher.js';
+import ElectrobunWorkerService from './service.js';
+
+const log = createLogger('electrobun-service', 'session');
+
+const activeLaunchers = new Map<WebdriverIO.Browser, ElectrobunLaunchService>();
+const activeServices = new WeakMap<WebdriverIO.Browser, ElectrobunWorkerService>();
+
+/**
+ * Initialise an Electrobun standalone session.
+ *
+ * Drives the launcher's onPrepare + onWorkerStart manually (WDIO's `remote()`
+ * runs only worker hooks) so the app is spawned and the CEF debugger endpoint is
+ * pinned onto the capability, then opens the Chromedriver session and installs
+ * the `browser.electrobun.*` surface.
+ */
+export async function init(
+  capabilities: ElectrobunCapabilities,
+  globalOptions?: ElectrobunServiceGlobalOptions,
+): Promise<WebdriverIO.Browser> {
+  log.debug('Initializing Electrobun service in standalone mode…');
+
+  const capability = Array.isArray(capabilities) ? capabilities[0] : capabilities;
+  const testRunnerOpts = { capabilities: [] } as unknown as Options.Testrunner;
+  const launcher = new ElectrobunLaunchService(globalOptions ?? {}, capability, testRunnerOpts);
+
+  await launcher.onPrepare(testRunnerOpts, [capability]);
+  await launcher.onWorkerStart('', [capability]);
+
+  const browser = await remote({
+    capabilities: capability as WebdriverIO.Capabilities,
+  }).catch(async (error: Error) => {
+    log.error(`Failed to create remote session: ${error.message}`);
+    await launcher
+      .onComplete()
+      .catch((cleanupErr: Error) => log.warn(`Failed to stop app during cleanup: ${cleanupErr.message}`));
+    throw error;
+  });
+
+  activeLaunchers.set(browser, launcher);
+
+  const serviceOptions = capability[CUSTOM_CAPABILITY_NAME] ?? {};
+  const service = new ElectrobunWorkerService(serviceOptions, capability);
+  try {
+    await service.before(capability, [], browser);
+  } catch (error) {
+    await browser
+      .deleteSession()
+      .catch((e: Error) => log.warn(`Failed to delete session during service.before cleanup: ${e.message}`));
+    await launcher
+      .onComplete()
+      .catch((e: Error) => log.warn(`Failed to stop app during service.before cleanup: ${e.message}`));
+    activeLaunchers.delete(browser);
+    throw error;
+  }
+  activeServices.set(browser, service);
+
+  log.debug('Electrobun standalone session initialised');
+  return browser;
+}
+
+/** Clean up a standalone Electrobun session created by {@link init}. */
+export async function cleanup(browser: WebdriverIO.Browser): Promise<void> {
+  log.debug('Cleaning up Electrobun standalone session…');
+
+  const launcher = activeLaunchers.get(browser);
+  if (!launcher) {
+    log.warn('No launcher found for this browser instance');
+    return;
+  }
+
+  const service = activeServices.get(browser);
+  try {
+    await service?.after();
+  } catch (e) {
+    log.warn(`service.after() failed during cleanup: ${(e as Error).message}`);
+  }
+  try {
+    await service?.afterSession();
+  } catch (e) {
+    log.warn(`service.afterSession() failed during cleanup: ${(e as Error).message}`);
+  } finally {
+    activeServices.delete(browser);
+  }
+
+  try {
+    if (browser.sessionId) {
+      await browser.deleteSession();
+    }
+  } catch (e) {
+    log.warn(`Failed to delete session during cleanup: ${(e as Error).message}`);
+  }
+
+  try {
+    await launcher.onComplete();
+  } finally {
+    activeLaunchers.delete(browser);
+  }
+  log.debug('Electrobun standalone session cleaned up');
+}
+
+/** Build a minimal ElectrobunCapabilities object for standalone use. */
+export function createElectrobunCapabilities(options: ElectrobunServiceOptions): ElectrobunCapabilities {
+  if (options.mode !== 'browser' && !options.appBinaryPath) {
+    throw new Error('appBinaryPath is required for native-mode Electrobun standalone sessions');
+  }
+
+  return {
+    browserName: 'electrobun',
+    [CUSTOM_CAPABILITY_NAME]: { ...options },
+  };
+}

--- a/packages/electrobun-service/test/electrobunConfig.spec.ts
+++ b/packages/electrobun-service/test/electrobunConfig.spec.ts
@@ -1,0 +1,243 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SevereServiceError } from 'webdriverio';
+
+import {
+  type BuildJson,
+  getRemoteDebuggingPort,
+  readBuildJson,
+  resolveElectrobunApp,
+  verifyCefRenderer,
+  writeRemoteDebuggingPort,
+} from '../src/electrobunConfig.js';
+
+const CEF_FRAMEWORK = 'Chromium Embedded Framework.framework';
+
+interface FakeAppOptions {
+  withFramework?: boolean;
+  buildJson?: BuildJson | undefined;
+  bundleName?: string;
+}
+
+/**
+ * Build a fake macOS `.app` tree under a temp dir. Returns useful paths.
+ */
+function makeFakeMacApp(root: string, opts: FakeAppOptions = {}): { appDir: string; binaryPath: string } {
+  const bundleName = opts.bundleName ?? 'Demo';
+  const appDir = join(root, `${bundleName}.app`);
+  const macosDir = join(appDir, 'Contents', 'MacOS');
+  const resourcesDir = join(appDir, 'Contents', 'Resources');
+  mkdirSync(macosDir, { recursive: true });
+  mkdirSync(resourcesDir, { recursive: true });
+
+  const binaryPath = join(macosDir, bundleName);
+  writeFileSync(binaryPath, '#!/bin/sh\n', 'utf8');
+
+  if (opts.buildJson !== undefined) {
+    writeFileSync(join(resourcesDir, 'build.json'), JSON.stringify(opts.buildJson, null, 2), 'utf8');
+  }
+
+  if (opts.withFramework) {
+    mkdirSync(join(appDir, 'Contents', 'Frameworks', CEF_FRAMEWORK), { recursive: true });
+  }
+
+  return { appDir, binaryPath };
+}
+
+describe('electrobunConfig', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'eb-config-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  describe('resolveElectrobunApp', () => {
+    it('should throw a SevereServiceError when appBinaryPath is missing', () => {
+      expect(() => resolveElectrobunApp(undefined, 'darwin')).toThrow(SevereServiceError);
+      expect(() => resolveElectrobunApp(undefined, 'darwin')).toThrow(/explicit appBinaryPath/);
+    });
+
+    it('should throw a SevereServiceError when the path does not exist', () => {
+      const missing = join(root, 'NoSuch.app');
+      expect(() => resolveElectrobunApp(missing, 'darwin')).toThrow(SevereServiceError);
+      expect(() => resolveElectrobunApp(missing, 'darwin')).toThrow(/does not exist/);
+    });
+
+    it('should resolve from a macOS .app directory', () => {
+      const { appDir } = makeFakeMacApp(root, { buildJson: { identifier: 'com.example.demo' } });
+
+      const resolved = resolveElectrobunApp(appDir, 'darwin');
+
+      expect(resolved.bundlePath).toBe(appDir);
+      expect(resolved.resourcesDir).toBe(join(appDir, 'Contents', 'Resources'));
+      expect(resolved.buildJsonPath).toBe(join(appDir, 'Contents', 'Resources', 'build.json'));
+      expect(resolved.binaryPath).toBe(join(appDir, 'Contents', 'MacOS', 'Demo'));
+      expect(resolved.identifier).toBe('com.example.demo');
+    });
+
+    it('should resolve from the inner macOS binary path', () => {
+      const { appDir, binaryPath } = makeFakeMacApp(root, { buildJson: { identifier: 'com.example.demo' } });
+
+      const resolved = resolveElectrobunApp(binaryPath, 'darwin');
+
+      expect(resolved.bundlePath).toBe(appDir);
+      expect(resolved.binaryPath).toBe(binaryPath);
+      expect(resolved.buildJsonPath).toBe(join(appDir, 'Contents', 'Resources', 'build.json'));
+    });
+
+    it('should resolve a sibling build.json on non-macOS platforms', () => {
+      const binDir = join(root, 'linux-app');
+      mkdirSync(binDir, { recursive: true });
+      const binaryPath = join(binDir, 'demo');
+      writeFileSync(binaryPath, '#!/bin/sh\n', 'utf8');
+      writeFileSync(join(binDir, 'build.json'), JSON.stringify({ identifier: 'com.example.linux' }), 'utf8');
+
+      const resolved = resolveElectrobunApp(binaryPath, 'linux');
+
+      expect(resolved.binaryPath).toBe(binaryPath);
+      expect(resolved.bundlePath).toBe(binDir);
+      expect(resolved.resourcesDir).toBe(binDir);
+      expect(resolved.buildJsonPath).toBe(join(binDir, 'build.json'));
+      expect(resolved.identifier).toBe('com.example.linux');
+    });
+  });
+
+  describe('verifyCefRenderer', () => {
+    it('should pass on macOS when the CEF framework is present', () => {
+      const { appDir } = makeFakeMacApp(root, { withFramework: true, buildJson: {} });
+      const resolved = resolveElectrobunApp(appDir, 'darwin');
+
+      expect(() => verifyCefRenderer(resolved, 'darwin')).not.toThrow();
+    });
+
+    it('should pass on macOS when build.json indicates the cef renderer', () => {
+      const { appDir } = makeFakeMacApp(root, { buildJson: { renderer: 'cef' } });
+      const resolved = resolveElectrobunApp(appDir, 'darwin');
+
+      expect(() => verifyCefRenderer(resolved, 'darwin')).not.toThrow();
+    });
+
+    it('should pass on macOS when build.json pins a remote-debugging port', () => {
+      const { appDir } = makeFakeMacApp(root, {
+        buildJson: { chromiumFlags: { 'remote-debugging-port': '9333' } },
+      });
+      const resolved = resolveElectrobunApp(appDir, 'darwin');
+
+      expect(() => verifyCefRenderer(resolved, 'darwin')).not.toThrow();
+    });
+
+    it('should throw cefRendererRequired on macOS when CEF is absent', () => {
+      const { appDir } = makeFakeMacApp(root, { buildJson: { renderer: 'webview' } });
+      const resolved = resolveElectrobunApp(appDir, 'darwin');
+
+      expect(() => verifyCefRenderer(resolved, 'darwin')).toThrow(SevereServiceError);
+      expect(() => verifyCefRenderer(resolved, 'darwin')).toThrow(/CEF renderer/);
+    });
+
+    it('should throw cefRendererRequired on macOS when build.json is missing entirely', () => {
+      const { appDir } = makeFakeMacApp(root, { buildJson: undefined });
+      const resolved = resolveElectrobunApp(appDir, 'darwin');
+
+      expect(() => verifyCefRenderer(resolved, 'darwin')).toThrow(/CEF renderer/);
+    });
+
+    it('should not false-negative on non-macOS when CEF cannot be confirmed', () => {
+      const binDir = join(root, 'linux-app');
+      mkdirSync(binDir, { recursive: true });
+      const binaryPath = join(binDir, 'demo');
+      writeFileSync(binaryPath, '#!/bin/sh\n', 'utf8');
+      const resolved = resolveElectrobunApp(binaryPath, 'linux');
+
+      expect(() => verifyCefRenderer(resolved, 'linux')).not.toThrow();
+    });
+
+    it('should pass on non-macOS when build.json indicates cef', () => {
+      const binDir = join(root, 'linux-app');
+      mkdirSync(binDir, { recursive: true });
+      const binaryPath = join(binDir, 'demo');
+      writeFileSync(binaryPath, '#!/bin/sh\n', 'utf8');
+      writeFileSync(join(binDir, 'build.json'), JSON.stringify({ defaultRenderer: 'cef' }), 'utf8');
+      const resolved = resolveElectrobunApp(binaryPath, 'linux');
+
+      expect(() => verifyCefRenderer(resolved, 'linux')).not.toThrow();
+    });
+  });
+
+  describe('readBuildJson', () => {
+    it('should return undefined when build.json does not exist', () => {
+      expect(readBuildJson(join(root, 'nope', 'build.json'))).toBeUndefined();
+    });
+
+    it('should return undefined when build.json is not valid JSON', () => {
+      const p = join(root, 'build.json');
+      writeFileSync(p, '{ not json', 'utf8');
+      expect(readBuildJson(p)).toBeUndefined();
+    });
+
+    it('should parse a valid build.json', () => {
+      const p = join(root, 'build.json');
+      writeFileSync(p, JSON.stringify({ identifier: 'com.example.demo', chromiumFlags: {} }), 'utf8');
+      expect(readBuildJson(p)?.identifier).toBe('com.example.demo');
+    });
+  });
+
+  describe('getRemoteDebuggingPort', () => {
+    it('should return undefined when no port is pinned', () => {
+      expect(getRemoteDebuggingPort({ chromiumFlags: {} })).toBeUndefined();
+      expect(getRemoteDebuggingPort(undefined)).toBeUndefined();
+    });
+
+    it('should parse the pinned port string into a number', () => {
+      expect(getRemoteDebuggingPort({ chromiumFlags: { 'remote-debugging-port': '9333' } })).toBe(9333);
+    });
+
+    it('should return undefined for a non-numeric pinned value', () => {
+      expect(getRemoteDebuggingPort({ chromiumFlags: { 'remote-debugging-port': 'abc' } })).toBeUndefined();
+    });
+  });
+
+  describe('writeRemoteDebuggingPort', () => {
+    it('should write the port as a string and round-trip via readBuildJson', () => {
+      const p = join(root, 'build.json');
+      writeFileSync(p, JSON.stringify({ identifier: 'com.example.demo', name: 'Demo' }), 'utf8');
+
+      writeRemoteDebuggingPort(p, 9350);
+
+      const after = readBuildJson(p);
+      expect(after?.chromiumFlags?.['remote-debugging-port']).toBe('9350');
+      expect(getRemoteDebuggingPort(after)).toBe(9350);
+      // Other keys are preserved.
+      expect(after?.identifier).toBe('com.example.demo');
+      expect(after?.name).toBe('Demo');
+    });
+
+    it('should preserve existing chromiumFlags when pinning the port', () => {
+      const p = join(root, 'build.json');
+      writeFileSync(p, JSON.stringify({ chromiumFlags: { 'disable-gpu': 'true' } }), 'utf8');
+
+      writeRemoteDebuggingPort(p, 9351);
+
+      const after = readBuildJson(p);
+      expect(after?.chromiumFlags?.['disable-gpu']).toBe('true');
+      expect(after?.chromiumFlags?.['remote-debugging-port']).toBe('9351');
+    });
+
+    it('should throw a SevereServiceError when build.json does not exist', () => {
+      expect(() => writeRemoteDebuggingPort(join(root, 'missing', 'build.json'), 9333)).toThrow(SevereServiceError);
+      expect(() => writeRemoteDebuggingPort(join(root, 'missing', 'build.json'), 9333)).toThrow(/not found/);
+    });
+
+    it('should throw a SevereServiceError when build.json is not valid JSON', () => {
+      const p = join(root, 'build.json');
+      writeFileSync(p, '{ broken', 'utf8');
+      expect(() => writeRemoteDebuggingPort(p, 9333)).toThrow(/not valid JSON/);
+    });
+  });
+});

--- a/packages/electrobun-service/test/execute.spec.ts
+++ b/packages/electrobun-service/test/execute.spec.ts
@@ -44,6 +44,22 @@ describe('execute', () => {
     await expect(execute(bridge, (_eb, _arg: unknown) => undefined, circular)).rejects.toThrow(/not JSON-serialisable/);
   });
 
+  it('should reject function/symbol args instead of silently dropping them', async () => {
+    const { bridge, send } = makeBridge({ result: { value: undefined } });
+
+    await expect(
+      execute(
+        bridge,
+        (_eb, _arg: unknown) => undefined,
+        () => 1,
+      ),
+    ).rejects.toThrow(/not JSON-serialisable/);
+    await expect(execute(bridge, (_eb, _arg: unknown) => undefined, Symbol('s'))).rejects.toThrow(
+      /not JSON-serialisable/,
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it('should surface Runtime.evaluate exceptionDetails as a thrown error', async () => {
     const { bridge } = makeBridge({ exceptionDetails: { text: 'ReferenceError: x is not defined' } });
 

--- a/packages/electrobun-service/test/execute.spec.ts
+++ b/packages/electrobun-service/test/execute.spec.ts
@@ -1,0 +1,52 @@
+import type { CdpBridge } from '@wdio/electrobun-cdp-bridge';
+import { describe, expect, it, vi } from 'vitest';
+
+import { execute } from '../src/commands/execute.js';
+
+function makeBridge(response: unknown): { bridge: CdpBridge; send: ReturnType<typeof vi.fn> } {
+  const send = vi.fn().mockResolvedValue(response);
+  const bridge = { send } as unknown as CdpBridge;
+  return { bridge, send };
+}
+
+describe('execute', () => {
+  it('should inline function args as JSON literals into the IIFE', async () => {
+    const { bridge, send } = makeBridge({ result: { value: 'done' } });
+
+    await execute(bridge, (_eb, a: number, b: string) => `${a}${b}`, 7, 'x');
+
+    const expression = send.mock.calls[0][1].expression as string;
+    expect(expression).toContain('7, "x"');
+    expect(expression).toContain('__WDIO_ELECTROBUN__');
+  });
+
+  it('should return the evaluated value', async () => {
+    const { bridge } = makeBridge({ result: { value: { ok: true } } });
+
+    const result = await execute(bridge, () => ({ ok: true }));
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('should pass a string expression through unchanged', async () => {
+    const { bridge, send } = makeBridge({ result: { value: 2 } });
+
+    await execute(bridge, 'document.title');
+
+    expect(send.mock.calls[0][1].expression).toBe('document.title');
+  });
+
+  it('should throw a descriptive error for non-JSON-serialisable args', async () => {
+    const { bridge } = makeBridge({ result: { value: undefined } });
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await expect(execute(bridge, (_eb, _arg: unknown) => undefined, circular)).rejects.toThrow(/not JSON-serialisable/);
+  });
+
+  it('should surface Runtime.evaluate exceptionDetails as a thrown error', async () => {
+    const { bridge } = makeBridge({ exceptionDetails: { text: 'ReferenceError: x is not defined' } });
+
+    await expect(execute(bridge, () => undefined)).rejects.toThrow(/x is not defined/);
+  });
+});

--- a/packages/electrobun-service/test/index.spec.ts
+++ b/packages/electrobun-service/test/index.spec.ts
@@ -30,4 +30,11 @@ describe('@wdio/electrobun-service public exports', () => {
     const { SevereServiceError } = await import('../src/index.js');
     expect(SevereServiceError).toBeTypeOf('function');
   });
+
+  it('should expose the standalone session helpers', async () => {
+    const mod = await import('../src/index.js');
+    expect(mod.startWdioSession).toBeTypeOf('function');
+    expect(mod.cleanupWdioSession).toBeTypeOf('function');
+    expect(mod.createElectrobunCapabilities).toBeTypeOf('function');
+  });
 });

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SevereServiceError } from 'webdriverio';
+
+import { cefRendererRequired } from '../src/errors.js';
+
+// Mock the IO-bound config helpers so the launcher matrix can be driven without
+// a real bundle on disk. resolveElectrobunApp returns a fixed resolved app;
+// verifyCefRenderer / writeRemoteDebuggingPort are spied so throws + port pinning
+// can be asserted. (Their real behaviour is covered in electrobunConfig.spec.ts.)
+vi.mock('../src/electrobunConfig.js', () => ({
+  resolveElectrobunApp: vi.fn(() => ({
+    binaryPath: '/apps/Demo.app/Contents/MacOS/Demo',
+    bundlePath: '/apps/Demo.app',
+    resourcesDir: '/apps/Demo.app/Contents/Resources',
+    buildJsonPath: '/apps/Demo.app/Contents/Resources/build.json',
+    identifier: 'com.example.demo',
+  })),
+  verifyCefRenderer: vi.fn(),
+  writeRemoteDebuggingPort: vi.fn(),
+}));
+
+// Mock the native-mode spawn so no real process is launched.
+vi.mock('../src/nativeMode.js', () => ({
+  spawnElectrobunApp: vi.fn(() => ({
+    proc: { pid: 4321, exitCode: null, signalCode: null, kill: vi.fn() },
+    userHomeDir: '/tmp/wdio-electrobun-home-test',
+    port: 9333,
+    logHandlers: [],
+  })),
+  stopElectrobunApp: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { resolveElectrobunApp, verifyCefRenderer, writeRemoteDebuggingPort } from '../src/electrobunConfig.js';
+import ElectrobunLaunchService from '../src/launcher.js';
+import { spawnElectrobunApp, stopElectrobunApp } from '../src/nativeMode.js';
+import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions } from '../src/types.js';
+
+const baseConfig = {} as Parameters<ElectrobunLaunchService['onPrepare']>[0];
+
+function makeLauncher(options: ElectrobunServiceGlobalOptions): ElectrobunLaunchService {
+  return new ElectrobunLaunchService(options, {} as ElectrobunCapabilities, baseConfig);
+}
+
+describe('ElectrobunLaunchService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('onPrepare — browser mode', () => {
+    it('should set browserName=chrome and return early when mode=browser', async () => {
+      const launcher = makeLauncher({ mode: 'browser', devServerUrl: 'http://localhost:3000' });
+      const caps: ElectrobunCapabilities[] = [{ browserName: 'electrobun' }];
+
+      await launcher.onPrepare(baseConfig, caps);
+
+      expect(caps[0].browserName).toBe('chrome');
+      expect(vi.mocked(resolveElectrobunApp)).not.toHaveBeenCalled();
+    });
+
+    it('should throw SevereServiceError when devServerUrl is missing in browser mode', async () => {
+      const launcher = makeLauncher({ mode: 'browser' });
+      await expect(launcher.onPrepare(baseConfig, [{}])).rejects.toThrow(SevereServiceError);
+    });
+
+    it('should explain that devServerUrl is required in browser mode', async () => {
+      const launcher = makeLauncher({ mode: 'browser' });
+      await expect(launcher.onPrepare(baseConfig, [{}])).rejects.toThrow(/devServerUrl is required/);
+    });
+
+    it('should throw SevereServiceError when devServerUrl is not a valid URL', async () => {
+      const launcher = makeLauncher({ mode: 'browser', devServerUrl: 'not-a-url' });
+      await expect(launcher.onPrepare(baseConfig, [{}])).rejects.toThrow(/not a valid URL/);
+    });
+
+    it('should skip app spawn in onWorkerStart when in browser mode', async () => {
+      const launcher = makeLauncher({ mode: 'browser', devServerUrl: 'http://localhost:3000' });
+      await launcher.onPrepare(baseConfig, [{ browserName: 'electrobun' }]);
+
+      await launcher.onWorkerStart('0-0', [{ browserName: 'chrome' }]);
+
+      expect(vi.mocked(spawnElectrobunApp)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onPrepare — native mode', () => {
+    it('should resolve, CEF-verify, and force browserName=chrome on each capability', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      const caps: ElectrobunCapabilities[] = [{ browserName: 'electrobun' }];
+
+      await launcher.onPrepare(baseConfig, caps);
+
+      expect(vi.mocked(resolveElectrobunApp)).toHaveBeenCalledWith('/apps/Demo.app');
+      expect(vi.mocked(verifyCefRenderer)).toHaveBeenCalledTimes(1);
+      expect(caps[0].browserName).toBe('chrome');
+    });
+
+    it('should propagate a missing-appBinaryPath SevereServiceError from resolution', async () => {
+      vi.mocked(resolveElectrobunApp).mockImplementationOnce(() => {
+        throw new SevereServiceError('@wdio/electrobun-service requires an explicit appBinaryPath in native mode.');
+      });
+      const launcher = makeLauncher({});
+
+      await expect(launcher.onPrepare(baseConfig, [{}])).rejects.toThrow(/explicit appBinaryPath/);
+    });
+
+    it('should propagate cefRendererRequired when the app lacks the CEF renderer', async () => {
+      vi.mocked(verifyCefRenderer).mockImplementationOnce(() => {
+        throw cefRendererRequired('darwin');
+      });
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+
+      await expect(launcher.onPrepare(baseConfig, [{}])).rejects.toThrow(/CEF renderer/);
+    });
+
+    it('should resolve a capability-level appBinaryPath override', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Global.app' });
+      const caps: ElectrobunCapabilities[] = [
+        { 'wdio:electrobunServiceOptions': { appBinaryPath: '/apps/PerCap.app' } },
+      ];
+
+      await launcher.onPrepare(baseConfig, caps);
+
+      expect(vi.mocked(resolveElectrobunApp)).toHaveBeenCalledWith('/apps/PerCap.app');
+    });
+  });
+
+  describe('onWorkerStart — native mode', () => {
+    it('should allocate a port, pin it into build.json, spawn, and set debuggerAddress', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}]);
+
+      const cap: ElectrobunCapabilities = {};
+      await launcher.onWorkerStart('0-0', [cap]);
+
+      expect(vi.mocked(writeRemoteDebuggingPort)).toHaveBeenCalledTimes(1);
+      const [buildJsonPath, port] = vi.mocked(writeRemoteDebuggingPort).mock.calls[0];
+      expect(buildJsonPath).toBe('/apps/Demo.app/Contents/Resources/build.json');
+      expect(typeof port).toBe('number');
+
+      expect(vi.mocked(spawnElectrobunApp)).toHaveBeenCalledTimes(1);
+      const spawnArg = vi.mocked(spawnElectrobunApp).mock.calls[0][0];
+      expect(spawnArg.binaryPath).toBe('/apps/Demo.app/Contents/MacOS/Demo');
+      expect(spawnArg.port).toBe(port);
+
+      expect(cap['goog:chromeOptions']).toEqual({ debuggerAddress: `localhost:${port}` });
+    });
+
+    it('should preserve existing goog:chromeOptions when setting debuggerAddress', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}]);
+
+      const cap: ElectrobunCapabilities = { 'goog:chromeOptions': { args: ['--headless'] } };
+      await launcher.onWorkerStart('0-0', [cap]);
+
+      const chromeOptions = cap['goog:chromeOptions'] as Record<string, unknown>;
+      expect(chromeOptions.args).toEqual(['--headless']);
+      expect(chromeOptions.debuggerAddress).toMatch(/^localhost:\d+$/);
+    });
+
+    it('should accept a single (non-array) capability', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}]);
+
+      const cap: ElectrobunCapabilities = {};
+      await launcher.onWorkerStart('0-0', cap);
+
+      expect(vi.mocked(spawnElectrobunApp)).toHaveBeenCalledTimes(1);
+      expect(cap['goog:chromeOptions']).toBeDefined();
+    });
+
+    it('should throw SevereServiceError when no app was resolved (onPrepare skipped)', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      // Note: onPrepare intentionally NOT called.
+      await expect(launcher.onWorkerStart('0-0', [{}])).rejects.toThrow(/no resolved Electrobun app/);
+    });
+
+    it('should skip and warn when no capabilities are provided', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}]);
+
+      await expect(launcher.onWorkerStart('0-0', undefined)).resolves.toBeUndefined();
+      expect(vi.mocked(spawnElectrobunApp)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onComplete', () => {
+    it('should stop every spawned app and resolve cleanly', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}]);
+      await launcher.onWorkerStart('0-0', [{}]);
+
+      await expect(launcher.onComplete()).resolves.toBeUndefined();
+      expect(vi.mocked(stopElectrobunApp)).toHaveBeenCalledTimes(1);
+    });
+
+    it('should resolve without error when no apps were spawned', async () => {
+      const launcher = makeLauncher({ mode: 'browser', devServerUrl: 'http://localhost:3000' });
+      await launcher.onPrepare(baseConfig, [{}]);
+
+      await expect(launcher.onComplete()).resolves.toBeUndefined();
+      expect(vi.mocked(stopElectrobunApp)).not.toHaveBeenCalled();
+    });
+
+    it('should swallow a stopElectrobunApp rejection and still resolve', async () => {
+      vi.mocked(stopElectrobunApp).mockRejectedValueOnce(new Error('kill failed'));
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}]);
+      await launcher.onWorkerStart('0-0', [{}]);
+
+      await expect(launcher.onComplete()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/electrobun-service/test/nativeMode.spec.ts
+++ b/packages/electrobun-service/test/nativeMode.spec.ts
@@ -1,0 +1,176 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.fn();
+const mkdtempSyncMock = vi.fn();
+const rmSyncMock = vi.fn();
+const createLogCaptureMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+vi.mock('node:fs', () => ({
+  mkdtempSync: (...args: unknown[]) => mkdtempSyncMock(...args),
+  rmSync: (...args: unknown[]) => rmSyncMock(...args),
+}));
+
+vi.mock('@wdio/native-core', () => ({
+  createLogCapture: (...args: unknown[]) => createLogCaptureMock(...args),
+}));
+
+import { spawnElectrobunApp, stopElectrobunApp } from '../src/nativeMode.js';
+import type { ElectrobunServiceOptions } from '../src/types.js';
+
+interface FakeProc extends EventEmitter {
+  pid: number;
+  exitCode: number | null;
+  signalCode: string | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeProc(): FakeProc {
+  const proc = new EventEmitter() as FakeProc;
+  proc.pid = 4321;
+  proc.exitCode = null;
+  proc.signalCode = null;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  return proc;
+}
+
+describe('nativeMode', () => {
+  let proc: FakeProc;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    proc = makeFakeProc();
+    spawnMock.mockReturnValue(proc);
+    mkdtempSyncMock.mockReturnValue('/tmp/wdio-electrobun-home-abc');
+    createLogCaptureMock.mockReturnValue({ close: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('spawnElectrobunApp', () => {
+    it('should create a per-run CFFIXED_USER_HOME and pass it in the spawn env', () => {
+      const result = spawnElectrobunApp({
+        binaryPath: '/apps/Demo',
+        appArgs: ['--flag'],
+        port: 9333,
+        options: {} as ElectrobunServiceOptions,
+      });
+
+      expect(mkdtempSyncMock).toHaveBeenCalledTimes(1);
+      expect(result.userHomeDir).toBe('/tmp/wdio-electrobun-home-abc');
+
+      const [binary, args, opts] = spawnMock.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
+      expect(binary).toBe('/apps/Demo');
+      expect(args).toEqual(['--flag']);
+      expect(opts.env.CFFIXED_USER_HOME).toBe('/tmp/wdio-electrobun-home-abc');
+    });
+
+    it('should merge user-supplied env over process.env', () => {
+      spawnElectrobunApp({
+        binaryPath: '/apps/Demo',
+        appArgs: [],
+        port: 9333,
+        options: { env: { MY_FLAG: 'on' } } as ElectrobunServiceOptions,
+      });
+
+      const opts = spawnMock.mock.calls[0][2] as { env: NodeJS.ProcessEnv };
+      expect(opts.env.MY_FLAG).toBe('on');
+    });
+
+    it('should not wire log capture when captureBackendLogs is off', () => {
+      spawnElectrobunApp({
+        binaryPath: '/apps/Demo',
+        appArgs: [],
+        port: 9333,
+        options: { captureBackendLogs: false } as ElectrobunServiceOptions,
+      });
+
+      expect(createLogCaptureMock).not.toHaveBeenCalled();
+    });
+
+    it('should wire stdout + stderr log capture when captureBackendLogs is on', () => {
+      const result = spawnElectrobunApp({
+        binaryPath: '/apps/Demo',
+        appArgs: [],
+        port: 9333,
+        options: { captureBackendLogs: true } as ElectrobunServiceOptions,
+      });
+
+      expect(createLogCaptureMock).toHaveBeenCalledTimes(2);
+      expect(result.logHandlers).toHaveLength(2);
+    });
+
+    it('should not throw when the process emits a post-spawn error', () => {
+      spawnElectrobunApp({
+        binaryPath: '/apps/Demo',
+        appArgs: [],
+        port: 9333,
+        options: {} as ElectrobunServiceOptions,
+      });
+
+      expect(() => proc.emit('error', new Error('ENOENT'))).not.toThrow();
+    });
+  });
+
+  describe('stopElectrobunApp', () => {
+    it('should close log handlers, SIGTERM the live process, and remove the temp dir', async () => {
+      const handler = { close: vi.fn() };
+      // Process exits promptly after SIGTERM.
+      proc.kill.mockImplementation(() => {
+        proc.exitCode = 0;
+        return true;
+      });
+
+      await stopElectrobunApp({
+        proc: proc as unknown as import('node:child_process').ChildProcess,
+        userHomeDir: '/tmp/wdio-electrobun-home-abc',
+        port: 9333,
+        logHandlers: [handler as unknown as import('node:readline').Interface],
+      });
+
+      expect(handler.close).toHaveBeenCalled();
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(rmSyncMock).toHaveBeenCalledWith('/tmp/wdio-electrobun-home-abc', { recursive: true, force: true });
+    });
+
+    it('should skip killing an already-exited process but still remove the temp dir', async () => {
+      proc.exitCode = 0;
+
+      await stopElectrobunApp({
+        proc: proc as unknown as import('node:child_process').ChildProcess,
+        userHomeDir: '/tmp/wdio-electrobun-home-abc',
+        port: 9333,
+        logHandlers: [],
+      });
+
+      expect(proc.kill).not.toHaveBeenCalled();
+      expect(rmSyncMock).toHaveBeenCalled();
+    });
+
+    it('should not throw when temp-dir removal fails', async () => {
+      proc.exitCode = 0;
+      rmSyncMock.mockImplementationOnce(() => {
+        throw new Error('EBUSY');
+      });
+
+      await expect(
+        stopElectrobunApp({
+          proc: proc as unknown as import('node:child_process').ChildProcess,
+          userHomeDir: '/tmp/wdio-electrobun-home-abc',
+          port: 9333,
+          logHandlers: [],
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const connectMock = vi.fn().mockResolvedValue(undefined);
+const sendMock = vi.fn();
+const switchTargetMock = vi.fn().mockResolvedValue(undefined);
+const listWindowsMock = vi.fn().mockReturnValue(['main', 'second']);
+const closeMock = vi.fn().mockResolvedValue(undefined);
+const cdpBridgeCtor = vi.fn();
+
+vi.mock('@wdio/electrobun-cdp-bridge', () => ({
+  CdpBridge: class {
+    constructor(opts: unknown) {
+      cdpBridgeCtor(opts);
+    }
+    connect = connectMock;
+    send = sendMock;
+    switchTarget = switchTargetMock;
+    listWindows = listWindowsMock;
+    close = closeMock;
+  },
+}));
+
+import type { ElectrobunServiceAPI } from '@wdio/native-types';
+import ElectrobunWorkerService from '../src/service.js';
+
+type Installed = { electrobun: ElectrobunServiceAPI };
+
+function nativeCap(port = 9333): Record<string, unknown> {
+  return { 'goog:chromeOptions': { debuggerAddress: `localhost:${port}` } };
+}
+
+function makeBrowser(): WebdriverIO.Browser {
+  return { isMultiremote: false, sessionId: 'abc' } as unknown as WebdriverIO.Browser;
+}
+
+describe('ElectrobunWorkerService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock.mockResolvedValue(undefined);
+    sendMock.mockResolvedValue({ result: { value: undefined } });
+    listWindowsMock.mockReturnValue(['main', 'second']);
+    closeMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('before() — native mode', () => {
+    it('should attach the CDP bridge using the capability debuggerAddress', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+
+      await service.before(nativeCap(9350), [], browser);
+
+      expect(cdpBridgeCtor).toHaveBeenCalledTimes(1);
+      expect(cdpBridgeCtor.mock.calls[0][0]).toMatchObject({ host: 'localhost', port: 9350 });
+      expect(connectMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should install browser.electrobun with the full API surface', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+
+      await service.before(nativeCap(), [], browser);
+
+      const { electrobun } = browser as unknown as Installed;
+      expect(electrobun).toBeDefined();
+      for (const name of [
+        'execute',
+        'switchWindow',
+        'listWindows',
+        'mock',
+        'isMockFunction',
+        'clearAllMocks',
+        'resetAllMocks',
+        'restoreAllMocks',
+        'triggerDeeplink',
+      ]) {
+        expect(typeof (electrobun as unknown as Record<string, unknown>)[name]).toBe('function');
+      }
+    });
+
+    it('should not attach a bridge when no debuggerAddress is present', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+
+      await service.before({}, [], browser);
+
+      expect(cdpBridgeCtor).not.toHaveBeenCalled();
+      expect((browser as unknown as Partial<Installed>).electrobun).toBeUndefined();
+    });
+  });
+
+  describe('before() — browser mode', () => {
+    it('should skip CDP attach when devServerUrl is set', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({ devServerUrl: 'http://localhost:3000' }, {});
+
+      await service.before(nativeCap(), [], browser);
+
+      expect(cdpBridgeCtor).not.toHaveBeenCalled();
+      expect((browser as unknown as Partial<Installed>).electrobun).toBeUndefined();
+    });
+
+    it('should read devServerUrl from capability-level options', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService(
+        {},
+        { 'wdio:electrobunServiceOptions': { devServerUrl: 'http://localhost:4000' } },
+      );
+
+      await service.before(nativeCap(), [], browser);
+
+      expect(cdpBridgeCtor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('execute', () => {
+    it('should evaluate a function in the active target via Runtime.evaluate and return its value', async () => {
+      sendMock.mockResolvedValueOnce({ result: { value: 42 } });
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      const result = await (browser as unknown as Installed).electrobun.execute(() => 42);
+
+      expect(result).toBe(42);
+      const [method, params] = sendMock.mock.calls[0];
+      expect(method).toBe('Runtime.evaluate');
+      expect(params).toMatchObject({ returnByValue: true, awaitPromise: true });
+      expect(params.expression).toContain('__WDIO_ELECTROBUN__');
+    });
+
+    it('should pass a raw string expression through unchanged', async () => {
+      sendMock.mockResolvedValueOnce({ result: { value: 'ok' } });
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      const result = await (browser as unknown as Installed).electrobun.execute('1 + 1');
+
+      expect(result).toBe('ok');
+      expect(sendMock.mock.calls[0][1].expression).toBe('1 + 1');
+    });
+
+    it('should throw when Runtime.evaluate reports exceptionDetails', async () => {
+      sendMock.mockResolvedValueOnce({ exceptionDetails: { exception: { description: 'boom' } } });
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      await expect((browser as unknown as Installed).electrobun.execute(() => 1)).rejects.toThrow(/boom/);
+    });
+  });
+
+  describe('switchWindow / listWindows', () => {
+    it('should delegate switchWindow to bridge.switchTarget', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      await (browser as unknown as Installed).electrobun.switchWindow('second');
+
+      expect(switchTargetMock).toHaveBeenCalledWith('second');
+    });
+
+    it('should delegate listWindows to bridge.listWindows', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      const windows = await (browser as unknown as Installed).electrobun.listWindows();
+
+      expect(windows).toEqual(['main', 'second']);
+    });
+  });
+
+  describe('stubs', () => {
+    it('should reject mock / clearAllMocks / resetAllMocks / restoreAllMocks as not implemented', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+      const { electrobun } = browser as unknown as Installed;
+
+      await expect(electrobun.mock('x')).rejects.toThrow(/not implemented yet/);
+      await expect(electrobun.clearAllMocks()).rejects.toThrow(/not implemented yet/);
+      await expect(electrobun.resetAllMocks()).rejects.toThrow(/not implemented yet/);
+      await expect(electrobun.restoreAllMocks()).rejects.toThrow(/not implemented yet/);
+    });
+
+    it('should throw for isMockFunction as not implemented', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      expect(() => (browser as unknown as Installed).electrobun.isMockFunction(() => undefined)).toThrow(
+        /not implemented yet/,
+      );
+    });
+
+    it('should reject triggerDeeplink (not implemented on macOS, unsupported elsewhere)', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      await expect((browser as unknown as Installed).electrobun.triggerDeeplink('app://x')).rejects.toThrow();
+    });
+  });
+
+  describe('teardown', () => {
+    it('should close the bridge on after() and afterSession()', async () => {
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      await service.after();
+      expect(closeMock).toHaveBeenCalledTimes(1);
+
+      // after() emptied the bridge list, so afterSession() has nothing more to close.
+      await service.afterSession();
+      expect(closeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should tolerate a bridge.close() rejection', async () => {
+      closeMock.mockRejectedValueOnce(new Error('socket gone'));
+      const browser = makeBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(nativeCap(), [], browser);
+
+      await expect(service.after()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('multiremote', () => {
+    it('should attach a bridge per instance', async () => {
+      const instanceA = {} as WebdriverIO.Browser;
+      const instanceB = {} as WebdriverIO.Browser;
+      const mrBrowser = {
+        isMultiremote: true,
+        instances: ['browserA', 'browserB'],
+        getInstance: (name: string) => (name === 'browserA' ? instanceA : instanceB),
+      } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+      const caps = {
+        browserA: { capabilities: nativeCap(9341) },
+        browserB: { capabilities: nativeCap(9342) },
+      };
+
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(caps, [], mrBrowser);
+
+      expect(cdpBridgeCtor).toHaveBeenCalledTimes(2);
+      expect((instanceA as unknown as Partial<Installed>).electrobun).toBeDefined();
+      expect((instanceB as unknown as Partial<Installed>).electrobun).toBeDefined();
+    });
+  });
+});

--- a/packages/electrobun-service/test/session.spec.ts
+++ b/packages/electrobun-service/test/session.spec.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const onPrepareMock = vi.fn().mockResolvedValue(undefined);
+const onWorkerStartMock = vi.fn().mockResolvedValue(undefined);
+const onCompleteMock = vi.fn().mockResolvedValue(undefined);
+const serviceBeforeMock = vi.fn().mockResolvedValue(undefined);
+const serviceAfterMock = vi.fn().mockResolvedValue(undefined);
+const serviceAfterSessionMock = vi.fn().mockResolvedValue(undefined);
+const remoteMock = vi.fn();
+const deleteSessionMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../src/launcher.js', () => ({
+  default: class {
+    onPrepare = onPrepareMock;
+    onWorkerStart = onWorkerStartMock;
+    onComplete = onCompleteMock;
+  },
+}));
+
+vi.mock('../src/service.js', () => ({
+  default: class {
+    before = serviceBeforeMock;
+    after = serviceAfterMock;
+    afterSession = serviceAfterSessionMock;
+  },
+}));
+
+vi.mock('webdriverio', () => ({
+  remote: (...args: unknown[]) => remoteMock(...args),
+}));
+
+import { cleanup, createElectrobunCapabilities, init } from '../src/session.js';
+
+function makeBrowser(): WebdriverIO.Browser {
+  return { sessionId: 'sess-1', deleteSession: deleteSessionMock } as unknown as WebdriverIO.Browser;
+}
+
+describe('session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onPrepareMock.mockResolvedValue(undefined);
+    onWorkerStartMock.mockResolvedValue(undefined);
+    onCompleteMock.mockResolvedValue(undefined);
+    serviceBeforeMock.mockResolvedValue(undefined);
+    remoteMock.mockResolvedValue(makeBrowser());
+    deleteSessionMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('createElectrobunCapabilities', () => {
+    it('should build a capability with the electrobun browserName and service options', () => {
+      const cap = createElectrobunCapabilities({ appBinaryPath: '/apps/Demo.app' });
+
+      expect(cap.browserName).toBe('electrobun');
+      expect(cap['wdio:electrobunServiceOptions']).toMatchObject({ appBinaryPath: '/apps/Demo.app' });
+    });
+
+    it('should throw when appBinaryPath is missing in native mode', () => {
+      expect(() => createElectrobunCapabilities({})).toThrow(/appBinaryPath is required/);
+    });
+
+    it('should not require appBinaryPath in browser mode', () => {
+      expect(() =>
+        createElectrobunCapabilities({ mode: 'browser', devServerUrl: 'http://localhost:3000' }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('init', () => {
+    it('should drive onPrepare + onWorkerStart, open the session, and run service.before', async () => {
+      const cap = createElectrobunCapabilities({ appBinaryPath: '/apps/Demo.app' });
+
+      const browser = await init(cap);
+
+      expect(onPrepareMock).toHaveBeenCalledTimes(1);
+      expect(onWorkerStartMock).toHaveBeenCalledTimes(1);
+      expect(remoteMock).toHaveBeenCalledTimes(1);
+      expect(serviceBeforeMock).toHaveBeenCalledTimes(1);
+      expect(browser).toBeDefined();
+    });
+
+    it('should call launcher.onComplete when remote() fails', async () => {
+      remoteMock.mockRejectedValueOnce(new Error('chromedriver missing'));
+      const cap = createElectrobunCapabilities({ appBinaryPath: '/apps/Demo.app' });
+
+      await expect(init(cap)).rejects.toThrow(/chromedriver missing/);
+      expect(onCompleteMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should tear down the session and call onComplete when service.before fails', async () => {
+      serviceBeforeMock.mockRejectedValueOnce(new Error('attach failed'));
+      const cap = createElectrobunCapabilities({ appBinaryPath: '/apps/Demo.app' });
+
+      await expect(init(cap)).rejects.toThrow(/attach failed/);
+      expect(deleteSessionMock).toHaveBeenCalledTimes(1);
+      expect(onCompleteMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should run service teardown, delete the session, and call onComplete', async () => {
+      const cap = createElectrobunCapabilities({ appBinaryPath: '/apps/Demo.app' });
+      const browser = await init(cap);
+
+      await cleanup(browser);
+
+      expect(serviceAfterMock).toHaveBeenCalledTimes(1);
+      expect(serviceAfterSessionMock).toHaveBeenCalledTimes(1);
+      expect(deleteSessionMock).toHaveBeenCalledTimes(1);
+      expect(onCompleteMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should warn and no-op when the browser was not created by init()', async () => {
+      const stray = makeBrowser();
+
+      await expect(cleanup(stray)).resolves.toBeUndefined();
+      expect(onCompleteMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/native-types/src/electrobun.ts
+++ b/packages/native-types/src/electrobun.ts
@@ -112,6 +112,8 @@ export interface ElectrobunServiceOptions extends BaseServiceOptions {
   mode?: 'native' | 'browser';
   /** When `mode === 'browser'`, the URL of the running dev server. */
   devServerUrl?: string;
+  /** Extra environment variables to set on the spawned app process (native mode). */
+  env?: Record<string, string>;
   /**
    * Force a specific CEF remote-debugging port. Normally unnecessary: the launcher
    * allocates a free port per worker and **pins** it by writing it into that
@@ -133,6 +135,7 @@ export interface ElectrobunServiceOptions extends BaseServiceOptions {
 export interface ElectrobunServiceGlobalOptions extends BaseServiceGlobalOptions {
   mode?: 'native' | 'browser';
   devServerUrl?: string;
+  env?: Record<string, string>;
   remoteDebuggingPort?: number;
   cdpConnectionTimeout?: number;
   cdpConnectionRetryCount?: number;


### PR DESCRIPTION
**PR2 of the 4-PR stack** (Foundation → **MVP** → Feature-complete → Ship). Stacked on #310 (`feat/electrobun-foundation`); GitHub will retarget this to the `feat/electrobun-service` integration branch once #310 merges.

Makes `@wdio/electrobun-service` functional for **single-instance** CDP automation, validated by the Phase 0 spike (`agent-os/specs/20260528-electrobun-service/RESEARCH_FINDINGS.md`).

## What's in this PR
- **`@wdio/electrobun-cdp-bridge` — multi-target connection manager**: `devTool` (keeps all `/json` page targets), `connection` (one typed CDP socket per target, no navigate helper), `targetRegistry` (classify `views://` content vs shell/other; stable `main`/`window-N` labels), `bridge` (discovery/routing/`switchTarget`/`listWindows`). **Invariant: never issues `Page.navigate`** (unit-tested).
- **`electrobunConfig.ts`** — resolve + CEF-verify a built app from an explicit `appBinaryPath`; `build.json` remote-debugging-port read/write helpers.
- **Launcher native mode** — `onPrepare` resolves+verifies CEF; `onWorkerStart` allocates a port (`PortManager`), pins it into the bundle's `build.json`, spawns the app with a per-run `CFFIXED_USER_HOME`, and sets `goog:chromeOptions.debuggerAddress`; `onComplete` tears down. (Spawn/teardown/backend-log-capture in `nativeMode.ts`.)
- **Worker `before()`** — attaches the `CdpBridge`; installs `browser.electrobun` with **real** `execute` (CDP `Runtime.evaluate`), `switchWindow`, `listWindows`. `mock`-family + `triggerDeeplink` are documented stubs (feature-complete PR).
- **`session.ts`** — standalone `createElectrobunCapabilities` / `startWdioSession` / `cleanupWdioSession`.

## Key findings baked in
- Multiremote IS achievable on macOS with no upstream change (per-worker `CFFIXED_USER_HOME` + per-bundle `build.json` port) — implemented single-instance here; **per-worker bundle-clone is deferred to the feature-complete PR**.
- The debug port is **per-bundle `build.json`**, not a launch arg (empirically confirmed).

## Known MVP limitations (documented in-code)
- Single-instance only (multiremote = next PR); `onWorkerStart` mutates the shared bundle `build.json` in place (`TODO(PR3)`: clone per worker).
- Windows/Linux bundle layout is best-effort (macOS validated); CDP on Linux still to be confirmed in CI.
- No live E2E yet (mocked unit tests); backend log-level filtering deferred (Electrobun log format unconfirmed).

## Verification
- typecheck clean; **87** `@wdio/electrobun-service` + **18** `@wdio/electrobun-cdp-bridge` unit tests green; Biome clean.
- No regressions: `@wdio/native-core`, `@wdio/dioxus-service`, `@wdio/native-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)