### PR TITLE
docs(skills): split E2E into its own PR for high-risk CI builds

### DIFF
--- a/.claude/skills/add-native-service/SKILL.md
+++ b/.claude/skills/add-native-service/SKILL.md
@@ -217,6 +217,8 @@ Default to a 4-PR stacked split:
 
 Every PR must be green on all affected service suites + any `cargo test`. No regressions, ever.
 
+**Split E2E into its own PR when the fixture's build+run in CI is itself high-risk.** The 4-PR default folds the E2E specs + `wdio.<framework>.conf.ts` + CI gates into Ship. That's fine for a framework with a *mature, proven build toolchain*. But for an **immature/novel toolchain** — a pre-1.0/beta CLI, large per-OS runtime downloads, a new driver, or a platform whose automation path is unverified — getting the fixture to build and run headless in CI is usually the single biggest unknown, and it's iterative and flaky-prone. Bundling that into Ship holds docs + release hostage to it and risks publishing a service E2E never actually exercised. In that case use a **5-PR split**: insert a dedicated **PR4: E2E** (`feat/<service>-e2e`) — fixture CI build + `_ci-build-<framework>-e2e-app` / `-all-providers` reusable workflows + e2e specs + `wdio.<framework>.conf.ts` + headless — and make **PR5: Ship** (docs + release) depend on it, so you *prove it runs before you publish*. (Electrobun is the worked example: beta Bun/CEF toolchain with build defects + an unverified Linux CDP path.) Keep the e2e *fixture app* itself in PR3 either way; it's only the CI-build-and-run that warrants isolating.
+
 ## Common gotchas
 
 1. **Pick the archetype first.** Cloning the wrong reference is the most expensive mistake. A CDP-based framework cloned from `tauri-service` would build a driver fork and Rust crates it never needs; a Wry framework cloned from `electron-service` would have no way to drive the webview. Confirm CDP vs WebDriver in the spike.

--- a/.claude/skills/add-native-service/SKILL.md
+++ b/.claude/skills/add-native-service/SKILL.md
@@ -219,6 +219,16 @@ Every PR must be green on all affected service suites + any `cargo test`. No reg
 
 **Split E2E into its own PR when the fixture's build+run in CI is itself high-risk.** The 4-PR default folds the E2E specs + `wdio.<framework>.conf.ts` + CI gates into Ship. That's fine for a framework with a *mature, proven build toolchain*. But for an **immature/novel toolchain** — a pre-1.0/beta CLI, large per-OS runtime downloads, a new driver, or a platform whose automation path is unverified — getting the fixture to build and run headless in CI is usually the single biggest unknown, and it's iterative and flaky-prone. Bundling that into Ship holds docs + release hostage to it and risks publishing a service E2E never actually exercised. In that case use a **5-PR split**: insert a dedicated **PR4: E2E** (`feat/<service>-e2e`) — fixture CI build + `_ci-build-<framework>-e2e-app` / `-all-providers` reusable workflows + e2e specs + `wdio.<framework>.conf.ts` + headless — and make **PR5: Ship** (docs + release) depend on it, so you *prove it runs before you publish*. (Electrobun is the worked example: beta Bun/CEF toolchain with build defects + an unverified Linux CDP path.) Keep the e2e *fixture app* itself in PR3 either way; it's only the CI-build-and-run that warrants isolating.
 
+The 5-PR split, mirroring the table above:
+
+| PR | Branch (off main) | Scope |
+|---|---|---|
+| **PR1: Foundation** | `feat/<service>-foundation` | As in the 4-PR split. |
+| **PR2: MVP** | `feat/<service>-mvp` (off PR1) | As in the 4-PR split. |
+| **PR3: Feature Complete** | `feat/<service>-feature-complete` (off PR2) | As in the 4-PR split, **plus the e2e fixture app** (the app source — not its CI run). |
+| **PR4: E2E** | `feat/<service>-e2e` (off PR3) | Fixture CI build + `_ci-build-<framework>-e2e-app` / `-all-providers` reusable workflows, e2e specs, `wdio.<framework>.conf.ts`, headless. The risky "prove it runs in CI" PR. |
+| **PR5: Ship** | `feat/<service>-ship` (off PR4) | Package-test fixture, full docs, complete CI gates, release pipeline (everything from 4-PR Ship except the e2e specs, which moved to PR4). |
+
 ## Common gotchas
 
 1. **Pick the archetype first.** Cloning the wrong reference is the most expensive mistake. A CDP-based framework cloned from `tauri-service` would build a driver fork and Rust crates it never needs; a Wry framework cloned from `electron-service` would have no way to drive the webview. Confirm CDP vs WebDriver in the spike.


### PR DESCRIPTION
Adds a conditional guideline to the `add-native-service` skill, learned from the Electrobun service.

The 4-PR default folds E2E specs + CI gates into the Ship PR. That's fine for a framework with a **mature, proven build toolchain**. But when getting the fixture to **build + run in CI** is itself high-risk — an immature/beta toolchain, large per-OS runtime downloads, a new driver, or an unverified automation platform — bundling E2E into Ship holds docs/release hostage to it and risks publishing a service E2E never actually exercised.

Guidance added: in that case use a **5-PR split** with a dedicated **PR4 (E2E)** before **PR5 (Ship)** — *prove it runs before you publish*. The e2e *fixture app* stays in PR3 either way; only the CI-build-and-run is isolated. Electrobun is cited as the worked example (beta Bun/CEF toolchain with build defects + unverified Linux CDP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)