### PR TITLE
feat(react-native-service): foundation — native-cdp-bridge consumption + type surface

### DIFF
--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -70,6 +70,23 @@ export type {
   NormalizedReadResult,
   ReadPackageUpOptions,
 } from './package.js';
+// React Native types
+export type {
+  ReactNativeAPIs,
+  ReactNativeBrowserExtension,
+  ReactNativeCapabilities,
+  ReactNativeExecuteOptions,
+  ReactNativeMock,
+  ReactNativeMockInstance,
+  ReactNativeResult,
+  ReactNativeServiceAPI,
+  ReactNativeServiceCapabilities,
+  ReactNativeServiceCapabilitiesType,
+  ReactNativeServiceCustomCapability,
+  ReactNativeServiceGlobalOptions,
+  ReactNativeServiceOptions,
+  WdioReactNativeConfig,
+} from './react-native.js';
 // Shared types
 export type {
   AbstractFn,
@@ -116,16 +133,18 @@ export type {
 import type { DioxusBrowserExtension } from './dioxus.js';
 import type { ElectrobunBrowserExtension } from './electrobun.js';
 import type { ElectronBrowserExtension } from './electron.js';
+import type { ReactNativeBrowserExtension } from './react-native.js';
 import type { TauriBrowserExtension } from './tauri.js';
 
 /**
- * Browser extension that supports Electron, Tauri, Dioxus, and Electrobun services
+ * Browser extension that supports Electron, Tauri, Dioxus, Electrobun, and React Native services
  */
 export interface BrowserExtension
   extends ElectronBrowserExtension,
     TauriBrowserExtension,
     DioxusBrowserExtension,
-    ElectrobunBrowserExtension {}
+    ElectrobunBrowserExtension,
+    ReactNativeBrowserExtension {}
 
 // ============================================================================
 // Module Augmentation (WebdriverIO)
@@ -142,6 +161,7 @@ import type {
   PackageJson,
   WdioElectronWindowObj,
 } from './electron.js';
+import type { ReactNativeServiceGlobalOptions, ReactNativeServiceOptions } from './react-native.js';
 import type { ElementBase, Fn } from './shared.js';
 import type { TauriServiceGlobalOptions, TauriServiceOptions } from './tauri.js';
 
@@ -156,24 +176,28 @@ declare global {
       extends ElectronBrowserExtension,
         TauriBrowserExtension,
         DioxusBrowserExtension,
-        ElectrobunBrowserExtension {}
+        ElectrobunBrowserExtension,
+        ReactNativeBrowserExtension {}
     interface Element extends ElementBase {}
     interface MultiRemoteBrowser
       extends ElectronBrowserExtension,
         TauriBrowserExtension,
         DioxusBrowserExtension,
-        ElectrobunBrowserExtension {}
+        ElectrobunBrowserExtension,
+        ReactNativeBrowserExtension {}
     interface Capabilities {
       'wdio:electronServiceOptions'?: ElectronServiceOptions;
       'wdio:tauriServiceOptions'?: TauriServiceOptions;
       'wdio:dioxusServiceOptions'?: DioxusServiceOptions;
       'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions;
+      'wdio:reactNativeServiceOptions'?: ReactNativeServiceOptions;
     }
     interface ServiceOption
       extends ElectronServiceGlobalOptions,
         TauriServiceGlobalOptions,
         DioxusServiceGlobalOptions,
-        ElectrobunServiceGlobalOptions {}
+        ElectrobunServiceGlobalOptions,
+        ReactNativeServiceGlobalOptions {}
   }
 
   var __name: (func: Fn) => Fn;

--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -82,7 +82,6 @@ export type {
   ReactNativeServiceAPI,
   ReactNativeServiceCapabilities,
   ReactNativeServiceCapabilitiesType,
-  ReactNativeServiceCustomCapability,
   ReactNativeServiceGlobalOptions,
   ReactNativeServiceOptions,
   WdioReactNativeConfig,

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -269,13 +269,9 @@ export interface ReactNativeServiceOptions extends LogCaptureConfig, MockLifecyc
 
 /**
  * React Native service global options (service-level; merged under per-capability options).
+ * Identical shape to {@link ReactNativeServiceOptions} — alias so the two types stay in sync.
  */
-export interface ReactNativeServiceGlobalOptions extends LogCaptureConfig, MockLifecycleConfig {
-  platform?: 'android' | 'ios';
-  metroHost?: string;
-  metroPort?: number;
-  appBinaryPath?: string;
-}
+export type ReactNativeServiceGlobalOptions = ReactNativeServiceOptions;
 
 /**
  * React Native service result type.
@@ -327,13 +323,6 @@ export type WdioReactNativeConfig = Options.Testrunner & {
   capabilities: ReactNativeServiceCapabilitiesType;
 };
 
-type ReactNativeServiceCustomCapability = {
-  /**
-   * custom capabilities to configure the React Native service
-   */
-  'wdio:reactNativeServiceOptions'?: ReactNativeServiceOptions;
-};
-
 /**
  * Browser extension for the React Native service.
  */
@@ -354,6 +343,3 @@ export interface ReactNativeBrowserExtension extends BrowserBase {
    */
   reactNative: ReactNativeServiceAPI;
 }
-
-// Re-export the custom capability for external use
-export type { ReactNativeServiceCustomCapability };

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -55,10 +55,10 @@ export interface ReactNativeMockInstance extends Omit<Mock, MockOverride> {
   withImplementation<ReturnValue, InnerArguments extends unknown[]>(
     implFn: AbstractFn,
     callbackFn: (rn: ReactNativeAPIs, ...innerArgs: InnerArguments) => ReturnValue,
-  ): Promise<unknown>;
+  ): Promise<ReturnValue>;
   mockName(name: string): ReactNativeMock;
   getMockName(): string;
-  getMockImplementation(): AbstractFn;
+  getMockImplementation(): AbstractFn | undefined;
   update(): Promise<ReactNativeMock>;
   __isReactNativeMock: boolean;
   mock: ReactNativeMockContext;
@@ -113,14 +113,6 @@ export interface ReactNativeServiceAPI {
     script: string | ((rn: ReactNativeAPIs, ...innerArgs: InnerArguments) => ReturnValue),
     options: ReactNativeExecuteOptions,
     ...args: InnerArguments
-  ): Promise<ReturnValue>;
-
-  /**
-   * Execute JavaScript in the app's Hermes JS realm with per-call options.
-   */
-  execute<ReturnValue>(
-    script: string | ((rn: ReactNativeAPIs) => ReturnValue),
-    options: ReactNativeExecuteOptions,
   ): Promise<ReturnValue>;
 
   /**

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -248,7 +248,7 @@ export interface ReactNativeServiceOptions extends LogCaptureConfig, MockLifecyc
    * Target mobile platform. Normally derived from the capability
    * (`platformName`); set explicitly to override.
    */
-  platform?: 'android' | 'ios';
+  platform?: 'Android' | 'iOS';
   /**
    * Host of the Metro inspector-proxy used for the Hermes CDP attach
    * (`execute`/`mock`).

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -2,9 +2,9 @@ import type { Mock } from '@wdio/native-spy';
 import type { Capabilities, Options } from '@wdio/types';
 import type {
   AbstractFn,
-  BaseServiceGlobalOptions,
-  BaseServiceOptions,
   BrowserBase,
+  LogCaptureConfig,
+  MockLifecycleConfig,
   MockOverride,
   Result,
   ServiceMockContext,
@@ -47,10 +47,7 @@ export interface ReactNativeMockInstance extends Omit<Mock, MockOverride> {
   mockReset(): Promise<ReactNativeMock>;
   mockRestore(): Promise<ReactNativeMock>;
   mockReturnThis(): Promise<ReactNativeMock>;
-  withImplementation<ReturnValue>(
-    implFn: AbstractFn,
-    callbackFn: (rn: ReactNativeAPIs) => ReturnValue,
-  ): Promise<ReturnValue>;
+  withImplementation<ReturnValue>(implFn: AbstractFn, callbackFn: () => ReturnValue): Promise<ReturnValue>;
   mockName(name: string): ReactNativeMock;
   getMockName(): string;
   getMockImplementation(): AbstractFn | undefined;
@@ -237,9 +234,15 @@ export interface ReactNativeServiceAPI {
 
 /**
  * The options for the React Native Service.
- * Extends base service options with React Native / Metro-specific configuration.
+ *
+ * Unlike the desktop services, this does **not** extend `BaseServiceOptions`: a
+ * React Native app is launched by Appium via capabilities (`appium:app` /
+ * `appium:appPackage`+`appium:appActivity` / `appium:bundleId`), so the
+ * desktop binary-launch fields (`appArgs`, startup/command timeouts) don't apply.
+ * Only the shared log-capture + mock-lifecycle config and RN/Metro-specific
+ * options are exposed.
  */
-export interface ReactNativeServiceOptions extends BaseServiceOptions {
+export interface ReactNativeServiceOptions extends LogCaptureConfig, MockLifecycleConfig {
   /**
    * Target mobile platform. Normally derived from the capability
    * (`platformName`); set explicitly to override.
@@ -256,16 +259,22 @@ export interface ReactNativeServiceOptions extends BaseServiceOptions {
    * @default 8081
    */
   metroPort?: number;
+  /**
+   * Path to a built app (`.apk` / `.app` / `.ipa`). Convenience that maps onto
+   * `appium:app` when the capability doesn't already set a launch target —
+   * prefer setting the `appium:*` launch capability directly.
+   */
+  appBinaryPath?: string;
 }
 
 /**
- * React Native service global options.
- * Extends base global options with React Native-specific configuration.
+ * React Native service global options (service-level; merged under per-capability options).
  */
-export interface ReactNativeServiceGlobalOptions extends BaseServiceGlobalOptions {
+export interface ReactNativeServiceGlobalOptions extends LogCaptureConfig, MockLifecycleConfig {
   platform?: 'android' | 'ios';
   metroHost?: string;
   metroPort?: number;
+  appBinaryPath?: string;
 }
 
 /**

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -47,9 +47,9 @@ export interface ReactNativeMockInstance extends Omit<Mock, MockOverride> {
   mockReset(): Promise<ReactNativeMock>;
   mockRestore(): Promise<ReactNativeMock>;
   mockReturnThis(): Promise<ReactNativeMock>;
-  withImplementation<ReturnValue, InnerArguments extends unknown[]>(
+  withImplementation<ReturnValue>(
     implFn: AbstractFn,
-    callbackFn: (rn: ReactNativeAPIs, ...innerArgs: InnerArguments) => ReturnValue,
+    callbackFn: (rn: ReactNativeAPIs) => ReturnValue,
   ): Promise<ReturnValue>;
   mockName(name: string): ReactNativeMock;
   getMockName(): string;
@@ -315,7 +315,7 @@ export type ReactNativeServiceCapabilitiesType =
   | ReactNativeServiceRequestedMultiremoteCapabilities[];
 
 export type WdioReactNativeConfig = Options.Testrunner & {
-  capabilities: ReactNativeServiceCapabilitiesType | ReactNativeServiceCapabilitiesType[];
+  capabilities: ReactNativeServiceCapabilitiesType;
 };
 
 type ReactNativeServiceCustomCapability = {

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -47,7 +47,8 @@ export interface ReactNativeMockInstance extends Omit<Mock, MockOverride> {
   mockReset(): Promise<ReactNativeMock>;
   mockRestore(): Promise<ReactNativeMock>;
   mockReturnThis(): Promise<ReactNativeMock>;
-  withImplementation<ReturnValue>(implFn: AbstractFn, callbackFn: () => ReturnValue): Promise<ReturnValue>;
+  withImplementation<ReturnValue>(implFn: AbstractFn, callbackFn: () => Promise<ReturnValue>): Promise<ReturnValue>;
+  withImplementation<ReturnValue>(implFn: AbstractFn, callbackFn: () => ReturnValue): ReturnValue;
   mockName(name: string): ReactNativeMock;
   getMockName(): string;
   getMockImplementation(): AbstractFn | undefined;

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -6,7 +6,6 @@ import type {
   BaseServiceOptions,
   BrowserBase,
   MockOverride,
-  MockResult,
   Result,
   ServiceMockContext,
 } from './shared.js';
@@ -29,12 +28,8 @@ export interface ReactNativeAPIs {
   [key: string]: unknown;
 }
 
-/**
- * React Native mock context
- */
-interface ReactNativeMockContext extends ServiceMockContext {
-  results: MockResult[];
-}
+/** React Native mock context — the shared {@link ServiceMockContext} as-is. */
+type ReactNativeMockContext = ServiceMockContext;
 
 /**
  * React Native mock instance interface

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -334,10 +334,14 @@ export interface ReactNativeBrowserExtension extends BrowserBase {
    *
    * - {@link ReactNativeServiceAPI.execute `browser.reactNative.execute`} - Execute code in the app's Hermes JS realm
    * - {@link ReactNativeServiceAPI.mock `browser.reactNative.mock`} - Mock a function in the React Native JS realm
+   * - {@link ReactNativeServiceAPI.isMockFunction `browser.reactNative.isMockFunction`} - Check whether a target/value is mocked
    * - {@link ReactNativeServiceAPI.clearAllMocks `browser.reactNative.clearAllMocks`} - Clear the React Native mock functions
    * - {@link ReactNativeServiceAPI.resetAllMocks `browser.reactNative.resetAllMocks`} - Reset the React Native mock functions
    * - {@link ReactNativeServiceAPI.restoreAllMocks `browser.reactNative.restoreAllMocks`} - Restore the original implementations
    * - {@link ReactNativeServiceAPI.triggerDeeplink `browser.reactNative.triggerDeeplink`} - Trigger a deeplink for testing `Linking`
+   * - {@link ReactNativeServiceAPI.switchWindow `browser.reactNative.switchWindow`} - Switch the active Appium context
+   * - {@link ReactNativeServiceAPI.listWindows `browser.reactNative.listWindows`} - List the available Appium contexts
+   * - {@link ReactNativeServiceAPI.emitEvent `browser.reactNative.emitEvent`} - Emit an event to RN's DeviceEventEmitter
    */
   reactNative: ReactNativeServiceAPI;
 }

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -52,7 +52,7 @@ export interface ReactNativeMockInstance extends Omit<Mock, MockOverride> {
   getMockName(): string;
   getMockImplementation(): AbstractFn | undefined;
   update(): Promise<ReactNativeMock>;
-  __isReactNativeMock: boolean;
+  __isReactNativeMock: true;
   mock: ReactNativeMockContext;
 }
 

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -1,0 +1,359 @@
+import type { Mock } from '@wdio/native-spy';
+import type { Capabilities, Options } from '@wdio/types';
+import type {
+  AbstractFn,
+  BaseServiceGlobalOptions,
+  BaseServiceOptions,
+  BrowserBase,
+  MockOverride,
+  MockResult,
+  Result,
+  ServiceMockContext,
+} from './shared.js';
+
+// ============================================================================
+// React Native-Specific Types
+// ============================================================================
+
+/**
+ * The React Native JS realm surface handed to `browser.reactNative.execute()`
+ * callbacks. Code runs in the app's own Hermes global (`globalThis`), so the
+ * shape is intentionally open — known RN globals are typed for convenience and
+ * an index signature keeps arbitrary realm access available.
+ */
+export interface ReactNativeAPIs {
+  /** RN's native-module proxy (TurboModules / legacy bridge), reachable in the Hermes realm. */
+  nativeModuleProxy?: Record<string, unknown>;
+  /** Present under Hermes; a truthy marker that the callback ran in the RN JS realm. */
+  HermesInternal?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * React Native mock context
+ */
+interface ReactNativeMockContext extends ServiceMockContext {
+  results: MockResult[];
+}
+
+/**
+ * React Native mock instance interface
+ */
+export interface ReactNativeMockInstance extends Omit<Mock, MockOverride> {
+  mockImplementation(fn: AbstractFn): Promise<ReactNativeMock>;
+  mockImplementationOnce(fn: AbstractFn): Promise<ReactNativeMock>;
+  mockReturnValue(obj: unknown): Promise<ReactNativeMock>;
+  mockReturnValueOnce(obj: unknown): Promise<ReactNativeMock>;
+  mockResolvedValue(obj: unknown): Promise<ReactNativeMock>;
+  mockResolvedValueOnce(obj: unknown): Promise<ReactNativeMock>;
+  mockRejectedValue(obj: unknown): Promise<ReactNativeMock>;
+  mockRejectedValueOnce(obj: unknown): Promise<ReactNativeMock>;
+  mockClear(): Promise<ReactNativeMock>;
+  mockReset(): Promise<ReactNativeMock>;
+  mockRestore(): Promise<ReactNativeMock>;
+  mockReturnThis(): Promise<ReactNativeMock>;
+  withImplementation<ReturnValue, InnerArguments extends unknown[]>(
+    implFn: AbstractFn,
+    callbackFn: (rn: ReactNativeAPIs, ...innerArgs: InnerArguments) => ReturnValue,
+  ): Promise<unknown>;
+  mockName(name: string): ReactNativeMock;
+  getMockName(): string;
+  getMockImplementation(): AbstractFn;
+  update(): Promise<ReactNativeMock>;
+  __isReactNativeMock: boolean;
+  mock: ReactNativeMockContext;
+}
+
+/**
+ * React Native mock function type
+ */
+export interface ReactNativeMock<TArgs extends unknown[] = unknown[], TReturns = unknown>
+  extends ReactNativeMockInstance {
+  new (...args: TArgs): TReturns;
+  (...args: TArgs): TReturns;
+}
+
+/**
+ * Options for browser.reactNative.execute() per-call overrides.
+ * Use withExecuteOptions() from @wdio/react-native-service to create properly-typed options.
+ */
+export interface ReactNativeExecuteOptions {
+  /**
+   * Sentinel property - set automatically by withExecuteOptions()
+   * @internal - do not set manually
+   */
+  __wdioOptions__: true;
+}
+
+/**
+ * React Native Service API interface for the browser object.
+ *
+ * Mirrors the converged `browser.<framework>.*` surface of the desktop services;
+ * `execute`/`mock` run in the app's Hermes JS realm over CDP (Metro inspector),
+ * find/tap and the Appium-native pieces run over the W3C session. `switchWindow`/
+ * `listWindows` are reinterpreted as Appium context switching (`NATIVE_APP` ↔
+ * `WEBVIEW_*`).
+ */
+export interface ReactNativeServiceAPI {
+  /**
+   * Execute JavaScript in the app's Hermes JS realm with per-call options and arguments.
+   *
+   * Requires a debug/Metro build with the Hermes inspector reachable.
+   *
+   * @example
+   * ```js
+   * const value = await browser.reactNative.execute(
+   *   (rn, key) => rn.nativeModuleProxy?.SettingsManager?.[key],
+   *   { __wdioOptions__: true },
+   *   'appTheme'
+   * );
+   * ```
+   */
+  execute<ReturnValue, InnerArguments extends unknown[]>(
+    script: string | ((rn: ReactNativeAPIs, ...innerArgs: InnerArguments) => ReturnValue),
+    options: ReactNativeExecuteOptions,
+    ...args: InnerArguments
+  ): Promise<ReturnValue>;
+
+  /**
+   * Execute JavaScript in the app's Hermes JS realm with per-call options.
+   */
+  execute<ReturnValue>(
+    script: string | ((rn: ReactNativeAPIs) => ReturnValue),
+    options: ReactNativeExecuteOptions,
+  ): Promise<ReturnValue>;
+
+  /**
+   * Execute JavaScript in the app's Hermes JS realm.
+   *
+   * @param script - Function to execute (receives the RN realm as first parameter) or string
+   * @param args - Additional arguments passed to the script
+   *
+   * @example
+   * ```js
+   * const isHermes = await browser.reactNative.execute(() => typeof HermesInternal === 'object');
+   * ```
+   */
+  execute<ReturnValue, InnerArguments extends unknown[]>(
+    script: string | ((rn: ReactNativeAPIs, ...innerArgs: InnerArguments) => ReturnValue),
+    ...args: InnerArguments
+  ): Promise<ReturnValue>;
+
+  /**
+   * Check if a value is a React Native mock function, or if a target path is mocked.
+   * Accepts either a mock function object or a target path string.
+   *
+   * @param targetOrFn - Target path (string) or mock function object to check
+   * @returns True if the target is mocked or the value is a ReactNativeMockInstance
+   */
+  isMockFunction: (targetOrFn: unknown) => boolean;
+
+  /**
+   * Mock a function in the React Native JS realm by dotted path
+   * (e.g. a native-module method on `nativeModuleProxy`).
+   *
+   * @param target - Dotted path of the function to mock in the Hermes global
+   * @returns Promise that resolves to the mock
+   *
+   * @example
+   * ```js
+   * const mock = await browser.reactNative.mock('nativeModuleProxy.Clipboard.getString');
+   * await mock.mockResolvedValue('mocked clipboard content');
+   * ```
+   */
+  mock: (target: string) => Promise<ReactNativeMock>;
+
+  /**
+   * Clear all React Native mocks.
+   *
+   * @param targetPrefix - Optional target-path prefix to filter which mocks to clear.
+   *                       If omitted, all mocks are cleared.
+   */
+  clearAllMocks: (targetPrefix?: string) => Promise<void>;
+
+  /**
+   * Reset all React Native mocks.
+   *
+   * @param targetPrefix - Optional target-path prefix to filter which mocks to reset.
+   *                       If omitted, all mocks are reset.
+   */
+  resetAllMocks: (targetPrefix?: string) => Promise<void>;
+
+  /**
+   * Restore all React Native mocks to their original implementations.
+   *
+   * @param targetPrefix - Optional target-path prefix to filter which mocks to restore.
+   *                       If omitted, all mocks are restored.
+   */
+  restoreAllMocks: (targetPrefix?: string) => Promise<void>;
+
+  /**
+   * Trigger a deeplink into the React Native application for testing `Linking` handlers.
+   *
+   * @param url - The deeplink URL to trigger (e.g., 'myapp://open?path=/test')
+   * @returns Promise that resolves when the deeplink has been triggered
+   *
+   * @example
+   * ```js
+   * await browser.reactNative.triggerDeeplink('myapp://open?file=test.txt');
+   * ```
+   */
+  triggerDeeplink: (url: string) => Promise<void>;
+
+  /**
+   * Switch the active Appium context (e.g. `NATIVE_APP` ↔ a `WEBVIEW_*`).
+   *
+   * The converged `switchWindow` of the desktop services, reinterpreted for
+   * mobile: React Native "windows" are Appium contexts.
+   *
+   * @param context - The context name to switch to (e.g. 'NATIVE_APP', 'WEBVIEW_com.app')
+   * @returns Promise that resolves when the context switch is complete
+   *
+   * @example
+   * ```js
+   * await browser.reactNative.switchWindow('NATIVE_APP');
+   * ```
+   */
+  switchWindow: (context: string) => Promise<void>;
+
+  /**
+   * List the available Appium contexts (`NATIVE_APP` and any `WEBVIEW_*`).
+   *
+   * The converged `listWindows` of the desktop services, reinterpreted for
+   * mobile contexts.
+   *
+   * @returns Promise that resolves to an array of context names
+   *
+   * @example
+   * ```js
+   * const contexts = await browser.reactNative.listWindows();
+   * console.log(contexts); // ['NATIVE_APP', 'WEBVIEW_com.app']
+   * ```
+   */
+  listWindows: () => Promise<string[]>;
+
+  /**
+   * Emit an event to listeners registered in the app via React Native's
+   * `DeviceEventEmitter` (or `NativeEventEmitter`).
+   *
+   * @param event - Event name to emit (e.g. `'data-loaded'`)
+   * @param payload - Optional event payload (JSON-serialised across the boundary)
+   *
+   * @example
+   * ```js
+   * // App: DeviceEventEmitter.addListener('data-loaded', (e) => updateUI(e));
+   * await browser.reactNative.emitEvent('data-loaded', { rows: 3 });
+   * ```
+   */
+  emitEvent: <T = unknown>(event: string, payload?: T) => Promise<void>;
+}
+
+/**
+ * The options for the React Native Service.
+ * Extends base service options with React Native / Metro-specific configuration.
+ */
+export interface ReactNativeServiceOptions extends BaseServiceOptions {
+  /**
+   * Target mobile platform. Normally derived from the capability
+   * (`platformName`); set explicitly to override.
+   */
+  platform?: 'android' | 'ios';
+  /**
+   * Host of the Metro inspector-proxy used for the Hermes CDP attach
+   * (`execute`/`mock`).
+   * @default 'localhost'
+   */
+  metroHost?: string;
+  /**
+   * Port of the Metro inspector-proxy.
+   * @default 8081
+   */
+  metroPort?: number;
+}
+
+/**
+ * React Native service global options.
+ * Extends base global options with React Native-specific configuration.
+ */
+export interface ReactNativeServiceGlobalOptions extends BaseServiceGlobalOptions {
+  platform?: 'android' | 'ios';
+  metroHost?: string;
+  metroPort?: number;
+}
+
+/**
+ * React Native service result type.
+ * Uses the standard Result pattern: check `result.ok`, then access `result.value` or `result.error`.
+ */
+export type ReactNativeResult<T = unknown> = Result<T, string>;
+
+/**
+ * React Native capabilities for WebdriverIO configuration.
+ *
+ * A plain interface (does not extend `WebdriverIO.Capabilities`) holding the
+ * Appium capabilities a React Native session needs, plus the service options.
+ */
+export interface ReactNativeCapabilities {
+  platformName: 'Android' | 'iOS';
+  'appium:automationName'?: 'UiAutomator2' | 'XCUITest';
+  'appium:deviceName'?: string;
+  'appium:udid'?: string;
+  'appium:platformVersion'?: string;
+  /** Path to a `.apk`/`.app`/`.ipa`, mapped to `appium:app`. */
+  'appium:app'?: string;
+  /** Android: launch by package + activity instead of an app path. */
+  'appium:appPackage'?: string;
+  'appium:appActivity'?: string;
+  /** iOS: launch by bundle id instead of an app path. */
+  'appium:bundleId'?: string;
+  'wdio:reactNativeServiceOptions'?: ReactNativeServiceOptions;
+}
+
+/**
+ * React Native service capabilities (requested-capability typing).
+ */
+export interface ReactNativeServiceCapabilities {
+  platformName?: 'Android' | 'iOS';
+  'wdio:reactNativeServiceOptions'?: ReactNativeServiceOptions;
+}
+
+type ReactNativeServiceRequestedStandaloneCapabilities = Capabilities.RequestedStandaloneCapabilities &
+  ReactNativeServiceCapabilities;
+type ReactNativeServiceRequestedMultiremoteCapabilities = Capabilities.RequestedMultiremoteCapabilities &
+  ReactNativeServiceCapabilities;
+
+export type ReactNativeServiceCapabilitiesType =
+  | ReactNativeServiceRequestedStandaloneCapabilities[]
+  | ReactNativeServiceRequestedMultiremoteCapabilities
+  | ReactNativeServiceRequestedMultiremoteCapabilities[];
+
+export type WdioReactNativeConfig = Options.Testrunner & {
+  capabilities: ReactNativeServiceCapabilitiesType | ReactNativeServiceCapabilitiesType[];
+};
+
+type ReactNativeServiceCustomCapability = {
+  /**
+   * custom capabilities to configure the React Native service
+   */
+  'wdio:reactNativeServiceOptions'?: ReactNativeServiceOptions;
+};
+
+/**
+ * Browser extension for the React Native service.
+ */
+export interface ReactNativeBrowserExtension extends BrowserBase {
+  /**
+   * Access the WebdriverIO React Native Service API.
+   *
+   * - {@link ReactNativeServiceAPI.execute `browser.reactNative.execute`} - Execute code in the app's Hermes JS realm
+   * - {@link ReactNativeServiceAPI.mock `browser.reactNative.mock`} - Mock a function in the React Native JS realm
+   * - {@link ReactNativeServiceAPI.clearAllMocks `browser.reactNative.clearAllMocks`} - Clear the React Native mock functions
+   * - {@link ReactNativeServiceAPI.resetAllMocks `browser.reactNative.resetAllMocks`} - Reset the React Native mock functions
+   * - {@link ReactNativeServiceAPI.restoreAllMocks `browser.reactNative.restoreAllMocks`} - Restore the original implementations
+   * - {@link ReactNativeServiceAPI.triggerDeeplink `browser.reactNative.triggerDeeplink`} - Trigger a deeplink for testing `Linking`
+   */
+  reactNative: ReactNativeServiceAPI;
+}
+
+// Re-export the custom capability for external use
+export type { ReactNativeServiceCustomCapability };

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -48,7 +48,7 @@ export interface ReactNativeMockInstance extends Omit<Mock, MockOverride> {
   mockRestore(): Promise<ReactNativeMock>;
   mockReturnThis(): Promise<ReactNativeMock>;
   withImplementation<ReturnValue>(implFn: AbstractFn, callbackFn: () => Promise<ReturnValue>): Promise<ReturnValue>;
-  withImplementation<ReturnValue>(implFn: AbstractFn, callbackFn: () => ReturnValue): ReturnValue;
+  withImplementation<ReturnValue>(implFn: AbstractFn, callbackFn: () => ReturnValue): Promise<ReturnValue>;
   mockName(name: string): ReactNativeMock;
   getMockName(): string;
   getMockImplementation(): AbstractFn | undefined;

--- a/packages/react-native-service/README.md
+++ b/packages/react-native-service/README.md
@@ -1,0 +1,37 @@
+# @wdio/react-native-service
+
+> **Status: experimental, in development.** This package is being built up across a
+> stack of PRs. The launcher/worker service, `execute`, and `mock` are not yet wired
+> — this release contains the foundation only.
+
+WebdriverIO service for testing **React Native** mobile applications on Android and iOS.
+
+React Native is a hybrid target: native find/tap runs over the Appium W3C session
+(UiAutomator2 / XCUITest), while `execute` and `mock` run in the app's **Hermes** JS
+realm over the Chrome DevTools Protocol, attached through **Metro's inspector-proxy**.
+
+## Foundation (this release)
+
+The shared CDP transport from [`@wdio/native-cdp-bridge`](../native-cdp-bridge) is
+configured for React Native:
+
+```ts
+import { createHermesBridge } from '@wdio/react-native-service';
+
+// Defaults to Metro at localhost:8081, selects the live Hermes target, and sets
+// the Origin header Fusebox's inspector-proxy CSRF check requires.
+const bridge = createHermesBridge();
+await bridge.connect();
+const result = await bridge.send('Runtime.evaluate', {
+  expression: 'typeof HermesInternal',
+  returnByValue: true,
+});
+await bridge.close();
+```
+
+The public type surface (`browser.reactNative.*`) ships in
+[`@wdio/native-types`](../native-types).
+
+## Documentation
+
+Full setup, capabilities, and API docs land alongside the complete service.

--- a/packages/react-native-service/package.json
+++ b/packages/react-native-service/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@wdio/react-native-service",
+  "version": "1.0.0-next.0",
+  "description": "WebdriverIO service for testing React Native mobile applications",
+  "author": "WebdriverIO Community",
+  "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/react-native-service",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": [
+      {
+        "import": {
+          "types": "./dist/esm/index.d.ts",
+          "default": "./dist/esm/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/index.d.ts",
+          "default": "./dist/cjs/index.js"
+        }
+      },
+      "./dist/cjs/index.js"
+    ]
+  },
+  "files": [
+    "dist",
+    "docs",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsx ../../scripts/build-package.ts",
+    "build:watch": "tsx ../../scripts/build-package.ts --watch",
+    "clean": "shx rm -rf dist",
+    "clean:dist": "shx rm -rf dist",
+    "dev": "pnpm run build:watch",
+    "lint": "biome check --linter-enabled=true --formatter-enabled=false src/",
+    "lint:fix": "biome check --write --linter-enabled=true --formatter-enabled=false src/",
+    "test": "vitest run",
+    "test:unit": "vitest run --config vitest.config.ts",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wdio/native-cdp-bridge": "workspace:*",
+    "@wdio/native-types": "workspace:*",
+    "tslib": "^2.8.1",
+    "webdriverio": "catalog:default"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "@vitest/coverage-v8": "^4.1.7",
+    "shx": "^0.4.0",
+    "tsx": "^4.22.3",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  },
+  "peerDependencies": {
+    "webdriverio": "^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "webdriverio": {
+      "optional": false
+    }
+  },
+  "keywords": [
+    "webdriverio",
+    "wdio",
+    "wdio-service",
+    "react-native",
+    "testing",
+    "e2e",
+    "mobile",
+    "appium"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webdriverio/desktop-mobile.git",
+    "directory": "packages/react-native-service"
+  },
+  "bugs": {
+    "url": "https://github.com/webdriverio/desktop-mobile/issues"
+  }
+}

--- a/packages/react-native-service/src/constants.ts
+++ b/packages/react-native-service/src/constants.ts
@@ -1,0 +1,5 @@
+/** Default host of the Metro inspector-proxy used for the Hermes CDP attach. */
+export const DEFAULT_METRO_HOST = 'localhost';
+
+/** Default port of the Metro inspector-proxy (Metro's standard bundler port). */
+export const DEFAULT_METRO_PORT = 8081;

--- a/packages/react-native-service/src/hermesBridge.ts
+++ b/packages/react-native-service/src/hermesBridge.ts
@@ -1,0 +1,36 @@
+import { CdpBridge, type CdpBridgeOptions } from '@wdio/native-cdp-bridge';
+
+import { DEFAULT_METRO_HOST, DEFAULT_METRO_PORT } from './constants.js';
+import { selectHermesTarget } from './hermesTarget.js';
+
+/**
+ * Options for {@link createHermesBridge}. Everything {@link CdpBridgeOptions}
+ * accepts except `selectTarget`, which is fixed to the Hermes selector.
+ */
+export type HermesBridgeOptions = Omit<CdpBridgeOptions, 'selectTarget'>;
+
+/**
+ * The WebSocket `Origin` React Native's Fusebox inspector-proxy requires. Its
+ * `verifyClient` CSRF check rejects upgrades whose Origin is not the proxy's own
+ * server base URL, so this must equal `http://<host>:<port>`.
+ */
+export const metroOrigin = (host: string, port: number): string => `http://${host}:${port}`;
+
+/**
+ * Build a single-target {@link CdpBridge} for a React Native app's Hermes
+ * inspector behind Metro's inspector-proxy. Defaults the host/port to Metro's
+ * (`localhost:8081`), wires in the {@link selectHermesTarget Hermes target
+ * selector}, and sets the Fusebox-required `Origin` header (unless the caller
+ * supplied one). The bridge stays dormant until `connect()`.
+ */
+export const createHermesBridge = (options: HermesBridgeOptions = {}): CdpBridge => {
+  const host = options.host ?? DEFAULT_METRO_HOST;
+  const port = options.port ?? DEFAULT_METRO_PORT;
+  return new CdpBridge({
+    ...options,
+    host,
+    port,
+    origin: options.origin ?? metroOrigin(host, port),
+    selectTarget: selectHermesTarget,
+  });
+};

--- a/packages/react-native-service/src/hermesBridge.ts
+++ b/packages/react-native-service/src/hermesBridge.ts
@@ -12,9 +12,13 @@ export type HermesBridgeOptions = Omit<CdpBridgeOptions, 'selectTarget'>;
 /**
  * The WebSocket `Origin` React Native's Fusebox inspector-proxy requires. Its
  * `verifyClient` CSRF check rejects upgrades whose Origin is not the proxy's own
- * server base URL, so this must equal `http://<host>:<port>`.
+ * server base URL, so this must equal `http://<host>:<port>`. An IPv6 host is
+ * bracketed so its colons aren't confused with the port separator.
  */
-export const metroOrigin = (host: string, port: number): string => `http://${host}:${port}`;
+export const metroOrigin = (host: string, port: number): string => {
+  const bracketedHost = host.includes(':') ? `[${host}]` : host;
+  return `http://${bracketedHost}:${port}`;
+};
 
 /**
  * Build a single-target {@link CdpBridge} for a React Native app's Hermes

--- a/packages/react-native-service/src/hermesBridge.ts
+++ b/packages/react-native-service/src/hermesBridge.ts
@@ -16,7 +16,7 @@ export type HermesBridgeOptions = Omit<CdpBridgeOptions, 'selectTarget'>;
  * bracketed so its colons aren't confused with the port separator.
  */
 export const metroOrigin = (host: string, port: number): string => {
-  const bracketedHost = host.includes(':') ? `[${host}]` : host;
+  const bracketedHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
   return `http://${bracketedHost}:${port}`;
 };
 

--- a/packages/react-native-service/src/hermesTarget.ts
+++ b/packages/react-native-service/src/hermesTarget.ts
@@ -4,9 +4,10 @@ import type { Debugger, DebuggerList, SelectTarget } from '@wdio/native-cdp-brid
  * Title/description hint that a discovered target is the React Native / Hermes
  * page (rather than, say, a leftover devtools entry). Metro's inspector-proxy
  * labels RN targets with strings like "React Native Experimental …" / the app
- * name; the discriminator stays loose because it drifts across RN versions.
+ * name; the discriminator stays loose (but not so loose as a bare `experimental`,
+ * which could match unrelated devtools pages) because it drifts across RN versions.
  */
-const HERMES_HINT = /hermes|react native|experimental/i;
+const HERMES_HINT = /hermes|react native/i;
 
 /** A discovered target is connectable only if it exposes a debugger socket. */
 const isConnectable = (target: Debugger): boolean => Boolean(target.webSocketDebuggerUrl);

--- a/packages/react-native-service/src/hermesTarget.ts
+++ b/packages/react-native-service/src/hermesTarget.ts
@@ -1,0 +1,35 @@
+import type { Debugger, DebuggerList, SelectTarget } from '@wdio/native-cdp-bridge';
+
+/**
+ * Title/description hint that a discovered target is the React Native / Hermes
+ * page (rather than, say, a leftover devtools entry). Metro's inspector-proxy
+ * labels RN targets with strings like "React Native Experimental …" / the app
+ * name; the discriminator stays loose because it drifts across RN versions.
+ */
+const HERMES_HINT = /hermes|react native|experimental/i;
+
+/** A discovered target is connectable only if it exposes a debugger socket. */
+const isConnectable = (target: Debugger): boolean => Boolean(target.webSocketDebuggerUrl);
+
+const looksLikeHermes = (target: Debugger): boolean =>
+  HERMES_HINT.test(target.title) || HERMES_HINT.test(target.description);
+
+/**
+ * Pick the live Hermes target from Metro's inspector-proxy `/json/list`.
+ *
+ * The proxy can expose several entries and briefly retains stale ones after a
+ * reload, so we don't blindly take the first like the single-target default:
+ * prefer a connectable entry whose title/description looks like the RN/Hermes
+ * page, and within that pool take the **last** (newest registration — the live
+ * page is appended after a reload). Falls back to the last connectable entry,
+ * then `undefined` when nothing is connectable.
+ */
+export const selectHermesTarget: SelectTarget = (targets: DebuggerList): Debugger | undefined => {
+  const connectable = targets.filter(isConnectable);
+  if (connectable.length === 0) {
+    return undefined;
+  }
+  const hinted = connectable.filter(looksLikeHermes);
+  const pool = hinted.length > 0 ? hinted : connectable;
+  return pool[pool.length - 1];
+};

--- a/packages/react-native-service/src/index.ts
+++ b/packages/react-native-service/src/index.ts
@@ -1,0 +1,25 @@
+// @wdio/react-native-service — WebdriverIO service for testing React Native apps.
+//
+// PR1 (Foundation): the @wdio/native-cdp-bridge consumption layer — Hermes target
+// selection behind Metro's inspector-proxy and the Fusebox `Origin` wiring — plus
+// the public type surface re-exported from @wdio/native-types. The launcher/worker
+// service, the full Metro/Hermes attach (adb reverse + foreground guard), `execute`
+// and `mock` land in subsequent PRs.
+
+export type {
+  ReactNativeAPIs,
+  ReactNativeBrowserExtension,
+  ReactNativeCapabilities,
+  ReactNativeExecuteOptions,
+  ReactNativeMock,
+  ReactNativeMockInstance,
+  ReactNativeResult,
+  ReactNativeServiceAPI,
+  ReactNativeServiceCapabilitiesType,
+  ReactNativeServiceGlobalOptions,
+  ReactNativeServiceOptions,
+  WdioReactNativeConfig,
+} from '@wdio/native-types';
+export * from './constants.js';
+export * from './hermesBridge.js';
+export * from './hermesTarget.js';

--- a/packages/react-native-service/src/index.ts
+++ b/packages/react-native-service/src/index.ts
@@ -1,24 +1,21 @@
 // @wdio/react-native-service — WebdriverIO service for testing React Native apps.
 //
 // PR1 (Foundation): the @wdio/native-cdp-bridge consumption layer — Hermes target
-// selection behind Metro's inspector-proxy and the Fusebox `Origin` wiring — plus
-// the public type surface re-exported from @wdio/native-types. The launcher/worker
-// service, the full Metro/Hermes attach (adb reverse + foreground guard), `execute`
-// and `mock` land in subsequent PRs.
+// selection behind Metro's inspector-proxy and the Fusebox `Origin` wiring. The
+// launcher/worker service, the full Metro/Hermes attach (adb reverse + foreground
+// guard), `execute` and `mock` land in subsequent PRs.
+//
+// The bare import pulls in @wdio/native-types' ambient module augmentation so
+// `browser.reactNative.*` and `wdio:reactNativeServiceOptions` are typed for
+// consumers. Only the config-time types are re-exported (mirroring the sibling
+// services) — the API/mock types reach users through the augmentation, not a
+// direct import.
+import '@wdio/native-types';
 
 export type {
-  ReactNativeAPIs,
-  ReactNativeBrowserExtension,
   ReactNativeCapabilities,
-  ReactNativeExecuteOptions,
-  ReactNativeMock,
-  ReactNativeMockInstance,
-  ReactNativeResult,
-  ReactNativeServiceAPI,
-  ReactNativeServiceCapabilitiesType,
   ReactNativeServiceGlobalOptions,
   ReactNativeServiceOptions,
-  WdioReactNativeConfig,
 } from '@wdio/native-types';
 export * from './constants.js';
 export * from './hermesBridge.js';

--- a/packages/react-native-service/test/hermesBridge.spec.ts
+++ b/packages/react-native-service/test/hermesBridge.spec.ts
@@ -18,34 +18,34 @@ beforeEach(() => {
 });
 
 describe('metroOrigin', () => {
-  it('builds the http origin the Fusebox CSRF check requires', () => {
+  it('should build the http origin the Fusebox CSRF check requires', () => {
     expect(metroOrigin('localhost', 8081)).toBe('http://localhost:8081');
     expect(metroOrigin('10.0.2.2', 9000)).toBe('http://10.0.2.2:9000');
   });
 });
 
 describe('createHermesBridge', () => {
-  it('defaults host/port to Metro and derives the matching origin', () => {
+  it('should default host/port to Metro and derive the matching origin', () => {
     createHermesBridge();
     expect(h.opts[0]).toMatchObject({ host: 'localhost', port: 8081, origin: 'http://localhost:8081' });
   });
 
-  it('injects the Hermes target selector', () => {
+  it('should inject the Hermes target selector', () => {
     createHermesBridge();
     expect(h.opts[0].selectTarget).toBe(selectHermesTarget);
   });
 
-  it('honours a custom host/port and derives the matching origin', () => {
+  it('should honour a custom host/port and derive the matching origin', () => {
     createHermesBridge({ host: '10.0.2.2', port: 9000 });
     expect(h.opts[0]).toMatchObject({ host: '10.0.2.2', port: 9000, origin: 'http://10.0.2.2:9000' });
   });
 
-  it('does not override an explicit origin', () => {
+  it('should not override an explicit origin', () => {
     createHermesBridge({ origin: 'http://custom:1234' });
     expect(h.opts[0].origin).toBe('http://custom:1234');
   });
 
-  it('passes other CdpBridge options through', () => {
+  it('should pass other CdpBridge options through', () => {
     createHermesBridge({ connectionRetryCount: 7, waitInterval: 250 });
     expect(h.opts[0]).toMatchObject({ connectionRetryCount: 7, waitInterval: 250 });
   });

--- a/packages/react-native-service/test/hermesBridge.spec.ts
+++ b/packages/react-native-service/test/hermesBridge.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ opts: [] as Array<Record<string, unknown>> }));
+
+vi.mock('@wdio/native-cdp-bridge', () => ({
+  CdpBridge: class {
+    constructor(options: Record<string, unknown>) {
+      h.opts.push(options);
+    }
+  },
+}));
+
+import { createHermesBridge, metroOrigin } from '../src/hermesBridge.js';
+import { selectHermesTarget } from '../src/hermesTarget.js';
+
+beforeEach(() => {
+  h.opts.length = 0;
+});
+
+describe('metroOrigin', () => {
+  it('builds the http origin the Fusebox CSRF check requires', () => {
+    expect(metroOrigin('localhost', 8081)).toBe('http://localhost:8081');
+    expect(metroOrigin('10.0.2.2', 9000)).toBe('http://10.0.2.2:9000');
+  });
+});
+
+describe('createHermesBridge', () => {
+  it('defaults host/port to Metro and derives the matching origin', () => {
+    createHermesBridge();
+    expect(h.opts[0]).toMatchObject({ host: 'localhost', port: 8081, origin: 'http://localhost:8081' });
+  });
+
+  it('injects the Hermes target selector', () => {
+    createHermesBridge();
+    expect(h.opts[0].selectTarget).toBe(selectHermesTarget);
+  });
+
+  it('honours a custom host/port and derives the matching origin', () => {
+    createHermesBridge({ host: '10.0.2.2', port: 9000 });
+    expect(h.opts[0]).toMatchObject({ host: '10.0.2.2', port: 9000, origin: 'http://10.0.2.2:9000' });
+  });
+
+  it('does not override an explicit origin', () => {
+    createHermesBridge({ origin: 'http://custom:1234' });
+    expect(h.opts[0].origin).toBe('http://custom:1234');
+  });
+
+  it('passes other CdpBridge options through', () => {
+    createHermesBridge({ connectionRetryCount: 7, waitInterval: 250 });
+    expect(h.opts[0]).toMatchObject({ connectionRetryCount: 7, waitInterval: 250 });
+  });
+});

--- a/packages/react-native-service/test/hermesBridge.spec.ts
+++ b/packages/react-native-service/test/hermesBridge.spec.ts
@@ -22,6 +22,11 @@ describe('metroOrigin', () => {
     expect(metroOrigin('localhost', 8081)).toBe('http://localhost:8081');
     expect(metroOrigin('10.0.2.2', 9000)).toBe('http://10.0.2.2:9000');
   });
+
+  it('should bracket an IPv6 host so its colons are not read as the port', () => {
+    expect(metroOrigin('::1', 8081)).toBe('http://[::1]:8081');
+    expect(metroOrigin('fe80::1', 8081)).toBe('http://[fe80::1]:8081');
+  });
 });
 
 describe('createHermesBridge', () => {

--- a/packages/react-native-service/test/hermesBridge.spec.ts
+++ b/packages/react-native-service/test/hermesBridge.spec.ts
@@ -27,6 +27,10 @@ describe('metroOrigin', () => {
     expect(metroOrigin('::1', 8081)).toBe('http://[::1]:8081');
     expect(metroOrigin('fe80::1', 8081)).toBe('http://[fe80::1]:8081');
   });
+
+  it('should not double-bracket an already-bracketed IPv6 host', () => {
+    expect(metroOrigin('[::1]', 8081)).toBe('http://[::1]:8081');
+  });
 });
 
 describe('createHermesBridge', () => {

--- a/packages/react-native-service/test/hermesTarget.spec.ts
+++ b/packages/react-native-service/test/hermesTarget.spec.ts
@@ -1,0 +1,57 @@
+import type { Debugger } from '@wdio/native-cdp-bridge';
+import { describe, expect, it } from 'vitest';
+
+import { selectHermesTarget } from '../src/hermesTarget.js';
+
+const target = (over: Partial<Debugger>): Debugger => ({
+  id: 'x',
+  title: '',
+  description: '',
+  type: 'node',
+  url: '',
+  devtoolsFrontendUrl: '',
+  devtoolsFrontendUrlCompat: '',
+  faviconUrl: '',
+  webSocketDebuggerUrl: 'ws://localhost:8081/inspector/debug?page=x',
+  ...over,
+});
+
+describe('selectHermesTarget', () => {
+  it('returns undefined when the list is empty', () => {
+    expect(selectHermesTarget([])).toBeUndefined();
+  });
+
+  it('returns undefined when no target is connectable', () => {
+    expect(selectHermesTarget([target({ webSocketDebuggerUrl: '' })])).toBeUndefined();
+  });
+
+  it('skips targets without a webSocketDebuggerUrl', () => {
+    const dead = target({ id: 'dead', title: 'React Native', webSocketDebuggerUrl: '' });
+    const live = target({ id: 'live', title: 'React Native' });
+    expect(selectHermesTarget([dead, live])?.id).toBe('live');
+  });
+
+  it('prefers a Hermes/React Native-hinted target over an unrelated one', () => {
+    const other = target({ id: 'other', title: 'some page' });
+    const hermes = target({ id: 'hermes', title: 'React Native Experimental (Improved Chrome Reloads)' });
+    expect(selectHermesTarget([hermes, other])?.id).toBe('hermes');
+  });
+
+  it('matches the hint in the description too', () => {
+    const other = target({ id: 'o', title: 'page', description: '' });
+    const hermes = target({ id: 'h', title: 'page', description: 'Hermes' });
+    expect(selectHermesTarget([other, hermes])?.id).toBe('h');
+  });
+
+  it('takes the newest (last) of multiple hinted targets', () => {
+    const stale = target({ id: 'stale', title: 'React Native' });
+    const live = target({ id: 'live', title: 'React Native' });
+    expect(selectHermesTarget([stale, live])?.id).toBe('live');
+  });
+
+  it('falls back to the last connectable when nothing is hinted', () => {
+    const a = target({ id: 'a', title: 'foo' });
+    const b = target({ id: 'b', title: 'bar' });
+    expect(selectHermesTarget([a, b])?.id).toBe('b');
+  });
+});

--- a/packages/react-native-service/test/hermesTarget.spec.ts
+++ b/packages/react-native-service/test/hermesTarget.spec.ts
@@ -17,39 +17,39 @@ const target = (over: Partial<Debugger>): Debugger => ({
 });
 
 describe('selectHermesTarget', () => {
-  it('returns undefined when the list is empty', () => {
+  it('should return undefined when the list is empty', () => {
     expect(selectHermesTarget([])).toBeUndefined();
   });
 
-  it('returns undefined when no target is connectable', () => {
+  it('should return undefined when no target is connectable', () => {
     expect(selectHermesTarget([target({ webSocketDebuggerUrl: '' })])).toBeUndefined();
   });
 
-  it('skips targets without a webSocketDebuggerUrl', () => {
+  it('should skip targets without a webSocketDebuggerUrl', () => {
     const dead = target({ id: 'dead', title: 'React Native', webSocketDebuggerUrl: '' });
     const live = target({ id: 'live', title: 'React Native' });
     expect(selectHermesTarget([dead, live])?.id).toBe('live');
   });
 
-  it('prefers a Hermes/React Native-hinted target over an unrelated one', () => {
+  it('should prefer a Hermes/React Native-hinted target over an unrelated one', () => {
     const other = target({ id: 'other', title: 'some page' });
     const hermes = target({ id: 'hermes', title: 'React Native Experimental (Improved Chrome Reloads)' });
     expect(selectHermesTarget([hermes, other])?.id).toBe('hermes');
   });
 
-  it('matches the hint in the description too', () => {
+  it('should match the hint in the description too', () => {
     const other = target({ id: 'o', title: 'page', description: '' });
     const hermes = target({ id: 'h', title: 'page', description: 'Hermes' });
     expect(selectHermesTarget([other, hermes])?.id).toBe('h');
   });
 
-  it('takes the newest (last) of multiple hinted targets', () => {
+  it('should take the newest (last) of multiple hinted targets', () => {
     const stale = target({ id: 'stale', title: 'React Native' });
     const live = target({ id: 'live', title: 'React Native' });
     expect(selectHermesTarget([stale, live])?.id).toBe('live');
   });
 
-  it('falls back to the last connectable when nothing is hinted', () => {
+  it('should fall back to the last connectable when nothing is hinted', () => {
     const a = target({ id: 'a', title: 'foo' });
     const b = target({ id: 'b', title: 'bar' });
     expect(selectHermesTarget([a, b])?.id).toBe('b');

--- a/packages/react-native-service/test/index.spec.ts
+++ b/packages/react-native-service/test/index.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import * as rn from '../src/index.js';
+
+describe('@wdio/react-native-service exports', () => {
+  it('exposes the Metro constants', () => {
+    expect(rn.DEFAULT_METRO_HOST).toBe('localhost');
+    expect(rn.DEFAULT_METRO_PORT).toBe(8081);
+  });
+
+  it('exposes the Hermes bridge foundation', () => {
+    expect(typeof rn.createHermesBridge).toBe('function');
+    expect(typeof rn.selectHermesTarget).toBe('function');
+    expect(typeof rn.metroOrigin).toBe('function');
+  });
+});

--- a/packages/react-native-service/test/index.spec.ts
+++ b/packages/react-native-service/test/index.spec.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest';
 import * as rn from '../src/index.js';
 
 describe('@wdio/react-native-service exports', () => {
-  it('exposes the Metro constants', () => {
+  it('should expose the Metro constants', () => {
     expect(rn.DEFAULT_METRO_HOST).toBe('localhost');
     expect(rn.DEFAULT_METRO_PORT).toBe(8081);
   });
 
-  it('exposes the Hermes bridge foundation', () => {
+  it('should expose the Hermes bridge foundation', () => {
     expect(typeof rn.createHermesBridge).toBe('function');
     expect(typeof rn.selectHermesTarget).toBe('function');
     expect(typeof rn.metroOrigin).toBe('function');

--- a/packages/react-native-service/tsconfig.json
+++ b/packages/react-native-service/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/react-native-service/vitest.config.ts
+++ b/packages/react-native-service/vitest.config.ts
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.spec.ts'],
+    exclude: [...configDefaults.exclude, 'test/integration/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.d.ts', '**/types.ts', 'src/index.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1272,6 +1272,40 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/react-native-service:
+    dependencies:
+      '@wdio/native-cdp-bridge':
+        specifier: workspace:*
+        version: link:../native-cdp-bridge
+      '@wdio/native-types':
+        specifier: workspace:*
+        version: link:../native-types
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      webdriverio:
+        specifier: catalog:default
+        version: 9.27.1(puppeteer-core@25.0.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
+      shx:
+        specifier: ^0.4.0
+        version: 0.4.0
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/tauri-plugin:
     dependencies:
       '@tauri-apps/api':

--- a/test/scripts/detect-changes.spec.ts
+++ b/test/scripts/detect-changes.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { classifyChanges, classifyFile, discoverServices } from '../../scripts/detect-changes.mjs';
 
-const SERVICES = ['dioxus', 'electrobun', 'electron', 'tauri'];
+const SERVICES = ['dioxus', 'electrobun', 'electron', 'react-native', 'tauri'];
 
 function decide(files: string[], forceAll = false) {
   return classifyChanges(files, SERVICES, { forceAll });
@@ -88,13 +88,13 @@ describe('classifyChanges decisions', () => {
 
   it('should run only electron for an electron src change', () => {
     const d = decide(['packages/electron-service/src/session.ts']);
-    expect(d.runs).toEqual({ dioxus: false, electrobun: false, electron: true, tauri: false });
+    expect(d.runs).toEqual({ dioxus: false, electrobun: false, electron: true, 'react-native': false, tauri: false });
     expect(d.lintOnly).toBe(false);
   });
 
   it('should run only tauri for the tauri-only script', () => {
     const d = decide(['scripts/update-tauri-version.ts']);
-    expect(d.runs).toEqual({ dioxus: false, electrobun: false, electron: false, tauri: true });
+    expect(d.runs).toEqual({ dioxus: false, electrobun: false, electron: false, 'react-native': false, tauri: true });
   });
 
   it('should run everything for a cross-service script', () => {


### PR DESCRIPTION
## React Native service — PR1 (Foundation)

First PR of the React Native service stack. Establishes the package and the `@wdio/native-cdp-bridge` consumption layer; the launcher/worker service, full Metro/Hermes attach, `execute` and `mock` land in later PRs. Targets the `feat/react-native` integration branch.

### What's here
- **`@wdio/native-types` — `react-native.ts`**: the public type surface (`ReactNativeServiceAPI`, `ReactNativeMock`/`…MockInstance`, `ReactNativeExecuteOptions`, `ReactNativeServiceOptions`/`…GlobalOptions`, `ReactNativeCapabilities`, `ReactNativeBrowserExtension`), wired into the global `WebdriverIO` augmentation (`Browser`/`MultiRemoteBrowser`/`Capabilities`/`ServiceOption`). Convergent `browser.reactNative.*` surface; `switchWindow`/`listWindows` reinterpreted as Appium contexts.
- **`@wdio/react-native-service` (`1.0.0-next.0`)**: package scaffold + the single-target `CdpBridge` consumption:
  - `selectHermesTarget` — picks the live Hermes target from Metro's `/json/list` (prefers RN/Hermes-hinted, newest-registration, skips stale/unconnectable).
  - `createHermesBridge` — Metro `localhost:8081` defaults + the Fusebox `Origin` header its inspector-proxy CSRF check (`verifyClient`) requires.

### Verification
- 15 unit tests (selector heuristics + bridge-factory option wiring)
- typecheck, dual ESM/CJS build, and lint green
- full-repo typecheck unaffected by the global augmentation (26/26)

Grounded in the mobile spike (`probes/rn-cdp-bridge-reuse.mjs`, `rn-cdp-raw.mjs`): RN's Hermes inspector is drivable by the shared CDP machinery once the `Origin` header is supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)