### PR TITLE
ci(release): individual release scope for native-cdp-bridge; close the scope:core label gap

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       scope:
-        description: 'Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, shared) — controls build and toolchain steps'
+        description: 'Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, cdp-bridge, shared) — controls build and toolchain steps'
         required: true
         type: string
     secrets:
@@ -126,6 +126,9 @@ jobs:
             core)
               echo "packages=@wdio/native-core" >> "$GITHUB_OUTPUT"
               ;;
+            cdp-bridge)
+              echo "packages=@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
+              ;;
             shared)
               echo "packages=@wdio/native-utils,@wdio/native-types,@wdio/native-spy,@wdio/native-core,@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
               ;;
@@ -209,6 +212,9 @@ jobs:
               ;;
             core)
               pnpm turbo run build --filter='@wdio/native-core...'
+              ;;
+            cdp-bridge)
+              pnpm turbo run build --filter='@wdio/native-cdp-bridge...'
               ;;
             shared)
               pnpm turbo run build \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: "Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, shared)"
+        description: "Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, cdp-bridge, shared)"
         required: true
         type: choice
         options:
@@ -17,6 +17,7 @@ on:
           - types
           - spy
           - core
+          - cdp-bridge
           - electron
           - tauri
           - dioxus

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -43,6 +43,8 @@
       "scope:utils": "@wdio/native-utils",
       "scope:types": "@wdio/native-types",
       "scope:spy": "@wdio/native-spy",
+      "scope:core": "@wdio/native-core",
+      "scope:cdp-bridge": "@wdio/native-cdp-bridge",
       "scope:tauri": "@wdio/tauri-*",
       "scope:dioxus": "@wdio/dioxus-*",
       "scope:electron": "@wdio/electron-*",


### PR DESCRIPTION
## Summary

Follow-up to #335, which extracted `@wdio/native-cdp-bridge` and wired it into the **shared** scope (package list, build filter, `skipPackages`, CONTRIBUTING) — but left two release-path gaps:

1. **No standalone release path for `native-cdp-bridge`.** Its first publish must land before electrobun's release (electrobun-service pins it at publish), and releasing it shouldn't require dragging the whole shared family through a release run. Adds the `cdp-bridge` scope: dispatch option, package mapping, build case, and `scope:cdp-bridge` scopeLabel.
2. **`scope:core` label-path hole.** The workflow dispatch has accepted `core` since the scope existed, but `ci.scopeLabels` never got the mapping — a PR labelled `scope:core` breaks at the gate (no pattern to resolve a target from). Adds the mapping.

Both repo labels (`scope:core`, `scope:cdp-bridge`) created to match.

## Verification

- Both workflows parse clean; config validated through releasekit's own zod loader (both new scopeLabels resolve)
- No changes to existing scope behavior — purely additive cases

## Release-ops context

`@wdio/native-cdp-bridge` also still needs its npm package created + trusted publisher configured (tracked in #328 — superseding the now-defunct `@wdio/electrobun-cdp-bridge` entry there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)