### PR TITLE
fix(electron): use WeakMap for standalone activeLaunchers

### DIFF
--- a/packages/electron-service/src/session.ts
+++ b/packages/electron-service/src/session.ts
@@ -15,7 +15,7 @@ import { getStandaloneLogWriter } from './logWriter.js';
 import ElectronWorkerService from './service.js';
 
 // Store launcher instances for cleanup
-const activeLaunchers = new Map<WebdriverIO.Browser, ElectronLaunchService>();
+const activeLaunchers = new WeakMap<WebdriverIO.Browser, ElectronLaunchService>();
 // Paired with activeLaunchers so cleanup() can drive the worker-service teardown
 // (mock store + puppeteer session cache) that WDIO's standalone path never
 // invokes itself. Without this, mock state leaks between sequential sessions
@@ -139,10 +139,8 @@ export async function cleanup(browser: WebdriverIO.Browser): Promise<void> {
     }
 
     // Close standalone log writer. The map delete is in a finally so a
-    // writer.close() throw can't strand the launcher entry in this regular
-    // Map (not a WeakMap, unlike tauri/dioxus) — that would pin the browser
-    // object indefinitely and leave subsequent cleanup() calls in an
-    // inconsistent state.
+    // writer.close() throw can't strand the launcher entry — a cleanup()
+    // retry would then re-drive teardown against an already-cleaned session.
     const writer = getStandaloneLogWriter();
     try {
       await writer.close();


### PR DESCRIPTION
## Summary

The standalone session module (`packages/electron-service/src/session.ts`) kept launcher instances in a regular `Map` keyed by the browser object. A caller that dropped its browser reference without calling `cleanup()` (crash, forgotten teardown in a long-lived harness) pinned the browser + launcher — and everything they reference — for the process lifetime.

- Switch `activeLaunchers` to a `WeakMap`, matching Tauri, Dioxus, and Electrobun — and `activeServices` five lines below in the same file.
- Rewrite the cleanup comment that leaned on the regular-Map semantics ("would pin the browser object indefinitely"); the `finally`-wrapped delete stays, since a `writer.close()` throw would otherwise strand the entry and make a `cleanup()` retry re-drive teardown against an already-cleaned session.

No Map-only behavior was in use — the module only ever calls `.get`/`.set`/`.delete`; there is no iteration or `.size` anywhere, including tests.

## Testing

- `pnpm --filter @wdio/electron-service typecheck` — clean
- `pnpm --filter @wdio/electron-service test` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)