### PR TITLE
feat(electrobun): Ship — 0.1.0, macOS-only guard, docs, package-test CI, release pipeline (PR5)

### DIFF
--- a/.claude/skills/add-native-service/SKILL.md
+++ b/.claude/skills/add-native-service/SKILL.md
@@ -93,11 +93,15 @@ multi-window, deeplink) may be blocked by a framework/runtime limitation you **c
 service layer**. Don't force-fit, and don't hold the whole package hostage to upstream — ship the
 working subset, clearly scoped, and recover the rest as upstream lands fixes.
 
-**Version: start at `0.1.0`, not `1.0.0-next.0`.** The `1.0.0-next.0` default is for a service that
-reaches the full convergent surface on its target platforms (just polishing toward 1.0). When
-upstream blocks a lot, `1.0.0-next.0` over-promises — use **`0.x`**, the semver signal for "early,
-partial, scope may change, gaps expected":
-- **`0.1.0`** initial release — the validated subset (e.g. one platform, the standard single-window surface).
+**Version: base at `0.1.0`, not `1.0.0`.** The default convention here is a `X.Y.0-next.0` dev
+placeholder in `package.json` that releases as stable `X.Y.0` on `latest` (with `-next.N` prereleases
+on the `next` dist-tag in between — every service does this: electron `10.0.0-next.N`→`10.0.0`, tauri
+`1.0.0-next.N`→`1.0.0`). A full-convergent-surface service bases that at `1.0` (placeholder
+`1.0.0-next.0`, release `1.0.0`). When upstream blocks a lot, `1.0` over-promises — base it at **`0.x`**,
+the semver signal for "early, partial, scope may change, gaps expected". Keep the same release
+*machinery*, just lower the base:
+- **Dev placeholder `0.1.0-next.0`** (a prerelease *of* 0.1.0 — NOT `1.0.0-next.0`, which implies a 1.0 target).
+- **First stable release `0.1.0`** on `latest`; `0.1.0-next.N` prereleases on `next` during lead-up. (`0.x` = unstable API; `-next.N` = staging channel — orthogonal, you want both.)
 - **Minor bumps** (`0.2.0`, `0.3.0`…) as each upstream fix recovers a platform/feature. Breaking changes are allowed within `0.x` (bump minor).
 - **Graduate to `1.0.0`** only at full parity with the sibling services — the whole standard surface on all intended platforms. `1.0` is the promise that the convergent surface works.
 
@@ -196,7 +200,7 @@ src/
 
 **Conventions:**
 
-- Initial npm version `1.0.0-next.0` for a service that reaches the full convergent surface on its target platforms — or **`0.1.0`** if upstream blocks a lot of the surface (see [When upstream blocks the standard surface](#when-upstream-blocks-the-standard-surface-shipping-pre-10)). Build script: `tsx ../../scripts/build-package.ts`.
+- Initial `package.json` dev placeholder `1.0.0-next.0` for a service that reaches the full convergent surface on its target platforms (releases as stable `1.0.0`) — or **`0.1.0-next.0`** (releases as `0.1.0`) if upstream blocks a lot of the surface (see [When upstream blocks the standard surface](#when-upstream-blocks-the-standard-surface-shipping-pre-10)). Build script: `tsx ../../scripts/build-package.ts`.
 - Mirror the closest sibling's `package.json` exactly (exports, scripts, devDeps, peerDeps): CDP → clone `@wdio/electron-service`; Wry → clone `@wdio/tauri-service`. Always depend on `@wdio/native-core`, `@wdio/native-spy`, `@wdio/native-types`, `@wdio/native-utils` as workspace deps.
 - `vitest.integration.config.ts` MUST set `fileParallelism: false` + 30s timeout + `setupFiles: ['test/integration/setup.ts']`.
 - `tsconfig.json` extends `../../tsconfig.base.json`, out `./dist`, root `./src`.

--- a/.github/workflows/_ci-build-electrobun-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-electrobun-package-app.reusable.yml
@@ -1,0 +1,127 @@
+name: Build Electrobun Package Test App
+# Description: Builds the Electrobun package-test fixture (CEF bundle) and uploads it as a
+# symlink-preserving tarball for the package-test job to install the packed service into.
+#
+# Mirrors the Electrobun e2e-app build: no Rust, Bun + bundled CEF (~150MB download), and a
+# tar artifact (NOT the zip-based upload-archive) because the macOS .app carries CEF
+# framework symlinks that `zip -r` would resolve/duplicate. macOS-only — the service is
+# macOS-only in 0.x (Linux/Windows CEF is upstream-blocked; see @wdio/electrobun-service).
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'OS of runner'
+        required: true
+        type: string
+      build_id:
+        description: 'Build ID from the main build job'
+        type: string
+        required: false
+      artifact_size:
+        description: 'Size of the build artifact in bytes'
+        type: string
+        required: false
+      cache_key:
+        description: 'Cache key to use for downloading artifacts'
+        type: string
+        required: false
+    outputs:
+      build_id:
+        description: 'Unique identifier for this build'
+        value: ${{ jobs.build-electrobun-package-app.outputs.build_id }}
+      build_date:
+        description: 'Timestamp when the build completed'
+        value: ${{ jobs.build-electrobun-package-app.outputs.build_date }}
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  build-electrobun-package-app:
+    name: Build
+    runs-on: ${{ inputs.os }}
+    outputs:
+      build_id: ${{ steps.build-info.outputs.build_id }}
+      build_date: ${{ steps.build-info.outputs.build_date }}
+    steps:
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: 🛠️ Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: '24'
+
+      - name: 🥟 Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          # Pinned for reproducibility — the beta CEF toolchain is fragile, so a
+          # silent Bun bump must not break `electrobun build`. Bump deliberately.
+          bun-version: '1.3.14'
+
+      - name: 📊 Generate Build Information
+        id: build-info
+        shell: bash
+        run: |
+          echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - name: 📦 Download Package Build Artifacts
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: wdio-desktop-mobile
+          path: wdio-desktop-mobile-build
+          filename: artifact.zip
+          cache_key_prefix: wdio-desktop-build
+          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
+
+      - name: 📊 Show Build Information
+        if: inputs.build_id != '' && inputs.artifact_size != ''
+        shell: bash
+        run: |
+          echo "::notice::Build artifact: ID=${{ inputs.build_id }}, Size=${{ inputs.artifact_size }} bytes"
+
+      - name: 📦 Install Dependencies
+        run: pnpm install --frozen-lockfile
+        shell: bash
+
+      # CEF download + bundle (~150MB) — the beta Bun/CEF toolchain is the biggest
+      # unknown here; a failure is most likely a toolchain/network issue, not a fixture
+      # regression.
+      - name: 🏗️ Build Electrobun Package Test App
+        run: pnpm run build
+        shell: bash
+        working-directory: fixtures/package-tests/electrobun-app
+
+      - name: 🔎 Locate Built Bundle
+        shell: bash
+        run: |
+          echo "Build output tree:"
+          ls -R fixtures/package-tests/electrobun-app/build || true
+          if [ ! -d "fixtures/package-tests/electrobun-app/build" ]; then
+            echo "::error::Electrobun package-app build directory was not produced."
+            exit 1
+          fi
+
+      # tar (not the shared zip-based upload-archive): the macOS .app carries CEF framework
+      # symlinks that `zip -r` resolves/duplicates. A symlink-preserving tarball shared via
+      # actions/upload-artifact round-trips the bundle intact (matches the e2e build).
+      - name: 🗜️ Archive bundle (tar preserves .app framework symlinks)
+        shell: bash
+        run: tar -czpf "${RUNNER_TEMP}/electrobun-package-app.tgz" -C fixtures/package-tests/electrobun-app build
+
+      - name: 📦 Upload Electrobun Package Test App Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: electrobun-package-app-${{ runner.os }}-${{ runner.arch }}
+          path: ${{ runner.temp }}/electrobun-package-app.tgz
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -180,6 +180,7 @@ jobs:
             # Electrobun-only workflow files (no -crates: Electrobun has no Rust)
             infra_electrobun:
               - '.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml'
+              - '.github/workflows/_ci-build-electrobun-package-app.reusable.yml'
               - '.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml'
 
       - name: Determine What to Run

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -14,10 +14,10 @@ on:
         type: string
         required: true
       service:
-        description: 'Service to test (electron, tauri, dioxus, or both)'
+        description: 'Service to test (electron, tauri, dioxus, electrobun, or all)'
         type: string
         required: false
-        default: 'both'
+        default: 'all'
       module-type:
         description: 'Module type for Electron package tests (cjs, esm, or both)'
         type: string
@@ -70,7 +70,7 @@ jobs:
       # Install Rust toolchain for auto-installing tauri-driver if testing Tauri service
       # The @wdio/tauri-service will automatically install tauri-driver via cargo if not found
       - name: 🦀 Setup Rust (for tauri-driver auto-install)
-        if: inputs.service == 'tauri' || inputs.service == 'both'
+        if: inputs.service == 'tauri' || inputs.service == 'all'
         shell: bash
         run: rustup update stable && rustup default stable && rustup component add rustfmt
 
@@ -91,7 +91,7 @@ jobs:
       # Install WebKit WebDriver and GTK/X11 runtime dependencies for Linux (required by tauri-driver)
       # Note: Build dependencies are handled in the build workflows, we only need runtime libs for testing
       - name: 🌐 Install WebKit WebDriver and GTK/X11 Runtime Dependencies (Linux)
-        if: (inputs.service == 'tauri' || inputs.service == 'both') && runner.os == 'Linux'
+        if: (inputs.service == 'tauri' || inputs.service == 'all') && runner.os == 'Linux'
         shell: bash
         run: |
           echo "Installing WebKit WebDriver and GTK/X11 runtime dependencies for Linux..."
@@ -137,7 +137,7 @@ jobs:
           exact_cache_key: ${{ inputs.dioxus_cache_key || '' }}
 
       - name: 📦 Download Tauri Package Test App Binary
-        if: inputs.service == 'tauri' || inputs.service == 'both'
+        if: inputs.service == 'tauri' || inputs.service == 'all'
         uses: ./.github/workflows/actions/download-archive
         with:
           name: tauri-package-app-${{ runner.os }}-${{ runner.arch == 'ARM64' && 'ARM64' || 'x64' }}
@@ -145,6 +145,28 @@ jobs:
           filename: artifact.zip
           cache_key_prefix: tauri-package-app
           exact_cache_key: ${{ inputs.tauri_cache_key || '' }}
+
+      # Electrobun is a CEF/Bun build whose macOS .app carries framework symlinks; it
+      # ships as a symlink-preserving tarball via actions/upload-artifact (NOT the
+      # zip-based download-archive used above), mirroring the e2e flow. macOS-only.
+      - name: 📦 Download Electrobun Package Test App Bundle
+        if: inputs.service == 'electrobun'
+        uses: actions/download-artifact@v4
+        with:
+          name: electrobun-package-app-${{ runner.os }}-${{ runner.arch }}
+          path: ${{ runner.temp }}
+
+      - name: 🗜️ Extract Electrobun Bundle
+        if: inputs.service == 'electrobun'
+        shell: bash
+        run: |
+          mkdir -p fixtures/package-tests/electrobun-app
+          tar -xzpf "${RUNNER_TEMP}/electrobun-package-app.tgz" -C fixtures/package-tests/electrobun-app
+          if [ ! -d "fixtures/package-tests/electrobun-app/build" ]; then
+            echo "::error::Electrobun package-app build dir not found — bundle was not extracted correctly."
+            find fixtures/package-tests/electrobun-app/ -maxdepth 1 || true
+            exit 1
+          fi
 
       # Verify the extracted dist directories exist
       - name: 🔍 Verify Extracted Files
@@ -179,7 +201,7 @@ jobs:
           done
 
           # Pack Electron service and dependencies if needed
-          if [ "$SERVICE" == "electron" ] || [ "$SERVICE" == "both" ]; then
+          if [ "$SERVICE" == "electron" ] || [ "$SERVICE" == "all" ]; then
             if [ -d "packages/electron-cdp-bridge/dist" ]; then
               (cd packages/electron-cdp-bridge && pnpm pack)
             fi
@@ -189,7 +211,7 @@ jobs:
           fi
 
            # Pack Tauri service and plugin if needed
-           if [ "$SERVICE" == "tauri" ] || [ "$SERVICE" == "both" ]; then
+           if [ "$SERVICE" == "tauri" ] || [ "$SERVICE" == "all" ]; then
              if [ -d "packages/tauri-plugin/dist-js" ]; then
                (cd packages/tauri-plugin && pnpm pack)
              fi
@@ -202,6 +224,16 @@ jobs:
            if [ "$SERVICE" == "dioxus" ]; then
              if [ -d "packages/dioxus-service/dist" ]; then
                (cd packages/dioxus-service && pnpm pack)
+             fi
+           fi
+
+           # Pack Electrobun service + its CDP bridge if needed
+           if [ "$SERVICE" == "electrobun" ]; then
+             if [ -d "packages/electrobun-cdp-bridge/dist" ]; then
+               (cd packages/electrobun-cdp-bridge && pnpm pack)
+             fi
+             if [ -d "packages/electrobun-service/dist" ]; then
+               (cd packages/electrobun-service && pnpm pack)
              fi
            fi
 
@@ -244,7 +276,7 @@ jobs:
                 pnpm run test:package:tauri -- --skip-build
               fi
               ;;
-            both)
+            all)
               if [[ "${{ runner.os }}" == "macOS" ]]; then
                 echo "⚠️  Skipping Tauri package tests on macOS (not supported)"
                 echo "Module type: ${{ inputs.module-type }}"
@@ -260,6 +292,11 @@ jobs:
                 xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" \
                   pnpm run test:package:tauri -- --skip-build
               fi
+              ;;
+            electrobun)
+              # macOS-only (CEF). Uses the pre-built bundle extracted above; no xvfb (macOS).
+              echo "Running Electrobun package tests (macOS-only; using the pre-built CEF bundle)"
+              pnpm run test:package:electrobun -- --skip-build
               ;;
             *)
               echo "Invalid service: $SERVICE"

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       scope:
-        description: 'Release scope (electron, tauri, dioxus, utils, types, spy, core, shared) — controls build and toolchain steps'
+        description: 'Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, shared) — controls build and toolchain steps'
         required: true
         type: string
     secrets:
@@ -111,6 +111,9 @@ jobs:
             dioxus)
               echo "packages=@wdio/dioxus-service,@wdio/dioxus-bridge,wdio-dioxus-bridge,wdio-dioxus-embedded-driver,wdio-dioxus-driver" >> "$GITHUB_OUTPUT"
               ;;
+            electrobun)
+              echo "packages=@wdio/electrobun-service,@wdio/electrobun-cdp-bridge" >> "$GITHUB_OUTPUT"
+              ;;
             utils)
               echo "packages=@wdio/native-utils" >> "$GITHUB_OUTPUT"
               ;;
@@ -188,6 +191,13 @@ jobs:
                 --filter='@wdio/dioxus-service...' \
                 --filter='@wdio/dioxus-bridge...'
               pnpm turbo run build:rust --filter='@wdio/dioxus-bridge'
+              ;;
+            electrobun)
+              # CDP service like electron — no Rust/build:rust step.
+              pnpm turbo run build \
+                --filter='@wdio/electrobun-service...' \
+                --filter='@wdio/electrobun-cdp-bridge...' \
+                --filter='@wdio/bundler...'
               ;;
             utils)
               pnpm turbo run build --filter='@wdio/native-utils...'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,20 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
 
+  # macOS-only (CEF). The package-test fixture build mirrors the e2e build (Bun/CEF, tar
+  # artifact). Linux/Windows are not built — the service is macOS-only in 0.x.
+  build-electrobun-package-app-macos-arm:
+    name: Build Electrobun Package Test App [macOS-ARM]
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-electrobun-package-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
   # Build Dioxus package test apps - only if Dioxus package tests will run
   build-dioxus-package-app-linux:
     name: Build Dioxus Package Test App [Linux]
@@ -792,6 +806,21 @@ jobs:
       cache_key: ${{ needs.build.outputs.cache_key }}
       dioxus_cache_key: ${{ needs.build-dioxus-package-app-linux-arm.outputs.cache_key }}
 
+  # Electrobun package test — macOS-only (CEF). The fixture bundle is downloaded by
+  # artifact name within the run (tar/symlinks), so no cache_key is threaded.
+  package-electrobun-macos-arm:
+    name: Package - Electrobun [macOS-ARM]
+    needs: [detect-changes, build, build-electrobun-package-app-macos-arm]
+    if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-package.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      service: 'electrobun'
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
   # Universal binary verification - Electron only
   package-electron-mac-universal:
     name: Package - Electron [macOS-Universal-Verify]
@@ -913,6 +942,7 @@ jobs:
       - package-dioxus-macos-arm
       - package-dioxus-macos-intel
       - package-dioxus-linux-arm
+      - package-electrobun-macos-arm
       - build-matrix
       - build-dioxus-crates-linux
       - build-tauri-e2e-app-linux
@@ -925,6 +955,7 @@ jobs:
       - build-dioxus-e2e-app-windows
       - build-dioxus-e2e-app-macos-arm
       - build-electrobun-e2e-app-macos-arm
+      - build-electrobun-package-app-macos-arm
       - build-dioxus-package-app-linux
       - build-dioxus-package-app-windows
       - build-dioxus-package-app-macos-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: "Release scope (electron, tauri, dioxus, utils, types, spy, core, shared)"
+        description: "Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, shared)"
         required: true
         type: choice
         options:
@@ -20,6 +20,7 @@ on:
           - electron
           - tauri
           - dioxus
+          - electrobun
         default: shared
       bump:
         description: "Version increment"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 - **Electron** - `@wdio/electron-service` (v10.x)
 - **Tauri** - `@wdio/tauri-service` (v1.x)
 - **Dioxus** - `@wdio/dioxus-service` (v1.x)
+- **Electrobun** - `@wdio/electrobun-service` (v0.1.x — **macOS-only**, requires the CEF renderer; Linux/Windows + multiremote/multi-window/deeplink are upstream-blocked, see the package README)
 
 **Planned:** React Native, Flutter, Capacitor, Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
 
@@ -32,11 +33,13 @@ packages/
 ├── electron-service/       # Electron WDIO service
 ├── tauri-service/          # Tauri WDIO service
 ├── dioxus-service/         # Dioxus WDIO service
+├── electrobun-service/     # Electrobun WDIO service (CDP-attach, macOS-only in 0.x)
 ├── tauri-plugin/           # Tauri v2 plugin (Rust + JS)
 ├── dioxus-bridge/          # Dioxus bridge crate (Rust) — IPC, mocking, log forwarding
 ├── dioxus-embedded-driver/ # Dioxus in-process WebDriver server (Rust)
 ├── dioxus-driver/          # Dioxus external WebDriver proxy (Rust, Windows 'external' provider)
-├── electron-cdp-bridge/    # Chrome DevTools Protocol bridge
+├── electron-cdp-bridge/    # Chrome DevTools Protocol bridge (Electron)
+├── electrobun-cdp-bridge/  # Multi-target CDP bridge (Electrobun)
 ├── native-utils/           # Cross-platform utilities
 ├── native-types/           # TypeScript type definitions
 ├── native-spy/             # Spy utilities for mocking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,6 +389,7 @@ GitHub release notes are published per **user-installed** package — not per in
 | Electron  | `@wdio/electron-service` | `@wdio/electron-cdp-bridge`, `@wdio/native-utils`, `@wdio/native-spy`, `@wdio/native-types` |
 | Tauri     | `@wdio/tauri-service`, `tauri-plugin`, `tauri-plugin-webdriver` | — |
 | Dioxus    | `@wdio/dioxus-service` | `wdio-dioxus-bridge`, `wdio-dioxus-embedded-driver`, `wdio-dioxus-driver` |
+| Electrobun | `@wdio/electrobun-service` | `@wdio/electrobun-cdp-bridge`, `@wdio/native-utils`, `@wdio/native-spy`, `@wdio/native-types` |
 
 Tauri publishes three sets of release notes because `tauri-plugin` and `tauri-plugin-webdriver` are installed and configured directly by users in their Tauri app (Cargo dependency, capability/permission setup), so their breaking changes need their own changelog entries. Electron's and Dioxus's internal packages have no equivalent direct-install surface — users only wire in the bridge crate once and changes are transparent thereafter.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@
 
 [`@wdio/dioxus-service`](./packages/dioxus-service) - Dioxus desktop applications (Windows / macOS / Linux)
 
+## Experimental Support
+
+> Early (`0.x`) support — scope is limited and the surface may change as upstream gaps are resolved. Not yet at parity with the frameworks above.
+
 <h4>
   <div>
     <a href="https://www.npmjs.com/package/@wdio/electrobun-service"><img src="https://img.shields.io/badge/@wdio-electrobun--service-E8590C?labelColor=1a1a1a&style=plastic" alt="npm package" /></a>
@@ -69,7 +73,7 @@
   </div>
 </h4>
 
-[`@wdio/electrobun-service`](./packages/electrobun-service) - Electrobun desktop applications (**macOS only** in `0.x`; requires the CEF renderer — see the package README)
+[`@wdio/electrobun-service`](./packages/electrobun-service) - Electrobun desktop applications — **experimental**, **macOS only** (`0.x`), requires the CEF renderer. Linux/Windows plus multiremote / multi-window / deeplink are upstream-blocked ([#317](https://github.com/webdriverio/desktop-mobile/issues/317)). See the [package README](./packages/electrobun-service).
 
 ## Planned Support
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@
 
 [`@wdio/dioxus-service`](./packages/dioxus-service) - Dioxus desktop applications (Windows / macOS / Linux)
 
+<h4>
+  <div>
+    <a href="https://www.npmjs.com/package/@wdio/electrobun-service"><img src="https://img.shields.io/badge/@wdio-electrobun--service-E8590C?labelColor=1a1a1a&style=plastic" alt="npm package" /></a>
+    <a href="https://www.npmjs.com/package/@wdio/electrobun-service"><img src="https://img.shields.io/npm/v/@wdio/electrobun-service" alt="npm version" /></a>
+    <a href="https://www.npmjs.com/package/@wdio/electrobun-service"><img src="https://img.shields.io/npm/dw/@wdio/electrobun-service" alt="npm downloads" /></a>
+  </div>
+</h4>
+
+[`@wdio/electrobun-service`](./packages/electrobun-service) - Electrobun desktop applications (**macOS only** in `0.x`; requires the CEF renderer — see the package README)
+
 ## Planned Support
 
 - **React Native** - Popular mobile and desktop framework
@@ -73,7 +83,7 @@ See [ROADMAP.md](./ROADMAP.md) for detailed sequencing, os support, and timeline
 
 ## Features
 
-- 🎯 **Framework-specific automation** - Native integration with Electron, Tauri, Dioxus
+- 🎯 **Framework-specific automation** - Native integration with Electron, Tauri, Dioxus, Electrobun
 - 🔍 **Smart binary detection** - Automatic app discovery and configuration
 - 🎭 **API mocking & isolation** - Built-in mocking for deterministic tests
 - 🌍 **Browser-only test mode** - Run the renderer in Chrome against a dev server, no binary required. See the [Electron](./packages/electron-service/docs/browser-mode.md), [Tauri](./packages/tauri-service/docs/browser-mode.md), and [Dioxus](./packages/dioxus-service/docs/browser-mode.md) guides.
@@ -88,7 +98,9 @@ desktop-mobile/
 │   ├── electron-service/        # Electron service implementation
 │   ├── tauri-service/           # Tauri service implementation
 │   ├── dioxus-service/          # Dioxus service implementation
-│   ├── electron-cdp-bridge/     # Chrome DevTools Protocol bridge
+│   ├── electrobun-service/      # Electrobun service implementation (macOS-only, 0.x)
+│   ├── electron-cdp-bridge/     # Chrome DevTools Protocol bridge (Electron)
+│   ├── electrobun-cdp-bridge/   # Multi-target CDP bridge (Electrobun)
 │   ├── native-utils/            # Cross-platform utilities
 │   ├── native-types/            # TypeScript type definitions
 │   ├── native-spy/              # Spy utilities for mocking

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,10 +101,18 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Standard Appium WebView context switching
 - appPackage/appActivity capabilities
 
-### Phase 5: Electrobun Desktop (Q2 2027)
+### Phase 5: Electrobun Desktop — ✅ Shipped `0.1.0` (macOS-only)
 **Priority:** Medium - Emerging TypeScript-first desktop framework
 
-**Target Platforms:** macOS 14+, Windows 11+, Linux (Ubuntu 22.04+)
+> **Status:** `@wdio/electrobun-service` ships at **`0.1.0`, macOS-only**. CDP-attach via the
+> CEF renderer works on macOS; **Linux/Windows** plus **multiremote / multi-window / deeplink**
+> are blocked by an upstream CEF profile-isolation limitation (CEF can't create the forced
+> `persist:default` profile and the global-context fallback serves no `/json` off macOS).
+> Pre-1.0 by design — each upstream fix re-enables a platform/feature, graduating to `1.0` at
+> full parity. Tracked in [#317](https://github.com/webdriverio/desktop-mobile/issues/317).
+> The original plan follows.
+
+**Target Platforms:** macOS 14+ (shipped); Windows 11+ / Linux (Ubuntu 22.04+) blocked upstream
 
 **Why Electrobun:**
 - Growing momentum in the lightweight desktop space (~12MB bundles, sub-50ms startup)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ This document describes the architecture of the WebdriverIO Desktop & Mobile mon
 | `@wdio/electron-service` | WebdriverIO service for Electron apps |
 | `@wdio/tauri-service` | WebdriverIO service for Tauri apps |
 | `@wdio/dioxus-service` | WebdriverIO service for Dioxus desktop apps |
+| `@wdio/electrobun-service` | WebdriverIO service for Electrobun desktop apps (CDP-attach; macOS-only in 0.x) |
 
 ### Bridge/Plugin Packages
 
@@ -89,7 +90,7 @@ Runs in the main process (no `browser` access). Responsible for:
 ### Service (`service.ts`)
 
 Runs in the worker process (receives `browser` via `before` hook). Responsible for:
-- API injection (`browser.tauri.*`, `browser.electron.*`, `browser.dioxus.*`)
+- API injection (`browser.tauri.*`, `browser.electron.*`, `browser.dioxus.*`, `browser.electrobun.*`)
 - Mock lifecycle management
 - Log forwarding setup
 - Plugin initialization

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -20,15 +20,19 @@ e2e/
 │   │   ├── api.spec.ts
 │   │   ├── logging.spec.ts
 │   │   └── ...
-│   └── dioxus/             # Dioxus E2E tests
+│   ├── dioxus/             # Dioxus E2E tests
+│   │   ├── api.spec.ts
+│   │   ├── mock.spec.ts
+│   │   └── ...
+│   └── electrobun/         # Electrobun E2E tests (macOS-only; CI runs the `standard` suite)
 │       ├── api.spec.ts
-│       ├── mock.spec.ts
 │       └── ...
 ├── lib/                    # Shared test utilities
 ├── wdio.electron.conf.ts   # Electron WDIO config
 ├── wdio.tauri.conf.ts      # Tauri WDIO config
 ├── wdio.tauri-embedded.conf.ts  # Tauri embedded WDIO config
-└── wdio.dioxus-embedded.conf.ts # Dioxus embedded WDIO config
+├── wdio.dioxus-embedded.conf.ts # Dioxus embedded WDIO config
+└── wdio.electrobun.conf.ts # Electrobun WDIO config (CDP-attach, macOS-only)
 
 fixtures/e2e-apps/
 ├── electron-builder/       # Electron app (builder packaging)

--- a/docs/package-structure.md
+++ b/docs/package-structure.md
@@ -99,7 +99,9 @@ All npm packages use the `@wdio/` scope:
 - `@wdio/electron-service` - Electron WDIO service
 - `@wdio/tauri-service` - Tauri WDIO service
 - `@wdio/dioxus-service` - Dioxus WDIO service
-- `@wdio/electron-cdp-bridge` - Chrome DevTools Protocol bridge
+- `@wdio/electrobun-service` - Electrobun WDIO service (CDP-attach; macOS-only in 0.x)
+- `@wdio/electron-cdp-bridge` - Chrome DevTools Protocol bridge (Electron)
+- `@wdio/electrobun-cdp-bridge` - Multi-target Chrome DevTools Protocol bridge (Electrobun)
 - `@wdio/native-utils` - Cross-platform utilities
 - `@wdio/native-types` - Shared TypeScript type definitions
 - `@wdio/native-spy` - Spy utilities for mocking

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -158,13 +158,14 @@ export const config = {
   logLevel: 'info',
   bail: 0,
   // Residual upstream CEF race on the macOS `standard` suite: the 2-window fixture
-  // (needed because a single CEF window exposes no `/json` target) occasionally trips
-  // CEF's failed-profile → global-context fallback into spawning a separate top-level
-  // window instead of embedding, leaving the main view's `#app-title` unreadable for
+  // (needed because a single CEF window exposes no `/json` target) trips CEF's
+  // failed-profile → global-context fallback, which surfaces as either an unpainted
+  // `#app-title` or a "Timeout of new browser info response" on the second frame — for
   // that app instance's whole lifetime (see the plan "Framework gaps"). mochaOpts.retries
-  // can't escape it — they re-run against the SAME instance — so retry the whole spec
-  // FILE, which tears down and re-spawns a fresh CEF instance (a new roll past the race).
-  specFileRetries: 2,
+  // can't escape it (same instance); a spec-FILE retry re-spawns a fresh CEF instance.
+  // Bumped to 3 (4 attempts/spec) — at 2 the gate occasionally exhausted retries on a
+  // run with an elevated CEF-timeout rate. Drop back once the upstream fix lands.
+  specFileRetries: 3,
   specFileRetriesDeferred: false,
   baseUrl: '',
   waitforTimeout: 10000,

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -134,9 +134,9 @@ const electrobunServiceOptions: ElectrobunServiceOptions = {
 
 const capabilities: ElectrobunCapability[] = [
   {
-    // CDP-attach: the launcher rewrites this to 'chrome' and sets
+    // CDP-attach: the launcher rewrites this 'electrobun' → 'chrome' and sets
     // goog:chromeOptions.debuggerAddress onto the capability in onWorkerStart.
-    browserName: 'chrome',
+    browserName: 'electrobun',
     // Electrobun 1.18.1 bundles CEF on Chromium 147 (147.0.7727.118); pin the
     // driver to that major so WDIO doesn't fetch the latest (148+), which refuses
     // to attach with "only supports Chrome version N". Matching the major is what

--- a/fixtures/package-tests/electrobun-app/package.json
+++ b/fixtures/package-tests/electrobun-app/package.json
@@ -4,13 +4,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "electrobun build"
+    "build": "electrobun build",
+    "test": "wdio run wdio.conf.ts"
   },
   "dependencies": {
     "electrobun": "1.18.1"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
+    "@types/mocha": "10.0.10",
     "@wdio/cli": "9.27.1",
     "@wdio/electrobun-service": "workspace:*",
     "@wdio/globals": "9.27.1",

--- a/fixtures/package-tests/electrobun-app/src/bun/index.ts
+++ b/fixtures/package-tests/electrobun-app/src/bun/index.ts
@@ -1,11 +1,32 @@
 import { BrowserWindow } from 'electrobun/bun';
 
-// Minimal Bun backend for the package-install smoke fixture: one CEF window.
+// Package-install smoke fixture. Opens TWO CEF windows, STAGGERED — the same workaround
+// the e2e fixture uses: a single CEF window exposes no `/json` page target once CEF's
+// forced `persist:default` partition falls back to the shared global context (an upstream
+// gap; see @wdio/electrobun-service "Framework gaps"), so the bridge/Chromedriver would
+// have nothing to attach to. Opening a second window makes a content target appear; doing
+// it only after the first view's DOM is ready avoids the global-context creation race that
+// otherwise leaves the main view unpainted. Both load the same mainview — the smoke only
+// reads the main target.
 const mainWindow = new BrowserWindow({
   title: 'WDIO Electrobun App',
   url: 'views://mainview/index.html',
   renderer: 'cef',
   frame: { x: 100, y: 100, width: 640, height: 480 },
 });
+console.log('[package-test] opened main window', mainWindow.id);
 
-console.log('[package-test] opened window', mainWindow.id);
+let secondOpened = false;
+mainWindow.webview.on('dom-ready', () => {
+  if (secondOpened) {
+    return;
+  }
+  secondOpened = true;
+  const secondWindow = new BrowserWindow({
+    title: 'WDIO Electrobun App — 2',
+    url: 'views://mainview/index.html',
+    renderer: 'cef',
+    frame: { x: 780, y: 150, width: 480, height: 360 },
+  });
+  console.log('[package-test] opened second window', secondWindow.id);
+});

--- a/fixtures/package-tests/electrobun-app/test/smoke.spec.ts
+++ b/fixtures/package-tests/electrobun-app/test/smoke.spec.ts
@@ -1,5 +1,9 @@
 import { browser, expect } from '@wdio/globals';
 
+// The webview callbacks run in the CEF page context; the e2e tsconfig has no DOM lib, so reach
+// `document` through a minimally-typed globalThis.
+type Doc = { getElementById(id: string): { textContent: string | null } | null };
+
 // Package-install smoke test: confirms the *installed* @wdio/electrobun-service tarball can
 // launch the CEF app, attach over CDP, and drive the webview. Reduced surface (#app-title +
 // #status) — the full feature matrix lives in the e2e suite.
@@ -9,7 +13,6 @@ describe('@wdio/electrobun-service package install', () => {
   });
 
   it('should launch the CEF app and render the title', async () => {
-    type Doc = { getElementById(id: string): { textContent: string | null } | null };
     const readTitle = () =>
       browser.electrobun.execute(() => {
         const el = (globalThis as unknown as { document: Doc }).document.getElementById('app-title');
@@ -31,7 +34,6 @@ describe('@wdio/electrobun-service package install', () => {
     // The mainview script overwrites #status to "Application loaded successfully" on load,
     // so reading it confirms the view's JS ran (not just the static HTML). Poll in case the
     // script hasn't run yet when the bridge first attaches.
-    type Doc = { getElementById(id: string): { textContent: string | null } | null };
     const readStatus = () =>
       browser.electrobun.execute(() => {
         const el = (globalThis as unknown as { document: Doc }).document.getElementById('status');

--- a/fixtures/package-tests/electrobun-app/test/smoke.spec.ts
+++ b/fixtures/package-tests/electrobun-app/test/smoke.spec.ts
@@ -1,0 +1,38 @@
+import { browser, expect } from '@wdio/globals';
+
+// Package-install smoke test: confirms the *installed* @wdio/electrobun-service tarball can
+// launch the CEF app, attach over CDP, and drive the webview. Reduced surface (#app-title +
+// #status) — the full feature matrix lives in the e2e suite.
+describe('@wdio/electrobun-service package install', () => {
+  it('should install the browser.electrobun API surface', async () => {
+    expect(typeof browser.electrobun.execute).toBe('function');
+  });
+
+  it('should launch the CEF app and render the title', async () => {
+    type Doc = { getElementById(id: string): { textContent: string | null } | null };
+    const readTitle = () =>
+      browser.electrobun.execute(() => {
+        const el = (globalThis as unknown as { document: Doc }).document.getElementById('app-title');
+        return el ? el.textContent : undefined;
+      });
+    // The webview may still be painting when the bridge attaches — poll rather than read once.
+    let title: string | null | undefined;
+    await browser.waitUntil(
+      async () => {
+        title = await readTitle();
+        return typeof title === 'string' && title.includes('Electrobun');
+      },
+      { timeout: 10_000, timeoutMsg: 'fixture #app-title never rendered' },
+    );
+    expect(title).toContain('Electrobun');
+  });
+
+  it('should read the status element from the webview DOM', async () => {
+    type Doc = { getElementById(id: string): { textContent: string | null } | null };
+    const status = await browser.electrobun.execute(() => {
+      const el = (globalThis as unknown as { document: Doc }).document.getElementById('status');
+      return el ? el.textContent : undefined;
+    });
+    expect(status).toContain('Ready');
+  });
+});

--- a/fixtures/package-tests/electrobun-app/test/smoke.spec.ts
+++ b/fixtures/package-tests/electrobun-app/test/smoke.spec.ts
@@ -27,12 +27,24 @@ describe('@wdio/electrobun-service package install', () => {
     expect(title).toContain('Electrobun');
   });
 
-  it('should read the status element from the webview DOM', async () => {
+  it('should reflect the view script through the status element', async () => {
+    // The mainview script overwrites #status to "Application loaded successfully" on load,
+    // so reading it confirms the view's JS ran (not just the static HTML). Poll in case the
+    // script hasn't run yet when the bridge first attaches.
     type Doc = { getElementById(id: string): { textContent: string | null } | null };
-    const status = await browser.electrobun.execute(() => {
-      const el = (globalThis as unknown as { document: Doc }).document.getElementById('status');
-      return el ? el.textContent : undefined;
-    });
-    expect(status).toContain('Ready');
+    const readStatus = () =>
+      browser.electrobun.execute(() => {
+        const el = (globalThis as unknown as { document: Doc }).document.getElementById('status');
+        return el ? el.textContent : undefined;
+      });
+    let status: string | null | undefined;
+    await browser.waitUntil(
+      async () => {
+        status = await readStatus();
+        return typeof status === 'string' && status.includes('loaded successfully');
+      },
+      { timeout: 10_000, timeoutMsg: '#status was not updated by the view script' },
+    );
+    expect(status).toContain('loaded successfully');
   });
 });

--- a/fixtures/package-tests/electrobun-app/tsconfig.wdio.json
+++ b/fixtures/package-tests/electrobun-app/tsconfig.wdio.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": [
+      "node",
+      "@wdio/globals/types",
+      "mocha"
+    ]
+  },
+  "include": [
+    "test/**/*.ts",
+    "wdio.conf.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "build",
+    "src"
+  ]
+}

--- a/fixtures/package-tests/electrobun-app/wdio.conf.ts
+++ b/fixtures/package-tests/electrobun-app/wdio.conf.ts
@@ -59,10 +59,11 @@ type ElectrobunCapability = ElectrobunCapabilities & {
 
 const capabilities: ElectrobunCapability[] = [
   {
-    // CDP-attach: the launcher rewrites this to 'chrome' + sets debuggerAddress in
-    // onWorkerStart. Pin the driver to CEF's Chromium major (147) so WDIO doesn't fetch a
-    // newer Chromedriver that refuses to attach. Bump alongside the Electrobun/CEF pin.
-    browserName: 'chrome',
+    // Idiomatic, like the sibling services (browserName: 'tauri'/'dioxus'): the launcher
+    // rewrites 'electrobun' → 'chrome' + sets debuggerAddress in onWorkerStart. Pin the
+    // driver to CEF's Chromium major (147) so WDIO doesn't fetch a newer Chromedriver that
+    // refuses to attach. Bump alongside the Electrobun/CEF pin.
+    browserName: 'electrobun',
     browserVersion: '147',
     'wdio:electrobunServiceOptions': electrobunServiceOptions,
   },

--- a/fixtures/package-tests/electrobun-app/wdio.conf.ts
+++ b/fixtures/package-tests/electrobun-app/wdio.conf.ts
@@ -1,0 +1,101 @@
+import { existsSync, globSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { ElectrobunCapabilities, ElectrobunServiceOptions } from '@wdio/native-types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Resolve the built Electrobun `.app` bundle for the package-install smoke test.
+ *
+ * macOS-only: `@wdio/electrobun-service` is macOS-only in 0.x (Linux/Windows CEF is
+ * upstream-blocked), and the package-test CI job runs on macOS only. Electrobun writes
+ * the bundle under `build/<environment>/<AppName>.app`; the environment subdir isn't fixed
+ * across the beta toolchain, so glob for the newest top-level `.app` (helper bundles nested
+ * inside `…/Contents/…` are filtered out). `ELECTROBUN_APP_PATH` overrides for local runs.
+ */
+function resolveAppBinaryPath(): string {
+  const override = process.env.ELECTROBUN_APP_PATH;
+  if (override) {
+    return override;
+  }
+  const buildDir = join(__dirname, 'build');
+  if (!existsSync(buildDir)) {
+    throw new Error(`Electrobun build directory not found: ${buildDir}. Run \`pnpm build\` in this fixture first.`);
+  }
+  const bundles = globSync(join(buildDir, '**', '*.app')).filter((p) => !/\.app[\\/]/.test(p));
+  if (bundles.length === 0) {
+    throw new Error(`No Electrobun .app bundle found under ${buildDir}. Set ELECTROBUN_APP_PATH to the built bundle.`);
+  }
+  const newestBy = (paths: string[]) => {
+    const mtime = (p: string) => {
+      try {
+        return statSync(p).mtimeMs;
+      } catch {
+        return 0;
+      }
+    };
+    return paths.map((path) => ({ path, mtime: mtime(path) })).sort((a, b) => b.mtime - a.mtime)[0].path;
+  };
+  return newestBy(bundles);
+}
+
+const appBinaryPath = resolveAppBinaryPath();
+
+const electrobunServiceOptions: ElectrobunServiceOptions = {
+  appBinaryPath,
+  captureBackendLogs: true,
+  backendLogLevel: 'info',
+};
+
+type ElectrobunCapability = ElectrobunCapabilities & {
+  // Standard W3C capability not on the (intentionally minimal) ElectrobunCapabilities
+  // interface — pins Chromedriver to CEF's Chromium major.
+  browserVersion?: string;
+  'wdio:electrobunServiceOptions': ElectrobunServiceOptions;
+};
+
+const capabilities: ElectrobunCapability[] = [
+  {
+    // CDP-attach: the launcher rewrites this to 'chrome' + sets debuggerAddress in
+    // onWorkerStart. Pin the driver to CEF's Chromium major (147) so WDIO doesn't fetch a
+    // newer Chromedriver that refuses to attach. Bump alongside the Electrobun/CEF pin.
+    browserName: 'chrome',
+    browserVersion: '147',
+    'wdio:electrobunServiceOptions': electrobunServiceOptions,
+  },
+];
+
+export const config = {
+  runner: 'local',
+  specs: ['./test/**/*.spec.ts'],
+  exclude: [],
+  // Single-instance: multiremote is blocked upstream (CEF can't isolate ≥2 instances).
+  maxInstances: 1,
+  capabilities,
+  logLevel: 'info',
+  bail: 0,
+  baseUrl: '',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 3,
+  // Residual upstream CEF race (same as the e2e conf): an app instance can occasionally
+  // come up with the main view unpainted (failed-profile → global-context fallback).
+  // mochaOpts.retries can't escape it (same instance); a spec-FILE retry re-spawns a fresh
+  // CEF instance.
+  specFileRetries: 2,
+  specFileRetriesDeferred: false,
+  autoXvfb: false,
+  outputDir: join(__dirname, 'logs'),
+  services: ['electrobun'],
+  framework: 'mocha',
+  reporters: ['spec'],
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+    retries: 2,
+  },
+  tsConfigPath: join(__dirname, 'tsconfig.wdio.json'),
+};

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:package:tauri:browser": "pnpx cross-env DEBUG=@wdio/tauri-service tsx ./scripts/test-package.ts --service=tauri --mode=browser",
     "test:package:dioxus": "pnpx tsx ./scripts/test-package.ts --service=dioxus",
     "test:package:dioxus:browser": "pnpx tsx ./scripts/test-package.ts --service=dioxus --mode=browser",
+    "test:package:electrobun": "pnpx tsx ./scripts/test-package.ts --service=electrobun",
     "test:unit": "turbo run test:unit",
     "typecheck": "turbo run typecheck",
     "update:dependencies": "pnpm catalog:update --default && pnpm catalog:update --next && pnpm up -iLr",

--- a/packages/electrobun-cdp-bridge/package.json
+++ b/packages/electrobun-cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/electrobun-cdp-bridge",
-  "version": "1.0.0-next.0",
+  "version": "0.1.0-next.0",
   "description": "Multi-target CDP Bridge for WebdriverIO Electrobun Service",
   "author": "WebdriverIO Community",
   "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/electrobun-cdp-bridge",

--- a/packages/electrobun-cdp-bridge/src/connection.ts
+++ b/packages/electrobun-cdp-bridge/src/connection.ts
@@ -115,12 +115,12 @@ export class Connection extends EventEmitter {
       this.#promises.get(CONNECT_PROMISE_ID)?.resolve();
       this.#promises.delete(CONNECT_PROMISE_ID);
     });
-    ws.on('message', async (rawMessage) => {
+    ws.on('message', (rawMessage) => {
       try {
         this.#messageHandler(rawMessage.toString());
       } catch (error) {
         log.error('Message handling error');
-        return await this.#errorHandler(error);
+        void this.#errorHandler(error);
       }
     });
     ws.on('error', async (error) => {

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -5,17 +5,27 @@ desktop applications — the TypeScript-first, Bun-powered desktop framework.
 
 It mirrors the surface of the sibling services (`@wdio/electron-service`,
 `@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
-Vitest-style mocking, multi-window `switchWindow`/`listWindows`, log capture,
-browser mode, standalone sessions, and multiremote.
+Vitest-style mocking, log capture, browser mode, and standalone sessions.
 
-> **Status:** pre-release (`1.0.0-next.x`). Shipping in stages (Foundation →
-> MVP → Feature-complete → Ship). This package currently provides the
-> foundation; `execute`/mocking/etc. arrive in subsequent releases.
+> **Status: `0.1.0` — macOS-only, pre-1.0.** This is a `0.x` release because the
+> CEF renderer Electrobun apps must be built with cannot currently be driven on
+> Linux/Windows, and multiremote/multi-window/deeplink are blocked by the same
+> upstream limitation. See [Known limitations](#known-limitations). `1.0` is
+> reserved for full parity once those gaps are filled
+> ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) tracks the work).
+
+## Installation
+
+```sh
+npm install --save-dev @wdio/electrobun-service
+```
 
 ## Platform requirement: the CEF renderer
 
 This is a **CDP-attach** service — it drives the app through the Chrome DevTools
-Protocol. Electrobun's webview engine differs per platform:
+Protocol (the launcher spawns the app binary and WebdriverIO attaches via
+Chromedriver's `debuggerAddress`). Electrobun's default webview engine differs
+per platform and only the Chromium-based ones speak CDP:
 
 | Platform | Default webview | CDP? |
 |---|---|---|
@@ -23,23 +33,75 @@ Protocol. Electrobun's webview engine differs per platform:
 | macOS | WKWebView (WebKit) | ❌ |
 | Linux | WebKitGTK (WebKit) | ❌ |
 
-Because the default WebKit webviews on macOS/Linux do **not** speak CDP, this
-service requires the app under test to be built with Electrobun's **CEF
-renderer** on every platform, for a single uniform Chromium target model:
+So the service requires the app under test to be built with Electrobun's **CEF
+renderer**:
 
 ```ts
 // electrobun.config.ts
 export default {
   build: {
     mac: { bundleCEF: true, defaultRenderer: 'cef' },
-    win: { bundleCEF: true, defaultRenderer: 'cef' },
-    linux: { bundleCEF: true, defaultRenderer: 'cef' },
   },
 };
 ```
 
 Apps built with the default WebKit renderer are an explicit, documented
 unsupported configuration — the launcher fails fast with a clear error.
+
+## Quick start
+
+```ts
+// wdio.conf.ts
+export const config = {
+  services: ['electrobun'],
+  capabilities: [
+    {
+      browserName: 'chrome',
+      // Pin Chromedriver to the CEF Chromium major (147 for current Electrobun).
+      browserVersion: '147',
+      'wdio:electrobunServiceOptions': {
+        appBinaryPath: '/path/to/build/<env>/MyApp.app',
+      },
+    },
+  ],
+  // ...mocha/spec config
+};
+```
+
+```ts
+// a spec
+const title = await browser.electrobun.execute(() => document.title);
+expect(title).toBe('My App');
+```
+
+## Supported surface (macOS)
+
+| Feature | Status |
+|---|---|
+| `execute` | ✅ |
+| mocking (`mock` + `clear`/`reset`/`restoreAllMocks` + `isMockFunction`) | ✅ |
+| frontend + backend log capture | ✅ |
+| browser mode (`mode: 'browser'` against a dev server) | ✅ |
+| standalone / session mode | ✅ |
+
+## Known limitations
+
+These are **upstream Electrobun/CEF limitations**, not service bugs — the service
+code implements the full surface and is unit-tested. CEF's chrome-runtime can't
+create the `persist:default` profile its `BrowserWindow` forces and falls back to
+a global browser context; macOS recovers (serves `/json`), but Linux/Windows do
+not. Tracked in [#317](https://github.com/webdriverio/desktop-mobile/issues/317).
+
+| Area | Status |
+|---|---|
+| **Linux / Windows** | ❌ unsupported — CEF exposes no reachable CDP endpoint there. The launcher throws a clear `SevereServiceError` in native mode. |
+| multiremote / parallel workers | ❌ blocked — CEF can't isolate ≥2 instances (single-instance only). |
+| `switchWindow` / `listWindows` (multi-window) | ⚠️ implemented but unreliable, even on macOS (2-window global-context race). |
+| `triggerDeeplink` (macOS) | ⚠️ unreliable — no open-url routing to the spawned instance. |
+| `emitEvent` | deferred — the Bun event bus isn't CDP-reachable. |
+
+As each upstream fix lands, the corresponding platform/feature is re-enabled and
+the service advances toward `1.0`.
 
 ## License
 

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -56,7 +56,8 @@ export const config = {
   services: ['electrobun'],
   capabilities: [
     {
-      browserName: 'chrome',
+      // The launcher rewrites this to 'chrome' + sets the CDP debuggerAddress.
+      browserName: 'electrobun',
       // Pin Chromedriver to the CEF Chromium major (147 for current Electrobun).
       browserVersion: '147',
       'wdio:electrobunServiceOptions': {

--- a/packages/electrobun-service/package.json
+++ b/packages/electrobun-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/electrobun-service",
-  "version": "1.0.0-next.0",
+  "version": "0.1.0-next.0",
   "description": "WebdriverIO service for testing Electrobun desktop applications",
   "author": "WebdriverIO Community",
   "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/electrobun-service",

--- a/packages/electrobun-service/src/electrobunConfig.ts
+++ b/packages/electrobun-service/src/electrobunConfig.ts
@@ -280,12 +280,15 @@ export function getRemoteDebuggingPort(buildJson: BuildJson | undefined): number
 }
 
 /**
- * Pin a CEF remote-debugging port (and optional `--user-data-dir`) into a bundle's
- * `build.json` under `chromiumFlags`, preserving every other key. CEF reads these
- * flags from build.json (not argv), so this is how the launcher both fixes the CDP
- * endpoint and isolates each worker's profile. A distinct `user-data-dir` per worker
- * gives CEF a flat, creatable profile root — unlike a redirected `$HOME`, where CEF
- * fails with "Cannot create profile at path .../Library/Application Support/...".
+ * Pin a CEF remote-debugging port into a bundle's `build.json` under `chromiumFlags`,
+ * preserving every other key. CEF reads these flags from build.json (not argv), so this is
+ * how the launcher fixes the CDP endpoint for each worker's cloned bundle.
+ *
+ * `userDataDir` is still supported (written as `--user-data-dir` when provided), but the
+ * launcher intentionally does NOT pass it: a separate `--user-data-dir` puts CEF's forced
+ * `persist:default` partition profile OUTSIDE `root_cache_path`, triggering "Cannot create
+ * profile" (the disproven multiremote approach — see nativeMode.ts for the full note). The
+ * parameter stays for completeness / future use if upstream relaxes the constraint.
  *
  * @throws SevereServiceError when build.json is missing/unwritable — without it
  *   the port can't be pinned and the worker's CDP attach has no fixed endpoint.

--- a/packages/electrobun-service/src/errors.ts
+++ b/packages/electrobun-service/src/errors.ts
@@ -27,6 +27,26 @@ export function cefRendererRequired(platform: NodeJS.Platform = process.platform
 }
 
 /**
+ * Thrown by the launcher in native mode on Linux/Windows. CEF-rendered Electrobun
+ * apps are only automatable on macOS in the 0.x line: on Linux/Windows, CEF's
+ * failed-`persist:default`-profile fallback serves no `/json`, so Chromedriver can
+ * never attach (an upstream electrobun/CEF limitation, not fixable from the service).
+ * Fail fast with an actionable message rather than letting the user hit a cryptic
+ * CDP-attach timeout. Native-renderer (WebView2/WebKitGTK) support that would cover
+ * these platforms is a planned follow-up — webdriverio/desktop-mobile#317.
+ */
+export function cefNativeModeMacOnly(platform: NodeJS.Platform = process.platform): Error {
+  return new SevereServiceError(
+    '@wdio/electrobun-service can only automate CEF-rendered Electrobun apps on macOS in this ' +
+      `0.x release (current platform: ${platform}). On Linux and Windows, CEF does not expose a ` +
+      'reachable Chrome DevTools Protocol endpoint (an upstream limitation), so the app cannot be ' +
+      "driven over CDP. Run your Electrobun e2e tests on macOS, or use browser mode (mode: 'browser') " +
+      'against a dev server. Native-renderer (WebView2/WebKitGTK) support for Windows/Linux is a ' +
+      'planned follow-up — see https://github.com/webdriverio/desktop-mobile/issues/317.',
+  );
+}
+
+/**
  * Returned (rejected) by `triggerDeeplink` on platforms where Electrobun does
  * not yet support custom URL schemes. v1 supports macOS only (schemes are
  * registered via the generated `Info.plist`); Windows/Linux are a documented

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -4,7 +4,7 @@ import type { Options } from '@wdio/types';
 
 import { DEFAULT_DEBUG_PORT_BASE, SERVICE_NAME } from './constants.js';
 import { type ResolvedElectrobunApp, resolveElectrobunApp, verifyCefRenderer } from './electrobunConfig.js';
-import { SevereServiceError } from './errors.js';
+import { cefNativeModeMacOnly, SevereServiceError } from './errors.js';
 import { type ElectrobunAppProcess, spawnElectrobunApp, stopElectrobunApp, waitForCdpReady } from './nativeMode.js';
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
 import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './types.js';
@@ -103,6 +103,15 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       this.browserMode = true;
       log.info('Browser mode enabled — skipping Electrobun binary/CDP setup');
       return;
+    }
+
+    // Native mode is macOS-only in the 0.x line: on Linux/Windows, CEF's failed-profile
+    // fallback serves no /json so Chromedriver can never attach (upstream-blocked, see the
+    // plan "Framework gaps" / #317). Fail fast here rather than let the user hit a cryptic
+    // CDP-attach timeout. Browser mode is unaffected — it already returned above. Lift this
+    // when the WebView2/WebKitGTK native-renderer transports land (#317).
+    if (process.platform !== 'darwin') {
+      throw cefNativeModeMacOnly(process.platform);
     }
 
     // Native mode: resolve + CEF-verify each bundle, force chrome capability. The

--- a/packages/electrobun-service/src/mock.ts
+++ b/packages/electrobun-service/src/mock.ts
@@ -98,7 +98,10 @@ function parseCallData(raw: unknown): CallData {
 /** Serialise a value/error to a JS literal for inlining into a setter script. */
 function valueLiteral(value: unknown, target: string): string {
   if (value instanceof Error) {
-    return JSON.stringify({ __wdioError: true, name: value.name, message: value.message });
+    // Include `stack` so an error pushed via mockRejectedValue arrives with the same shape
+    // the read-call-data path returns (which includes stack) — no asymmetry for users
+    // inspecting thrown mock errors.
+    return JSON.stringify({ __wdioError: true, name: value.name, message: value.message, stack: value.stack });
   }
   return jsonLiteral(value, `browser.electrobun.mock("${target}") value`);
 }

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -149,6 +149,7 @@ async function syncWebDriverWindow(browser: WebdriverIO.Browser, bridge: CdpBrid
     const targets = bridge.listTargets();
     const targetUrl = targets.find((t) => t.label === bridge.activeLabel)?.url ?? targets[0]?.url;
     const handles = await browser.getWindowHandles();
+    const originalHandle = await browser.getWindowHandle().catch(() => undefined);
     let fallback: string | undefined;
     for (const handle of handles) {
       await browser.switchToWindow(handle);
@@ -163,6 +164,11 @@ async function syncWebDriverWindow(browser: WebdriverIO.Browser, bridge: CdpBrid
     if (fallback) {
       await browser.switchToWindow(fallback);
       return;
+    }
+    // No match: don't strand the session on the last handle we probed — restore the
+    // caller's original active window so element commands stay where they were.
+    if (originalHandle) {
+      await browser.switchToWindow(originalHandle).catch(() => {});
     }
     log.warn('No non-blank content window found; element commands may target a blank document.');
   } catch (error) {

--- a/packages/electrobun-service/test/errors.spec.ts
+++ b/packages/electrobun-service/test/errors.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { SevereServiceError } from 'webdriverio';
 
-import { cefRendererRequired, deeplinkUnsupportedOnPlatform } from '../src/errors.js';
+import { cefNativeModeMacOnly, cefRendererRequired, deeplinkUnsupportedOnPlatform } from '../src/errors.js';
 
 describe('cefRendererRequired', () => {
   it('should be a SevereServiceError so the runner aborts', () => {
@@ -18,6 +18,24 @@ describe('cefRendererRequired', () => {
   it('should name the current platform in the message', () => {
     expect(cefRendererRequired('linux').message).toContain('linux');
     expect(cefRendererRequired('win32').message).toContain('win32');
+  });
+});
+
+describe('cefNativeModeMacOnly', () => {
+  it('should be a SevereServiceError so the runner aborts', () => {
+    expect(cefNativeModeMacOnly('linux')).toBeInstanceOf(SevereServiceError);
+  });
+
+  it('should state macOS-only and name the unsupported platform', () => {
+    expect(cefNativeModeMacOnly('linux').message).toMatch(/macOS/);
+    expect(cefNativeModeMacOnly('linux').message).toContain('linux');
+    expect(cefNativeModeMacOnly('win32').message).toContain('win32');
+  });
+
+  it('should point to browser mode and the #317 native-renderer follow-up', () => {
+    const err = cefNativeModeMacOnly('win32');
+    expect(err.message).toContain("mode: 'browser'");
+    expect(err.message).toContain('issues/317');
   });
 });
 

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -45,13 +45,22 @@ function makeLauncher(options: ElectrobunServiceGlobalOptions): ElectrobunLaunch
   return new ElectrobunLaunchService(options, {} as ElectrobunCapabilities, baseConfig);
 }
 
+// Native mode is macOS-only (0.x), so default every test to darwin; the platform-guard
+// tests below override to linux/win32. Restored after each test.
+const originalPlatform = process.platform;
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, writable: true, configurable: true });
+}
+
 describe('ElectrobunLaunchService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setPlatform('darwin');
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    setPlatform(originalPlatform);
   });
 
   describe('onPrepare — browser mode', () => {
@@ -139,6 +148,37 @@ describe('ElectrobunLaunchService', () => {
       await launcher.onPrepare(baseConfig, caps);
 
       expect(vi.mocked(resolveElectrobunApp)).toHaveBeenCalledWith('/apps/PerCap.app');
+    });
+
+    it('should fail fast with a SevereServiceError in native mode on Linux (CEF macOS-only)', async () => {
+      setPlatform('linux');
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+
+      await expect(launcher.onPrepare(baseConfig, [{}])).rejects.toThrow(SevereServiceError);
+      // Fails fast — before touching the bundle.
+      expect(vi.mocked(resolveElectrobunApp)).not.toHaveBeenCalled();
+    });
+
+    it('should explain native mode is macOS-only and cite the #317 follow-up on Windows', async () => {
+      setPlatform('win32');
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
+
+      const error = await launcher.onPrepare(baseConfig, [{}]).catch((e: Error) => e);
+      expect(error).toBeInstanceOf(SevereServiceError);
+      expect((error as Error).message).toMatch(/macOS/);
+      expect((error as Error).message).toContain('win32');
+      expect((error as Error).message).toContain('issues/317');
+    });
+
+    it('should NOT apply the macOS-only guard in browser mode on Linux', async () => {
+      setPlatform('linux');
+      const launcher = makeLauncher({ mode: 'browser', devServerUrl: 'http://localhost:3000' });
+      const caps: ElectrobunCapabilities[] = [{ browserName: 'electrobun' }];
+
+      await launcher.onPrepare(baseConfig, caps);
+
+      expect(caps[0].browserName).toBe('chrome');
+      expect(vi.mocked(resolveElectrobunApp)).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -107,6 +107,17 @@ describe('ElectrobunLaunchService', () => {
 
       await expect(launcher.onPrepare(baseConfig, caps)).rejects.toThrow(/Mixed browser-mode and native-mode/);
     });
+
+    it('should NOT apply the native-mode macOS guard in browser mode on Linux', async () => {
+      setPlatform('linux');
+      const launcher = makeLauncher({ mode: 'browser', devServerUrl: 'http://localhost:3000' });
+      const caps: ElectrobunCapabilities[] = [{ browserName: 'electrobun' }];
+
+      await launcher.onPrepare(baseConfig, caps);
+
+      expect(caps[0].browserName).toBe('chrome');
+      expect(vi.mocked(resolveElectrobunApp)).not.toHaveBeenCalled();
+    });
   });
 
   describe('onPrepare — native mode', () => {
@@ -168,17 +179,6 @@ describe('ElectrobunLaunchService', () => {
       expect((error as Error).message).toMatch(/macOS/);
       expect((error as Error).message).toContain('win32');
       expect((error as Error).message).toContain('issues/317');
-    });
-
-    it('should NOT apply the macOS-only guard in browser mode on Linux', async () => {
-      setPlatform('linux');
-      const launcher = makeLauncher({ mode: 'browser', devServerUrl: 'http://localhost:3000' });
-      const caps: ElectrobunCapabilities[] = [{ browserName: 'electrobun' }];
-
-      await launcher.onPrepare(baseConfig, caps);
-
-      expect(caps[0].browserName).toBe('chrome');
-      expect(vi.mocked(resolveElectrobunApp)).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -46,6 +46,7 @@ function makeBrowser(
     isMultiremote: false,
     sessionId: 'abc',
     getWindowHandles: vi.fn().mockResolvedValue(windows.map((w) => w.handle)),
+    getWindowHandle: vi.fn(async () => current),
     switchToWindow: vi.fn(async (handle: string) => {
       current = handle;
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       '@types/bun':
         specifier: 1.3.14
         version: 1.3.14
+      '@types/mocha':
+        specifier: 10.0.10
+        version: 10.0.10
       '@wdio/cli':
         specifier: 9.27.1
         version: 9.27.1(@types/node@25.9.1)(expect-webdriverio@5.6.5)(puppeteer-core@25.0.4)

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -29,7 +29,9 @@
       "electron-script-app-example-esm",
       "electron-script-e2e-app",
       "tauri-app-example",
-      "tauri-e2e-app"
+      "tauri-e2e-app",
+      "electrobun-app-example",
+      "electrobun-e2e-app"
     ]
   },
   "ci": {
@@ -40,7 +42,8 @@
       "scope:types": "@wdio/native-types",
       "scope:spy": "@wdio/native-spy",
       "scope:tauri": "@wdio/tauri-*",
-      "scope:electron": "@wdio/electron-*"
+      "scope:electron": "@wdio/electron-*",
+      "scope:electrobun": "@wdio/electrobun-*"
     }
   },
   "notes": {

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -30,6 +30,8 @@
       "electron-script-e2e-app",
       "tauri-app-example",
       "tauri-e2e-app",
+      "dioxus-app-example",
+      "wdio-dioxus-e2e-app",
       "electrobun-app-example",
       "electrobun-e2e-app"
     ]
@@ -42,6 +44,7 @@
       "scope:types": "@wdio/native-types",
       "scope:spy": "@wdio/native-spy",
       "scope:tauri": "@wdio/tauri-*",
+      "scope:dioxus": "@wdio/dioxus-*",
       "scope:electron": "@wdio/electron-*",
       "scope:electrobun": "@wdio/electrobun-*"
     }

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 /**
  * Script to test the wdio-electron-service, wdio-tauri-service, and wdio-dioxus-service packages in the package test apps
- * Usage: pnpx tsx scripts/test-package.ts [--package=<package-name>] [--service=<electron|tauri|dioxus|both>] [--module-type=<cjs|esm|both>] [--mode=<native|browser>] [--skip-build]
+ * Usage: pnpx tsx scripts/test-package.ts [--package=<package-name>] [--service=<electron|tauri|dioxus|electrobun|all>] [--module-type=<cjs|esm|both>] [--mode=<native|browser>] [--skip-build]
  *
  * Examples:
  * pnpx tsx scripts/test-package.ts
@@ -11,6 +11,7 @@
  * pnpx tsx scripts/test-package.ts --service=electron --mode=browser
  * pnpx tsx scripts/test-package.ts --service=tauri
  * pnpx tsx scripts/test-package.ts --service=dioxus
+ * pnpx tsx scripts/test-package.ts --service=electrobun  (macOS only)
  * pnpx tsx scripts/test-package.ts --package=electron-builder-app-cjs
  * pnpx tsx scripts/test-package.ts --package=electron-builder-app-esm
  * pnpx tsx scripts/test-package.ts --package=tauri-app --skip-build
@@ -78,7 +79,7 @@ function readWorkspaceOverrides(): Record<string, string> {
 interface TestOptions {
   package?: string;
   skipBuild?: boolean;
-  service?: 'electron' | 'tauri' | 'dioxus' | 'both';
+  service?: 'electron' | 'tauri' | 'dioxus' | 'electrobun' | 'all';
   moduleType?: 'cjs' | 'esm' | 'both';
   /** 'native' runs the existing app-launch tests. 'browser' starts a static
    * HTTP server against the fixture's `browser/` directory and runs the
@@ -134,14 +135,18 @@ function execCommand(command: string, cwd: string, description: string) {
   }
 }
 
-async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'both' = 'both'): Promise<{
+async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'electrobun' | 'all' = 'all'): Promise<{
   electronServicePath?: string;
   tauriServicePath?: string;
   dioxusServicePath?: string;
+  electrobunServicePath?: string;
   utilsPath: string;
   spyPath: string;
   corePath: string;
   typesPath?: string;
+  // Holds the electron-cdp-bridge tarball for `electron`, or the electrobun-cdp-bridge
+  // tarball for `electrobun` — the two services never pack together (electrobun is not
+  // part of `all`), so one field is unambiguous per run.
   cdpBridgePath?: string;
 }> {
   log(`Building and packing services and dependencies (service: ${service})...`);
@@ -150,11 +155,14 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
     // Build only the packages required for the requested service. Each
     // service depends on @wdio/native-core (extracted in the Dioxus
     // foundation work), so include it in every filter set.
-    const buildFilters: Record<'electron' | 'tauri' | 'dioxus' | 'both', string> = {
+    const buildFilters: Record<'electron' | 'tauri' | 'dioxus' | 'electrobun' | 'all', string> = {
       electron: '--filter=@wdio/electron-service --filter=@wdio/native-spy --filter=@wdio/native-core',
       tauri: '--filter=@wdio/tauri-service --filter=@wdio/native-core',
       dioxus: '--filter=@wdio/dioxus-service --filter=@wdio/native-core',
-      both: '--filter=./packages/*',
+      electrobun: '--filter=@wdio/electrobun-service --filter=@wdio/native-spy --filter=@wdio/native-core',
+      // `all` builds every package; it does NOT include electrobun's fixtures — electrobun
+      // is macOS-only and always run via its own `--service=electrobun` job.
+      all: '--filter=./packages/*',
     };
     execCommand(`pnpm turbo run build ${buildFilters[service]}`, rootDir, `Building packages for ${service}`);
 
@@ -197,6 +205,7 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
       electronServicePath?: string;
       tauriServicePath?: string;
       dioxusServicePath?: string;
+      electrobunServicePath?: string;
       utilsPath: string;
       spyPath: string;
       corePath: string;
@@ -205,7 +214,7 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
     } = { utilsPath, spyPath, corePath };
 
     // Pack Electron service and dependencies if needed
-    if (service === 'electron' || service === 'both') {
+    if (service === 'electron' || service === 'all') {
       const electronServiceDir = normalize(join(rootDir, 'packages', 'electron-service'));
       const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
       const cdpBridgeDir = normalize(join(rootDir, 'packages', 'electron-cdp-bridge'));
@@ -227,7 +236,7 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
     }
 
     // Pack Tauri service if needed
-    if (service === 'tauri' || service === 'both') {
+    if (service === 'tauri' || service === 'all') {
       const tauriServiceDir = normalize(join(rootDir, 'packages', 'tauri-service'));
       const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
       if (!existsSync(tauriServiceDir)) {
@@ -243,7 +252,7 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
     }
 
     // Pack Dioxus service if needed
-    if (service === 'dioxus' || service === 'both') {
+    if (service === 'dioxus' || service === 'all') {
       const dioxusServiceDir = normalize(join(rootDir, 'packages', 'dioxus-service'));
       if (!existsSync(dioxusServiceDir)) {
         throw new Error(`Dioxus service directory does not exist: ${dioxusServiceDir}`);
@@ -258,6 +267,26 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
       }
       execCommand('pnpm pack', dioxusServiceDir, 'Packing @wdio/dioxus-service');
       result.dioxusServicePath = findTgzFile(dioxusServiceDir, 'wdio-dioxus-service-');
+    }
+
+    // Pack Electrobun service if needed (CDP archetype like Electron: service +
+    // native-types + its own electrobun-cdp-bridge). Never part of `all`.
+    if (service === 'electrobun') {
+      const electrobunServiceDir = normalize(join(rootDir, 'packages', 'electrobun-service'));
+      const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
+      const cdpBridgeDir = normalize(join(rootDir, 'packages', 'electrobun-cdp-bridge'));
+      if (!existsSync(electrobunServiceDir)) {
+        throw new Error(`Electrobun service directory does not exist: ${electrobunServiceDir}`);
+      }
+      if (!existsSync(cdpBridgeDir)) {
+        throw new Error(`Electrobun CDP Bridge directory does not exist: ${cdpBridgeDir}`);
+      }
+      execCommand('pnpm pack', typesDir, 'Packing @wdio/native-types');
+      execCommand('pnpm pack', cdpBridgeDir, 'Packing @wdio/electrobun-cdp-bridge');
+      execCommand('pnpm pack', electrobunServiceDir, 'Packing @wdio/electrobun-service');
+      result.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
+      result.cdpBridgePath = findTgzFile(cdpBridgeDir, 'wdio-electrobun-cdp-bridge-');
+      result.electrobunServicePath = findTgzFile(electrobunServiceDir, 'wdio-electrobun-service-');
     }
 
     log(`📦 Packages packed:`);
@@ -280,6 +309,11 @@ async function buildAndPackService(service: 'electron' | 'tauri' | 'dioxus' | 'b
       if (result.typesPath) {
         log(`   Types: ${result.typesPath}`);
       }
+    }
+    if (result.electrobunServicePath) {
+      log(`   Electrobun Service: ${result.electrobunServicePath}`);
+      log(`   Types: ${result.typesPath}`);
+      log(`   CDP Bridge: ${result.cdpBridgePath}`);
     }
 
     return result;
@@ -351,13 +385,14 @@ async function testExample(
     electronServicePath?: string;
     tauriServicePath?: string;
     dioxusServicePath?: string;
+    electrobunServicePath?: string;
     utilsPath: string;
     spyPath: string;
     corePath: string;
     typesPath?: string;
     cdpBridgePath?: string;
   },
-  service: 'electron' | 'tauri' | 'dioxus',
+  service: 'electron' | 'tauri' | 'dioxus' | 'electrobun',
   skipBuild: boolean,
   mode: 'native' | 'browser' = 'native',
 ) {
@@ -457,6 +492,14 @@ async function testExample(
       overrides['@wdio/dioxus-service'] = `file:${packages.dioxusServicePath}`;
       overrides['@wdio/native-types'] = `file:${packages.typesPath}`;
       packagesToInstall.push(packages.typesPath, packages.dioxusServicePath);
+    } else if (service === 'electrobun') {
+      if (!packages.electrobunServicePath || !packages.typesPath || !packages.cdpBridgePath) {
+        throw new Error('Electrobun service packages not available');
+      }
+      overrides['@wdio/electrobun-service'] = `file:${packages.electrobunServicePath}`;
+      overrides['@wdio/native-types'] = `file:${packages.typesPath}`;
+      overrides['@wdio/electrobun-cdp-bridge'] = `file:${packages.cdpBridgePath}`;
+      packagesToInstall.push(packages.typesPath, packages.cdpBridgePath, packages.electrobunServicePath);
     }
 
     packageJson.pnpm = {
@@ -726,6 +769,26 @@ async function testExample(
       } else if (packageJson.scripts?.build) {
         execCommand('pnpm build', packageDir, `Building ${packageName} app`);
       }
+    } else if (service === 'electrobun' && mode === 'native') {
+      // CDP-attach CEF bundle. CI builds it as a separate macOS artifact (the ~150MB
+      // CEF download is slow), so in skipBuild mode copy the pre-built bundle rather
+      // than re-running `electrobun build` in the isolated environment.
+      const sourceBuildDir = join(rootDir, 'fixtures', 'package-tests', 'electrobun-app', 'build');
+      const destBuildDir = join(packageDir, 'build');
+      if (skipBuild) {
+        if (!existsSync(sourceBuildDir)) {
+          throw new Error(
+            `Pre-built Electrobun bundle not found at ${sourceBuildDir}. ` +
+              'Was the build artifact downloaded and extracted correctly?',
+          );
+        }
+        log(`Copying pre-built Electrobun bundle from ${sourceBuildDir}...`);
+        mkdirSync(destBuildDir, { recursive: true });
+        cpSync(sourceBuildDir, destBuildDir, { recursive: true });
+        log(`✅ Pre-built Electrobun bundle copied successfully`);
+      } else if (packageJson.scripts?.build) {
+        execCommand('pnpm build', packageDir, `Building ${packageName} app`);
+      }
     } else if (packageJson.scripts?.build && mode === 'native') {
       // Build other apps (e.g. Electron) in isolated environment
       execCommand('pnpm build', packageDir, `Building ${packageName} app`);
@@ -849,13 +912,21 @@ async function main() {
     const args = process.argv.slice(2);
     const serviceArg = args.find((arg) => arg.startsWith('--service='))?.split('=')[1];
 
-    // Validate service argument if provided, default to 'both' if not provided
-    let service: 'electron' | 'tauri' | 'dioxus' | 'both' = 'both';
+    // Validate service argument if provided, default to 'all' if not provided
+    let service: 'electron' | 'tauri' | 'dioxus' | 'electrobun' | 'all' = 'all';
     if (serviceArg) {
-      if (serviceArg === 'electron' || serviceArg === 'tauri' || serviceArg === 'dioxus' || serviceArg === 'both') {
+      if (
+        serviceArg === 'electron' ||
+        serviceArg === 'tauri' ||
+        serviceArg === 'dioxus' ||
+        serviceArg === 'electrobun' ||
+        serviceArg === 'all'
+      ) {
         service = serviceArg;
       } else {
-        throw new Error(`Invalid service value: ${serviceArg}. Must be 'electron', 'tauri', 'dioxus', or 'both'`);
+        throw new Error(
+          `Invalid service value: ${serviceArg}. Must be 'electron', 'tauri', 'dioxus', 'electrobun', or 'all'`,
+        );
       }
     }
 
@@ -892,6 +963,7 @@ async function main() {
       electronServicePath?: string;
       tauriServicePath?: string;
       dioxusServicePath?: string;
+      electrobunServicePath?: string;
       utilsPath: string;
       spyPath: string;
       corePath: string;
@@ -918,7 +990,7 @@ async function main() {
         corePath: findTgzFile(coreDir, 'wdio-native-core-'),
       };
 
-      if (options.service === 'electron' || options.service === 'both') {
+      if (options.service === 'electron' || options.service === 'all') {
         const electronServiceDir = normalize(join(rootDir, 'packages', 'electron-service'));
         const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
         const cdpBridgeDir = normalize(join(rootDir, 'packages', 'electron-cdp-bridge'));
@@ -927,18 +999,27 @@ async function main() {
         packages.cdpBridgePath = findTgzFile(cdpBridgeDir, 'wdio-electron-cdp-bridge-');
       }
 
-      if (options.service === 'tauri' || options.service === 'both') {
+      if (options.service === 'tauri' || options.service === 'all') {
         const tauriServiceDir = normalize(join(rootDir, 'packages', 'tauri-service'));
         const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
         packages.tauriServicePath = findTgzFile(tauriServiceDir, 'wdio-tauri-service-');
         packages.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
       }
 
-      if (options.service === 'dioxus' || options.service === 'both') {
+      if (options.service === 'dioxus' || options.service === 'all') {
         const dioxusServiceDir = normalize(join(rootDir, 'packages', 'dioxus-service'));
         const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
         packages.dioxusServicePath = findTgzFile(dioxusServiceDir, 'wdio-dioxus-service-');
         packages.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
+      }
+
+      if (options.service === 'electrobun') {
+        const electrobunServiceDir = normalize(join(rootDir, 'packages', 'electrobun-service'));
+        const typesDir = normalize(join(rootDir, 'packages', 'native-types'));
+        const cdpBridgeDir = normalize(join(rootDir, 'packages', 'electrobun-cdp-bridge'));
+        packages.electrobunServicePath = findTgzFile(electrobunServiceDir, 'wdio-electrobun-service-');
+        packages.typesPath = findTgzFile(typesDir, 'wdio-native-types-');
+        packages.cdpBridgePath = findTgzFile(cdpBridgeDir, 'wdio-electrobun-cdp-bridge-');
       }
 
       log(`📦 Using existing packages:`);
@@ -955,6 +1036,10 @@ async function main() {
       }
       if (packages.dioxusServicePath) {
         log(`   Dioxus Service: ${packages.dioxusServicePath}`);
+      }
+      if (packages.electrobunServicePath) {
+        log(`   Electrobun Service: ${packages.electrobunServicePath}`);
+        log(`   CDP Bridge: ${packages.cdpBridgePath}`);
       }
     } else {
       packages = await buildAndPackService(options.service);
@@ -979,11 +1064,13 @@ async function main() {
       filteredDirs = packageTestDirs.filter((name) => name.startsWith('tauri-'));
     } else if (options.service === 'dioxus') {
       filteredDirs = packageTestDirs.filter((name) => name.startsWith('dioxus-'));
+    } else if (options.service === 'electrobun') {
+      filteredDirs = packageTestDirs.filter((name) => name.startsWith('electrobun-'));
     }
-    // If service is 'both', don't filter
+    // If service is 'all', don't filter
 
     // Filter by module type for Electron packages
-    if (options.service === 'electron' || options.service === 'both') {
+    if (options.service === 'electron' || options.service === 'all') {
       if (options.moduleType === 'cjs') {
         filteredDirs = filteredDirs.filter((name) => name.endsWith('-cjs') || !name.match(/-cjs$|-esm$/));
       } else if (options.moduleType === 'esm') {
@@ -1006,7 +1093,7 @@ async function main() {
     if (
       options.moduleType === 'both' &&
       !options.package &&
-      (options.service === 'electron' || options.service === 'both')
+      (options.service === 'electron' || options.service === 'all')
     ) {
       const expandedPackages: string[] = [];
       const seenBaseNames = new Set<string>();
@@ -1052,12 +1139,15 @@ async function main() {
         continue;
       }
 
-      // Detect service type from package name (already filtered by prefix, but needed for testExample)
-      const detectedService: 'electron' | 'tauri' | 'dioxus' = packageName.startsWith('tauri-')
-        ? 'tauri'
-        : packageName.startsWith('dioxus-')
-          ? 'dioxus'
-          : 'electron';
+      // Detect service type from the package-name prefix (already filtered, but
+      // testExample needs it). Electron is the default — its fixtures carry no prefix.
+      const servicePrefixes = [
+        ['tauri-', 'tauri'],
+        ['dioxus-', 'dioxus'],
+        ['electrobun-', 'electrobun'],
+      ] as const;
+      const detectedService: 'electron' | 'tauri' | 'dioxus' | 'electrobun' =
+        servicePrefixes.find(([prefix]) => packageName.startsWith(prefix))?.[1] ?? 'electron';
 
       // Log module type for Electron packages
       if (detectedService === 'electron') {

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -1066,8 +1066,14 @@ async function main() {
       filteredDirs = packageTestDirs.filter((name) => name.startsWith('dioxus-'));
     } else if (options.service === 'electrobun') {
       filteredDirs = packageTestDirs.filter((name) => name.startsWith('electrobun-'));
+    } else {
+      // 'all' = electron + tauri + dioxus (the services sharing the cross-OS matrix).
+      // Electrobun is NEVER part of 'all' — it's macOS-only with a bespoke CEF flow and
+      // buildAndPackService('all') doesn't pack its tarball, so its fixtures must be
+      // excluded or a bare `pnpm test:package` would try to test electrobun-app without a
+      // packed service and throw. Run it explicitly via `--service=electrobun`.
+      filteredDirs = packageTestDirs.filter((name) => !name.startsWith('electrobun-'));
     }
-    // If service is 'all', don't filter
 
     // Filter by module type for Electron packages
     if (options.service === 'electron' || options.service === 'all') {


### PR DESCRIPTION
## PR5 — Ship (stack: `feat/electrobun-ship` → `feat/electrobun-service` → `main`)

Final PR in the `@wdio/electrobun-service` stack. The service ships **pre-1.0 (`0.1.0`), macOS-only** — see [#316](https://github.com/webdriverio/desktop-mobile/pull/316) and the "Framework gaps" for the upstream CEF catch-22.

### Done
- **Version → `0.1.0-next.0`** (both packages) — releases as `0.1.0`; `0.x` because upstream blocks Linux/Windows/multiremote/multi-window/deeplink, `1.0` reserved for full parity.
- **macOS-only CEF runtime guard** — `SevereServiceError` in `launcher.onPrepare` native mode on Linux/Windows, framed around the CEF renderer, pointing to macOS / browser mode / #317. Browser mode unaffected. (+ unit tests)
- **Package-test CI** (macOS-only) — `_ci-build-electrobun-package-app.reusable.yml` (Bun/CEF, symlink-preserving tar), the `electrobun` arm in `_ci-package.reusable.yml`, `ci.yml` build + package jobs + ci-status, detect-changes, `test:package:electrobun`. Plus the fixture **test harness** (2-staggered-window backend, `wdio.conf.ts`, smoke spec, `tsconfig.wdio.json`) — PR3 had stubbed only a `build` script.
- **`scripts/test-package.ts`** — electrobun threaded (CDP arm) + renamed the stale `both` service option → `all` (now excludes electrobun; flattened the service-detect ternary).
- **Release pipeline** — `electrobun` scope in `release.yml` + `_release.reusable.yml` (CDP target set, no Rust/GTK) + `releasekit.config.json` (skip fixtures, `scope:electrobun`). Also fixed the pre-existing dioxus gap in the same file.
- **Docs** — service README rewritten (`0.1.0`/macOS-only/limitations/#317); root README **Experimental Support** section; AGENTS/ROADMAP/architecture/package-structure/e2e-testing/CONTRIBUTING.
- **Greptile #314 ×4** — Error-mock `stack` symmetry, `writeRemoteDebuggingPort` JSDoc, `syncWebDriverWindow` handle restore, drop needless `async`.

### Notes
- ReleaseKit generates release notes + CHANGELOG; no hand-authored `docs/release-notes/` file.
- The recurring `E2E - Electron/Dioxus [Windows]` CI reds are known-flaky and unrelated (re-run clears them).
