### PR TITLE
feat(electrobun): PR3 feature-complete — mocking, multiremote, deeplink, fixtures

### DIFF
--- a/fixtures/e2e-apps/electrobun/.gitignore
+++ b/fixtures/e2e-apps/electrobun/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/fixtures/e2e-apps/electrobun/electrobun.config.ts
+++ b/fixtures/e2e-apps/electrobun/electrobun.config.ts
@@ -1,0 +1,47 @@
+import type { ElectrobunConfig } from 'electrobun';
+
+// CEF renderer is mandatory on every OS: it is the only renderer that exposes a
+// CDP endpoint, which is how @wdio/electrobun-service attaches. The service pins
+// the remote-debugging port into the built bundle's build.json at launch, so no
+// port is hardcoded here.
+const bundleCEF = true;
+
+export default {
+  app: {
+    name: 'WDIO Electrobun E2E',
+    identifier: 'com.wdio.electrobun.e2e',
+    version: '0.1.0',
+    urlSchemes: ['wdio-electrobun'],
+  },
+  build: {
+    bun: {
+      entrypoint: 'src/bun/index.ts',
+    },
+    // Two views drive the multi-window surface (switchWindow / listWindows): the
+    // main counter window plus a second window with its own CEF page target.
+    views: {
+      mainview: {
+        entrypoint: 'src/mainview/index.ts',
+      },
+      secondview: {
+        entrypoint: 'src/secondview/index.ts',
+      },
+    },
+    copy: {
+      'src/mainview/index.html': 'views/mainview/index.html',
+      'src/secondview/index.html': 'views/secondview/index.html',
+    },
+    mac: {
+      bundleCEF,
+      defaultRenderer: 'cef',
+    },
+    win: {
+      bundleCEF,
+      defaultRenderer: 'cef',
+    },
+    linux: {
+      bundleCEF,
+      defaultRenderer: 'cef',
+    },
+  },
+} satisfies ElectrobunConfig;

--- a/fixtures/e2e-apps/electrobun/package.json
+++ b/fixtures/e2e-apps/electrobun/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "electrobun-e2e-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "electrobun build",
+    "dev": "electrobun dev",
+    "start": "electrobun run"
+  },
+  "dependencies": {
+    "electrobun": "1.18.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "typescript": "5.9.3"
+  }
+}

--- a/fixtures/e2e-apps/electrobun/src/bun/index.ts
+++ b/fixtures/e2e-apps/electrobun/src/bun/index.ts
@@ -1,0 +1,39 @@
+import { app, BrowserWindow } from 'electrobun/bun';
+
+// Bun (main-process) backend for the Electrobun E2E fixture. Opens two CEF
+// windows so the service's multi-window surface (switchWindow / listWindows)
+// has more than one CDP page target to enumerate, and forwards deeplinks into
+// the main view's DOM so triggerDeeplink assertions can read them.
+
+const mainWindow = new BrowserWindow({
+  title: 'WDIO Electrobun E2E — Main',
+  url: 'views://mainview/index.html',
+  renderer: 'cef',
+  frame: { x: 100, y: 100, width: 760, height: 640 },
+});
+
+const secondWindow = new BrowserWindow({
+  title: 'WDIO Electrobun E2E — Second',
+  url: 'views://secondview/index.html',
+  renderer: 'cef',
+  frame: { x: 900, y: 150, width: 520, height: 440 },
+});
+
+console.log('[e2e] opened windows', { main: mainWindow.id, second: secondWindow.id });
+
+// Deeplink handler — `open wdio-electrobun://<path>` (macOS), routed via the
+// urlSchemes entry in electrobun.config.ts. Surface the URL into the main view
+// so a WebDriver test can read window.__wdioDeeplinks without a CDP side-channel.
+app.on('open-url', (payload: unknown) => {
+  const url = (payload as { url?: string })?.url ?? '';
+  console.log('[e2e][open-url] received:', url);
+  const js = `(() => {
+    window.__wdioDeeplinks = window.__wdioDeeplinks || [];
+    window.__wdioDeeplinks.push(${JSON.stringify(url)});
+    var statusEl = document.getElementById('status');
+    if (statusEl) { statusEl.textContent = 'Deeplink: ' + ${JSON.stringify(url)}; }
+  })();`;
+  mainWindow.webview.executeJavascript(js);
+});
+
+console.log('[e2e] bun backend ready');

--- a/fixtures/e2e-apps/electrobun/src/mainview/index.html
+++ b/fixtures/e2e-apps/electrobun/src/mainview/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Electrobun E2E Test App</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 20px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
+        text-align: center;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
+      }
+      h1 {
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+      }
+      button {
+        background: rgba(255, 255, 255, 0.25);
+        border: 2px solid rgba(255, 255, 255, 0.4);
+        color: white;
+        padding: 15px 20px;
+        border-radius: 12px;
+        cursor: pointer;
+        font-size: 1em;
+        font-weight: 500;
+        transition: all 0.3s ease;
+        backdrop-filter: blur(5px);
+        margin: 8px;
+      }
+      button:hover {
+        background: rgba(255, 255, 255, 0.35);
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+      }
+      .counter-section {
+        margin: 2rem 0;
+      }
+      #counter {
+        font-size: 4em;
+        font-weight: bold;
+        margin: 1rem 0;
+        color: #61dafb;
+      }
+      .info-section {
+        margin-top: 40px;
+        padding: 25px;
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 15px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        line-height: 1.5;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .status {
+        margin-top: 1rem;
+        padding: 0.5rem;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 4px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 id="app-title">🚀 Electrobun Basic App</h1>
+
+      <div class="counter-section">
+        <div id="counter">0</div>
+        <button type="button" id="increment-button">Increment</button>
+        <button type="button" id="decrement-button">Decrement</button>
+        <button type="button" id="reset-button">Reset</button>
+      </div>
+
+      <div class="info-section">
+        <p>This is a basic Electrobun application for WebDriverIO testing.</p>
+        <div class="status" id="status">Ready for testing</div>
+      </div>
+    </div>
+
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/fixtures/e2e-apps/electrobun/src/mainview/index.ts
+++ b/fixtures/e2e-apps/electrobun/src/mainview/index.ts
@@ -1,0 +1,31 @@
+export {};
+
+const counterEl = document.getElementById('counter') as HTMLSpanElement;
+const statusEl = document.getElementById('status') as HTMLDivElement;
+const incrementButton = document.getElementById('increment-button') as HTMLButtonElement;
+const decrementButton = document.getElementById('decrement-button') as HTMLButtonElement;
+const resetButton = document.getElementById('reset-button') as HTMLButtonElement;
+
+let count = 0;
+
+function render(message: string): void {
+  counterEl.textContent = String(count);
+  statusEl.textContent = message;
+}
+
+incrementButton.addEventListener('click', () => {
+  count += 1;
+  render(`Incremented to ${count}`);
+});
+
+decrementButton.addEventListener('click', () => {
+  count -= 1;
+  render(`Decremented to ${count}`);
+});
+
+resetButton.addEventListener('click', () => {
+  count = 0;
+  render('Counter reset');
+});
+
+render('Application loaded successfully');

--- a/fixtures/e2e-apps/electrobun/src/secondview/index.html
+++ b/fixtures/e2e-apps/electrobun/src/secondview/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Electrobun E2E Second Window</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 20px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
+        text-align: center;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
+      }
+      h1 {
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+      }
+      .info-section {
+        margin-top: 40px;
+        padding: 25px;
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 15px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        line-height: 1.5;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .status {
+        margin-top: 1rem;
+        padding: 0.5rem;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 4px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 id="second-title">🪟 Second Window</h1>
+
+      <div class="info-section">
+        <p id="second-marker">This is the second CEF page target, used to exercise switchWindow / listWindows.</p>
+        <div class="status" id="status">Ready for testing</div>
+      </div>
+    </div>
+
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/fixtures/e2e-apps/electrobun/src/secondview/index.ts
+++ b/fixtures/e2e-apps/electrobun/src/secondview/index.ts
@@ -1,0 +1,4 @@
+export {};
+
+const statusEl = document.getElementById('status') as HTMLDivElement;
+statusEl.textContent = 'Second window loaded';

--- a/fixtures/e2e-apps/electrobun/tsconfig.json
+++ b/fixtures/e2e-apps/electrobun/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "types": [
+      "bun"
+    ],
+    "noEmit": true
+  },
+  "include": [
+    "src",
+    "electrobun.config.ts"
+  ]
+}

--- a/fixtures/package-tests/electrobun-app/.gitignore
+++ b/fixtures/package-tests/electrobun-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+artifacts/
+*.tsbuildinfo

--- a/fixtures/package-tests/electrobun-app/electrobun.config.ts
+++ b/fixtures/package-tests/electrobun-app/electrobun.config.ts
@@ -1,0 +1,39 @@
+import type { ElectrobunConfig } from 'electrobun';
+
+// Reduced install-smoke fixture: a single CEF window. CEF is still enabled so the
+// bundle matches what @wdio/electrobun-service attaches to over CDP.
+const bundleCEF = true;
+
+export default {
+  app: {
+    name: 'WDIO Electrobun App',
+    identifier: 'com.wdio.electrobun.app',
+    version: '0.1.0',
+    urlSchemes: ['wdio-electrobun-app'],
+  },
+  build: {
+    bun: {
+      entrypoint: 'src/bun/index.ts',
+    },
+    views: {
+      mainview: {
+        entrypoint: 'src/mainview/index.ts',
+      },
+    },
+    copy: {
+      'src/mainview/index.html': 'views/mainview/index.html',
+    },
+    mac: {
+      bundleCEF,
+      defaultRenderer: 'cef',
+    },
+    win: {
+      bundleCEF,
+      defaultRenderer: 'cef',
+    },
+    linux: {
+      bundleCEF,
+      defaultRenderer: 'cef',
+    },
+  },
+} satisfies ElectrobunConfig;

--- a/fixtures/package-tests/electrobun-app/package.json
+++ b/fixtures/package-tests/electrobun-app/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "electrobun-app-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "electrobun build"
+  },
+  "dependencies": {
+    "electrobun": "1.18.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "@wdio/cli": "9.27.1",
+    "@wdio/electrobun-service": "workspace:*",
+    "@wdio/globals": "9.27.1",
+    "@wdio/local-runner": "9.27.1",
+    "@wdio/mocha-framework": "9.27.1",
+    "@wdio/native-types": "workspace:*",
+    "@wdio/spec-reporter": "9.27.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/fixtures/package-tests/electrobun-app/src/bun/index.ts
+++ b/fixtures/package-tests/electrobun-app/src/bun/index.ts
@@ -1,0 +1,11 @@
+import { BrowserWindow } from 'electrobun/bun';
+
+// Minimal Bun backend for the package-install smoke fixture: one CEF window.
+const mainWindow = new BrowserWindow({
+  title: 'WDIO Electrobun App',
+  url: 'views://mainview/index.html',
+  renderer: 'cef',
+  frame: { x: 100, y: 100, width: 640, height: 480 },
+});
+
+console.log('[package-test] opened window', mainWindow.id);

--- a/fixtures/package-tests/electrobun-app/src/mainview/index.html
+++ b/fixtures/package-tests/electrobun-app/src/mainview/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Electrobun Package Test App</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 20px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
+        text-align: center;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
+      }
+      h1 {
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+      }
+      .info-section {
+        margin-top: 40px;
+        padding: 25px;
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 15px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        line-height: 1.5;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .status {
+        margin-top: 1rem;
+        padding: 0.5rem;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 4px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 id="app-title">🚀 Electrobun App</h1>
+
+      <div class="info-section">
+        <p>Electrobun package-install smoke fixture for WebDriverIO testing.</p>
+        <div class="status" id="status">Ready for testing</div>
+      </div>
+    </div>
+
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/fixtures/package-tests/electrobun-app/src/mainview/index.ts
+++ b/fixtures/package-tests/electrobun-app/src/mainview/index.ts
@@ -1,0 +1,4 @@
+export {};
+
+const statusEl = document.getElementById('status') as HTMLDivElement;
+statusEl.textContent = 'Application loaded successfully';

--- a/fixtures/package-tests/electrobun-app/tsconfig.json
+++ b/fixtures/package-tests/electrobun-app/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "types": [
+      "bun"
+    ],
+    "noEmit": true
+  },
+  "include": [
+    "src",
+    "electrobun.config.ts"
+  ]
+}

--- a/packages/electrobun-service/src/commands/allMocks.ts
+++ b/packages/electrobun-service/src/commands/allMocks.ts
@@ -1,0 +1,55 @@
+// Mock-lifecycle helpers — clear/reset/restore across every mock created against
+// one bridge's store. Each is filterable by `prefix` (a target-path prefix) so a
+// multi-suite run can isolate e.g. all 'api.*' mocks. isMockFunction is a
+// structural check used by callers to branch on mock-vs-plain functions.
+
+import type { ElectrobunMock } from '@wdio/native-types';
+
+import type { ElectrobunMockStore } from '../mockStore.js';
+
+function matchesPrefix(target: string, prefix?: string): boolean {
+  if (!prefix) {
+    return true;
+  }
+  return target.startsWith(prefix);
+}
+
+async function forEachMock(
+  store: ElectrobunMockStore,
+  prefix: string | undefined,
+  fn: (mock: ElectrobunMock) => Promise<unknown>,
+): Promise<void> {
+  // Snapshot first: mockRestore mutates the store mid-iteration.
+  for (const [target, mock] of store.getMocks()) {
+    if (matchesPrefix(target, prefix)) {
+      await fn(mock);
+    }
+  }
+}
+
+export async function clearAllMocks(store: ElectrobunMockStore, prefix?: string): Promise<void> {
+  await forEachMock(store, prefix, (mock) => mock.mockClear());
+}
+
+export async function resetAllMocks(store: ElectrobunMockStore, prefix?: string): Promise<void> {
+  await forEachMock(store, prefix, (mock) => mock.mockReset());
+}
+
+export async function restoreAllMocks(store: ElectrobunMockStore, prefix?: string): Promise<void> {
+  await forEachMock(store, prefix, (mock) => mock.mockRestore());
+}
+
+/**
+ * True iff `candidate` is an ElectrobunMock — checked structurally via the
+ * `__isElectrobunMock: true` flag set in mock.ts. A bare target-path string is
+ * resolved against the store so `isMockFunction('api.fetchData')` works too.
+ */
+export function isMockFunction(candidate: unknown, store: ElectrobunMockStore): boolean {
+  if (typeof candidate === 'string') {
+    return store.getMock(candidate) !== undefined;
+  }
+  if (candidate == null || typeof candidate !== 'function') {
+    return false;
+  }
+  return (candidate as { __isElectrobunMock?: unknown }).__isElectrobunMock === true;
+}

--- a/packages/electrobun-service/src/commands/execute.ts
+++ b/packages/electrobun-service/src/commands/execute.ts
@@ -27,28 +27,58 @@ interface EvaluateResponse {
   };
 }
 
+/**
+ * Serialise a value to a JS literal for inlining into a script source, rejecting
+ * anything `JSON.stringify` would silently drop or choke on. Shared by `execute`
+ * (user args) and the mock layer (impl/return values pushed into the page).
+ *
+ * @param context - caller label used in the error message (e.g. `browser.electrobun.execute`).
+ * @param index - optional positional index appended to the error message.
+ */
+export function jsonLiteral(value: unknown, context: string, index?: number): string {
+  const at = index === undefined ? '' : ` at index ${index}`;
+  // JSON.stringify(fn) / JSON.stringify(symbol) returns `undefined` rather than
+  // throwing, which would silently drop the value — reject those up front.
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    throw new Error(
+      `${context}${at} is not JSON-serialisable ` +
+        `(a ${typeof value} cannot be inlined into the script source; JSON.stringify would silently drop it).`,
+    );
+  }
+  try {
+    return JSON.stringify(value) ?? 'undefined';
+  } catch (err) {
+    throw new Error(
+      `${context}${at} is not JSON-serialisable ` +
+        '(values are inlined into the script source via JSON.stringify). This typically means the ' +
+        `value contains a circular reference, a BigInt, or a function. Underlying error: ${(err as Error).message}`,
+    );
+  }
+}
+
 function inlineArgs(args: unknown[]): string {
-  return args
-    .map((arg, index) => {
-      // JSON.stringify(fn) / JSON.stringify(symbol) returns `undefined` rather
-      // than throwing, which would silently drop the arg — reject those up front.
-      if (typeof arg === 'function' || typeof arg === 'symbol') {
-        throw new Error(
-          `browser.electrobun.execute argument at index ${index} is not JSON-serialisable ` +
-            `(a ${typeof arg} cannot be inlined into the script source; JSON.stringify would silently drop it).`,
-        );
-      }
-      try {
-        return JSON.stringify(arg) ?? 'undefined';
-      } catch (err) {
-        throw new Error(
-          `browser.electrobun.execute argument at index ${index} is not JSON-serialisable ` +
-            '(args are inlined into the script source via JSON.stringify). This typically means the ' +
-            `value contains a circular reference, a BigInt, or a function. Underlying error: ${(err as Error).message}`,
-        );
-      }
-    })
-    .join(', ');
+  return args.map((arg, index) => jsonLiteral(arg, 'browser.electrobun.execute argument', index)).join(', ');
+}
+
+/**
+ * Evaluate a raw JS expression in the active CEF content target and return its
+ * (returned-by-value) result. Centralises `Runtime.evaluate` + exception
+ * handling for both `execute` and the mock layer. Never issues Page.navigate.
+ */
+export async function evaluateInActiveTarget<ReturnValue>(bridge: CdpBridge, expression: string): Promise<ReturnValue> {
+  const response = (await bridge.send('Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  })) as EvaluateResponse;
+
+  if (response.exceptionDetails) {
+    const detail =
+      response.exceptionDetails.exception?.description ?? response.exceptionDetails.text ?? 'Unknown evaluation error';
+    throw new Error(`browser.electrobun.execute failed: ${detail}`);
+  }
+
+  return response.result?.value as ReturnValue;
 }
 
 /**
@@ -73,17 +103,5 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
         })()`
       : script;
 
-  const response = (await bridge.send('Runtime.evaluate', {
-    expression,
-    returnByValue: true,
-    awaitPromise: true,
-  })) as EvaluateResponse;
-
-  if (response.exceptionDetails) {
-    const detail =
-      response.exceptionDetails.exception?.description ?? response.exceptionDetails.text ?? 'Unknown evaluation error';
-    throw new Error(`browser.electrobun.execute failed: ${detail}`);
-  }
-
-  return response.result?.value as ReturnValue;
+  return evaluateInActiveTarget<ReturnValue>(bridge, expression);
 }

--- a/packages/electrobun-service/src/commands/mock.ts
+++ b/packages/electrobun-service/src/commands/mock.ts
@@ -1,0 +1,11 @@
+// browser.electrobun.mock(target) — public entry point.
+
+import type { CdpBridge } from '@wdio/electrobun-cdp-bridge';
+import type { ElectrobunMock } from '@wdio/native-types';
+
+import { createMock } from '../mock.js';
+import type { ElectrobunMockStore } from '../mockStore.js';
+
+export function mock(target: string, bridge: CdpBridge, store: ElectrobunMockStore): Promise<ElectrobunMock> {
+  return createMock(target, bridge, store);
+}

--- a/packages/electrobun-service/src/commands/triggerDeeplink.ts
+++ b/packages/electrobun-service/src/commands/triggerDeeplink.ts
@@ -1,0 +1,43 @@
+// browser.electrobun.triggerDeeplink implementation.
+//
+// Fires the OS-native protocol handler so the Electrobun app's registered
+// `open-url` handler receives the URL — the same path production sees, and the
+// most realistic test of a registered URI scheme (no IPC mocking).
+//
+// macOS-only in v1: Electrobun registers `app.urlSchemes` via the generated
+// Info.plist `CFBundleURLTypes`, and `open <url>` reaches the running app's
+// open-url handler. Windows/Linux deeplink support isn't available upstream yet
+// (RESEARCH_FINDINGS §6), so this rejects there with a documented-gap error.
+
+import { executeDeeplinkCommand, getPlatformCommand, validateDeeplinkUrl } from '@wdio/native-core';
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from '../constants.js';
+import { deeplinkUnsupportedOnPlatform } from '../errors.js';
+
+const log = createLogger(SERVICE_NAME, 'triggerDeeplink');
+
+/**
+ * Trigger a deeplink to the Electrobun app by spawning the OS-native protocol
+ * handler (macOS `open <url>`).
+ *
+ * @param url - The deeplink URL (e.g. `wdio-electrobun://open?path=/test`). Must
+ *   use a custom scheme — `http`, `https`, and `file` are rejected.
+ * @throws when the URL is malformed/disallowed, or on a non-macOS platform.
+ *
+ * @example
+ * ```ts
+ * await browser.electrobun.triggerDeeplink('wdio-electrobun://open?file=test.txt');
+ * ```
+ */
+export async function triggerDeeplink(url: string): Promise<void> {
+  if (process.platform !== 'darwin') {
+    throw deeplinkUnsupportedOnPlatform();
+  }
+  const validated = validateDeeplinkUrl(url);
+  log.debug(`triggering deeplink ${validated}`);
+
+  const { command, args } = getPlatformCommand(validated, process.platform);
+  await executeDeeplinkCommand(command, args);
+  log.debug(`deeplink dispatched: ${command} ${args.join(' ')}`);
+}

--- a/packages/electrobun-service/src/innerRecorder.ts
+++ b/packages/electrobun-service/src/innerRecorder.ts
@@ -172,13 +172,25 @@ export function buildReadCallDataScript(target: string): string {
     var entry = reg && reg[${key}];
     if (!entry || !entry.spy || !entry.spy.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
     var m = entry.spy.mock;
-    var errorReplacer = function(_k, v) {
-      if (v instanceof Error) { return { __wdioError: true, name: v.name, message: v.message, stack: v.stack }; }
-      return v;
+    // Fresh replacer per stringify: serialise Errors to a marker, and guard
+    // against circular/function values (e.g. mockReturnThis storing a live
+    // \`this\` that back-references its parent) so update() never throws a
+    // "Converting circular structure to JSON" out of the page.
+    var makeSafe = function() {
+      var seen = [];
+      return function(_k, v) {
+        if (v instanceof Error) { return { __wdioError: true, name: v.name, message: v.message, stack: v.stack }; }
+        if (typeof v === 'function') { return '[Function]'; }
+        if (v && typeof v === 'object') {
+          if (seen.indexOf(v) !== -1) { return '[Circular]'; }
+          seen.push(v);
+        }
+        return v;
+      };
     };
     return {
-      calls: JSON.parse(JSON.stringify(m.calls || [], errorReplacer)),
-      results: JSON.parse(JSON.stringify(m.results || [], errorReplacer)),
+      calls: JSON.parse(JSON.stringify(m.calls || [], makeSafe())),
+      results: JSON.parse(JSON.stringify(m.results || [], makeSafe())),
       invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
     };
   })()`;

--- a/packages/electrobun-service/src/innerRecorder.ts
+++ b/packages/electrobun-service/src/innerRecorder.ts
@@ -219,7 +219,11 @@ export function buildSetValueScript(target: string, method: InnerMockSetterMetho
     var entry = reg && reg[${key}];
     if (!entry || !entry.spy) { return; }
     var _v = ${valueLiteral};
-    var arg = (_v && typeof _v === 'object' && _v.__wdioError === true) ? new Error(_v.message) : _v;
+    var arg = _v;
+    if (_v && typeof _v === 'object' && _v.__wdioError === true) {
+      arg = new Error(_v.message);
+      if (_v.name) { arg.name = _v.name; }
+    }
     entry.spy.${method}(arg);
   })()`;
 }

--- a/packages/electrobun-service/src/innerRecorder.ts
+++ b/packages/electrobun-service/src/innerRecorder.ts
@@ -1,0 +1,259 @@
+// Inner-recorder script builders for the Electrobun mock layer.
+//
+// Electrobun has no enumerable main-process API, so `browser.electrobun.mock`
+// targets a *dotted path to a function in the webview global scope* (e.g.
+// 'api.fetchData' → window.api.fetchData) — the in-page analogue of Electron's
+// browser-mode IPC-channel mock. These builders return JS expression strings
+// that the worker evaluates over CDP via `Runtime.evaluate` (see
+// commands/execute.ts#evaluateInActiveTarget). They never navigate the page.
+//
+// All recorders live under a single registry, window.__WDIO_ELECTROBUN_MOCKS__,
+// keyed by target path. Each entry preserves the original function so
+// mockRestore can put it back exactly where it was. The recorder function itself
+// is a vitest-shaped spy whose call/result history is read back one-way into the
+// outer mock by buildReadCallDataScript (mirrors the inner spy in
+// @wdio/native-spy's WDIO_MOCK_SETUP_SCRIPT).
+//
+// The string semantics here are exercised end-to-end only against a real CEF app
+// (no CEF in unit tests) — unit tests assert the *expressions* we emit, not their
+// in-page behaviour. See test/mock.spec.ts.
+
+import type { InnerMockSetterMethod } from './mockTypes.js';
+
+const REGISTRY = 'window.__WDIO_ELECTROBUN_MOCKS__';
+
+/** JSON literal of a target path, safe to inline as an object key / string arg. */
+function pathLiteral(target: string): string {
+  return JSON.stringify(target);
+}
+
+/**
+ * Self-contained spy factory + registry setup. Idempotent: re-evaluating leaves
+ * an existing registry and any already-installed recorders untouched. Mirrors the
+ * mock-function shape used across the other services so call-data read-back is
+ * identical (calls / results / invocationCallOrder).
+ */
+const SETUP = `
+  if (!${REGISTRY}) { ${REGISTRY} = {}; }
+  var __ebReg = ${REGISTRY};
+  if (!__ebReg.__callId) { __ebReg.__callId = 0; }
+  if (!__ebReg.__createSpy) {
+    var NOT_SET = {};
+    __ebReg.__createSpy = function() {
+      var _defaultImpl;
+      var _implQueue = [];
+      var _defaultReturnValue = NOT_SET;
+      var _defaultResolvedValue = NOT_SET;
+      var _defaultRejectedValue = NOT_SET;
+      var _returnThis = false;
+      var _calls = [];
+      var _results = [];
+      var _invocationCallOrder = [];
+      function spy() {
+        var args = Array.prototype.slice.call(arguments);
+        _calls.push(args);
+        _invocationCallOrder.push(__ebReg.__callId++);
+        var impl = _implQueue.length > 0 ? _implQueue.shift() : _defaultImpl;
+        if (impl !== null && impl !== undefined && typeof impl === 'object' && impl.__wdioType) {
+          if (impl.__wdioType === 'resolve') {
+            _results.push({ type: 'return', value: impl.__wdioVal });
+            return Promise.resolve(impl.__wdioVal);
+          }
+          _results.push({ type: 'throw', value: impl.__wdioVal });
+          return Promise.reject(impl.__wdioVal);
+        }
+        if (impl !== undefined) {
+          try {
+            var val = impl.apply(this, args);
+            _results.push({ type: 'return', value: val });
+            return val;
+          } catch (e) {
+            _results.push({ type: 'throw', value: e });
+            throw e;
+          }
+        } else if (_defaultRejectedValue !== NOT_SET) {
+          _results.push({ type: 'throw', value: _defaultRejectedValue });
+          return Promise.reject(_defaultRejectedValue);
+        } else if (_defaultResolvedValue !== NOT_SET) {
+          _results.push({ type: 'return', value: _defaultResolvedValue });
+          return Promise.resolve(_defaultResolvedValue);
+        } else if (_returnThis) {
+          _results.push({ type: 'return', value: this });
+          return this;
+        } else if (_defaultReturnValue !== NOT_SET) {
+          _results.push({ type: 'return', value: _defaultReturnValue });
+          return _defaultReturnValue;
+        } else {
+          _results.push({ type: 'return', value: undefined });
+          return undefined;
+        }
+      }
+      spy.__isWdioSpy = true;
+      spy.mock = { calls: _calls, results: _results, invocationCallOrder: _invocationCallOrder };
+      spy.mockImplementation = function(fn) {
+        _defaultImpl = fn; _defaultReturnValue = NOT_SET; _defaultResolvedValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockImplementationOnce = function(fn) { _implQueue.push(fn); return spy; };
+      spy.mockReturnValue = function(v) {
+        _defaultImpl = undefined; _defaultReturnValue = v; _defaultResolvedValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockReturnValueOnce = function(v) { _implQueue.push(function() { return v; }); return spy; };
+      spy.mockResolvedValue = function(v) {
+        _defaultImpl = undefined; _defaultResolvedValue = v; _defaultReturnValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockResolvedValueOnce = function(v) { _implQueue.push({ __wdioType: 'resolve', __wdioVal: v }); return spy; };
+      spy.mockRejectedValue = function(v) {
+        _defaultImpl = undefined; _defaultRejectedValue = v; _defaultReturnValue = NOT_SET;
+        _defaultResolvedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockRejectedValueOnce = function(v) { _implQueue.push({ __wdioType: 'reject', __wdioVal: v }); return spy; };
+      spy.mockReturnThis = function() {
+        _returnThis = true; _defaultReturnValue = NOT_SET; _defaultResolvedValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _defaultImpl = undefined; return spy;
+      };
+      spy.mockClear = function() {
+        _calls.length = 0; _results.length = 0; _invocationCallOrder.length = 0; return spy;
+      };
+      spy.mockReset = function() {
+        spy.mockClear();
+        _implQueue = []; _defaultImpl = undefined; _defaultReturnValue = NOT_SET;
+        _defaultResolvedValue = NOT_SET; _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      return spy;
+    };
+  }`;
+
+/** Walk a dotted path to its `{ parent, key }`, returning undefined if any hop is missing. */
+const RESOLVE_PATH = `
+    var __resolve = function(path) {
+      var parts = path.split('.');
+      var parent = window;
+      for (var i = 0; i < parts.length - 1; i++) {
+        if (parent == null) { return undefined; }
+        parent = parent[parts[i]];
+      }
+      if (parent == null) { return undefined; }
+      return { parent: parent, key: parts[parts.length - 1] };
+    };`;
+
+/**
+ * Install (idempotently) a recorder over the target function. Preserves the
+ * original on the registry entry, replaces `parent[key]` with the spy, and
+ * throws inside the page if the path doesn't resolve to a function. Re-running
+ * with an existing entry is a no-op (no double-wrap).
+ */
+export function buildInstallScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {${SETUP}${RESOLVE_PATH}
+    var existing = __ebReg[${key}];
+    if (existing) { return; }
+    var loc = __resolve(${key});
+    if (!loc) {
+      throw new Error('browser.electrobun.mock target ' + ${key} + ' could not be resolved: a parent on the path is undefined.');
+    }
+    var original = loc.parent[loc.key];
+    if (typeof original !== 'function') {
+      throw new Error('browser.electrobun.mock target ' + ${key} + ' is not a function (got ' + typeof original + ').');
+    }
+    var spy = __ebReg.__createSpy();
+    __ebReg[${key}] = { spy: spy, original: original, parent: loc.parent, key: loc.key };
+    loc.parent[loc.key] = spy;
+  })()`;
+}
+
+/** Read the recorder's call data back as a JSON-cloned `{ calls, results, invocationCallOrder }`. */
+export function buildReadCallDataScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (!entry || !entry.spy || !entry.spy.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
+    var m = entry.spy.mock;
+    var errorReplacer = function(_k, v) {
+      if (v instanceof Error) { return { __wdioError: true, name: v.name, message: v.message, stack: v.stack }; }
+      return v;
+    };
+    return {
+      calls: JSON.parse(JSON.stringify(m.calls || [], errorReplacer)),
+      results: JSON.parse(JSON.stringify(m.results || [], errorReplacer)),
+      invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
+    };
+  })()`;
+}
+
+/** Push a serialised implementation (function source) into the recorder. */
+export function buildSetImplementationScript(target: string, source: string, once = false): string {
+  const key = pathLiteral(target);
+  const method = once ? 'mockImplementationOnce' : 'mockImplementation';
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.${method}((${source})); }
+  })()`;
+}
+
+/**
+ * Push a value-based behaviour into the recorder. `valueLiteral` must already be
+ * a JS literal (see jsonLiteral / errorLiteral in mock.ts). Errors flagged with
+ * `__wdioError` are reconstructed into real `Error` objects inside the page.
+ */
+export function buildSetValueScript(target: string, method: InnerMockSetterMethod, valueLiteral: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (!entry || !entry.spy) { return; }
+    var _v = ${valueLiteral};
+    var arg = (_v && typeof _v === 'object' && _v.__wdioError === true) ? new Error(_v.message) : _v;
+    entry.spy.${method}(arg);
+  })()`;
+}
+
+/** Clear the recorder's call history (mockClear). */
+export function buildClearScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.mockClear(); }
+  })()`;
+}
+
+/** Reset the recorder's implementation and history (mockReset). */
+export function buildResetScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.mockReset(); }
+  })()`;
+}
+
+/** Invoke mockReturnThis on the recorder. */
+export function buildReturnThisScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.mockReturnThis(); }
+  })()`;
+}
+
+/**
+ * Restore the original function at the target path and drop the registry entry.
+ * Re-assigns `parent[key]` to the preserved original so production code sees the
+ * real implementation again.
+ */
+export function buildRestoreScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (!entry) { return; }
+    if (entry.parent) { entry.parent[entry.key] = entry.original; }
+    delete reg[${key}];
+  })()`;
+}

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -55,6 +55,20 @@ export default class ElectrobunLaunchService extends BaseLauncher {
     capabilities: ElectrobunCapabilities[] | Record<string, { capabilities: ElectrobunCapabilities }>,
   ): Promise<void> {
     const capsList = normaliseCaps(capabilities);
+
+    // Reject a mixed browser-mode + native-mode capability set: this launcher
+    // applies one mode to all caps (browser mode forces browserName:'chrome' on
+    // every cap and skips setup; native mode spawns a binary per cap). Silently
+    // treating a native cap as browser (or vice-versa) because a sibling cap set
+    // the other mode would be a confusing footgun — fail fast on a consistent mode.
+    const modes = capsList.map((cap) => mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap)).mode);
+    if (modes.some((mode) => mode === 'browser') && modes.some((mode) => mode !== 'browser')) {
+      throw new SevereServiceError(
+        'Mixed browser-mode and native-mode Electrobun capabilities in a single run are not supported. ' +
+          'Set `mode` consistently across all capabilities (all "browser", or all native).',
+      );
+    }
+
     // Detect browser mode even when set on a non-first capability.
     const primaryCap =
       capsList.find(

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -3,12 +3,7 @@ import { createLogger } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
 
 import { DEFAULT_DEBUG_PORT_BASE, SERVICE_NAME } from './constants.js';
-import {
-  type ResolvedElectrobunApp,
-  resolveElectrobunApp,
-  verifyCefRenderer,
-  writeRemoteDebuggingPort,
-} from './electrobunConfig.js';
+import { type ResolvedElectrobunApp, resolveElectrobunApp, verifyCefRenderer } from './electrobunConfig.js';
 import { SevereServiceError } from './errors.js';
 import { type ElectrobunAppProcess, spawnElectrobunApp, stopElectrobunApp } from './nativeMode.js';
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
@@ -23,10 +18,11 @@ const log = createLogger(SERVICE_NAME, 'launcher');
  * the worker attaches over CDP through Chromedriver (`debuggerAddress`). It
  * extends `BaseLauncher` to reuse `@wdio/native-core`'s port/process/log infra.
  *
- * Native-mode flow (MVP, single-instance):
+ * Native-mode flow (parallel-safe):
  *  - `onPrepare`: resolve + CEF-verify each app bundle, force `browserName: 'chrome'`.
- *  - `onWorkerStart`: allocate a port, pin it into the bundle's build.json, spawn
- *    the app with a per-run CFFIXED_USER_HOME, and set `goog:chromeOptions.debuggerAddress`.
+ *  - `onWorkerStart`: allocate a port, then spawn the app — the spawn path clones
+ *    the bundle per worker, pins the port into the clone's build.json, and uses a
+ *    per-run CFFIXED_USER_HOME — and set `goog:chromeOptions.debuggerAddress`.
  *  - `onComplete`: kill spawned apps + clean temp dirs.
  */
 export default class ElectrobunLaunchService extends BaseLauncher {
@@ -86,9 +82,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       return;
     }
 
-    // Native mode (MVP single-instance): resolve + CEF-verify each bundle, force
-    // chrome capability. The app spawn + port pinning happen in onWorkerStart so
-    // each worker gets a freshly allocated port.
+    // Native mode: resolve + CEF-verify each bundle, force chrome capability. The
+    // app clone + port pinning + spawn happen in onWorkerStart so each worker gets
+    // a freshly allocated port pinned into its own bundle clone.
     this.resolvedApps = [];
     for (const cap of capsList) {
       const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
@@ -117,8 +113,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
 
     for (let i = 0; i < capsList.length; i++) {
       const cap = capsList[i];
-      // MVP single-instance: one resolved app drives all workers. PR3 clones the
-      // bundle per worker; until then app[0] is the canonical bundle.
+      // The resolved bundle is the source template; each worker (cid) clones it
+      // and pins its own port inside spawnApp, so one resolved app safely drives
+      // any number of parallel workers.
       const app = this.resolvedApps[i] ?? this.resolvedApps[0];
       if (!app) {
         throw new SevereServiceError(
@@ -130,12 +127,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
       const port = await this.portManager.allocatePort(this.options.remoteDebuggingPort ?? DEFAULT_DEBUG_PORT_BASE);
 
-      // Pin the allocated port into the bundle's build.json — the CEF port is
-      // fixed per bundle (a launch arg does NOT work, see RESEARCH_FINDINGS).
-      // TODO(PR3): clone the bundle per worker and pin into the clone instead of
-      // mutating the shared bundle in place (mutation is acceptable single-instance).
-      writeRemoteDebuggingPort(app.buildJsonPath, port);
-
+      // The allocated port is pinned into the per-worker bundle clone inside
+      // spawnApp — the CEF port is fixed per bundle (a launch arg does NOT work,
+      // see RESEARCH_FINDINGS), so the clone is what makes parallel workers safe.
       const spawned = this.spawnApp(app, port, instanceOptions, cid);
       this.spawnedApps.push(spawned);
 
@@ -156,7 +150,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
     instanceId?: string,
   ): ElectrobunAppProcess {
     return spawnElectrobunApp({
-      binaryPath: app.binaryPath,
+      app,
       appArgs: options.appArgs ?? [],
       port,
       options,

--- a/packages/electrobun-service/src/mock.ts
+++ b/packages/electrobun-service/src/mock.ts
@@ -1,0 +1,208 @@
+// createMock — the workhorse behind browser.electrobun.mock(target).
+//
+// An Electrobun mock is two cooperating objects (see
+// agent-os/standards/global/mock-architecture.md):
+//
+//   1. The "outer mock" — a vitest-flavoured fn() from @wdio/native-spy that
+//      lives in the WDIO worker. Tests inspect it via mock.mock.calls/results.
+//   2. The "inner recorder" — a spy installed over window.<target> in the CEF
+//      webview (innerRecorder.ts), driven over CDP Runtime.evaluate.
+//
+// `target` is a dotted path to a function in the webview global scope
+// ('api.fetchData' → window.api.fetchData). This is the in-page analogue of
+// browser.dioxus.mock(command) / browser.tauri.mock — Electrobun has no
+// enumerable main-process API to mock, so we replace the function in place and
+// preserve the original for restore.
+//
+// User-facing setters (mockReturnValue, mockImplementation, …) push behaviour
+// into the inner recorder. update() reads the recorder's call history back and
+// syncs it ONE-WAY into the outer mock. clear/reset/restore apply to both sides.
+
+import type { CdpBridge } from '@wdio/electrobun-cdp-bridge';
+import { fn as vitestFn } from '@wdio/native-spy';
+import type { AbstractFn, ElectrobunMock, MockResult } from '@wdio/native-types';
+import { createLogger } from '@wdio/native-utils';
+
+import { evaluateInActiveTarget, jsonLiteral } from './commands/execute.js';
+import { SERVICE_NAME } from './constants.js';
+import {
+  buildClearScript,
+  buildInstallScript,
+  buildReadCallDataScript,
+  buildResetScript,
+  buildRestoreScript,
+  buildReturnThisScript,
+  buildSetImplementationScript,
+  buildSetValueScript,
+} from './innerRecorder.js';
+import type { ElectrobunMockStore } from './mockStore.js';
+import type { InnerMockSetterMethod } from './mockTypes.js';
+
+const log = createLogger(SERVICE_NAME, 'mock');
+
+interface CallData {
+  calls: unknown[][];
+  results: MockResult[];
+  invocationCallOrder: number[];
+}
+
+/**
+ * Revive `{ __wdioError: true, message }` markers produced by the in-page
+ * errorReplacer (innerRecorder.ts#buildReadCallDataScript) back into real Error
+ * objects. Mirrors the shared sync protocol in @wdio/native-spy/interceptor;
+ * inlined here because that package only exports it as a type, not at runtime.
+ */
+function reconstructErrors(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(reconstructErrors);
+  }
+  const obj = value as Record<string, unknown>;
+  if (obj.__wdioError === true) {
+    const err = new Error(typeof obj.message === 'string' ? obj.message : '');
+    if (typeof obj.name === 'string') {
+      err.name = obj.name;
+    }
+    if (typeof obj.stack === 'string') {
+      err.stack = obj.stack;
+    }
+    return err;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    out[key] = reconstructErrors(obj[key]);
+  }
+  return out;
+}
+
+function parseCallData(raw: unknown): CallData {
+  if (!raw || typeof raw !== 'object') {
+    return { calls: [], results: [], invocationCallOrder: [] };
+  }
+  const r = raw as Record<string, unknown>;
+  const calls = Array.isArray(r.calls)
+    ? (r.calls as unknown[][]).map((args) => (Array.isArray(args) ? args.map(reconstructErrors) : args) as unknown[])
+    : [];
+  const results = Array.isArray(r.results)
+    ? (r.results as MockResult[]).map((res) => ({ type: res.type, value: reconstructErrors(res.value) }))
+    : [];
+  return {
+    calls,
+    results,
+    invocationCallOrder: Array.isArray(r.invocationCallOrder) ? (r.invocationCallOrder as number[]) : [],
+  };
+}
+
+/** Serialise a value/error to a JS literal for inlining into a setter script. */
+function valueLiteral(value: unknown, target: string): string {
+  if (value instanceof Error) {
+    return JSON.stringify({ __wdioError: true, message: value.message });
+  }
+  return jsonLiteral(value, `browser.electrobun.mock("${target}") value`);
+}
+
+/**
+ * Create (and register) a mock over `window.<target>` in the active webview.
+ * Injects the inner recorder up front, wires the outer mock's lifecycle to the
+ * bridge, stores it in `store`, and returns it.
+ */
+export async function createMock(
+  target: string,
+  bridge: CdpBridge,
+  store: ElectrobunMockStore,
+): Promise<ElectrobunMock> {
+  log.debug(`[${target}] createMock — installing inner recorder`);
+
+  const existing = store.getMock(target);
+  if (existing) {
+    // Re-mocking the same target returns the existing handle; the install script
+    // is idempotent in-page so we don't double-wrap.
+    await evaluateInActiveTarget<void>(bridge, buildInstallScript(target));
+    return existing;
+  }
+
+  await evaluateInActiveTarget<void>(bridge, buildInstallScript(target));
+
+  const outerMock = vitestFn();
+  outerMock.mockName(`electrobun.${target}`);
+  const outerMockClear = outerMock.mockClear.bind(outerMock);
+  const outerMockReset = outerMock.mockReset.bind(outerMock);
+
+  const mock = outerMock as unknown as ElectrobunMock;
+  mock.__isElectrobunMock = true;
+
+  const originalMock = outerMock.mock;
+
+  const setValue = async (method: InnerMockSetterMethod, value: unknown): Promise<ElectrobunMock> => {
+    await evaluateInActiveTarget<void>(bridge, buildSetValueScript(target, method, valueLiteral(value, target)));
+    return mock;
+  };
+
+  mock.update = async () => {
+    const raw = await evaluateInActiveTarget<unknown>(bridge, buildReadCallDataScript(target));
+    const sync = parseCallData(raw);
+
+    (originalMock.calls as unknown[][]).length = 0;
+    (originalMock.results as { type: string; value: unknown }[]).length = 0;
+    (originalMock.invocationCallOrder as number[]).length = 0;
+    for (let i = 0; i < sync.calls.length; i++) {
+      (originalMock.calls as unknown[][]).push(sync.calls[i]);
+      (originalMock.results as { type: string; value: unknown }[]).push(
+        sync.results[i] ?? { type: 'return', value: undefined },
+      );
+      (originalMock.invocationCallOrder as number[]).push(
+        sync.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+      );
+    }
+    return mock;
+  };
+
+  mock.mockImplementation = async (implFn: AbstractFn) => {
+    await evaluateInActiveTarget<void>(bridge, buildSetImplementationScript(target, implFn.toString()));
+    return mock;
+  };
+
+  mock.mockImplementationOnce = async (implFn: AbstractFn) => {
+    await evaluateInActiveTarget<void>(bridge, buildSetImplementationScript(target, implFn.toString(), true));
+    return mock;
+  };
+
+  mock.mockReturnValue = (value: unknown) => setValue('mockReturnValue', value);
+  mock.mockReturnValueOnce = (value: unknown) => setValue('mockReturnValueOnce', value);
+  mock.mockResolvedValue = (value: unknown) => setValue('mockResolvedValue', value);
+  mock.mockResolvedValueOnce = (value: unknown) => setValue('mockResolvedValueOnce', value);
+  mock.mockRejectedValue = (value: unknown) => setValue('mockRejectedValue', value);
+  mock.mockRejectedValueOnce = (value: unknown) => setValue('mockRejectedValueOnce', value);
+
+  mock.mockReturnThis = async () => {
+    await evaluateInActiveTarget<void>(bridge, buildReturnThisScript(target));
+    return mock;
+  };
+
+  mock.mockClear = async () => {
+    await evaluateInActiveTarget<void>(bridge, buildClearScript(target));
+    outerMockClear();
+    return mock;
+  };
+
+  mock.mockReset = async () => {
+    const currentName = outerMock.getMockName();
+    await evaluateInActiveTarget<void>(bridge, buildResetScript(target));
+    outerMockReset();
+    outerMock.mockName(currentName);
+    return mock;
+  };
+
+  mock.mockRestore = async () => {
+    await evaluateInActiveTarget<void>(bridge, buildRestoreScript(target));
+    outerMockClear();
+    store.deleteMock(target);
+    return mock;
+  };
+
+  store.setMock(target, mock);
+  log.debug(`[${target}] mock ready`);
+  return mock;
+}

--- a/packages/electrobun-service/src/mock.ts
+++ b/packages/electrobun-service/src/mock.ts
@@ -197,7 +197,9 @@ export async function createMock(
 
   mock.mockRestore = async () => {
     await evaluateInActiveTarget<void>(bridge, buildRestoreScript(target));
-    outerMockClear();
+    // Match vitest semantics: restore fully resets the outer spy (history +
+    // implementation), not just clears its call history.
+    outerMockReset();
     store.deleteMock(target);
     return mock;
   };

--- a/packages/electrobun-service/src/mock.ts
+++ b/packages/electrobun-service/src/mock.ts
@@ -98,7 +98,7 @@ function parseCallData(raw: unknown): CallData {
 /** Serialise a value/error to a JS literal for inlining into a setter script. */
 function valueLiteral(value: unknown, target: string): string {
   if (value instanceof Error) {
-    return JSON.stringify({ __wdioError: true, message: value.message });
+    return JSON.stringify({ __wdioError: true, name: value.name, message: value.message });
   }
   return jsonLiteral(value, `browser.electrobun.mock("${target}") value`);
 }

--- a/packages/electrobun-service/src/mockStore.ts
+++ b/packages/electrobun-service/src/mockStore.ts
@@ -1,0 +1,31 @@
+// Per-installed-instance registry of every ElectrobunMock created against one
+// bridge. Backs clearAllMocks / resetAllMocks / restoreAllMocks (filterable by
+// prefix) and isMockFunction. NOT a singleton: each attached browser/bridge gets
+// its own store so multiremote instances don't cross-contaminate.
+
+import type { ElectrobunMock } from '@wdio/native-types';
+
+export class ElectrobunMockStore {
+  #mocks = new Map<string, ElectrobunMock>();
+
+  setMock(target: string, mock: ElectrobunMock): ElectrobunMock {
+    this.#mocks.set(target, mock);
+    return mock;
+  }
+
+  getMock(target: string): ElectrobunMock | undefined {
+    return this.#mocks.get(target);
+  }
+
+  getMocks(): Array<[string, ElectrobunMock]> {
+    return Array.from(this.#mocks.entries());
+  }
+
+  deleteMock(target: string): boolean {
+    return this.#mocks.delete(target);
+  }
+
+  clear(): void {
+    this.#mocks.clear();
+  }
+}

--- a/packages/electrobun-service/src/mockTypes.ts
+++ b/packages/electrobun-service/src/mockTypes.ts
@@ -1,0 +1,11 @@
+// Internal mock-layer types for @wdio/electrobun-service. Kept local (not in
+// @wdio/native-types) because they only describe the inner-recorder transport,
+// not the public browser.electrobun.* surface.
+
+export type InnerMockSetterMethod =
+  | 'mockReturnValue'
+  | 'mockReturnValueOnce'
+  | 'mockResolvedValue'
+  | 'mockResolvedValueOnce'
+  | 'mockRejectedValue'
+  | 'mockRejectedValueOnce';

--- a/packages/electrobun-service/src/nativeMode.ts
+++ b/packages/electrobun-service/src/nativeMode.ts
@@ -2,29 +2,34 @@
 //
 // Electrobun is CDP-attach: the launcher spawns the built app binary, CEF binds
 // the port pinned in build.json, and the worker's CdpBridge attaches over CDP.
-// This module owns the spawn + per-run CFFIXED_USER_HOME temp dir + backend log
-// capture, and the teardown that kills the process and removes the temp dir.
+// This module owns the per-worker bundle clone, the spawn + per-run
+// CFFIXED_USER_HOME temp dir + backend log capture, and the teardown that kills
+// the process and removes both temp dirs.
 //
-// MVP is single-instance. A per-run CFFIXED_USER_HOME gives each run a clean,
-// isolated CEF cache root (RESEARCH_FINDINGS: NSApplicationSupportDirectory
-// honours CFFIXED_USER_HOME, defeating CEF's single-instance-per-cache-root
-// folding). PR3 will clone the bundle per worker for true multi-worker
-// parallelism; this module is the N=1 path of that mechanism.
+// Multi-worker parallelism needs two isolations per worker (RESEARCH_FINDINGS):
+//  - a distinct CFFIXED_USER_HOME → CEF's single-instance-per-cache-root folding
+//    keys on the cache root, so a per-run home gives each launch its own session;
+//  - a private bundle clone → CEF reads the remote-debugging port ONLY from the
+//    bundle's build.json (not a launch arg), so each worker needs its own bundle
+//    copy to pin its own port. We clone here and write the port into the clone,
+//    never mutating the user's shared bundle.
 //
-// E2E-validation gap: spawn/teardown can only be exercised against a real built
-// CEF bundle (none in unit tests). Unit tests mock node:child_process / node:fs
-// at the @wdio/native-core + node boundary; the live path is covered by E2E.
+// E2E-validation gap: clone/spawn/teardown can only be exercised against a real
+// built CEF bundle (none in unit tests). Unit tests mock node:child_process /
+// node:fs at the @wdio/native-core + node boundary; the live path is E2E-only.
 
-import { type ChildProcess, spawn } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { type ChildProcess, execFileSync, spawn } from 'node:child_process';
+import { cpSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { Interface as ReadlineInterface } from 'node:readline';
 
 import { createLogCapture } from '@wdio/native-core';
 import { createLogger } from '@wdio/native-utils';
 
 import { SERVICE_NAME } from './constants.js';
+import { type ResolvedElectrobunApp, writeRemoteDebuggingPort } from './electrobunConfig.js';
+import { SevereServiceError } from './errors.js';
 import type { ElectrobunServiceOptions } from './types.js';
 
 const log = createLogger(SERVICE_NAME, 'launcher');
@@ -33,15 +38,15 @@ const SIGKILL_GRACE_MS = 5_000;
 
 export interface ElectrobunAppProcess {
   proc: ChildProcess;
-  /** Per-run CFFIXED_USER_HOME temp dir to remove on teardown. */
-  userHomeDir: string;
-  /** Allocated CEF remote-debugging port (pinned into the bundle's build.json). */
+  /** Temp dirs to remove on teardown: the per-run CFFIXED_USER_HOME + the bundle-clone parent. */
+  cleanupDirs: string[];
+  /** Allocated CEF remote-debugging port (pinned into the cloned bundle's build.json). */
   port: number;
   logHandlers: ReadlineInterface[];
 }
 
 export interface SpawnElectrobunAppParams {
-  binaryPath: string;
+  app: ResolvedElectrobunApp;
   appArgs: string[];
   port: number;
   options: ElectrobunServiceOptions;
@@ -53,18 +58,59 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Clone an app bundle into a fresh temp parent so each worker can pin its own CEF
+ * remote-debugging port without mutating the user's shared bundle.
+ *
+ * On macOS this uses `cp -Rc` (APFS clonefile) so the ~125MB CEF framework is
+ * copy-on-write rather than duplicated — near-instant. On a non-APFS volume `cp
+ * -Rc` fails; we fall back to a recursive `cpSync`. Non-darwin platforms always
+ * take the `cpSync` path.
+ */
+export function cloneAppBundle(bundlePath: string): { cloneParentDir: string; clonedBundlePath: string } {
+  const cloneParentDir = mkdtempSync(join(tmpdir(), 'wdio-electrobun-bundle-'));
+  const clonedBundlePath = join(cloneParentDir, basename(bundlePath));
+
+  if (process.platform === 'darwin') {
+    try {
+      execFileSync('cp', ['-Rc', bundlePath, clonedBundlePath]);
+      return { cloneParentDir, clonedBundlePath };
+    } catch (error) {
+      // Non-APFS volume (clonefile unsupported) — fall back to a full recursive copy.
+      log.debug(`APFS clone failed for ${bundlePath}, falling back to recursive copy: ${(error as Error).message}`);
+    }
+  }
+
+  cpSync(bundlePath, clonedBundlePath, { recursive: true });
+  return { cloneParentDir, clonedBundlePath };
+}
+
+/**
  * Spawn a built Electrobun app for native-mode CDP attach.
  *
- * Creates a per-run `CFFIXED_USER_HOME` temp dir for an isolated CEF cache root,
- * spawns the binary, and (when log capture is enabled) wires stdout/stderr
- * through `createLogCapture`. Returns the process handle plus the temp dir so the
- * launcher can tear both down.
- *
- * The caller MUST have already pinned `port` into the bundle's build.json — the
- * port is fixed per bundle, not a launch arg.
+ * Clones the resolved bundle into a per-worker temp dir, pins `port` into the
+ * clone's build.json (CEF reads the port from build.json, never a launch arg),
+ * creates a per-run `CFFIXED_USER_HOME` temp dir for an isolated CEF cache root,
+ * spawns the CLONED binary, and (when log capture is enabled) wires stdout/stderr
+ * through `createLogCapture`. Returns the process handle plus the temp dirs so the
+ * launcher can tear them all down.
  */
 export function spawnElectrobunApp(params: SpawnElectrobunAppParams): ElectrobunAppProcess {
-  const { binaryPath, appArgs, port, options, instanceId } = params;
+  const { app, appArgs, port, options, instanceId } = params;
+
+  if (!app.buildJsonPath) {
+    throw new SevereServiceError(
+      `Cannot pin the CEF remote-debugging port: the resolved Electrobun app has no build.json path ` +
+        `(bundle: ${app.bundlePath}). The port is read from build.json, not a launch arg, so a worker ` +
+        'cannot get an isolated port without one.',
+    );
+  }
+
+  const { cloneParentDir, clonedBundlePath } = cloneAppBundle(app.bundlePath);
+  // Rebase the binary + build.json onto the clone by swapping the bundle prefix.
+  const clonedBinaryPath = app.binaryPath.replace(app.bundlePath, clonedBundlePath);
+  const clonedBuildJsonPath = app.buildJsonPath.replace(app.bundlePath, clonedBundlePath);
+
+  writeRemoteDebuggingPort(clonedBuildJsonPath, port);
 
   const userHomeDir = mkdtempSync(join(tmpdir(), 'wdio-electrobun-home-'));
 
@@ -76,8 +122,8 @@ export function spawnElectrobunApp(params: SpawnElectrobunAppParams): Electrobun
     CFFIXED_USER_HOME: userHomeDir,
   };
 
-  log.info(`Spawning Electrobun app: ${binaryPath} ${appArgs.join(' ')} (CDP port ${port})`);
-  const proc = spawn(binaryPath, appArgs, {
+  log.info(`Spawning Electrobun app: ${clonedBinaryPath} ${appArgs.join(' ')} (CDP port ${port})`);
+  const proc = spawn(clonedBinaryPath, appArgs, {
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false,
@@ -107,13 +153,13 @@ export function spawnElectrobunApp(params: SpawnElectrobunAppParams): Electrobun
     log.error(`Electrobun app process error: ${err.message}`);
   });
 
-  return { proc, userHomeDir, port, logHandlers };
+  return { proc, cleanupDirs: [userHomeDir, cloneParentDir], port, logHandlers };
 }
 
 /**
  * Stop a spawned Electrobun app: close log handlers, SIGTERM (SIGKILL after a
- * grace period), then remove the per-run CFFIXED_USER_HOME temp dir. Tolerant of
- * an already-dead process and a missing temp dir.
+ * grace period), then remove the per-run CFFIXED_USER_HOME temp dir and the
+ * bundle-clone parent. Tolerant of an already-dead process and missing temp dirs.
  */
 export async function stopElectrobunApp(app: ElectrobunAppProcess): Promise<void> {
   for (const handler of app.logHandlers) {
@@ -142,9 +188,11 @@ export async function stopElectrobunApp(app: ElectrobunAppProcess): Promise<void
     }
   }
 
-  try {
-    rmSync(app.userHomeDir, { recursive: true, force: true });
-  } catch (error) {
-    log.warn(`Failed to remove CFFIXED_USER_HOME temp dir ${app.userHomeDir}: ${(error as Error).message}`);
+  for (const dir of app.cleanupDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (error) {
+      log.warn(`Failed to remove Electrobun temp dir ${dir}: ${(error as Error).message}`);
+    }
   }
 }

--- a/packages/electrobun-service/src/nativeMode.ts
+++ b/packages/electrobun-service/src/nativeMode.ts
@@ -70,18 +70,25 @@ export function cloneAppBundle(bundlePath: string): { cloneParentDir: string; cl
   const cloneParentDir = mkdtempSync(join(tmpdir(), 'wdio-electrobun-bundle-'));
   const clonedBundlePath = join(cloneParentDir, basename(bundlePath));
 
-  if (process.platform === 'darwin') {
-    try {
-      execFileSync('cp', ['-Rc', bundlePath, clonedBundlePath]);
-      return { cloneParentDir, clonedBundlePath };
-    } catch (error) {
-      // Non-APFS volume (clonefile unsupported) — fall back to a full recursive copy.
-      log.debug(`APFS clone failed for ${bundlePath}, falling back to recursive copy: ${(error as Error).message}`);
+  try {
+    if (process.platform === 'darwin') {
+      try {
+        execFileSync('cp', ['-Rc', bundlePath, clonedBundlePath]);
+        return { cloneParentDir, clonedBundlePath };
+      } catch (error) {
+        // Non-APFS volume (clonefile unsupported) — fall back to a full recursive copy.
+        log.debug(`APFS clone failed for ${bundlePath}, falling back to recursive copy: ${(error as Error).message}`);
+      }
     }
-  }
 
-  cpSync(bundlePath, clonedBundlePath, { recursive: true });
-  return { cloneParentDir, clonedBundlePath };
+    cpSync(bundlePath, clonedBundlePath, { recursive: true });
+    return { cloneParentDir, clonedBundlePath };
+  } catch (error) {
+    // The copy failed (e.g. cpSync threw) — remove the empty temp parent mkdtempSync
+    // created so it doesn't leak, then rethrow.
+    rmSync(cloneParentDir, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 /**

--- a/packages/electrobun-service/src/nativeMode.ts
+++ b/packages/electrobun-service/src/nativeMode.ts
@@ -110,9 +110,17 @@ export function spawnElectrobunApp(params: SpawnElectrobunAppParams): Electrobun
   const clonedBinaryPath = app.binaryPath.replace(app.bundlePath, clonedBundlePath);
   const clonedBuildJsonPath = app.buildJsonPath.replace(app.bundlePath, clonedBundlePath);
 
-  writeRemoteDebuggingPort(clonedBuildJsonPath, port);
-
-  const userHomeDir = mkdtempSync(join(tmpdir(), 'wdio-electrobun-home-'));
+  // The clone isn't tracked for teardown until we return the process handle, so
+  // if pinning the port or creating the home dir throws, remove it here to avoid
+  // leaking the (large, CEF-bearing) temp dir.
+  let userHomeDir: string;
+  try {
+    writeRemoteDebuggingPort(clonedBuildJsonPath, port);
+    userHomeDir = mkdtempSync(join(tmpdir(), 'wdio-electrobun-home-'));
+  } catch (error) {
+    rmSync(cloneParentDir, { recursive: true, force: true });
+    throw error;
+  }
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -3,8 +3,8 @@ import type { ElectrobunServiceAPI } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 
 import { execute } from './commands/execute.js';
+import { triggerDeeplink } from './commands/triggerDeeplink.js';
 import { DEFAULT_REMOTE_DEBUGGING_PORT, SERVICE_NAME } from './constants.js';
-import { deeplinkUnsupportedOnPlatform } from './errors.js';
 import type { ElectrobunServiceOptions } from './types.js';
 
 const log = createLogger(SERVICE_NAME, 'service');
@@ -144,12 +144,7 @@ function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge): void {
     clearAllMocks: () => Promise.reject(notImplemented('clearAllMocks')),
     resetAllMocks: () => Promise.reject(notImplemented('resetAllMocks')),
     restoreAllMocks: () => Promise.reject(notImplemented('restoreAllMocks')),
-    triggerDeeplink: () => {
-      if (process.platform !== 'darwin') {
-        return Promise.reject(deeplinkUnsupportedOnPlatform());
-      }
-      return Promise.reject(notImplemented('triggerDeeplink'));
-    },
+    triggerDeeplink: (url: string) => triggerDeeplink(url),
   };
   (browser as unknown as { electrobun: ElectrobunServiceAPI }).electrobun = electrobun;
   log.debug('Installed browser.electrobun.*');

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -2,18 +2,15 @@ import { CdpBridge } from '@wdio/electrobun-cdp-bridge';
 import type { ElectrobunServiceAPI } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
 
+import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from './commands/allMocks.js';
 import { execute } from './commands/execute.js';
+import { mock } from './commands/mock.js';
 import { triggerDeeplink } from './commands/triggerDeeplink.js';
 import { DEFAULT_REMOTE_DEBUGGING_PORT, SERVICE_NAME } from './constants.js';
+import { ElectrobunMockStore } from './mockStore.js';
 import type { ElectrobunServiceOptions } from './types.js';
 
 const log = createLogger(SERVICE_NAME, 'service');
-
-const NOT_IMPLEMENTED_SUFFIX = 'is not implemented yet (lands in @wdio/electrobun-service feature-complete release)';
-
-function notImplemented(name: string): Error {
-  return new Error(`${name} ${NOT_IMPLEMENTED_SUFFIX}`);
-}
 
 /** Parse a `host:port` debuggerAddress into its parts. Defaults the host to localhost. */
 function parseDebuggerAddress(address: string): { host: string; port: number } {
@@ -29,15 +26,14 @@ function parseDebuggerAddress(address: string): { host: string; port: number } {
 /**
  * Worker-process service for `@wdio/electrobun-service`. Attaches a CdpBridge to
  * the CEF debugger endpoint (`goog:chromeOptions.debuggerAddress`, set by the
- * launcher) and installs the `browser.electrobun.*` surface.
- *
- * MVP scope: `execute` + `switchWindow`/`listWindows` are real (over the bridge);
- * mocking + `triggerDeeplink` are stubs that throw a clear not-implemented error.
+ * launcher) and installs the `browser.electrobun.*` surface (execute, window
+ * switching, mocking, and triggerDeeplink — all over the bridge).
  */
 export default class ElectrobunWorkerService {
   private devServerUrl?: string;
   private options: ElectrobunServiceOptions;
   private bridges: CdpBridge[] = [];
+  private mockStores: ElectrobunMockStore[] = [];
 
   constructor(options: ElectrobunServiceOptions, capabilities: unknown) {
     const capOptions = (capabilities as { 'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions })[
@@ -100,7 +96,9 @@ export default class ElectrobunWorkerService {
     await bridge.connect();
     this.bridges.push(bridge);
 
-    installApi(browser, bridge);
+    const mockStore = new ElectrobunMockStore();
+    this.mockStores.push(mockStore);
+    installApi(browser, bridge, mockStore);
   }
 
   async after(): Promise<void> {
@@ -118,6 +116,10 @@ export default class ElectrobunWorkerService {
       });
     }
     this.bridges = [];
+    for (const store of this.mockStores) {
+      store.clear();
+    }
+    this.mockStores = [];
   }
 }
 
@@ -130,20 +132,22 @@ function capabilityFor(capabilities: unknown, instanceName: string): unknown {
   return capabilities;
 }
 
-/** Build and install the `browser.electrobun.*` surface backed by `bridge`. */
-function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge): void {
+/**
+ * Build and install the `browser.electrobun.*` surface backed by `bridge`. The
+ * `mockStore` is per-installed-instance so multiremote instances keep separate
+ * mock registries.
+ */
+function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge, mockStore: ElectrobunMockStore): void {
   const electrobun: ElectrobunServiceAPI = {
     execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>
       execute<R, A>(bridge, script, ...args),
     switchWindow: (label: string) => bridge.switchTarget(label),
     listWindows: async () => bridge.listWindows(),
-    mock: () => Promise.reject(notImplemented('mock')),
-    isMockFunction: () => {
-      throw notImplemented('isMockFunction');
-    },
-    clearAllMocks: () => Promise.reject(notImplemented('clearAllMocks')),
-    resetAllMocks: () => Promise.reject(notImplemented('resetAllMocks')),
-    restoreAllMocks: () => Promise.reject(notImplemented('restoreAllMocks')),
+    mock: (target: string) => mock(target, bridge, mockStore),
+    isMockFunction: (targetOrFn: unknown) => isMockFunction(targetOrFn, mockStore),
+    clearAllMocks: (prefix?: string) => clearAllMocks(mockStore, prefix),
+    resetAllMocks: (prefix?: string) => resetAllMocks(mockStore, prefix),
+    restoreAllMocks: (prefix?: string) => restoreAllMocks(mockStore, prefix),
     triggerDeeplink: (url: string) => triggerDeeplink(url),
   };
   (browser as unknown as { electrobun: ElectrobunServiceAPI }).electrobun = electrobun;

--- a/packages/electrobun-service/test/allMocks.spec.ts
+++ b/packages/electrobun-service/test/allMocks.spec.ts
@@ -1,0 +1,118 @@
+import vm from 'node:vm';
+
+import type { CdpBridge } from '@wdio/electrobun-cdp-bridge';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wdio/electrobun-cdp-bridge', () => ({ CdpBridge: class {} }));
+
+import { clearAllMocks, isMockFunction, resetAllMocks, restoreAllMocks } from '../src/commands/allMocks.js';
+import { createMock } from '../src/mock.js';
+import { ElectrobunMockStore } from '../src/mockStore.js';
+
+interface FakeWindow {
+  __WDIO_ELECTROBUN_MOCKS__?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function makeBridge(initialWindow: FakeWindow): { bridge: CdpBridge; window: FakeWindow } {
+  const sandbox: { window: FakeWindow } = { window: initialWindow };
+  vm.createContext(sandbox);
+  Object.defineProperty(sandbox, 'globalThis', { value: sandbox });
+  const send = vi.fn(async (_method: string, params: { expression: string }) => {
+    const value = await Promise.resolve(vm.runInContext(params.expression, sandbox));
+    return { result: { value: value === undefined ? undefined : JSON.parse(JSON.stringify(value)) } };
+  });
+  return { bridge: { send } as unknown as CdpBridge, window: initialWindow };
+}
+
+describe('allMocks helpers', () => {
+  let store: ElectrobunMockStore;
+
+  beforeEach(() => {
+    store = new ElectrobunMockStore();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isMockFunction', () => {
+    it('should return true for an ElectrobunMock', async () => {
+      const { bridge } = makeBridge({ api: { a: () => 1 } });
+      const mock = await createMock('api.a', bridge, store);
+      expect(isMockFunction(mock, store)).toBe(true);
+    });
+
+    it('should return true for a registered target-path string', async () => {
+      const { bridge } = makeBridge({ api: { a: () => 1 } });
+      await createMock('api.a', bridge, store);
+      expect(isMockFunction('api.a', store)).toBe(true);
+      expect(isMockFunction('api.unknown', store)).toBe(false);
+    });
+
+    it('should return false for a plain function or non-function', () => {
+      expect(isMockFunction(() => 1, store)).toBe(false);
+      expect(isMockFunction(undefined, store)).toBe(false);
+      expect(isMockFunction(42, store)).toBe(false);
+    });
+  });
+
+  describe('clear/reset/restore all', () => {
+    it('should clear history across all mocks', async () => {
+      const { bridge, window } = makeBridge({ api: { a: () => 1, b: () => 2 } });
+      const a = await createMock('api.a', bridge, store);
+      const b = await createMock('api.b', bridge, store);
+      (window.api as { a: () => unknown }).a();
+      (window.api as { b: () => unknown }).b();
+      await a.update();
+      await b.update();
+      expect(a.mock.calls).toHaveLength(1);
+      expect(b.mock.calls).toHaveLength(1);
+
+      await clearAllMocks(store);
+
+      expect(a.mock.calls).toHaveLength(0);
+      expect(b.mock.calls).toHaveLength(0);
+    });
+
+    it('should honour a prefix filter', async () => {
+      const { bridge, window } = makeBridge({ fs: { read: () => 1 }, net: { get: () => 2 } });
+      const read = await createMock('fs.read', bridge, store);
+      const get = await createMock('net.get', bridge, store);
+      (window.fs as { read: () => unknown }).read();
+      (window.net as { get: () => unknown }).get();
+      await read.update();
+      await get.update();
+
+      await clearAllMocks(store, 'fs.');
+
+      expect(read.mock.calls).toHaveLength(0);
+      expect(get.mock.calls).toHaveLength(1);
+    });
+
+    it('should reset implementations across all mocks', async () => {
+      const { bridge, window } = makeBridge({ api: { a: () => 1 } });
+      const a = await createMock('api.a', bridge, store);
+      await a.mockReturnValue(5);
+      expect((window.api as { a: () => unknown }).a()).toBe(5);
+
+      await resetAllMocks(store);
+
+      expect((window.api as { a: () => unknown }).a()).toBeUndefined();
+    });
+
+    it('should restore originals and empty the store on restoreAllMocks', async () => {
+      const origA = (): string => 'a';
+      const origB = (): string => 'b';
+      const { bridge, window } = makeBridge({ api: { a: origA, b: origB } });
+      await createMock('api.a', bridge, store);
+      await createMock('api.b', bridge, store);
+
+      await restoreAllMocks(store);
+
+      expect((window.api as { a: unknown }).a).toBe(origA);
+      expect((window.api as { b: unknown }).b).toBe(origB);
+      expect(store.getMocks()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -87,6 +87,16 @@ describe('ElectrobunLaunchService', () => {
 
       expect(vi.mocked(spawnElectrobunApp)).not.toHaveBeenCalled();
     });
+
+    it('should reject a mixed browser-mode + native-mode capability set', async () => {
+      const launcher = makeLauncher({});
+      const caps: ElectrobunCapabilities[] = [
+        { 'wdio:electrobunServiceOptions': { mode: 'browser', devServerUrl: 'http://localhost:3000' } },
+        { 'wdio:electrobunServiceOptions': { mode: 'native' } },
+      ];
+
+      await expect(launcher.onPrepare(baseConfig, caps)).rejects.toThrow(/Mixed browser-mode and native-mode/);
+    });
   });
 
   describe('onPrepare — native mode', () => {

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -5,8 +5,10 @@ import { cefRendererRequired } from '../src/errors.js';
 
 // Mock the IO-bound config helpers so the launcher matrix can be driven without
 // a real bundle on disk. resolveElectrobunApp returns a fixed resolved app;
-// verifyCefRenderer / writeRemoteDebuggingPort are spied so throws + port pinning
-// can be asserted. (Their real behaviour is covered in electrobunConfig.spec.ts.)
+// verifyCefRenderer is spied so throws can be asserted. The launcher no longer
+// pins the port itself — that now happens inside the (mocked) spawn path — but
+// writeRemoteDebuggingPort is still mocked so we can assert the launcher never
+// calls it directly. (Real behaviour is covered in electrobunConfig.spec.ts.)
 vi.mock('../src/electrobunConfig.js', () => ({
   resolveElectrobunApp: vi.fn(() => ({
     binaryPath: '/apps/Demo.app/Contents/MacOS/Demo',
@@ -19,11 +21,12 @@ vi.mock('../src/electrobunConfig.js', () => ({
   writeRemoteDebuggingPort: vi.fn(),
 }));
 
-// Mock the native-mode spawn so no real process is launched.
+// Mock the native-mode spawn so no real process is launched (and no real bundle
+// is cloned). The clone + port-pin now live inside spawnElectrobunApp.
 vi.mock('../src/nativeMode.js', () => ({
   spawnElectrobunApp: vi.fn(() => ({
     proc: { pid: 4321, exitCode: null, signalCode: null, kill: vi.fn() },
-    userHomeDir: '/tmp/wdio-electrobun-home-test',
+    cleanupDirs: ['/tmp/wdio-electrobun-home-test', '/tmp/wdio-electrobun-bundle-test'],
     port: 9333,
     logHandlers: [],
   })),
@@ -129,24 +132,44 @@ describe('ElectrobunLaunchService', () => {
   });
 
   describe('onWorkerStart — native mode', () => {
-    it('should allocate a port, pin it into build.json, spawn, and set debuggerAddress', async () => {
+    it('should allocate a port, spawn with the resolved app, and set debuggerAddress', async () => {
       const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
       await launcher.onPrepare(baseConfig, [{}]);
 
       const cap: ElectrobunCapabilities = {};
       await launcher.onWorkerStart('0-0', [cap]);
 
-      expect(vi.mocked(writeRemoteDebuggingPort)).toHaveBeenCalledTimes(1);
-      const [buildJsonPath, port] = vi.mocked(writeRemoteDebuggingPort).mock.calls[0];
-      expect(buildJsonPath).toBe('/apps/Demo.app/Contents/Resources/build.json');
-      expect(typeof port).toBe('number');
-
       expect(vi.mocked(spawnElectrobunApp)).toHaveBeenCalledTimes(1);
       const spawnArg = vi.mocked(spawnElectrobunApp).mock.calls[0][0];
-      expect(spawnArg.binaryPath).toBe('/apps/Demo.app/Contents/MacOS/Demo');
-      expect(spawnArg.port).toBe(port);
+      expect(spawnArg.app.bundlePath).toBe('/apps/Demo.app');
+      expect(spawnArg.app.buildJsonPath).toBe('/apps/Demo.app/Contents/Resources/build.json');
+      expect(typeof spawnArg.port).toBe('number');
 
-      expect(cap['goog:chromeOptions']).toEqual({ debuggerAddress: `localhost:${port}` });
+      expect(cap['goog:chromeOptions']).toEqual({ debuggerAddress: `localhost:${spawnArg.port}` });
+    });
+
+    it('should NOT pin the port directly — clone + port-write happen inside the spawn path', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}]);
+
+      await launcher.onWorkerStart('0-0', [{}]);
+
+      expect(vi.mocked(writeRemoteDebuggingPort)).not.toHaveBeenCalled();
+    });
+
+    it('should allocate a distinct port + spawn per capability for multiremote', async () => {
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+      await launcher.onPrepare(baseConfig, [{}, {}]);
+
+      const caps: ElectrobunCapabilities[] = [{}, {}];
+      await launcher.onWorkerStart('0-0', caps);
+
+      expect(vi.mocked(spawnElectrobunApp)).toHaveBeenCalledTimes(2);
+      const portA = vi.mocked(spawnElectrobunApp).mock.calls[0][0].port;
+      const portB = vi.mocked(spawnElectrobunApp).mock.calls[1][0].port;
+      expect(portA).not.toBe(portB);
+      expect((caps[0]['goog:chromeOptions'] as Record<string, unknown>).debuggerAddress).toBe(`localhost:${portA}`);
+      expect((caps[1]['goog:chromeOptions'] as Record<string, unknown>).debuggerAddress).toBe(`localhost:${portB}`);
     });
 
     it('should preserve existing goog:chromeOptions when setting debuggerAddress', async () => {

--- a/packages/electrobun-service/test/mock.spec.ts
+++ b/packages/electrobun-service/test/mock.spec.ts
@@ -1,0 +1,235 @@
+import vm from 'node:vm';
+
+import type { CdpBridge } from '@wdio/electrobun-cdp-bridge';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock at the boundary — the CdpBridge — not the local modules. send() runs the
+// emitted Runtime.evaluate expression in a Node vm sandbox holding a shared
+// `window`, so the actual inner-recorder JS (innerRecorder.ts) is exercised
+// end-to-end: install → record real calls → read-back → impl/return/clear/etc.
+// (No CEF in unit tests; the in-webview round-trip itself is only fully proven
+// against a real app — see the E2E-validation gap note in the PR.)
+vi.mock('@wdio/electrobun-cdp-bridge', () => ({ CdpBridge: class {} }));
+
+import { createMock } from '../src/mock.js';
+import { ElectrobunMockStore } from '../src/mockStore.js';
+
+interface FakeWindow {
+  __WDIO_ELECTROBUN_MOCKS__?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * A bridge whose `send('Runtime.evaluate', { expression })` runs the expression
+ * against a persistent sandbox. The expression form the service emits is
+ * `(function(){ ... })()` / `(async()=>{...})()`, which `vm.runInContext`
+ * evaluates and returns. Results are JSON-cloned to mimic CDP returnByValue.
+ */
+function makeBridge(initialWindow: FakeWindow = {}): {
+  bridge: CdpBridge;
+  send: ReturnType<typeof vi.fn>;
+  window: FakeWindow;
+} {
+  const window = initialWindow;
+  const sandbox: { window: FakeWindow } = { window };
+  // Inside the page `window.x` and bare `x` are the same global; expose both.
+  vm.createContext(sandbox);
+  Object.defineProperty(sandbox, 'globalThis', { value: sandbox });
+
+  const send = vi.fn(async (method: string, params: { expression: string }) => {
+    if (method !== 'Runtime.evaluate') {
+      throw new Error(`unexpected CDP method ${method}`);
+    }
+    const value = vm.runInContext(params.expression, sandbox);
+    const resolved = await Promise.resolve(value);
+    // returnByValue semantics: serialise then revive.
+    const cloned = resolved === undefined ? undefined : JSON.parse(JSON.stringify(resolved));
+    return { result: { value: cloned } };
+  });
+
+  const bridge = { send } as unknown as CdpBridge;
+  return { bridge, send, window };
+}
+
+describe('createMock (Electrobun mocking)', () => {
+  let store: ElectrobunMockStore;
+
+  beforeEach(() => {
+    store = new ElectrobunMockStore();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('install', () => {
+    it('should inject the inner recorder over the dotted target path on mock()', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 'real' } });
+
+      await createMock('api.fetchData', bridge, store);
+
+      const reg = window.__WDIO_ELECTROBUN_MOCKS__ as Record<string, { original: unknown }>;
+      expect(reg['api.fetchData']).toBeDefined();
+      // The live function is now the spy, not the original.
+      expect((window.api as { fetchData: unknown }).fetchData).not.toBe(reg['api.fetchData'].original);
+    });
+
+    it('should register the outer mock in the store and flag it as an electrobun mock', async () => {
+      const { bridge } = makeBridge({ api: { fetchData: () => 1 } });
+
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      expect(store.getMock('api.fetchData')).toBe(mock);
+      expect((mock as unknown as { __isElectrobunMock: boolean }).__isElectrobunMock).toBe(true);
+      expect(mock.getMockName()).toBe('electrobun.api.fetchData');
+    });
+
+    it('should throw inside the page when the target is not a function', async () => {
+      const { bridge } = makeBridge({ api: { fetchData: 42 } });
+
+      await expect(createMock('api.fetchData', bridge, store)).rejects.toThrow(/is not a function/);
+    });
+
+    it('should return the existing handle (idempotent install) when re-mocking the same target', async () => {
+      const { bridge, send } = makeBridge({ api: { fetchData: () => 1 } });
+
+      const first = await createMock('api.fetchData', bridge, store);
+      send.mockClear();
+      const second = await createMock('api.fetchData', bridge, store);
+
+      expect(second).toBe(first);
+      // Install re-runs (idempotent in-page) but no second outer mock is built.
+      expect(store.getMocks()).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should read inner call data back and populate the outer mock.calls/results', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 'real' } });
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      // Drive real calls through the installed spy in the page.
+      const spy = (window.api as { fetchData: (...a: unknown[]) => unknown }).fetchData;
+      spy('a', 1);
+      spy('b', 2);
+
+      await mock.update();
+
+      expect(mock.mock.calls).toEqual([
+        ['a', 1],
+        ['b', 2],
+      ]);
+      expect(mock.mock.results).toHaveLength(2);
+      expect(mock.mock.invocationCallOrder).toHaveLength(2);
+    });
+
+    it('should replace outer state wholesale when the inner history shrinks', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 1 } });
+      const mock = await createMock('api.fetchData', bridge, store);
+      const spy = (window.api as { fetchData: (...a: unknown[]) => unknown }).fetchData;
+
+      spy('x');
+      await mock.update();
+      expect(mock.mock.calls).toEqual([['x']]);
+
+      await mock.mockClear();
+      await mock.update();
+      expect(mock.mock.calls).toEqual([]);
+    });
+  });
+
+  describe('behaviour setters push to the inner recorder', () => {
+    it('should make the inner spy return the mockReturnValue', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 'real' } });
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      await mock.mockReturnValue(99);
+
+      const spy = (window.api as { fetchData: () => unknown }).fetchData;
+      expect(spy()).toBe(99);
+    });
+
+    it('should make the inner spy resolve the mockResolvedValue', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 'real' } });
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      await mock.mockResolvedValue({ ok: true });
+
+      const spy = (window.api as { fetchData: () => Promise<unknown> }).fetchData;
+      await expect(spy()).resolves.toEqual({ ok: true });
+    });
+
+    it('should reconstruct an Error for mockRejectedValue inside the page', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 'real' } });
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      await mock.mockRejectedValue(new Error('boom'));
+
+      const spy = (window.api as { fetchData: () => Promise<unknown> }).fetchData;
+      await expect(spy()).rejects.toThrow(/boom/);
+    });
+
+    it('should run the pushed mockImplementation in the page', async () => {
+      const { bridge, window } = makeBridge({ api: { add: () => 0 } });
+      const mock = await createMock('api.add', bridge, store);
+
+      await mock.mockImplementation((...args: unknown[]) => (args[0] as number) + (args[1] as number));
+
+      const spy = (window.api as { add: (...a: unknown[]) => unknown }).add;
+      expect(spy(2, 3)).toBe(5);
+    });
+
+    it('should reject a function passed as a mockReturnValue (not JSON-serialisable)', async () => {
+      const { bridge } = makeBridge({ api: { fetchData: () => 1 } });
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      await expect(mock.mockReturnValue(() => 1)).rejects.toThrow(/not JSON-serialisable/);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('should clear inner + outer call history on mockClear', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 1 } });
+      const mock = await createMock('api.fetchData', bridge, store);
+      const spy = (window.api as { fetchData: (...a: unknown[]) => unknown }).fetchData;
+
+      spy('x');
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(1);
+
+      await mock.mockClear();
+      expect(mock.mock.calls).toHaveLength(0);
+      // Inner cleared too: a fresh read shows no calls.
+      await mock.update();
+      expect(mock.mock.calls).toHaveLength(0);
+    });
+
+    it('should reset the inner implementation on mockReset and keep the mock name', async () => {
+      const { bridge, window } = makeBridge({ api: { fetchData: () => 1 } });
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      await mock.mockReturnValue(7);
+      const spy = (window.api as { fetchData: () => unknown }).fetchData;
+      expect(spy()).toBe(7);
+
+      await mock.mockReset();
+      // Default behaviour after reset is undefined.
+      expect(spy()).toBeUndefined();
+      expect(mock.getMockName()).toBe('electrobun.api.fetchData');
+    });
+
+    it('should restore the original function and drop the store entry on mockRestore', async () => {
+      const original = (): string => 'real';
+      const { bridge, window } = makeBridge({ api: { fetchData: original } });
+      const mock = await createMock('api.fetchData', bridge, store);
+
+      expect((window.api as { fetchData: unknown }).fetchData).not.toBe(original);
+
+      await mock.mockRestore();
+
+      expect((window.api as { fetchData: unknown }).fetchData).toBe(original);
+      expect(store.getMock('api.fetchData')).toBeUndefined();
+      expect(window.__WDIO_ELECTROBUN_MOCKS__?.['api.fetchData']).toBeUndefined();
+    });
+  });
+});

--- a/packages/electrobun-service/test/nativeMode.spec.ts
+++ b/packages/electrobun-service/test/nativeMode.spec.ts
@@ -132,6 +132,16 @@ describe('nativeMode', () => {
         recursive: true,
       });
     });
+
+    it('should remove the empty temp parent dir if the copy throws (no leak)', () => {
+      setPlatform('linux');
+      cpSyncMock.mockImplementationOnce(() => {
+        throw new Error('ENOSPC: no space left on device');
+      });
+
+      expect(() => cloneAppBundle('/apps/Demo')).toThrow('ENOSPC');
+      expect(rmSyncMock).toHaveBeenCalledWith('/tmp/wdio-electrobun-bundle-xyz', { recursive: true, force: true });
+    });
   });
 
   describe('spawnElectrobunApp', () => {

--- a/packages/electrobun-service/test/nativeMode.spec.ts
+++ b/packages/electrobun-service/test/nativeMode.spec.ts
@@ -1,17 +1,23 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SevereServiceError } from 'webdriverio';
 
 const spawnMock = vi.fn();
+const execFileSyncMock = vi.fn();
 const mkdtempSyncMock = vi.fn();
+const cpSyncMock = vi.fn();
 const rmSyncMock = vi.fn();
 const createLogCaptureMock = vi.fn();
+const writeRemoteDebuggingPortMock = vi.fn();
 
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => spawnMock(...args),
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
 }));
 
 vi.mock('node:fs', () => ({
   mkdtempSync: (...args: unknown[]) => mkdtempSyncMock(...args),
+  cpSync: (...args: unknown[]) => cpSyncMock(...args),
   rmSync: (...args: unknown[]) => rmSyncMock(...args),
 }));
 
@@ -19,7 +25,12 @@ vi.mock('@wdio/native-core', () => ({
   createLogCapture: (...args: unknown[]) => createLogCaptureMock(...args),
 }));
 
-import { spawnElectrobunApp, stopElectrobunApp } from '../src/nativeMode.js';
+vi.mock('../src/electrobunConfig.js', () => ({
+  writeRemoteDebuggingPort: (...args: unknown[]) => writeRemoteDebuggingPortMock(...args),
+}));
+
+import type { ResolvedElectrobunApp } from '../src/electrobunConfig.js';
+import { cloneAppBundle, spawnElectrobunApp, stopElectrobunApp } from '../src/nativeMode.js';
 import type { ElectrobunServiceOptions } from '../src/types.js';
 
 interface FakeProc extends EventEmitter {
@@ -42,6 +53,23 @@ function makeFakeProc(): FakeProc {
   return proc;
 }
 
+const APP: ResolvedElectrobunApp = {
+  binaryPath: '/apps/Demo.app/Contents/MacOS/Demo',
+  bundlePath: '/apps/Demo.app',
+  resourcesDir: '/apps/Demo.app/Contents/Resources',
+  buildJsonPath: '/apps/Demo.app/Contents/Resources/build.json',
+  identifier: 'com.example.demo',
+};
+
+const CLONE_PARENT = '/tmp/wdio-electrobun-bundle-xyz';
+const USER_HOME = '/tmp/wdio-electrobun-home-abc';
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
 describe('nativeMode', () => {
   let proc: FakeProc;
 
@@ -49,35 +77,161 @@ describe('nativeMode', () => {
     vi.clearAllMocks();
     proc = makeFakeProc();
     spawnMock.mockReturnValue(proc);
-    mkdtempSyncMock.mockReturnValue('/tmp/wdio-electrobun-home-abc');
+    // mkdtempSync is called with distinct prefixes for the bundle clone vs the
+    // CFFIXED_USER_HOME; key the stub off the prefix so call order doesn't matter.
+    mkdtempSyncMock.mockImplementation((prefix: string) => (prefix.includes('bundle') ? CLONE_PARENT : USER_HOME));
     createLogCaptureMock.mockReturnValue({ close: vi.fn() });
+    setPlatform('darwin');
   });
 
   afterEach(() => {
+    setPlatform(originalPlatform);
     vi.useRealTimers();
   });
 
+  describe('cloneAppBundle', () => {
+    it('should use the APFS clonefile (cp -Rc) on darwin', () => {
+      setPlatform('darwin');
+
+      const result = cloneAppBundle('/apps/Demo.app');
+
+      expect(execFileSyncMock).toHaveBeenCalledWith('cp', [
+        '-Rc',
+        '/apps/Demo.app',
+        '/tmp/wdio-electrobun-bundle-xyz/Demo.app',
+      ]);
+      expect(cpSyncMock).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        cloneParentDir: CLONE_PARENT,
+        clonedBundlePath: '/tmp/wdio-electrobun-bundle-xyz/Demo.app',
+      });
+    });
+
+    it('should fall back to a recursive cpSync when the APFS clone fails', () => {
+      setPlatform('darwin');
+      execFileSyncMock.mockImplementationOnce(() => {
+        throw new Error('clonefile unsupported on this volume');
+      });
+
+      const result = cloneAppBundle('/apps/Demo.app');
+
+      expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+      expect(cpSyncMock).toHaveBeenCalledWith('/apps/Demo.app', '/tmp/wdio-electrobun-bundle-xyz/Demo.app', {
+        recursive: true,
+      });
+      expect(result.clonedBundlePath).toBe('/tmp/wdio-electrobun-bundle-xyz/Demo.app');
+    });
+
+    it('should use cpSync (not cp -Rc) on non-darwin platforms', () => {
+      setPlatform('linux');
+
+      cloneAppBundle('/apps/Demo');
+
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      expect(cpSyncMock).toHaveBeenCalledWith('/apps/Demo', '/tmp/wdio-electrobun-bundle-xyz/Demo', {
+        recursive: true,
+      });
+    });
+  });
+
   describe('spawnElectrobunApp', () => {
-    it('should create a per-run CFFIXED_USER_HOME and pass it in the spawn env', () => {
-      const result = spawnElectrobunApp({
-        binaryPath: '/apps/Demo',
+    it('should clone the bundle and pin the port into the CLONE build.json (not the original)', () => {
+      spawnElectrobunApp({
+        app: APP,
         appArgs: ['--flag'],
         port: 9333,
         options: {} as ElectrobunServiceOptions,
       });
 
-      expect(mkdtempSyncMock).toHaveBeenCalledTimes(1);
-      expect(result.userHomeDir).toBe('/tmp/wdio-electrobun-home-abc');
+      expect(execFileSyncMock).toHaveBeenCalledWith('cp', [
+        '-Rc',
+        '/apps/Demo.app',
+        '/tmp/wdio-electrobun-bundle-xyz/Demo.app',
+      ]);
+      expect(writeRemoteDebuggingPortMock).toHaveBeenCalledTimes(1);
+      const [buildJsonPath, port] = writeRemoteDebuggingPortMock.mock.calls[0];
+      expect(buildJsonPath).toBe('/tmp/wdio-electrobun-bundle-xyz/Demo.app/Contents/Resources/build.json');
+      expect(buildJsonPath).not.toBe(APP.buildJsonPath);
+      expect(port).toBe(9333);
+    });
+
+    it('should spawn the CLONED binary with a per-run CFFIXED_USER_HOME', () => {
+      const result = spawnElectrobunApp({
+        app: APP,
+        appArgs: ['--flag'],
+        port: 9333,
+        options: {} as ElectrobunServiceOptions,
+      });
 
       const [binary, args, opts] = spawnMock.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
-      expect(binary).toBe('/apps/Demo');
+      expect(binary).toBe('/tmp/wdio-electrobun-bundle-xyz/Demo.app/Contents/MacOS/Demo');
       expect(args).toEqual(['--flag']);
-      expect(opts.env.CFFIXED_USER_HOME).toBe('/tmp/wdio-electrobun-home-abc');
+      expect(opts.env.CFFIXED_USER_HOME).toBe(USER_HOME);
+      expect(result.cleanupDirs).toEqual([USER_HOME, CLONE_PARENT]);
+    });
+
+    it('should take the cpSync fallback when the APFS clone fails', () => {
+      execFileSyncMock.mockImplementationOnce(() => {
+        throw new Error('clonefile unsupported');
+      });
+
+      spawnElectrobunApp({
+        app: APP,
+        appArgs: [],
+        port: 9333,
+        options: {} as ElectrobunServiceOptions,
+      });
+
+      expect(cpSyncMock).toHaveBeenCalledWith('/apps/Demo.app', '/tmp/wdio-electrobun-bundle-xyz/Demo.app', {
+        recursive: true,
+      });
+      const [binary] = spawnMock.mock.calls[0] as [string];
+      expect(binary).toBe('/tmp/wdio-electrobun-bundle-xyz/Demo.app/Contents/MacOS/Demo');
+    });
+
+    it('should clone with cpSync on non-darwin and spawn the cloned binary', () => {
+      setPlatform('linux');
+      const linuxApp: ResolvedElectrobunApp = {
+        binaryPath: '/apps/Demo/Demo',
+        bundlePath: '/apps/Demo',
+        resourcesDir: '/apps/Demo',
+        buildJsonPath: '/apps/Demo/build.json',
+      };
+
+      spawnElectrobunApp({
+        app: linuxApp,
+        appArgs: [],
+        port: 9333,
+        options: {} as ElectrobunServiceOptions,
+      });
+
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      expect(writeRemoteDebuggingPortMock).toHaveBeenCalledWith(
+        '/tmp/wdio-electrobun-bundle-xyz/Demo/build.json',
+        9333,
+      );
+      const [binary] = spawnMock.mock.calls[0] as [string];
+      expect(binary).toBe('/tmp/wdio-electrobun-bundle-xyz/Demo/Demo');
+    });
+
+    it('should throw a SevereServiceError when the app has no build.json path', () => {
+      const noBuildJson = { ...APP, buildJsonPath: undefined as unknown as string };
+
+      expect(() =>
+        spawnElectrobunApp({
+          app: noBuildJson,
+          appArgs: [],
+          port: 9333,
+          options: {} as ElectrobunServiceOptions,
+        }),
+      ).toThrow(SevereServiceError);
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(writeRemoteDebuggingPortMock).not.toHaveBeenCalled();
     });
 
     it('should merge user-supplied env over process.env', () => {
       spawnElectrobunApp({
-        binaryPath: '/apps/Demo',
+        app: APP,
         appArgs: [],
         port: 9333,
         options: { env: { MY_FLAG: 'on' } } as ElectrobunServiceOptions,
@@ -89,7 +243,7 @@ describe('nativeMode', () => {
 
     it('should not wire log capture when captureBackendLogs is off', () => {
       spawnElectrobunApp({
-        binaryPath: '/apps/Demo',
+        app: APP,
         appArgs: [],
         port: 9333,
         options: { captureBackendLogs: false } as ElectrobunServiceOptions,
@@ -100,7 +254,7 @@ describe('nativeMode', () => {
 
     it('should wire stdout + stderr log capture when captureBackendLogs is on', () => {
       const result = spawnElectrobunApp({
-        binaryPath: '/apps/Demo',
+        app: APP,
         appArgs: [],
         port: 9333,
         options: { captureBackendLogs: true } as ElectrobunServiceOptions,
@@ -112,7 +266,7 @@ describe('nativeMode', () => {
 
     it('should not throw when the process emits a post-spawn error', () => {
       spawnElectrobunApp({
-        binaryPath: '/apps/Demo',
+        app: APP,
         appArgs: [],
         port: 9333,
         options: {} as ElectrobunServiceOptions,
@@ -123,7 +277,7 @@ describe('nativeMode', () => {
   });
 
   describe('stopElectrobunApp', () => {
-    it('should close log handlers, SIGTERM the live process, and remove the temp dir', async () => {
+    it('should close log handlers, SIGTERM the live process, and remove every cleanup dir', async () => {
       const handler = { close: vi.fn() };
       // Process exits promptly after SIGTERM.
       proc.kill.mockImplementation(() => {
@@ -133,31 +287,32 @@ describe('nativeMode', () => {
 
       await stopElectrobunApp({
         proc: proc as unknown as import('node:child_process').ChildProcess,
-        userHomeDir: '/tmp/wdio-electrobun-home-abc',
+        cleanupDirs: [USER_HOME, CLONE_PARENT],
         port: 9333,
         logHandlers: [handler as unknown as import('node:readline').Interface],
       });
 
       expect(handler.close).toHaveBeenCalled();
       expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
-      expect(rmSyncMock).toHaveBeenCalledWith('/tmp/wdio-electrobun-home-abc', { recursive: true, force: true });
+      expect(rmSyncMock).toHaveBeenCalledWith(USER_HOME, { recursive: true, force: true });
+      expect(rmSyncMock).toHaveBeenCalledWith(CLONE_PARENT, { recursive: true, force: true });
     });
 
-    it('should skip killing an already-exited process but still remove the temp dir', async () => {
+    it('should skip killing an already-exited process but still remove the cleanup dirs', async () => {
       proc.exitCode = 0;
 
       await stopElectrobunApp({
         proc: proc as unknown as import('node:child_process').ChildProcess,
-        userHomeDir: '/tmp/wdio-electrobun-home-abc',
+        cleanupDirs: [USER_HOME, CLONE_PARENT],
         port: 9333,
         logHandlers: [],
       });
 
       expect(proc.kill).not.toHaveBeenCalled();
-      expect(rmSyncMock).toHaveBeenCalled();
+      expect(rmSyncMock).toHaveBeenCalledTimes(2);
     });
 
-    it('should not throw when temp-dir removal fails', async () => {
+    it('should keep removing remaining dirs when one removal fails', async () => {
       proc.exitCode = 0;
       rmSyncMock.mockImplementationOnce(() => {
         throw new Error('EBUSY');
@@ -166,11 +321,13 @@ describe('nativeMode', () => {
       await expect(
         stopElectrobunApp({
           proc: proc as unknown as import('node:child_process').ChildProcess,
-          userHomeDir: '/tmp/wdio-electrobun-home-abc',
+          cleanupDirs: [USER_HOME, CLONE_PARENT],
           port: 9333,
           logHandlers: [],
         }),
       ).resolves.toBeUndefined();
+
+      expect(rmSyncMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/electrobun-service/test/nativeMode.spec.ts
+++ b/packages/electrobun-service/test/nativeMode.spec.ts
@@ -155,6 +155,18 @@ describe('nativeMode', () => {
       expect(port).toBe(9333);
     });
 
+    it('should remove the cloned bundle dir if pinning the port throws (no temp-dir leak)', () => {
+      writeRemoteDebuggingPortMock.mockImplementationOnce(() => {
+        throw new Error('EACCES: build.json not writable');
+      });
+
+      expect(() =>
+        spawnElectrobunApp({ app: APP, appArgs: [], port: 9333, options: {} as ElectrobunServiceOptions }),
+      ).toThrow('EACCES');
+
+      expect(rmSyncMock).toHaveBeenCalledWith(CLONE_PARENT, { recursive: true, force: true });
+    });
+
     it('should spawn the CLONED binary with a per-run CFFIXED_USER_HOME', () => {
       const result = spawnElectrobunApp({
         app: APP,

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -198,14 +198,7 @@ describe('ElectrobunWorkerService', () => {
         /not implemented yet/,
       );
     });
-
-    it('should reject triggerDeeplink (not implemented on macOS, unsupported elsewhere)', async () => {
-      const browser = makeBrowser();
-      const service = new ElectrobunWorkerService({}, {});
-      await service.before(nativeCap(), [], browser);
-
-      await expect((browser as unknown as Installed).electrobun.triggerDeeplink('app://x')).rejects.toThrow();
-    });
+    // triggerDeeplink is now real (macOS) — covered in test/triggerDeeplink.spec.ts.
   });
 
   describe('teardown', () => {

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -176,27 +176,59 @@ describe('ElectrobunWorkerService', () => {
     });
   });
 
-  describe('stubs', () => {
-    it('should reject mock / clearAllMocks / resetAllMocks / restoreAllMocks as not implemented', async () => {
+  describe('mock surface (wired over the bridge)', () => {
+    // Detailed inner-recorder semantics live in test/mock.spec.ts / allMocks.spec.ts;
+    // here we assert installApi wires the family onto the bridge-backed store.
+    it('should install a recorder via Runtime.evaluate and return an electrobun mock', async () => {
       const browser = makeBrowser();
       const service = new ElectrobunWorkerService({}, {});
       await service.before(nativeCap(), [], browser);
       const { electrobun } = browser as unknown as Installed;
 
-      await expect(electrobun.mock('x')).rejects.toThrow(/not implemented yet/);
-      await expect(electrobun.clearAllMocks()).rejects.toThrow(/not implemented yet/);
-      await expect(electrobun.resetAllMocks()).rejects.toThrow(/not implemented yet/);
-      await expect(electrobun.restoreAllMocks()).rejects.toThrow(/not implemented yet/);
+      const mock = await electrobun.mock('api.fetchData');
+
+      expect((mock as unknown as { __isElectrobunMock: boolean }).__isElectrobunMock).toBe(true);
+      expect(mock.getMockName()).toBe('electrobun.api.fetchData');
+      const [method, params] = sendMock.mock.calls[0];
+      expect(method).toBe('Runtime.evaluate');
+      expect(params.expression).toContain('__WDIO_ELECTROBUN_MOCKS__');
+      expect(params.expression).toContain('api.fetchData');
     });
 
-    it('should throw for isMockFunction as not implemented', async () => {
+    it('should report mocks via isMockFunction and resolve clear/reset/restore-all', async () => {
       const browser = makeBrowser();
       const service = new ElectrobunWorkerService({}, {});
       await service.before(nativeCap(), [], browser);
+      const { electrobun } = browser as unknown as Installed;
 
-      expect(() => (browser as unknown as Installed).electrobun.isMockFunction(() => undefined)).toThrow(
-        /not implemented yet/,
-      );
+      const mock = await electrobun.mock('api.fetchData');
+      expect(electrobun.isMockFunction(mock)).toBe(true);
+      expect(electrobun.isMockFunction('api.fetchData')).toBe(true);
+      expect(electrobun.isMockFunction(() => undefined)).toBe(false);
+
+      await expect(electrobun.clearAllMocks()).resolves.toBeUndefined();
+      await expect(electrobun.resetAllMocks()).resolves.toBeUndefined();
+      await expect(electrobun.restoreAllMocks()).resolves.toBeUndefined();
+    });
+
+    it('should keep a separate mock store per multiremote instance', async () => {
+      const instanceA = {} as WebdriverIO.Browser;
+      const instanceB = {} as WebdriverIO.Browser;
+      const mrBrowser = {
+        isMultiremote: true,
+        instances: ['browserA', 'browserB'],
+        getInstance: (name: string) => (name === 'browserA' ? instanceA : instanceB),
+      } as unknown as WebdriverIO.MultiRemoteBrowser;
+      const caps = { browserA: { capabilities: nativeCap(9361) }, browserB: { capabilities: nativeCap(9362) } };
+
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(caps, [], mrBrowser);
+
+      const electrobunA = (instanceA as unknown as Installed).electrobun;
+      const electrobunB = (instanceB as unknown as Installed).electrobun;
+      await electrobunA.mock('api.only');
+      expect(electrobunA.isMockFunction('api.only')).toBe(true);
+      expect(electrobunB.isMockFunction('api.only')).toBe(false);
     });
     // triggerDeeplink is now real (macOS) — covered in test/triggerDeeplink.spec.ts.
   });

--- a/packages/electrobun-service/test/triggerDeeplink.spec.ts
+++ b/packages/electrobun-service/test/triggerDeeplink.spec.ts
@@ -1,0 +1,42 @@
+import * as nativeCore from '@wdio/native-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { triggerDeeplink } from '../src/commands/triggerDeeplink.js';
+
+// Keep the pure validators (validateDeeplinkUrl / getPlatformCommand) real; only
+// stub the side-effecting spawn so no real process is launched.
+vi.mock('@wdio/native-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof nativeCore>();
+  return { ...actual, executeDeeplinkCommand: vi.fn(async () => {}) };
+});
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  vi.clearAllMocks();
+});
+
+describe('triggerDeeplink', () => {
+  it('should spawn the macOS open handler for a valid custom-scheme URL', async () => {
+    setPlatform('darwin');
+    await triggerDeeplink('wdio-electrobun://open?path=/test');
+    expect(nativeCore.executeDeeplinkCommand).toHaveBeenCalledWith('open', ['wdio-electrobun://open?path=/test']);
+  });
+
+  it('should reject http/https/file URLs', async () => {
+    setPlatform('darwin');
+    await expect(triggerDeeplink('https://example.com')).rejects.toThrow();
+    expect(nativeCore.executeDeeplinkCommand).not.toHaveBeenCalled();
+  });
+
+  it('should throw the documented-gap error on non-macOS platforms', async () => {
+    setPlatform('win32');
+    await expect(triggerDeeplink('wdio-electrobun://x')).rejects.toThrow(/macOS/);
+    expect(nativeCore.executeDeeplinkCommand).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,19 @@ importers:
 
   fixtures/e2e-apps/dioxus: {}
 
+  fixtures/e2e-apps/electrobun:
+    dependencies:
+      electrobun:
+        specifier: 1.18.1
+        version: 1.18.1
+    devDependencies:
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   fixtures/e2e-apps/electron-builder:
     devDependencies:
       '@types/node':
@@ -353,6 +366,40 @@ importers:
         version: 9.27.1
       typescript:
         specifier: ^5.0.0
+        version: 5.9.3
+
+  fixtures/package-tests/electrobun-app:
+    dependencies:
+      electrobun:
+        specifier: 1.18.1
+        version: 1.18.1
+    devDependencies:
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
+      '@wdio/cli':
+        specifier: 9.27.1
+        version: 9.27.1(@types/node@25.9.1)(expect-webdriverio@5.6.5)(puppeteer-core@25.0.4)
+      '@wdio/electrobun-service':
+        specifier: workspace:*
+        version: link:../../../packages/electrobun-service
+      '@wdio/globals':
+        specifier: 9.27.1
+        version: 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@25.0.4))
+      '@wdio/local-runner':
+        specifier: 9.27.1
+        version: 9.27.1(@wdio/globals@9.27.1)(webdriverio@9.27.1(puppeteer-core@25.0.4))
+      '@wdio/mocha-framework':
+        specifier: 9.27.1
+        version: 9.27.1
+      '@wdio/native-types':
+        specifier: workspace:*
+        version: link:../../../packages/native-types
+      '@wdio/spec-reporter':
+        specifier: 9.27.1
+        version: 9.27.1
+      typescript:
+        specifier: 5.9.3
         version: 5.9.3
 
   fixtures/package-tests/electron-builder-app-cjs:
@@ -1423,6 +1470,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@babylonjs/core@7.54.3':
+    resolution: {integrity: sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -3402,6 +3452,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -3461,6 +3514,9 @@ packages:
 
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
+
+  '@types/node@17.0.45':
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
@@ -4092,6 +4148,9 @@ packages:
   builder-util@26.8.1:
     resolution: {integrity: sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==}
 
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -4361,6 +4420,10 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  cross-spawn-windows-exe@1.2.0:
+    resolution: {integrity: sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==}
+    engines: {node: '>= 10'}
+
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -4557,6 +4620,10 @@ packages:
   ejs@4.0.1:
     resolution: {integrity: sha512-krvQtxc0btwSm/nvnt1UpnaFDFVJpJ0fdckmALpCgShsr/iGYHTnJiUliZTgmzq/UxTX33TtOQVKaNigMQp/6Q==}
     engines: {node: '>=0.12.18'}
+    hasBin: true
+
+  electrobun@1.18.1:
+    resolution: {integrity: sha512-tgZ+WKGskn/1/Y5i1mpVCCkgRa1O31Tz7MIArBTK44GfPzT43uOq9c/HvxdQGrLeZV8ZvjK1lQrwqSXCgh6tvA==}
     hasBin: true
 
   electron-builder-squirrel-windows@26.8.1:
@@ -5324,10 +5391,6 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
-
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -5342,6 +5405,11 @@ packages:
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -5418,6 +5486,10 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -6265,6 +6337,11 @@ packages:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
 
+  png-to-ico@2.1.8:
+    resolution: {integrity: sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   pngjs@6.0.0:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
     engines: {node: '>=12.13.0'}
@@ -6367,6 +6444,11 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  rcedit@4.0.1:
+    resolution: {integrity: sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==}
+    engines: {node: '>= 14.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -6680,10 +6762,6 @@ packages:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
-  socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -6923,6 +7001,9 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  three@0.165.0:
+    resolution: {integrity: sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==}
 
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
@@ -7622,6 +7703,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babylonjs/core@7.54.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -9088,7 +9171,6 @@ snapshots:
   '@malept/cross-spawn-promise@1.1.1':
     dependencies:
       cross-spawn: 7.0.6
-    optional: true
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -9629,6 +9711,10 @@ snapshots:
   '@turbo/windows-arm64@2.9.14':
     optional: true
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -9688,6 +9774,8 @@ snapshots:
       '@types/node': 25.9.1
 
   '@types/node@16.9.1': {}
+
+  '@types/node@17.0.45': {}
 
   '@types/node@20.19.41':
     dependencies:
@@ -10530,6 +10618,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.1
+
   cac@6.7.14: {}
 
   cacache@16.1.3:
@@ -10831,6 +10923,12 @@ snapshots:
       '@epic-web/invariant': 1.0.0
       cross-spawn: 7.0.6
 
+  cross-spawn-windows-exe@1.2.0:
+    dependencies:
+      '@malept/cross-spawn-promise': 1.1.1
+      is-wsl: 2.2.0
+      which: 2.0.2
+
   cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
@@ -11043,6 +11141,17 @@ snapshots:
   ejs@4.0.1:
     dependencies:
       jake: 10.9.4
+
+  electrobun@1.18.1:
+    dependencies:
+      '@babylonjs/core': 7.54.3
+      '@types/bun': 1.3.14
+      png-to-ico: 2.1.8
+      proxy-agent: 6.5.0
+      rcedit: 4.0.1
+      three: 0.165.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1):
     dependencies:
@@ -12042,8 +12151,6 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  ip-address@10.1.0: {}
-
   ip-address@10.2.0: {}
 
   is-arrayish@0.2.1: {}
@@ -12055,6 +12162,8 @@ snapshots:
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
+
+  is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -12099,6 +12208,10 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isarray@1.0.0: {}
 
@@ -13010,6 +13123,12 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
+  png-to-ico@2.1.8:
+    dependencies:
+      '@types/node': 17.0.45
+      minimist: 1.2.8
+      pngjs: 6.0.0
+
   pngjs@6.0.0: {}
 
   pngjs@7.0.0: {}
@@ -13112,6 +13231,10 @@ snapshots:
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  rcedit@4.0.1:
+    dependencies:
+      cross-spawn-windows-exe: 1.2.0
 
   react-is@18.3.1: {}
 
@@ -13480,14 +13603,9 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      socks: 2.8.7
+      socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
-
-  socks@2.8.7:
-    dependencies:
-      ip-address: 10.1.0
-      smart-buffer: 4.2.0
 
   socks@2.8.9:
     dependencies:
@@ -13724,6 +13842,8 @@ snapshots:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
+
+  three@0.165.0: {}
 
   time-span@5.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - fixtures/e2e-apps/electron-script
   - fixtures/e2e-apps/tauri
   - fixtures/e2e-apps/dioxus
+  - fixtures/e2e-apps/electrobun
   - fixtures/package-tests/electron-builder-app-cjs
   - fixtures/package-tests/electron-builder-app-esm
   - fixtures/package-tests/electron-forge-app-cjs
@@ -15,6 +16,7 @@ packages:
   - fixtures/package-tests/electron-script-app-esm
   - fixtures/package-tests/tauri-app
   - fixtures/package-tests/dioxus-app
+  - fixtures/package-tests/electrobun-app
 allowBuilds:
   edgedriver: false
   electron: true


### PR DESCRIPTION
**PR3 of the stack** (Foundation → MVP → **Feature-complete** → E2E → Ship). Stacked on #311; GitHub retargets to the integration branch as the stack merges.

Brings `@wdio/electrobun-service` to the **full standard surface** (all real, not stubbed), validated by unit tests at the CdpBridge boundary. E2E (CI fixture build + specs) is split into the next PR so the beta-toolchain CEF-CI risk doesn't block this feature work or the eventual release.

## What's in this PR
- **`triggerDeeplink` (macOS)** — fires the OS `open <url>` so the app's `open-url` handler receives it (`@wdio/native-core` deeplink helpers); non-macOS throws the documented-gap error.
- **Multiremote** — per-worker `.app` clone (APFS `cp -Rc`, `cpSync` fallback) + per-clone `build.json` port + distinct `CFFIXED_USER_HOME`, replacing the MVP's in-place mutation. Removes the single-instance limitation (no upstream change needed — empirically validated in the spike).
- **Mocking** — `browser.electrobun.mock(target)` + full lifecycle (`mockImplementation`/`mockReturnValue`/`mockResolvedValue`/`mockRejectedValue`/`…Once`/`mockReturnThis`/`mockClear`/`mockReset`/`mockRestore`) + `clear/reset/restoreAllMocks` + `isMockFunction`, over CDP. In-webview vitest-shaped recorder injected via `Runtime.evaluate` (never navigates), one-way `update()` sync — modeled on Electron's browser-mode mock; satisfies the `ElectrobunMock` types.
- **Fixtures** — `fixtures/e2e-apps/electrobun` (CEF all-OS, 2 windows, `open-url`, big-glass counter UI) + `fixtures/package-tests/electrobun-app` + workspace wiring.

## Standard surface — now all real
`execute`, mocking, `switchWindow`/`listWindows`, `triggerDeeplink` (macOS), browser mode, standalone, multiremote. **Documented gaps:** `emitEvent` (Bun bus not CDP-reachable), `mockAll`/class-mock (Electron-only), Win/Linux deeplink (upstream).

## Verification
- typecheck 10/10; **121** `@wdio/electrobun-service` + **18** `@wdio/electrobun-cdp-bridge` unit tests; Biome clean; no regressions (native-core, dioxus-service, native-types).
- **E2E gap (by design):** unit tests mock the CdpBridge boundary; the real in-webview round-trip (mock recorder, execute, multiremote clone+spawn) is proven only against a built CEF app — that lands in the **E2E PR** (CI fixture build + specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)