### PR TITLE
docs(electron): add legacy-package downloads badge (≤ v9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
         <a href="https://www.npmjs.com/package/@wdio/electron-service"><img src="https://img.shields.io/badge/@wdio-electron--service-9feaf9?labelColor=1a1a1a&style=plastic" alt="npm package" /></a>
         <a href="https://www.npmjs.com/package/@wdio/electron-service"><img src="https://img.shields.io/npm/v/@wdio/electron-service" alt="npm version" /></a>
         <a href="https://www.npmjs.com/package/@wdio/electron-service"><img src="https://img.shields.io/npm/dw/@wdio/electron-service" alt="npm downloads" /></a>
+        <a href="https://www.npmjs.com/package/wdio-electron-service"><img src="https://img.shields.io/npm/dw/wdio-electron-service?label=downloads%20(%E2%89%A4%20v9)" alt="npm downloads (legacy wdio-electron-service, ≤ v9)" /></a>
     </div>
 </h4>
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
     <div>
         <a href="https://www.npmjs.com/package/@wdio/electron-service"><img src="https://img.shields.io/badge/@wdio-electron--service-9feaf9?labelColor=1a1a1a&style=plastic" alt="npm package" /></a>
         <a href="https://www.npmjs.com/package/@wdio/electron-service"><img src="https://img.shields.io/npm/v/@wdio/electron-service" alt="npm version" /></a>
-        <a href="https://www.npmjs.com/package/@wdio/electron-service"><img src="https://img.shields.io/npm/dw/@wdio/electron-service" alt="npm downloads" /></a>
+        <a href="https://www.npmjs.com/package/@wdio/electron-service"><img src="https://img.shields.io/npm/dw/@wdio/electron-service?label=downloads%20(v10%2B)" alt="npm downloads (v10+)" /></a>
         <a href="https://www.npmjs.com/package/wdio-electron-service"><img src="https://img.shields.io/npm/dw/wdio-electron-service?label=downloads%20(%E2%89%A4%20v9)" alt="npm downloads (legacy wdio-electron-service, ≤ v9)" /></a>
     </div>
 </h4>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@
 - **React Native** - Popular mobile and desktop framework
 - **Flutter** - Google's UI toolkit for mobile and beyond
 - **Capacitor** - Ionic's cross-platform mobile framework
-- **Electrobun** - TypeScript-first desktop apps with system webviews and the Bun runtime
 - **Neutralino** - Lightweight desktop applications
 
 See [ROADMAP.md](./ROADMAP.md) for detailed sequencing, os support, and timelines.

--- a/packages/electron-service/README.md
+++ b/packages/electron-service/README.md
@@ -3,6 +3,7 @@
 [![@wdio/electron-service](https://img.shields.io/badge/@wdio-electron--service-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/electron-service)
 [![Version](https://img.shields.io/npm/v/@wdio/electron-service?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@wdio/electron-service)
 [![Downloads](https://img.shields.io/npm/dw/@wdio/electron-service?color=6f42c1&labelColor=1a1a1a)](https://www.npmjs.com/package/@wdio/electron-service)
+[![Downloads (≤ v9)](https://img.shields.io/npm/dw/wdio-electron-service?label=downloads%20(%E2%89%A4%20v9)&color=9e9e9e&labelColor=1a1a1a)](https://www.npmjs.com/package/wdio-electron-service)
 
 **WebdriverIO service for testing Electron applications**
 

--- a/packages/electron-service/README.md
+++ b/packages/electron-service/README.md
@@ -2,7 +2,7 @@
 
 [![@wdio/electron-service](https://img.shields.io/badge/@wdio-electron--service-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/electron-service)
 [![Version](https://img.shields.io/npm/v/@wdio/electron-service?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@wdio/electron-service)
-[![Downloads](https://img.shields.io/npm/dw/@wdio/electron-service?color=6f42c1&labelColor=1a1a1a)](https://www.npmjs.com/package/@wdio/electron-service)
+[![Downloads (v10+)](https://img.shields.io/npm/dw/@wdio/electron-service?label=downloads%20(v10%2B)&color=6f42c1&labelColor=1a1a1a)](https://www.npmjs.com/package/@wdio/electron-service)
 [![Downloads (≤ v9)](https://img.shields.io/npm/dw/wdio-electron-service?label=downloads%20(%E2%89%A4%20v9)&color=9e9e9e&labelColor=1a1a1a)](https://www.npmjs.com/package/wdio-electron-service)
 
 **WebdriverIO service for testing Electron applications**


### PR DESCRIPTION
## Summary

The electron service's true download count is invisible today: the npm package was renamed at the v10 monorepo migration, so downloads are split across two names — `wdio-electron-service` carried **0.x–9.x** (still ~16k/week, the bulk of usage) while `@wdio/electron-service` starts at v10.

Adds a second downloads badge for the legacy package next to the existing one:

- **Root README** (Supported Frameworks → Electron row): plain shields style matching the row's other badges
- **`packages/electron-service/README.md`**: house style (`labelColor=1a1a1a`), greyed (`color=9e9e9e`) to visually subordinate it to the current package's badge

Labels are the pair `downloads (v10+)` / `downloads (≤ v9)` — two disjoint ranges that sum to the true total. A plain `downloads` next to the legacy badge would read as the all-time total rather than the v10+ partition; "legacy" alone is vague and "< v9" is off by one (v9 itself lives on the old name, published as recently as Oct 2025). Both stay permanently correct. Other services keep plain `downloads` badges — only electron has the split.

Rendered (verified against shields.io): `downloads (v10+): 1k/week` + `downloads (≤ v9): 16k/week`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rider

Also drops **Electrobun** from the root README's *Planned Support* list — it shipped in #314 and already appears under *Supported Frameworks*; the planned entry was left behind. (ROADMAP.md was already current.)

