### PR TITLE
fix(ci): change detection ran every pipeline on every PR

### DIFF
--- a/.claude/skills/add-native-service/ci-and-release.md
+++ b/.claude/skills/add-native-service/ci-and-release.md
@@ -8,14 +8,26 @@ Concrete wiring for getting a new service gated in CI and published. Grounded in
 
 This computes per-framework `run_*` flags from path filters so CI only runs affected jobs.
 
+**Filter shape is load-bearing.** The paths-filter step runs with `predicate-quantifier: 'every'`
+(a file matches a filter only when it satisfies ALL of the filter's patterns — required for the
+`'!**/*.md'` exclusions). Two consequences when adding a framework:
+
+- A filter's positive paths must be **one single brace alternation**, never a list of path
+  patterns — under AND semantics a file can never match two disjoint paths, so a multi-pattern
+  filter silently never fires. `packages/{<framework>-service,<framework>-cdp-bridge}/**` ✓;
+  two separate `packages/...` lines ✗.
+- Every content filter carries `- '!**/*.md'` as its second pattern, so doc-only changes
+  (including package READMEs) fall through to lint-only. Don't omit it on the new filters.
+
 1. Add output `run_<framework>` to the `workflow_call.outputs` block **and** the job `outputs` block (`run_<framework>: ${{ steps.determine.outputs.run_<framework> || 'false' }}`).
-2. Add `paths-filter` entries:
-   - `<framework>_service`: `packages/<framework>-service/**` + any Rust crate paths (`packages/<framework>-bridge/**`, `-driver/**`, `-embedded-driver/**`).
-   - `e2e_<framework>`: `e2e/test/<framework>/**`, `e2e/wdio.<framework>.conf.ts` (+ `wdio.<framework>-embedded.conf.ts`).
-   - `fixtures_<framework>`: `fixtures/e2e-apps/<framework>/**`, `fixtures/package-tests/<framework>-app/**`.
-   - `infra_<framework>`: the per-framework reusable workflow files (see below).
-3. **Extend the `shared` filter** to include every `packages/native-*` (`native-types`, `native-utils`, `native-core`, `native-spy`). Missing one is a latent CI gap (see the `shared` paths-filter gotcha in SKILL.md → Common gotchas).
+2. Add `paths-filter` entries (each: one brace alternation + the md exclusion):
+   - `<framework>_service`: `packages/{<framework>-service,<framework>-cdp-bridge}/**` — include every crate dir for Wry frameworks (`<framework>-bridge`, `-driver`, `-embedded-driver`) in the same braces.
+   - `e2e_<framework>`: `{e2e/test/<framework>/**,e2e/wdio.<framework>.conf.ts}` (+ `e2e/wdio.<framework>-embedded.conf.ts` in the braces).
+   - `fixtures_<framework>`: `{fixtures/e2e-apps/<framework>/**,fixtures/package-tests/<framework>-app/**}`.
+   - `infra_<framework>`: the per-framework reusable workflow files (see below), as one brace alternation.
+3. **Extend the `shared` filter's braces** to include every `packages/native-*` (`native-types`, `native-utils`, `native-core`, `native-spy`). Missing one is a latent CI gap (see the `shared` paths-filter gotcha in SKILL.md → Common gotchas).
 4. In the `determine` step compute `run_<framework> = <framework>_service || e2e_<framework> || fixtures_<framework> || shared || infra || infra_<framework>`, and set it under the "run everything" branch (e.g. when CI infra itself changes).
+5. **Verify the filters before pushing**: simulate dorny's matching locally (picomatch with `dot: true`, `every` = `patterns.every`) against representative changed-file sets — a service src file, the service's README alone (must stay lint-only), and an unrelated service's file (must stay false).
 
 ### `ci.yml`
 

--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -53,73 +53,82 @@ jobs:
         id: changes
         uses: dorny/paths-filter@v4
         with:
+          # 'every': a file matches a filter only when it satisfies ALL of the filter's
+          # patterns — required for the '!' exclusions below to work. Under the default
+          # 'some', a negated pattern matches every file EXCEPT its target, so any filter
+          # containing one matched the whole repo (this made `infra` always-true and
+          # force-ran every service pipeline on every PR). The flip side: each filter's
+          # positive patterns have to collapse into a single brace alternation, because
+          # one file can never match two disjoint path patterns.
+          predicate-quantifier: 'every'
           filters: |
-            # Documentation only (triggers lint only)
+            # Documentation (markdown is excluded from every filter below, so doc-only
+            # changes anywhere — including package READMEs — fall through to lint-only)
             docs:
               - '**/*.md'
 
             # Electron service packages
             electron_service:
-              - 'packages/electron-service/**'
-              - 'packages/electron-cdp-bridge/**'
+              - 'packages/{electron-service,electron-cdp-bridge}/**'
+              - '!**/*.md'
 
             # Tauri service packages
             tauri_service:
-              - 'packages/tauri-service/**'
-              - 'packages/tauri-plugin/**'
+              - 'packages/{tauri-service,tauri-plugin}/**'
+              - '!**/*.md'
 
             # Dioxus service packages
             dioxus_service:
-              - 'packages/dioxus-service/**'
-              - 'packages/dioxus-bridge/**'
-              - 'packages/dioxus-driver/**'
+              - 'packages/{dioxus-service,dioxus-bridge,dioxus-driver,dioxus-embedded-driver}/**'
+              - '!**/*.md'
 
             # Electrobun service packages (CDP-attach, no Rust)
             electrobun_service:
-              - 'packages/electrobun-service/**'
-              - 'packages/electrobun-cdp-bridge/**'
+              - 'packages/{electrobun-service,electrobun-cdp-bridge}/**'
+              - '!**/*.md'
 
             # Shared packages (affect all services)
             shared:
-              - 'packages/native-types/**'
-              - 'packages/native-utils/**'
-              - 'packages/native-core/**'
-              - 'packages/native-spy/**'
-              - 'packages/bundler/**'
+              - 'packages/{native-types,native-utils,native-core,native-spy,bundler}/**'
+              - '!**/*.md'
 
             # E2E tests
             e2e_electron:
-              - 'e2e/test/electron/**'
-              - 'e2e/wdio.electron.conf.ts'
+              - '{e2e/test/electron/**,e2e/wdio.electron.conf.ts}'
+              - '!**/*.md'
             e2e_tauri:
-              - 'e2e/test/tauri/**'
-              - 'e2e/wdio.tauri.conf.ts'
+              - '{e2e/test/tauri/**,e2e/wdio.tauri.conf.ts}'
+              - '!**/*.md'
             e2e_dioxus:
-              - 'e2e/test/dioxus/**'
-              - 'e2e/wdio.dioxus.conf.ts'
-              - 'e2e/wdio.dioxus-embedded.conf.ts'
+              - '{e2e/test/dioxus/**,e2e/wdio.dioxus.conf.ts,e2e/wdio.dioxus-embedded.conf.ts}'
+              - '!**/*.md'
             e2e_electrobun:
-              - 'e2e/test/electrobun/**'
-              - 'e2e/wdio.electrobun.conf.ts'
+              - '{e2e/test/electrobun/**,e2e/wdio.electrobun.conf.ts}'
+              - '!**/*.md'
 
             # Test fixtures and apps
             fixtures_electron:
-              - 'fixtures/e2e-apps/electron-builder/**'
-              - 'fixtures/e2e-apps/electron-forge/**'
-              - 'fixtures/e2e-apps/electron-script/**'
+              - 'fixtures/e2e-apps/{electron-builder,electron-forge,electron-script}/**'
+              - '!**/*.md'
             fixtures_tauri:
               - 'fixtures/e2e-apps/tauri/**'
+              - '!**/*.md'
             fixtures_dioxus:
-              - 'fixtures/e2e-apps/dioxus/**'
-              - 'fixtures/package-tests/dioxus-app/**'
+              - '{fixtures/e2e-apps/dioxus/**,fixtures/package-tests/dioxus-app/**}'
+              - '!**/*.md'
             fixtures_electrobun:
-              - 'fixtures/e2e-apps/electrobun/**'
-              - 'fixtures/package-tests/electrobun-app/**'
+              - '{fixtures/e2e-apps/electrobun/**,fixtures/package-tests/electrobun-app/**}'
+              - '!**/*.md'
 
             # Shared infrastructure — triggers all service pipelines.
             # Service-specific workflow files are split into infra_{electron,tauri,dioxus}
             # below so that editing (e.g.) a Dioxus build workflow does not trigger Electron
             # or Tauri tests unnecessarily.
+            #
+            # The brace alternation covers: core CI orchestration workflows, release
+            # workflows (publish shape for all services), composite actions, build/test/
+            # release scripts (minus the tauri-only one, excluded below), workspace and
+            # dependency configuration, and TypeScript/build/test configuration.
             #
             # biome.jsonc and eslint.config.js are intentionally excluded: the lint job
             # runs unconditionally (no `if:` gate in ci.yml), so changes there do not need
@@ -129,60 +138,25 @@ jobs:
             # expense.yml, release-preview.yml) are also excluded — changes to those never
             # require running service tests.
             infra:
-              # Core CI orchestration (affect all service pipelines)
-              - '.github/workflows/ci.yml'
-              - '.github/workflows/_ci-detect-changes.reusable.yml'
-              - '.github/workflows/_ci-build.reusable.yml'
-              - '.github/workflows/_ci-lint.reusable.yml'
-              - '.github/workflows/_ci-unit.reusable.yml'
-              - '.github/workflows/_ci-package.reusable.yml'
-              # Release workflows affect publish shape for all services
-              - '.github/workflows/release.yml'
-              - '.github/workflows/_release.reusable.yml'
-              # Composite actions (all shared across every service)
-              - '.github/workflows/actions/**'
-              # Build / test / release scripts (mostly cross-service)
-              - 'scripts/**'
+              - '{.github/workflows/ci.yml,.github/workflows/_ci-detect-changes.reusable.yml,.github/workflows/_ci-build.reusable.yml,.github/workflows/_ci-lint.reusable.yml,.github/workflows/_ci-unit.reusable.yml,.github/workflows/_ci-package.reusable.yml,.github/workflows/release.yml,.github/workflows/_release.reusable.yml,.github/workflows/actions/**,scripts/**,package.json,pnpm-workspace.yaml,pnpm-lock.yaml,.nvmrc,tsconfig*.json,turbo.json,version.config.json,vitest.config.ts,wdio.conf.ts}'
               - '!scripts/update-tauri-version.ts'
-              # Workspace and dependency configuration
-              - 'package.json'
-              - 'pnpm-workspace.yaml'
-              - 'pnpm-lock.yaml'
-              - '.nvmrc'
-              # TypeScript, build, and test configuration
-              - 'tsconfig*.json'
-              - 'turbo.json'
-              - 'version.config.json'
-              - 'vitest.config.ts'
-              - 'wdio.conf.ts'
+              - '!**/*.md'
 
             # Electron-only workflow files
             infra_electron:
-              - '.github/workflows/_ci-e2e.reusable.yml'
-              - '.github/workflows/_ci-build-electron-package-apps.reusable.yml'
+              - '{.github/workflows/_ci-e2e.reusable.yml,.github/workflows/_ci-build-electron-package-apps.reusable.yml}'
 
             # Tauri-only workflow files and scripts
             infra_tauri:
-              - 'scripts/update-tauri-version.ts'
-              - '.github/workflows/_ci-build-tauri-apps.reusable.yml'
-              - '.github/workflows/_ci-build-tauri-e2e-app.reusable.yml'
-              - '.github/workflows/_ci-build-tauri-package-app.reusable.yml'
-              - '.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml'
-              - '.github/workflows/_ci-package-docker.reusable.yml'
+              - '{scripts/update-tauri-version.ts,.github/workflows/_ci-build-tauri-apps.reusable.yml,.github/workflows/_ci-build-tauri-e2e-app.reusable.yml,.github/workflows/_ci-build-tauri-package-app.reusable.yml,.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml,.github/workflows/_ci-package-docker.reusable.yml}'
 
             # Dioxus-only workflow files
             infra_dioxus:
-              - '.github/workflows/_ci-build-dioxus-crates.reusable.yml'
-              - '.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml'
-              - '.github/workflows/_ci-build-dioxus-package-app.reusable.yml'
-              - '.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml'
-              - '.github/workflows/_ci-package-docker-dioxus.reusable.yml'
+              - '{.github/workflows/_ci-build-dioxus-crates.reusable.yml,.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml,.github/workflows/_ci-build-dioxus-package-app.reusable.yml,.github/workflows/_ci-e2e-dioxus-all-providers.reusable.yml,.github/workflows/_ci-package-docker-dioxus.reusable.yml}'
 
             # Electrobun-only workflow files (no -crates: Electrobun has no Rust)
             infra_electrobun:
-              - '.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml'
-              - '.github/workflows/_ci-build-electrobun-package-app.reusable.yml'
-              - '.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml'
+              - '{.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml,.github/workflows/_ci-build-electrobun-package-app.reusable.yml,.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml}'
 
       - name: Determine What to Run
         id: determine


### PR DESCRIPTION
## Problem

Prompted by #329 (a two-file docs PR) spinning up the full CI matrix. Two compounding faults in `_ci-detect-changes.reusable.yml`:

1. **The gate has been wide-open for every PR.** dorny/paths-filter's default `predicate-quantifier: 'some'` ORs a filter's patterns, and negations go straight to picomatch — so the `infra` filter's `'!scripts/update-tauri-version.ts'` matches **every file in the repo except that one script**. `infra=true` on every PR → all four service pipelines force-ran regardless of the change. The lint-only path was dead code. (Verified against dorny v4 source — no `!` special-casing — and reproduced with the same picomatch version: the negation matches `README.md`.)
2. **Package READMEs counted as service changes.** `packages/electron-service/**` matches `packages/electron-service/README.md`, so even with (1) fixed, package-level doc edits ran that service's pipeline. The `docs` filter existed but was only ever echoed in the summary — never consulted in decisions.

## Fix

- `predicate-quantifier: 'every'` — the documented dorny remedy for exclusion patterns (a file must match **all** of a filter's patterns)
- Each filter's positive patterns collapse into a single brace alternation (under AND semantics one file can never match two disjoint path globs)
- `'!**/*.md'` excluded from every content filter → doc-only changes **anywhere** (root, `docs/`, package READMEs, skills) fall through to lint-only
- The `infra` negation now does what it always intended: `scripts/update-tauri-version.ts` routes to `infra_tauri` only

Also fixes a third latent gap found while restructuring: **`packages/dioxus-embedded-driver` was in no filter at all** — changes to it would have run zero dioxus CI once (1) was fixed. Added to the dioxus filter.

## Verification

Simulated dorny's exact matching algorithm (same picomatch version, `dot: true`, `every` quantifier) against the real filter block parsed from this file — 17 scenarios, all passing:

| Scenario | Result |
|---|---|
| #329's exact file set (root + package README) | **lint-only** (on main today: all 4 pipelines) |
| package README only / CONTRIBUTING / agent-os md / skill md | lint-only |
| electron src / cdp-bridge src | electron only |
| `scripts/update-tauri-version.ts` | tauri only (not infra) |
| cross-service script / `package.json` / native-utils | all four (unchanged) |
| `_ci-package-docker.reusable.yml` | tauri only |
| dioxus-embedded-driver src | dioxus (new coverage) |
| mixed README + electron src | electron only, not lint-only |

`ci.yml` consumes the same outputs unchanged — no edits needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)