### PR TITLE
fix(ci/tauri): extract Docker container test to a script file

### DIFF
--- a/.github/workflows/_ci-package-docker.reusable.yml
+++ b/.github/workflows/_ci-package-docker.reusable.yml
@@ -33,6 +33,7 @@ jobs:
           ./test.sh ${{ inputs.distro }} test
 
       - name: Copy logs to workspace
+        if: always()
         run: |
           # Copy Docker test logs to workspace for upload
           mkdir -p fixtures/package-tests/tauri-app/logs-docker/

--- a/fixtures/package-tests/dioxus-app/docker/container-test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/container-test.sh
@@ -63,7 +63,7 @@ echo '=== Copying logs to mounted volume ==='
 cp -r /workspace/fixtures/package-tests/dioxus-app/logs* /workspace/logs-output/ 2>/dev/null || echo 'No logs to copy'
 
 # Clean up Xvfb if it was started
-if [ ! -z "$XVFB_PID" ]; then
+if [ -n "$XVFB_PID" ]; then
     kill $XVFB_PID 2>/dev/null || true
 fi
 

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -51,7 +51,7 @@ echo '=== Copying logs to mounted volume ==='
 cp -r /workspace/fixtures/package-tests/tauri-app/logs-* /workspace/logs-output/ 2>/dev/null || echo 'No logs to copy'
 
 # Clean up Xvfb if it was started
-if [ ! -z "$XVFB_PID" ]; then
+if [ -n "$XVFB_PID" ]; then
     kill $XVFB_PID 2>/dev/null || true
 fi
 

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Runs INSIDE the distro container (test.sh bind-mounts the workspace at
+# /workspace and invokes this file). Kept as a separate script rather than an
+# inline `bash -c "..."` string: an unescaped double quote inside an inline
+# script silently truncates it at that quote, and the container then exits 0
+# having run nothing — CI reports a green no-op. That exact failure shipped
+# two false-positive runs of the sibling Dioxus matrix.
+
+set -e
+
+export TURBO_TELEMETRY_DISABLED=1
+export DISPLAY=:99
+
+echo '=== Starting Xvfb ==='
+# Start Xvfb in background (some distros use different paths)
+if command -v Xvfb > /dev/null; then
+    Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+    XVFB_PID=$!
+    sleep 2
+    echo "Xvfb started with PID: $XVFB_PID"
+else
+    echo '⚠️  Xvfb not found, tests may fail'
+fi
+
+echo '=== Installing workspace dependencies ==='
+pnpm install --frozen-lockfile
+
+echo '=== Building tauri-service and dependencies ==='
+pnpm --filter @wdio/tauri-service... build
+
+echo '=== Building tauri-plugin (required for app build) ==='
+pnpm --filter @wdio/tauri-plugin build
+
+echo '=== Building Tauri app ==='
+cd fixtures/package-tests/tauri-app
+pnpm run build
+
+echo '=== Running Tauri package test ==='
+# Capture the exit code instead of letting set -e abort here, so the wdio
+# session logs are still copied out on failure — that is exactly when they
+# are needed.
+set +e
+pnpm test
+TEST_EXIT=$?
+set -e
+
+echo '=== Copying logs to mounted volume ==='
+# Absolute path: CWD is the app dir at this point, so a repo-relative
+# path would double-nest and silently copy nothing.
+cp -r /workspace/fixtures/package-tests/tauri-app/logs-* /workspace/logs-output/ 2>/dev/null || echo 'No logs to copy'
+
+# Clean up Xvfb if it was started
+if [ ! -z "$XVFB_PID" ]; then
+    kill $XVFB_PID 2>/dev/null || true
+fi
+
+exit $TEST_EXIT

--- a/fixtures/package-tests/tauri-app/docker/test.sh
+++ b/fixtures/package-tests/tauri-app/docker/test.sh
@@ -53,52 +53,18 @@ run_tests_in_container() {
 
     echo -e "${YELLOW}=== Running tests for $distro ===${NC}"
 
+    # The in-container logic lives in container-test.sh (reached through the
+    # workspace bind mount) instead of an inline `bash -c` string — an
+    # unescaped double quote in an inline script truncates it silently and
+    # the run reports a green no-op. See the header of container-test.sh.
     docker run --rm \
         -u root \
         -v "$REPO_ROOT:/workspace" \
         -v "$log_dir:/workspace/logs-output" \
         -w /workspace \
         "tauri-distro-test:$distro" \
-        bash -c "
-            set -e
-            export TURBO_TELEMETRY_DISABLED=1
-            export DISPLAY=:99
-
-            echo '=== Starting Xvfb ==='
-            # Start Xvfb in background (some distros use different paths)
-            if command -v Xvfb > /dev/null; then
-                Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-                XVFB_PID=\$!
-                sleep 2
-                echo \"Xvfb started with PID: \$XVFB_PID\"
-            else
-                echo '⚠️  Xvfb not found, tests may fail'
-            fi
-
-            echo '=== Installing workspace dependencies ==='
-            pnpm install --frozen-lockfile
-
-            echo '=== Building tauri-service and dependencies ==='
-            pnpm --filter @wdio/tauri-service... build
-
-            echo '=== Building tauri-plugin (required for app build) ==='
-            pnpm --filter @wdio/tauri-plugin build
-
-            echo '=== Building Tauri app ==='
-            cd fixtures/package-tests/tauri-app
-            pnpm run build
-
-            echo '=== Running Tauri package test ==='
-            pnpm test
-
-            echo '=== Copying logs to mounted volume ==='
-            cp -r fixtures/package-tests/tauri-app/logs-* /workspace/logs-output/ 2>/dev/null || echo 'No logs to copy'
-
-            # Clean up Xvfb if it was started
-            if [ ! -z \"\$XVFB_PID\" ]; then
-                kill \$XVFB_PID 2>/dev/null || true
-            fi
-        " 2>&1 | tee "/tmp/docker-test-$distro.log"
+        bash /workspace/fixtures/package-tests/tauri-app/docker/container-test.sh \
+        2>&1 | tee "/tmp/docker-test-$distro.log"
 
     # Check the exit code of docker run (PIPESTATUS[0]), not tee (PIPESTATUS[1])
     local docker_exit_code=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

Ports the harness hardening from #319 to the Tauri Docker distro matrix — the last remaining user of the inline `bash -c "..."` pattern.

## Why

An inline double-quoted script is one unescaped `"` away from **silent truncation**: bash receives only the script's leading exports/comments, the container exits 0 having run nothing, and CI reports a green no-op. This exact failure shipped two false-positive runs of the Dioxus matrix before being caught (see #319) — Tauri's harness works today only because none of its comments happen to contain a quote.

Repo-wide, this was the only remaining inline `bash -c` test script. Electron and Electrobun are unaffected — they have no Docker distro harnesses (bundled renderers, no distro matrix; see #319's scope note).

## Changes

- **`fixtures/package-tests/tauri-app/docker/container-test.sh`** (new) — the in-container logic, invoked through the existing workspace bind mount; no escaping needed, truncation class eliminated
- **`fixtures/package-tests/tauri-app/docker/test.sh`** — `docker run` now invokes the script file
- The port also picks up the two sibling fixes the inline script still carried:
  - `pnpm test`'s exit code is captured (`set +e`/`TEST_EXIT`) so the wdio logs are copied out **on failure** — previously `set -e` aborted before the copy
  - log copy uses an **absolute** path — the relative one double-nested after `cd`ing into the app dir and silently copied nothing
- **`.github/workflows/_ci-package-docker.reusable.yml`** — `if: always()` on the log-copy step so failed-run artifacts aren't empty (matches the Dioxus reusable workflow)

## Validation

- `bash -n` clean on both scripts; `container-test.sh` is executable
- `actionlint` clean on the workflow
- The workflow file is registered under `infra_tauri` in detect-changes, so this PR triggers the real 5-distro Tauri Docker matrix as its own validation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)