### PR TITLE
fix(electrobun): validate mock target as a dotted identifier path (CodeQL)

### DIFF
--- a/packages/electrobun-service/src/innerRecorder.ts
+++ b/packages/electrobun-service/src/innerRecorder.ts
@@ -22,8 +22,22 @@ import type { InnerMockSetterMethod } from './mockTypes.js';
 
 const REGISTRY = 'window.__WDIO_ELECTROBUN_MOCKS__';
 
-/** JSON literal of a target path, safe to inline as an object key / string arg. */
+// A mock target is a dotted path of JS identifiers (`api.fetchData`) — that's all
+// the RESOLVE_PATH `.split('.')` walk can address. Restricting to that charset here
+// means the value inlined into the evaluated scripts below can never contain a
+// quote, backslash, newline, or line/paragraph separator, so `JSON.stringify` is a
+// provably-safe escaping into the JS-string context (closes the CodeQL
+// `js/bad-code-sanitization` reports on the `${key}` interpolations).
+const VALID_TARGET = /^[A-Za-z_$][A-Za-z0-9_$]*(\.[A-Za-z_$][A-Za-z0-9_$]*)*$/;
+
+/** JSON literal of a validated target path, safe to inline as an object key / string arg. */
 function pathLiteral(target: string): string {
+  if (!VALID_TARGET.test(target)) {
+    throw new Error(
+      `browser.electrobun.mock target ${JSON.stringify(target)} is not a valid dotted property path ` +
+        `(expected identifiers separated by dots, e.g. 'api.fetchData').`,
+    );
+  }
   return JSON.stringify(target);
 }
 

--- a/packages/electrobun-service/test/mock.spec.ts
+++ b/packages/electrobun-service/test/mock.spec.ts
@@ -84,6 +84,15 @@ describe('createMock (Electrobun mocking)', () => {
       expect(mock.getMockName()).toBe('electrobun.api.fetchData');
     });
 
+    it('should reject a target that is not a valid dotted property path', async () => {
+      const { bridge, send } = makeBridge({ api: { fetchData: () => 1 } });
+
+      await expect(createMock("api['fetch-data']", bridge, store)).rejects.toThrow(/valid dotted property path/);
+      await expect(createMock("x'); doEvil(); //", bridge, store)).rejects.toThrow(/valid dotted property path/);
+      // Rejected before any script reaches the page.
+      expect(send).not.toHaveBeenCalled();
+    });
+
     it('should throw inside the page when the target is not a function', async () => {
       const { bridge } = makeBridge({ api: { fetchData: 42 } });
 


### PR DESCRIPTION
## What

Closes the 5 CodeQL **`js/bad-code-sanitization`** alerts (medium) flagged on the feature branch in `packages/electrobun-service/src/innerRecorder.ts` (the `${key}` interpolations in `buildInstallScript` et al).

## Why / analysis

`browser.electrobun.mock(target)` takes a **dotted path to a function in the webview global scope** (e.g. `api.fetchData`). The path is `JSON.stringify`'d and inlined into scripts the worker evaluates over CDP. CodeQL flags `JSON.stringify` as an improper escaper for a *code* context.

In practice the risk was low (the value is the test author's own input — who already has arbitrary code execution via `browser.electrobun.execute()` — and `JSON.stringify` yields a valid JS string literal in the CEF/Chromium 147 target). But the proper fix is genuine and cheap:

## How

`pathLiteral()` now validates `target` against `^[A-Za-z_$][A-Za-z0-9_$]*(\.[A-Za-z_$][A-Za-z0-9_$]*)*$` — exactly the dotted-identifier charset the `RESOLVE_PATH` `.split('.')` walk can address. The inlined value can therefore never contain a quote, backslash, newline, or line/paragraph separator, so `JSON.stringify` is a provably-safe escaping into the JS-string context (and the regex guard is a sanitiser CodeQL recognises). Invalid targets reject with a clear error **before any script reaches the page**.

Adds a unit test (bracket-notation + injection-attempt targets both rejected, `send` never called). Full suite: 125 passing.