### PR TITLE
ci(release): adopt standing-PR release strategy (releasekit v0.30.0)

### DIFF
--- a/.claude/skills/add-native-service/ci-and-release.md
+++ b/.claude/skills/add-native-service/ci-and-release.md
@@ -74,7 +74,16 @@ Mobile has no driver providers; instead it splits **per platform** (the per-plat
 
 ## Release pipeline
 
-Releases run through **ReleaseKit** (`goosewobbler/releasekit`), driven by a **scope**. Two entry points in `release.yml`: auto (on successful CI push to `main`, gated by a ReleaseKit `gate` job) and manual (`workflow_dispatch` with `scope` / `bump` / `release_type` / `dry_run`).
+Releases run through **ReleaseKit** (`goosewobbler/releasekit`) under the **standing-PR strategy**: merges to `main` accumulate in a standing release PR (`release/next`, maintained by `standing-pr.yml`); merging it publishes everything queued. Two bypass paths in `release.yml`: immediate (merge labelled `release:immediate` + scope/bump — CI-gated by the ReleaseKit `gate` job) and manual (`workflow_dispatch` with `scope` / `bump` / `release_type` / `dry_run`).
+
+### First release: npm packages must be created by the wdio npm admin
+
+npm OIDC trusted publishing **cannot create packages** — a trusted-publisher entry only attaches to an existing package. Before a new service's first release run, the wdio npm admin must, for each new `@wdio/*` package (service, bridge, any new shared package):
+
+1. Do an initial publish to create the package under the `@wdio` scope
+2. Configure the trusted publisher: repo `webdriverio/desktop-mobile`, workflow `release.yml`
+
+File this as an issue **early in the Ship phase** (example: #328) — a release run that includes an uncreated package fails at its publish step. crates.io is NOT affected: the account is controlled by us, so the pipeline's `CRATES_IO_TOKEN` creates a crate on its first `cargo publish` — new Rust crates need no pre-creation.
 
 The pipeline has **two layers that must both be updated and kept in lock-step** — ReleaseKit's config *and* the GitHub Actions wrapper around it. Updating only one ships broken in a way every *other* CI check passes, so it's easy to miss (React Native did — see the warning below).
 

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -30,6 +30,11 @@ on:
         description: 'Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, utils, types, spy, core, cdp-bridge, shared) — controls build and toolchain steps'
         required: true
         type: string
+      standing_pr_number:
+        description: 'When set, run the manifest-driven standing-pr publish for this PR number instead of the scoped release flow'
+        required: false
+        type: string
+        default: ''
     secrets:
       ssh_key:
         description: 'SSH deploy key for pushing to the repository'
@@ -77,12 +82,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Rust
-        if: ${{ contains(inputs.scope, 'tauri') || contains(inputs.scope, 'dioxus') }}
+        if: ${{ contains(inputs.scope, 'tauri') || contains(inputs.scope, 'dioxus') || inputs.scope == 'all' }}
         shell: bash
         run: rustup update stable && rustup default stable
 
       - name: Install GTK development libraries
-        if: ${{ contains(inputs.scope, 'tauri') || contains(inputs.scope, 'dioxus') }}
+        if: ${{ contains(inputs.scope, 'tauri') || contains(inputs.scope, 'dioxus') || inputs.scope == 'all' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -140,6 +145,10 @@ jobs:
               ;;
             shared)
               echo "packages=@wdio/native-utils,@wdio/native-types,@wdio/native-spy,@wdio/native-core,@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
+              ;;
+            all)
+              # standing-pr publish resolves its package set from the merged PR's manifest
+              echo "packages=" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unknown scope: $scope"
@@ -245,6 +254,11 @@ jobs:
                 --filter='@wdio/native-core...' \
                 --filter='@wdio/native-cdp-bridge...'
               ;;
+            all)
+              # standing-pr publish path — the manifest can span every scope
+              pnpm build
+              pnpm turbo run build:rust --filter='@wdio/tauri-plugin' --filter='@wdio/dioxus-bridge'
+              ;;
             *)
               echo "::error::Unknown scope: $scope"
               exit 1
@@ -282,7 +296,8 @@ jobs:
 
       - name: Run ReleaseKit
         id: releasekit
-        uses: goosewobbler/releasekit@v0.23.0
+        if: ${{ inputs.standing_pr_number == '' }}
+        uses: goosewobbler/releasekit@v0.24.0
         with:
           mode: release
           node-version: '24'
@@ -305,3 +320,24 @@ jobs:
       # as part of the `flutter` scope. This is handled inside ReleaseKit — peer to its npm +
       # crates.io publishing — rather than a bespoke step here, so the pubspec.yaml version bumps in
       # lockstep with the @wdio/flutter-service npm line. Tracked: goosewobbler/releasekit#285.
+
+      # Manifest-driven publish from a merged standing release PR. Versions and notes come
+      # from the manifest comment on the PR, so bump/target/stable don't apply. The mode
+      # has no dry-run support — the dispatch in standing-pr.yml always sends dry_run=false.
+      - name: Run ReleaseKit (standing PR publish)
+        id: releasekit-standing
+        if: ${{ inputs.standing_pr_number != '' }}
+        uses: goosewobbler/releasekit@v0.24.0
+        with:
+          mode: standing-pr-publish
+          node-version: '24'
+          pr: ${{ inputs.standing_pr_number }}
+          json: 'true'
+          project-dir: .
+          verbose: 'true'
+          summary: 'true'
+          skip-checkout: 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+          OLLAMA_API_KEY: ${{ secrets.ollama_api_key }}

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -152,6 +152,10 @@ jobs:
               echo "packages=@wdio/native-utils,@wdio/native-types,@wdio/native-spy,@wdio/native-core,@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
               ;;
             all)
+              if [[ -z "${{ inputs.standing_pr_number }}" ]]; then
+                echo "::error::scope=all requires standing_pr_number; use a specific scope for a direct release"
+                exit 1
+              fi
               # standing-pr publish resolves its package set from the merged PR's manifest
               echo "packages=" >> "$GITHUB_OUTPUT"
               ;;

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -306,7 +306,7 @@ jobs:
       - name: Run ReleaseKit
         id: releasekit
         if: ${{ inputs.standing_pr_number == '' }}
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.0
         with:
           mode: release
           node-version: '24'
@@ -336,7 +336,7 @@ jobs:
       - name: Run ReleaseKit (standing PR publish)
         id: releasekit-standing
         if: ${{ inputs.standing_pr_number != '' }}
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.0
         with:
           mode: standing-pr-publish
           node-version: '24'

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -46,9 +46,13 @@ on:
         description: 'Ollama API key for LLM-enhanced release notes'
         required: false
 
+# pull-requests: write is needed by the standing-pr publish path (manifest comment read +
+# completion comment). Called workflows can only downgrade caller permissions, so it must
+# be declared here too — callers that don't grant it (release-auto/manual) cap it to none.
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
 
 env:
   NPM_CONFIG_PROVENANCE: true
@@ -60,6 +64,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Run ReleaseKit
         id: releasekit
         if: ${{ inputs.standing_pr_number == '' }}
-        uses: goosewobbler/releasekit@v0.24.0
+        uses: goosewobbler/releasekit@v0.25.0
         with:
           mode: release
           node-version: '24'
@@ -327,7 +327,7 @@ jobs:
       - name: Run ReleaseKit (standing PR publish)
         id: releasekit-standing
         if: ${{ inputs.standing_pr_number != '' }}
-        uses: goosewobbler/releasekit@v0.24.0
+        uses: goosewobbler/releasekit@v0.25.0
         with:
           mode: standing-pr-publish
           node-version: '24'

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Run ReleaseKit
         id: releasekit
         if: ${{ inputs.standing_pr_number == '' }}
-        uses: goosewobbler/releasekit@v0.25.0
+        uses: goosewobbler/releasekit@v0.29.1
         with:
           mode: release
           node-version: '24'
@@ -332,7 +332,7 @@ jobs:
       - name: Run ReleaseKit (standing PR publish)
         id: releasekit-standing
         if: ${{ inputs.standing_pr_number != '' }}
-        uses: goosewobbler/releasekit@v0.25.0
+        uses: goosewobbler/releasekit@v0.29.1
         with:
           mode: standing-pr-publish
           node-version: '24'

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -43,7 +43,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update standing release PR
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.0
         with:
           mode: standing-pr-update
           node-version: '24'

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -8,6 +8,12 @@ name: Standing PR Update (Reusable)
 
 on:
   workflow_call:
+    inputs:
+      reconcile:
+        description: 'Bypass the skip-pattern guard — required for post-release reconcile runs, where HEAD is a release commit'
+        required: false
+        type: boolean
+        default: false
     secrets:
       ssh_key:
         description: 'SSH deploy key for pushing the release branch'
@@ -37,11 +43,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update standing release PR
-        uses: goosewobbler/releasekit@v0.24.0
+        uses: goosewobbler/releasekit@v0.25.0
         with:
           mode: standing-pr-update
           node-version: '24'
           project-dir: .
+          reconcile: ${{ inputs.reconcile && 'true' || 'false' }}
           verbose: 'true'
           summary: 'true'
           skip-checkout: 'true'

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -1,0 +1,50 @@
+name: Standing PR Update (Reusable)
+
+# Wraps releasekit standing-pr-update for the routine push-triggered update
+# (standing-pr.yml) and the post-release reconcile jobs (release.yml). Pushes the
+# release branch over SSH (DEPLOY_KEY) so CI runs on the standing PR — pushes made
+# with GITHUB_TOKEN don't trigger workflows, which would leave the PR unmergeable
+# under required status checks.
+
+on:
+  workflow_call:
+    secrets:
+      ssh_key:
+        description: 'SSH deploy key for pushing the release branch'
+        required: true
+      ollama_api_key:
+        description: 'Ollama API key for LLM-enhanced release notes'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Update standing PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.ssh_key }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update standing release PR
+        uses: goosewobbler/releasekit@v0.24.0
+        with:
+          mode: standing-pr-update
+          node-version: '24'
+          project-dir: .
+          verbose: 'true'
+          summary: 'true'
+          skip-checkout: 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OLLAMA_API_KEY: ${{ secrets.ollama_api_key }}

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -43,7 +43,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update standing release PR
-        uses: goosewobbler/releasekit@v0.25.0
+        uses: goosewobbler/releasekit@v0.29.1
         with:
           mode: standing-pr-update
           node-version: '24'

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release Preview
-        uses: goosewobbler/releasekit@v0.23.0
+        uses: goosewobbler/releasekit@v0.24.0
         with:
           node-version: '24'
           mode: preview

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release Preview
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.0
         with:
           node-version: '24'
           mode: preview

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release Preview
-        uses: goosewobbler/releasekit@v0.25.0
+        uses: goosewobbler/releasekit@v0.29.1
         with:
           node-version: '24'
           mode: preview

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release Preview
-        uses: goosewobbler/releasekit@v0.24.0
+        uses: goosewobbler/releasekit@v0.25.0
         with:
           node-version: '24'
           mode: preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,13 @@
 name: Release
 
+# Three release paths funnel through this workflow so npm OIDC trusted publishing sees
+# a single workflow_ref:
+#   1. Standing-PR publish — standing-pr.yml detects the standing PR merge and dispatches
+#      this workflow with standing_pr_number.
+#   2. Immediate release — under ci.releaseStrategy: standing-pr the gate only fires for
+#      merges labelled release:immediate (CI-gated via workflow_run, as before).
+#   3. Manual scoped release — workflow_dispatch with scope/bump inputs.
+
 on:
   workflow_run:
     workflows: [CI]
@@ -54,6 +62,16 @@ on:
         required: false
         type: boolean
         default: false
+      standing_pr_number:
+        description: "PR number of a merged standing release PR. When set, runs the manifest-driven publish path and ignores scope/bump. Set by standing-pr.yml; manual callers should leave blank."
+        required: false
+        type: string
+        default: ''
+      reconcile_after:
+        description: "Rebuild the standing release PR after this release completes. Manual callers may enable it so the standing PR drops the just-released changes."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release
@@ -65,13 +83,16 @@ permissions:
   id-token: write
 
 jobs:
+  # Under ci.releaseStrategy: standing-pr the gate is the immediate-release evaluator:
+  # it only fires for merges carrying release:immediate — everything else accumulates
+  # into the standing release PR maintained by standing-pr.yml.
   gate:
     name: Gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read
-      pull-requests: read
+      pull-requests: write
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     outputs:
       should_release: ${{ steps.gate.outputs.should-release }}
@@ -86,7 +107,7 @@ jobs:
 
       - name: Run ReleaseKit Gate
         id: gate
-        uses: goosewobbler/releasekit@v0.23.0
+        uses: goosewobbler/releasekit@v0.24.0
         with:
           mode: gate
           node-version: '24'
@@ -99,7 +120,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   release-auto:
-    name: Release (Auto)
+    name: Release (Immediate)
     needs: [gate]
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && needs.gate.outputs.should_release == 'true'
     uses: ./.github/workflows/_release.reusable.yml
@@ -117,9 +138,24 @@ jobs:
       crates_io_token: ${{ secrets.CRATES_IO_TOKEN }}
       ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
 
+  # An immediate release leaves the standing PR holding changes that overlap with what
+  # was just published. Re-running standing-pr update reconciles: closes the standing PR
+  # if nothing's left, otherwise rebuilds the release branch against the new HEAD.
+  reconcile-after-auto:
+    name: Reconcile standing PR
+    needs: [release-auto]
+    if: needs.release-auto.result == 'success'
+    uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
+
   release-manual:
     name: Release (Manual)
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.standing_pr_number == ''
     uses: ./.github/workflows/_release.reusable.yml
     permissions:
       contents: write
@@ -130,6 +166,43 @@ jobs:
       release_type: ${{ inputs.release_type }}
       dry_run: ${{ inputs.dry_run }}
       scope: ${{ inputs.scope }}
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      crates_io_token: ${{ secrets.CRATES_IO_TOKEN }}
+      ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
+
+  reconcile-after-manual:
+    name: Reconcile standing PR
+    needs: [release-manual]
+    if: github.event_name == 'workflow_dispatch' && inputs.reconcile_after && !inputs.dry_run && needs.release-manual.result == 'success'
+    uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
+
+  # Standing-PR publish path. Dispatched by standing-pr.yml via `gh workflow run` so the
+  # OIDC token's workflow_ref claim is release.yml — the trusted-publisher entry on
+  # npmjs.com is keyed off the top-level workflow filename, and only one is allowed per
+  # package, so all OIDC publishes have to funnel through here.
+  release-standing-pr:
+    name: Release from Standing PR
+    if: github.event_name == 'workflow_dispatch' && inputs.standing_pr_number != ''
+    uses: ./.github/workflows/_release.reusable.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      target_branch: main
+      # bump/release_type are required inputs of the reusable but unused on the
+      # standing-pr publish path — versions come from the merged PR's manifest.
+      bump: patch
+      release_type: stable
+      dry_run: false
+      scope: all
+      standing_pr_number: ${{ inputs.standing_pr_number }}
     secrets:
       ssh_key: ${{ secrets.DEPLOY_KEY }}
       crates_io_token: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Run ReleaseKit Gate
         id: gate
-        uses: goosewobbler/releasekit@v0.29.1
+        uses: goosewobbler/releasekit@v0.30.0
         with:
           mode: gate
           node-version: '24'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Run ReleaseKit Gate
         id: gate
-        uses: goosewobbler/releasekit@v0.24.0
+        uses: goosewobbler/releasekit@v0.25.0
         with:
           mode: gate
           node-version: '24'
@@ -141,6 +141,8 @@ jobs:
   # An immediate release leaves the standing PR holding changes that overlap with what
   # was just published. Re-running standing-pr update reconciles: closes the standing PR
   # if nothing's left, otherwise rebuilds the release branch against the new HEAD.
+  # reconcile=true bypasses the skip-pattern guard, which would otherwise noop on the
+  # release commit at HEAD.
   reconcile-after-auto:
     name: Reconcile standing PR
     needs: [release-auto]
@@ -149,6 +151,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    with:
+      reconcile: true
     secrets:
       ssh_key: ${{ secrets.DEPLOY_KEY }}
       ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
@@ -179,6 +183,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    with:
+      reconcile: true
     secrets:
       ssh_key: ${{ secrets.DEPLOY_KEY }}
       ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Run ReleaseKit Gate
         id: gate
-        uses: goosewobbler/releasekit@v0.25.0
+        uses: goosewobbler/releasekit@v0.29.1
         with:
           mode: gate
           node-version: '24'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,9 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      # standing-pr-publish reads the manifest comment from the merged PR and posts a
+      # completion comment back — without this every PR API call 403s.
+      pull-requests: write
     with:
       target_branch: main
       # bump/release_type are required inputs of the reusable but unused on the

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -121,10 +121,15 @@ jobs:
   # triggered from this workflow would be rejected with ENEEDAUTH. Routing through
   # `gh workflow run release.yml` makes the dispatched run's `workflow_ref` resolve to
   # `release.yml`, which matches the trusted-publisher config.
+  # Push events only: a manual workflow_dispatch fired while HEAD is still the standing-PR
+  # merge commit would re-detect it and dispatch a second publish against an already-released
+  # manifest. The push event has already handled the publish; a dispatch in that window
+  # deliberately does nothing (update-release-pr is also gated off by pr_number, since
+  # rebuilding the release branch would race the in-flight publish's tagging).
   trigger-publish:
     name: Trigger publish via release.yml
     needs: detect-release-merge
-    if: needs.detect-release-merge.outputs.pr_number != ''
+    if: github.event_name == 'push' && needs.detect-release-merge.outputs.pr_number != ''
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -1,0 +1,144 @@
+name: Standing Release PR
+
+# Maintains the standing release PR (ci.releaseStrategy: standing-pr). On every push
+# to main, either the push is the merge of the standing PR itself — in which case the
+# publish is dispatched to release.yml — or it's a regular merge whose changes get
+# accumulated into the standing PR.
+#
+# The release:immediate bypass path does NOT live here: it's handled by release.yml's
+# CI-gated gate job (workflow_run after CI), so immediate releases only publish from
+# green commits. Release commits carry [skip ci], so they never trigger this workflow;
+# the standing-pr update CLI also skip-pattern-guards against them.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: standing-release-pr
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Runs first on every push to main so the downstream jobs can serialize on its output:
+  # if the push is the merge of the standing PR, only `trigger-publish` runs (which
+  # dispatches release.yml); otherwise only `update-release-pr` runs. Without this gate,
+  # both would run in parallel and `update-release-pr` could collect the just-released
+  # commits as "unreleased" before the dispatched release.yml run finishes tagging.
+  detect-release-merge:
+    name: Detect release merge
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.detect.outputs.pr_number }}
+    steps:
+      # Sparse checkout of just the config file — avoids cloning the whole repo while
+      # letting the branch name come from a single source of truth (ci.standingPr.branch).
+      - name: Checkout config
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: releasekit.config.json
+          sparse-checkout-cone-mode: false
+
+      - name: Find PR for merge commit
+        id: detect
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          STANDING_PR_BRANCH=$(jq -r '.ci.standingPr.branch // "release/next"' releasekit.config.json)
+
+          # Primary path: parse the PR number from the squash-merge subject `(#N)` suffix.
+          # GitHub's commits→PRs cross-reference index is eventually consistent and can
+          # return an empty list for ~30s after a merge. Looking up the PR object by number
+          # is immediately stable, so when we know the number from the subject we skip the
+          # racy endpoint entirely. Falls back to the API approach if the subject doesn't
+          # match (merge commit, rebase merge, direct push).
+          PR_NUM=""
+          SUBJECT=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+          if [[ "$SUBJECT" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+            CANDIDATE="${BASH_REMATCH[1]}"
+            HEAD_REF=$(gh pr view "$CANDIDATE" --repo "$REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
+            if [ "$HEAD_REF" = "$STANDING_PR_BRANCH" ]; then
+              PR_NUM="$CANDIDATE"
+            else
+              echo "Subject references PR #$CANDIDATE but its head ref ('$HEAD_REF') is not '$STANDING_PR_BRANCH' — not a standing-PR merge"
+            fi
+          fi
+
+          # Fallback path: ask the API for PRs cross-referencing this commit. Used when the
+          # subject doesn't carry a PR number (non-squash merges) or when the candidate's
+          # head ref didn't match. Retry on API errors (rate limits, 5xx, network blips); a
+          # successful empty result means there's no PR for this commit.
+          if [ -z "$PR_NUM" ]; then
+            PRS=""
+            for attempt in 1 2 3; do
+              if PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>&1); then
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "::warning::gh api failed (attempt $attempt/3): $PRS — retrying after ${attempt}s"
+                sleep "$attempt"
+                PRS=""
+              else
+                echo "::error::gh api failed after 3 attempts: $PRS"
+                exit 1
+              fi
+            done
+
+            PR_NUM=$(echo "$PRS" | jq --arg branch "$STANDING_PR_BRANCH" -r \
+              '[.[] | select(.head.ref == $branch)][0].number // empty')
+          fi
+
+          if [ -n "$PR_NUM" ]; then
+            echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "Detected standing PR merge: PR #$PR_NUM (head: $STANDING_PR_BRANCH)"
+          else
+            echo "No standing PR merge detected for this push (looking for head: $STANDING_PR_BRANCH)"
+          fi
+
+  update-release-pr:
+    name: Update Release PR
+    needs: detect-release-merge
+    if: needs.detect-release-merge.outputs.pr_number == ''
+    uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
+
+  # Trigger release.yml via workflow_dispatch instead of publishing here directly.
+  # npm trusted publishing matches the OIDC token's top-level `workflow_ref` claim
+  # (one trusted-publisher entry per package, currently `release.yml`), so any publish
+  # triggered from this workflow would be rejected with ENEEDAUTH. Routing through
+  # `gh workflow run release.yml` makes the dispatched run's `workflow_ref` resolve to
+  # `release.yml`, which matches the trusted-publisher config.
+  trigger-publish:
+    name: Trigger publish via release.yml
+    needs: detect-release-merge
+    if: needs.detect-release-merge.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch release.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.detect-release-merge.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --repo "$REPO" \
+            --ref main \
+            --field "standing_pr_number=$PR_NUMBER"
+          echo "Dispatched release.yml with standing_pr_number=$PR_NUMBER"
+          echo "Watch publish progress: https://github.com/$REPO/actions/workflows/release.yml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,53 +332,49 @@ This repository does not maintain LTS or backport branches. Only the latest vers
 
 ## Release Process
 
-Releases are automated via GitHub Actions and triggered by PR labels.
+Releases are automated via GitHub Actions using a **standing release PR** (ReleaseKit's `standing-pr` strategy): changes merged to `main` accumulate in an always-open PR from `release/next`, and merging that PR publishes everything queued in it.
 
-### Autorelease (Recommended)
+### Standing Release PR (default)
 
-When your PR is merged to `main`, the release workflow checks for release labels:
+1. Merge your PR to `main` normally — no release labels needed
+2. The `standing-pr.yml` workflow rebuilds the standing release PR with the queued version bumps (derived from conventional commits) and changelogs
+3. When ready to release, merge the standing PR — the publish runs automatically with the versions from its manifest
 
-1. Add a scope label to your PR: `scope:electron`, `scope:tauri`, `scope:dioxus`, or `scope:shared`
-2. Add a version label: `bump:patch`, `bump:minor`, `bump:major`, or prerelease variants
-3. After CI passes and the PR is merged, the release workflow automatically publishes packages
+**Adjusting the queued release:** labels on the **standing PR itself** override its contents — `bump:patch`/`bump:minor`/`bump:major` force a bump magnitude, `scope:*` limits which packages release, `release:stable`/`release:prerelease` set the channel. Labels on feeder PRs are advisory only.
 
-**Preview:** The `release-preview.yml` workflow runs on PRs with release labels to show what will be released.
+**Preview:** The `release-preview.yml` workflow comments on PRs showing what their merge would queue.
+
+### Immediate Release (bypass the standing PR)
+
+For changes that must publish on merge without waiting for the standing PR:
+
+1. Add `release:immediate` to your PR, plus a scope label (`scope:tauri`, `scope:shared`, …) and a bump label (`bump:patch`, `bump:minor`, `bump:major`)
+2. After CI passes on the merge, the gate dispatches a direct scoped release
+3. The standing PR is reconciled afterwards so it no longer contains the just-released changes
 
 **Examples:**
-- `scope:electron` + `bump:major` → Electron packages at major bump
-- `scope:tauri` + `bump:minor` → Tauri packages at minor bump
-- `scope:dioxus` + `bump:patch` → Dioxus packages at patch bump
-- `scope:shared` + `bump:patch` → Shared packages at patch bump
+- `release:immediate` + `scope:electron` + `bump:major` → Electron packages at major bump
+- `release:immediate` + `scope:shared` + `bump:patch` → Shared packages at patch bump
+- Add `release:prerelease` to publish the immediate release as a prerelease (e.g., 11.0.0-next.0)
 
 ### Manual Release
 
-For releases without PR labels or for dry runs:
+For scoped releases without labels or for dry runs:
 
 1. Go to Actions → Release in GitHub
 2. Click "Run workflow"
-3. Select scope, version type, and dry run option
+3. Select scope, version type, and dry run option (leave `standing_pr_number` blank; enable `reconcile_after` to rebuild the standing PR afterwards)
 4. Monitor the workflow execution
 
-### Required Labels
+### Labels
 
 | Label | Effect |
 |-------|--------|
-| `scope:electron` | Release Electron packages |
-| `scope:tauri` | Release Tauri packages |
-| `scope:dioxus` | Release Dioxus packages |
-| `scope:shared` | Release shared packages |
-| `bump:patch` | Patch bump |
-| `bump:minor` | Minor bump |
-| `bump:major` | Major bump |
+| `scope:electron` / `scope:tauri` / `scope:dioxus` / `scope:electrobun` / `scope:shared` | Package set (immediate release, or scope override on the standing PR) |
+| `bump:patch` / `bump:minor` / `bump:major` | Version bump (immediate release, or bump override on the standing PR) |
+| `release:immediate` | Bypass the standing PR — direct release on merge (requires scope + bump labels) |
 | `release:prerelease` | Prerelease modifier (use with bump labels) |
-| `release:stable` | Stable release modifier (use with bump labels to clean prerelease) |
-
-### Pre-releases
-
-For testing changes before a stable release, use the `release:prerelease` label combined with a bump label:
-- `scope:electron` + `bump:major` + `release:prerelease` → Electron packages as major prerelease (e.g., 11.0.0-next.0)
-- `scope:dioxus` + `bump:minor` + `release:prerelease` → Dioxus packages as minor prerelease (e.g., 1.1.0-next.0)
-- `scope:shared` + `bump:patch` + `release:prerelease` → Shared packages as patch prerelease (e.g., 2.0.0-next.0)
+| `release:stable` | Stable release modifier (graduates a prerelease) |
 
 ### Release Notes Policy
 
@@ -386,7 +382,7 @@ GitHub release notes are published per **user-installed** package — not per in
 
 | Framework | Packages with release notes | Skipped (internal only) |
 |-----------|-----------------------------|-------------------------|
-| Electron  | `@wdio/electron-service` | `@wdio/electron-cdp-bridge`, `@wdio/native-utils`, `@wdio/native-spy`, `@wdio/native-types` |
+| Electron  | `@wdio/electron-service` | `@wdio/electron-cdp-bridge`, `@wdio/native-utils`, `@wdio/native-spy`, `@wdio/native-types`, `@wdio/native-core` |
 | Tauri     | `@wdio/tauri-service`, `tauri-plugin`, `tauri-plugin-webdriver` | — |
 | Dioxus    | `@wdio/dioxus-service` | `wdio-dioxus-bridge`, `wdio-dioxus-embedded-driver`, `wdio-dioxus-driver` |
 | Electrobun | `@wdio/electrobun-service` | `@wdio/native-cdp-bridge`, `@wdio/native-utils`, `@wdio/native-spy`, `@wdio/native-types` |

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@biomejs/biome": "2.4.15",
     "@inquirer/prompts": "^8.4.3",
     "@octokit/rest": "^22.0.1",
-    "@releasekit/release": "^0.23.0",
+    "@releasekit/release": "^0.25.0",
     "@types/node": "^25.9.1",
     "@types/shelljs": "^0.10.0",
     "@typescript-eslint/parser": "^8.59.4",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@biomejs/biome": "2.4.15",
     "@inquirer/prompts": "^8.4.3",
     "@octokit/rest": "^22.0.1",
-    "@releasekit/release": "^0.25.0",
+    "@releasekit/release": "^0.29.1",
     "@types/node": "^25.9.1",
     "@types/shelljs": "^0.10.0",
     "@typescript-eslint/parser": "^8.59.4",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@biomejs/biome": "2.4.15",
     "@inquirer/prompts": "^8.4.3",
     "@octokit/rest": "^22.0.1",
-    "@releasekit/release": "^0.29.1",
+    "@releasekit/release": "^0.30.0",
     "@types/node": "^25.9.1",
     "@types/shelljs": "^0.10.0",
     "@typescript-eslint/parser": "^8.59.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@releasekit/release':
-        specifier: ^0.25.0
-        version: 0.25.0(conventional-commits-parser@6.4.0)(ws@8.21.0)
+        specifier: ^0.29.1
+        version: 0.29.1(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -1534,8 +1534,8 @@ packages:
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
-  '@anthropic-ai/sdk@0.100.1':
-    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
+  '@anthropic-ai/sdk@0.104.2':
+    resolution: {integrity: sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -3367,24 +3367,24 @@ packages:
       proxy-agent:
         optional: true
 
-  '@releasekit/notes@0.25.0':
-    resolution: {integrity: sha512-UB3o9HYNVu11YnUkfjEpf7o4Tzjgt9UZn9L+V8WX5n3RIWfKHQLvizCK0/SyDpR6wjSox4xkbhvFf74LqLH27A==}
-    engines: {node: '>=20'}
+  '@releasekit/notes@0.29.1':
+    resolution: {integrity: sha512-LOc9yD7YQnhdBN1NsovtR/iYix3+wWdhsjWERDnBAQM5FFYPo/5jzXtqk495FL2n8k3pXJXP2SV6qdoo4Z9UHg==}
+    engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/publish@0.25.0':
-    resolution: {integrity: sha512-IceVATdc/FPbs2qN6o7UrUbgYs1utT0ITvMsESkZyJeYRFZN8g4qA+2EG05F5JsMNdK/elyf6LH45SI/bjQYpQ==}
-    engines: {node: '>=20.17'}
+  '@releasekit/publish@0.29.1':
+    resolution: {integrity: sha512-HJFbY+Zc2XQyXflTzlNyJoANWxP8BB1S4yvqUMr9QG0PfrsjsSRidICGwzWKPHoYHLslSaDdZMMBUpPNIoiN1Q==}
+    engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/release@0.25.0':
-    resolution: {integrity: sha512-8YayLcixjX8pyBhds2khT9RmgVc7YAdjSA50FhVD6/Aj7EnHkUrNJ0A0HxOauP1xFE0LoK21fiLgDTHtxSSTTA==}
-    engines: {node: '>=20'}
+  '@releasekit/release@0.29.1':
+    resolution: {integrity: sha512-wqRpt9YGBb2NXLRBHS+X6Tcr7afml6B5sh177Y+r+sWfmv81wqZWduViqp11i0u/gWdAdqr/EMDd4WjHbnmEbg==}
+    engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/version@0.25.0':
-    resolution: {integrity: sha512-y4VIsE4NEdZJxRZ4Zd6a/9EH48x/MBy0h7Vr741o4k0O+mkJr2eG6nlMw4wxjb4IcQAHwyTf2/49PZXurF/zMA==}
-    engines: {node: '>=20'}
+  '@releasekit/version@0.29.1':
+    resolution: {integrity: sha512-RcpJkVR5nAKCqr46xy49U73VNZ/KP8LFfe9xvbZIoXsWhivzACwGxBSYjXO4bY04tYBRbxxsRszVYyhwNfOQ4Q==}
+    engines: {node: '>=22'}
     hasBin: true
 
   '@rollup/plugin-node-resolve@16.0.3':
@@ -8817,7 +8817,7 @@ snapshots:
 
   7zip-bin@5.2.0: {}
 
-  '@anthropic-ai/sdk@0.100.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.104.2(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -9614,7 +9614,7 @@ snapshots:
       node-gyp: 11.5.0
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.7.4
+      semver: 7.8.4
       tar: 7.5.13
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -10993,9 +10993,9 @@ snapshots:
       modern-tar: 0.7.6
       yargs: 17.7.2
 
-  '@releasekit/notes@0.25.0(ws@8.21.0)':
+  '@releasekit/notes@0.29.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.104.2(zod@4.4.3)
       '@octokit/request-error': 7.1.0
       '@octokit/rest': 22.0.1
       chalk: 5.6.2
@@ -11005,43 +11005,46 @@ snapshots:
       jsonc-parser: 3.3.1
       liquidjs: 10.27.0
       minimatch: 10.2.5
-      openai: 6.42.0(ws@8.21.0)(zod@4.4.3)
+      openai: 6.42.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
       smol-toml: 1.6.1
+      yaml: 2.9.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ws
 
-  '@releasekit/publish@0.25.0':
+  '@releasekit/publish@0.29.1':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
       jsonc-parser: 3.3.1
       minimatch: 10.2.5
-      semver: 7.8.2
+      semver: 7.8.4
       smol-toml: 1.6.1
+      yaml: 2.9.0
       zod: 4.4.3
 
-  '@releasekit/release@0.25.0(conventional-commits-parser@6.4.0)(ws@8.21.0)':
+  '@releasekit/release@0.29.1(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@octokit/rest': 22.0.1
-      '@releasekit/notes': 0.25.0(ws@8.21.0)
-      '@releasekit/publish': 0.25.0
-      '@releasekit/version': 0.25.0(conventional-commits-parser@6.4.0)
+      '@releasekit/notes': 0.29.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@releasekit/publish': 0.29.1
+      '@releasekit/version': 0.29.1(conventional-commits-parser@6.4.0)
       chalk: 5.6.2
       commander: 14.0.3
       conventional-changelog-angular: 8.3.1
       conventional-changelog-conventionalcommits: 9.3.1
       jsonc-parser: 3.3.1
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.4
       smol-toml: 1.6.1
+      yaml: 2.9.0
       zod: 4.4.3
     transitivePeerDependencies:
       - conventional-commits-parser
       - ws
 
-  '@releasekit/version@0.25.0(conventional-commits-parser@6.4.0)':
+  '@releasekit/version@0.29.1(conventional-commits-parser@6.4.0)':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@types/minimatch': 5.1.2
@@ -11056,8 +11059,9 @@ snapshots:
       git-semver-tags: 8.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
       jsonc-parser: 3.3.1
       minimatch: 10.2.5
-      semver: 7.8.2
+      semver: 7.8.4
       smol-toml: 1.6.1
+      yaml: 2.9.0
       zod: 4.4.3
     transitivePeerDependencies:
       - conventional-commits-parser
@@ -15482,7 +15486,7 @@ snapshots:
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.3
-      semver: 7.8.1
+      semver: 7.8.4
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -15559,7 +15563,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.42.0(ws@8.21.0)(zod@4.4.3):
+  openai@6.42.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@releasekit/release':
-        specifier: ^0.23.0
-        version: 0.23.0(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        specifier: ^0.25.0
+        version: 0.25.0(conventional-commits-parser@6.4.0)(ws@8.21.0)
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -1534,8 +1534,8 @@ packages:
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
-  '@anthropic-ai/sdk@0.95.2':
-    resolution: {integrity: sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==}
+  '@anthropic-ai/sdk@0.100.1':
+    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -3367,23 +3367,23 @@ packages:
       proxy-agent:
         optional: true
 
-  '@releasekit/notes@0.23.0':
-    resolution: {integrity: sha512-G/b+Yyl0qSkKATfFS2ykoA396GjzpJngJ6c+4/0GbVcNOsMLgqq31LPX2jNtDzffwO4Y3XJ899GKHIsELJXhPg==}
+  '@releasekit/notes@0.25.0':
+    resolution: {integrity: sha512-UB3o9HYNVu11YnUkfjEpf7o4Tzjgt9UZn9L+V8WX5n3RIWfKHQLvizCK0/SyDpR6wjSox4xkbhvFf74LqLH27A==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@releasekit/publish@0.23.0':
-    resolution: {integrity: sha512-CaBPGiUnYmhPMTP1YQqg4rxWNxWISP0v0Y6VQiqCwUizTklsxnZFvMVyb8D4ImN8SusdZouSuvgjO44HaikFfw==}
+  '@releasekit/publish@0.25.0':
+    resolution: {integrity: sha512-IceVATdc/FPbs2qN6o7UrUbgYs1utT0ITvMsESkZyJeYRFZN8g4qA+2EG05F5JsMNdK/elyf6LH45SI/bjQYpQ==}
     engines: {node: '>=20.17'}
     hasBin: true
 
-  '@releasekit/release@0.23.0':
-    resolution: {integrity: sha512-zoReN6d9LhULLpjJPDYZVP/LBWvoKdDUHSqxIOnInuU356eC4AHwAghzTCyCemldh8RZJ8QjWHveLUO67A6IQQ==}
+  '@releasekit/release@0.25.0':
+    resolution: {integrity: sha512-8YayLcixjX8pyBhds2khT9RmgVc7YAdjSA50FhVD6/Aj7EnHkUrNJ0A0HxOauP1xFE0LoK21fiLgDTHtxSSTTA==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@releasekit/version@0.23.0':
-    resolution: {integrity: sha512-EJCTRw9fHbb77sxzave6qZdywudFufYLMUNjgbdFu7XHJDXHT3b2qUfCfnVshM619/f8ENybnPOxUSa6ZZsGsA==}
+  '@releasekit/version@0.25.0':
+    resolution: {integrity: sha512-y4VIsE4NEdZJxRZ4Zd6a/9EH48x/MBy0h7Vr741o4k0O+mkJr2eG6nlMw4wxjb4IcQAHwyTf2/49PZXurF/zMA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -6469,6 +6469,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -7053,9 +7056,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openai@6.39.0:
-    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
-    hasBin: true
+  openai@6.42.0:
+    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
@@ -8815,7 +8817,7 @@ snapshots:
 
   7zip-bin@5.2.0: {}
 
-  '@anthropic-ai/sdk@0.95.2(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.100.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -10991,43 +10993,46 @@ snapshots:
       modern-tar: 0.7.6
       yargs: 17.7.2
 
-  '@releasekit/notes@0.23.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@releasekit/notes@0.25.0(ws@8.21.0)':
     dependencies:
-      '@anthropic-ai/sdk': 0.95.2(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)
       '@octokit/request-error': 7.1.0
       '@octokit/rest': 22.0.1
       chalk: 5.6.2
       commander: 14.0.3
       ejs: 4.0.1
       handlebars: 4.7.9
+      jsonc-parser: 3.3.1
       liquidjs: 10.27.0
       minimatch: 10.2.5
-      openai: 6.39.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
+      openai: 6.42.0(ws@8.21.0)(zod@4.4.3)
       smol-toml: 1.6.1
       zod: 4.4.3
     transitivePeerDependencies:
       - ws
 
-  '@releasekit/publish@0.23.0':
+  '@releasekit/publish@0.25.0':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
+      jsonc-parser: 3.3.1
       minimatch: 10.2.5
       semver: 7.8.2
       smol-toml: 1.6.1
       zod: 4.4.3
 
-  '@releasekit/release@0.23.0(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@releasekit/release@0.25.0(conventional-commits-parser@6.4.0)(ws@8.21.0)':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@octokit/rest': 22.0.1
-      '@releasekit/notes': 0.23.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@releasekit/publish': 0.23.0
-      '@releasekit/version': 0.23.0(conventional-commits-parser@6.4.0)
+      '@releasekit/notes': 0.25.0(ws@8.21.0)
+      '@releasekit/publish': 0.25.0
+      '@releasekit/version': 0.25.0(conventional-commits-parser@6.4.0)
       chalk: 5.6.2
       commander: 14.0.3
       conventional-changelog-angular: 8.3.1
       conventional-changelog-conventionalcommits: 9.3.1
+      jsonc-parser: 3.3.1
       minimatch: 10.2.5
       semver: 7.8.1
       smol-toml: 1.6.1
@@ -11036,7 +11041,7 @@ snapshots:
       - conventional-commits-parser
       - ws
 
-  '@releasekit/version@0.23.0(conventional-commits-parser@6.4.0)':
+  '@releasekit/version@0.25.0(conventional-commits-parser@6.4.0)':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@types/minimatch': 5.1.2
@@ -11049,6 +11054,7 @@ snapshots:
       conventional-recommended-bump: 11.2.0
       figlet: 1.11.0
       git-semver-tags: 8.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
+      jsonc-parser: 3.3.1
       minimatch: 10.2.5
       semver: 7.8.2
       smol-toml: 1.6.1
@@ -14920,6 +14926,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -15551,7 +15559,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.39.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3):
+  openai@6.42.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@releasekit/release':
-        specifier: ^0.29.1
-        version: 0.29.1(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        specifier: ^0.30.0
+        version: 0.30.0(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -3367,23 +3367,23 @@ packages:
       proxy-agent:
         optional: true
 
-  '@releasekit/notes@0.29.1':
-    resolution: {integrity: sha512-LOc9yD7YQnhdBN1NsovtR/iYix3+wWdhsjWERDnBAQM5FFYPo/5jzXtqk495FL2n8k3pXJXP2SV6qdoo4Z9UHg==}
+  '@releasekit/notes@0.30.0':
+    resolution: {integrity: sha512-UD0cL5L8+J2OAcpqI2y0rAWdF/sNTUOIKQA8kFh5pcjO41Vn69qF+KqTciQm0KmNP2Z06rNTG+OIoT5Dy4ifJg==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/publish@0.29.1':
-    resolution: {integrity: sha512-HJFbY+Zc2XQyXflTzlNyJoANWxP8BB1S4yvqUMr9QG0PfrsjsSRidICGwzWKPHoYHLslSaDdZMMBUpPNIoiN1Q==}
+  '@releasekit/publish@0.30.0':
+    resolution: {integrity: sha512-7xT2qPyv8LfqCoxsgUzo6EDXrcGEg+F5pT0977v6WxXZBponOT+8dhyxYOBfpdA8NwcevEwZX1fuhr2CNWAdqg==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/release@0.29.1':
-    resolution: {integrity: sha512-wqRpt9YGBb2NXLRBHS+X6Tcr7afml6B5sh177Y+r+sWfmv81wqZWduViqp11i0u/gWdAdqr/EMDd4WjHbnmEbg==}
+  '@releasekit/release@0.30.0':
+    resolution: {integrity: sha512-ZSb071Hdh4ryxh/SK/hhXlO6ujxn6Qr+Z7SO6CvvJeQAaCZkYbCamG22XHm+R6TVFBcB1vhARMhGFwEsJok2/A==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/version@0.29.1':
-    resolution: {integrity: sha512-RcpJkVR5nAKCqr46xy49U73VNZ/KP8LFfe9xvbZIoXsWhivzACwGxBSYjXO4bY04tYBRbxxsRszVYyhwNfOQ4Q==}
+  '@releasekit/version@0.30.0':
+    resolution: {integrity: sha512-fGmXhAkpuJ6uoVTjG8fniM/dsUbMYKsseh5WRs95e5aaX8JhIS8lom87eo/yAapaT/6xVt759A+4FAh2P0cxjg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -10993,7 +10993,7 @@ snapshots:
       modern-tar: 0.7.6
       yargs: 17.7.2
 
-  '@releasekit/notes@0.29.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@releasekit/notes@0.30.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@anthropic-ai/sdk': 0.104.2(zod@4.4.3)
       '@octokit/request-error': 7.1.0
@@ -11012,7 +11012,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  '@releasekit/publish@0.29.1':
+  '@releasekit/publish@0.30.0':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
@@ -11023,13 +11023,13 @@ snapshots:
       yaml: 2.9.0
       zod: 4.4.3
 
-  '@releasekit/release@0.29.1(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@releasekit/release@0.30.0(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@octokit/rest': 22.0.1
-      '@releasekit/notes': 0.29.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@releasekit/publish': 0.29.1
-      '@releasekit/version': 0.29.1(conventional-commits-parser@6.4.0)
+      '@releasekit/notes': 0.30.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@releasekit/publish': 0.30.0
+      '@releasekit/version': 0.30.0(conventional-commits-parser@6.4.0)
       chalk: 5.6.2
       commander: 14.0.3
       conventional-changelog-angular: 8.3.1
@@ -11044,7 +11044,7 @@ snapshots:
       - conventional-commits-parser
       - ws
 
-  '@releasekit/version@0.29.1(conventional-commits-parser@6.4.0)':
+  '@releasekit/version@0.30.0(conventional-commits-parser@6.4.0)':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@types/minimatch': 5.1.2

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -39,7 +39,16 @@
     ]
   },
   "ci": {
+    "releaseStrategy": "standing-pr",
     "releaseTrigger": "label",
+    "labels": {
+      "stable": "release:stable",
+      "prerelease": "release:prerelease"
+    },
+    "standingPr": {
+      "branch": "release/next",
+      "mergeMethod": "squash"
+    },
     "scopeLabels": {
       "scope:shared": "@wdio/native-*",
       "scope:utils": "@wdio/native-utils",
@@ -142,7 +151,11 @@
         "@wdio/native-cdp-bridge",
         "@wdio/native-utils",
         "@wdio/native-spy",
-        "@wdio/native-types"
+        "@wdio/native-types",
+        "@wdio/native-core",
+        "wdio-dioxus-bridge",
+        "wdio-dioxus-embedded-driver",
+        "wdio-dioxus-driver"
       ]
     }
   }

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -56,8 +56,8 @@
       "scope:spy": "@wdio/native-spy",
       "scope:core": "@wdio/native-core",
       "scope:cdp-bridge": "@wdio/native-cdp-bridge",
-      "scope:tauri": "@wdio/tauri-*",
-      "scope:dioxus": "@wdio/dioxus-*",
+      "scope:tauri": "@wdio/tauri-*,tauri-plugin-wdio*",
+      "scope:dioxus": "@wdio/dioxus-*,wdio-dioxus-*",
       "scope:electron": "@wdio/electron-*",
       "scope:electrobun": "@wdio/electrobun-*",
       "scope:react-native": "@wdio/react-native-*"

--- a/scripts/update-releasekit.ts
+++ b/scripts/update-releasekit.ts
@@ -11,6 +11,7 @@ const ROOT = join(__dirname, '..');
 
 const WORKFLOW_FILES = [
   join(ROOT, '.github/workflows/_release.reusable.yml'),
+  join(ROOT, '.github/workflows/_standing-pr-update.reusable.yml'),
   join(ROOT, '.github/workflows/release-preview.yml'),
   join(ROOT, '.github/workflows/release.yml'),
 ];


### PR DESCRIPTION
## Summary

Wires up ReleaseKit's [standing-PR release strategy](https://github.com/goosewobbler/releasekit) (v0.30.0) as the default release flow.

- **Standing PR** (`release/next`) accumulates version bumps and changelogs as PRs merge to `main`; merging it publishes everything queued in its manifest
- **Immediate release** (`release:immediate` + scope + bump labels) bypasses the standing PR for changes that must publish on merge
- **Release preview** comments on open PRs showing what their merge would queue
- **Post-release reconcile** rebuilds the standing PR after any scoped release so it stays current

### New workflows
| File | Purpose |
|---|---|
| `standing-pr.yml` | Rebuilds the standing PR on every push to `main` |
| `_standing-pr-update.reusable.yml` | Reusable wrapper around releasekit's `standing-pr-update` mode |
| `release-preview.yml` | PR comment showing queued version bumps |

### Changes to existing workflows
- `release.yml` — adds `release:immediate` auto-gate + standing-PR dispatch path
- `_release.reusable.yml` — adds `standing_pr_number` input + `standing-pr-publish` mode; `scope=all` guard; extended scope globs for Cargo crates (`scope:tauri`, `scope:dioxus`)
- `releasekit.config.json` — `releaseStrategy: standing-pr`, scope label map, standing PR config
- `CONTRIBUTING.md` — documents the new release flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)