### PR TITLE
fix(native-types): mock-instance type bugs in service modules

### DIFF
--- a/packages/electron-service/src/mock.ts
+++ b/packages/electron-service/src/mock.ts
@@ -343,7 +343,9 @@ export async function createElectronBrowserModeMock(
       throw new Error((result as { __wdioAsyncErr__: string }).__wdioAsyncErr__);
     }
     await mock.update();
-    return result;
+    // The wire result is the callback's (serialized) return value; TS can't connect an
+    // assigned arrow's body to the contextual generic, so assert it back.
+    return result as ReturnType<typeof callbackFn>;
   };
 
   // Used by the re-registration path in service.ts to replay persistent implementation

--- a/packages/electron-service/src/mockFactory.ts
+++ b/packages/electron-service/src/mockFactory.ts
@@ -422,7 +422,9 @@ export async function buildMockMethods(mock: ElectronFunctionMock, opts: BuildMo
   };
 
   mock.withImplementation = async (implFn, callbackFn) => {
-    return await browserToUse.electron.execute<unknown, [MockAccessor, string, string, ExecuteOpts]>(
+    // The wire result is the callback's (serialized) return value; TS can't connect an
+    // assigned arrow's body to the contextual generic, so assert it back.
+    return (await browserToUse.electron.execute<unknown, [MockAccessor, string, string, ExecuteOpts]>(
       async (electron, accessor, implFnStr, callbackFnStr) => {
         let innerMock: { withImplementation?: (impl: unknown, cb: () => unknown) => unknown } | undefined;
         if (accessor.kind === 'api') {
@@ -451,6 +453,6 @@ export async function buildMockMethods(mock: ElectronFunctionMock, opts: BuildMo
       implFn.toString(),
       callbackFn.toString(),
       { internal: true },
-    );
+    )) as ReturnType<typeof callbackFn>;
   };
 }

--- a/packages/native-types/src/dioxus.ts
+++ b/packages/native-types/src/dioxus.ts
@@ -66,7 +66,7 @@ export interface DioxusMockInstance extends Omit<Mock, MockOverride> {
   mockReturnThis(): Promise<DioxusMock>;
   mockName(name: string): DioxusMock;
   getMockName(): string;
-  getMockImplementation(): AbstractFn;
+  getMockImplementation(): AbstractFn | undefined;
   update(): Promise<DioxusMock>;
   __isDioxusMock: boolean;
   mock: DioxusMockContext;

--- a/packages/native-types/src/electrobun.ts
+++ b/packages/native-types/src/electrobun.ts
@@ -55,7 +55,7 @@ export interface ElectrobunMockInstance extends Omit<Mock, MockOverride> {
   mockReturnThis(): Promise<ElectrobunMock>;
   mockName(name: string): ElectrobunMock;
   getMockName(): string;
-  getMockImplementation(): AbstractFn;
+  getMockImplementation(): AbstractFn | undefined;
   update(): Promise<ElectrobunMock>;
   __isElectrobunMock: boolean;
   mock: ElectrobunMockContext;

--- a/packages/native-types/src/electron.ts
+++ b/packages/native-types/src/electron.ts
@@ -427,14 +427,14 @@ export interface ElectronMockInstance extends Omit<Mock, MockOverride> {
   mockClear(): Promise<ElectronFunctionMock>;
   mockReset(): Promise<ElectronFunctionMock>;
   mockRestore(): Promise<ElectronFunctionMock>;
-  mockReturnThis(): Promise<unknown>;
+  mockReturnThis(): Promise<ElectronFunctionMock>;
   withImplementation<ReturnValue, InnerArguments extends unknown[]>(
     implFn: AbstractFn,
     callbackFn: (electron: typeof Electron, ...innerArgs: InnerArguments) => ReturnValue,
-  ): Promise<unknown>;
+  ): Promise<ReturnValue>;
   mockName(name: string): ElectronFunctionMock;
   getMockName(): string;
-  getMockImplementation(): AbstractFn;
+  getMockImplementation(): AbstractFn | undefined;
   update(): Promise<ElectronFunctionMock>;
   mock: ElectronMockContext;
   __isElectronMock: boolean;

--- a/packages/native-types/src/tauri.ts
+++ b/packages/native-types/src/tauri.ts
@@ -59,10 +59,10 @@ export interface TauriMockInstance extends Omit<Mock, MockOverride> {
   withImplementation<ReturnValue, InnerArguments extends unknown[]>(
     implFn: AbstractFn,
     callbackFn: (tauri: TauriAPIs, ...innerArgs: InnerArguments) => ReturnValue,
-  ): Promise<unknown>;
+  ): Promise<ReturnValue>;
   mockName(name: string): TauriMock;
   getMockName(): string;
-  getMockImplementation(): AbstractFn;
+  getMockImplementation(): AbstractFn | undefined;
   update(): Promise<TauriMock>;
   __isTauriMock: boolean;
   mock: TauriMockContext;
@@ -125,22 +125,6 @@ export interface TauriServiceAPI {
     script: string | ((tauri: TauriAPIs, ...innerArgs: InnerArguments) => ReturnValue),
     options: TauriExecuteOptions,
     ...args: InnerArguments
-  ): Promise<ReturnValue>;
-
-  /**
-   * Execute JavaScript code with per-call options.
-   *
-   * @example
-   * ```js
-   * const result = await browser.tauri.execute(
-   *   ({ core }) => core.invoke('get_data'),
-   *   { windowLabel: 'settings' }
-   * );
-   * ```
-   */
-  execute<ReturnValue>(
-    script: string | ((tauri: TauriAPIs) => ReturnValue),
-    options: TauriExecuteOptions,
   ): Promise<ReturnValue>;
 
   /**

--- a/packages/tauri-service/src/mock.ts
+++ b/packages/tauri-service/src/mock.ts
@@ -186,7 +186,7 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
   };
 
   mock.withImplementation = async (implFn, callbackFn) => {
-    return await tauriExecute<unknown>(
+    const result = await tauriExecute<unknown>(
       browserToUse,
       interceptor.buildWithImplementationScript(
         command,
@@ -194,6 +194,9 @@ export async function createMock(command: string, browserContext?: WebdriverIO.B
         callbackFn as (...a: unknown[]) => unknown,
       ),
     );
+    // The wire result is the callback's (serialized) return value; TS can't connect an
+    // assigned arrow's body to the contextual generic, so assert it back.
+    return result as ReturnType<typeof callbackFn>;
   };
 
   wrapperMock.mockImplementation = mock.mockImplementation.bind(mock);
@@ -369,7 +372,8 @@ async function createBrowserModeMock(command: string, browser: WebdriverIO.Brows
     if (result && typeof result === 'object' && '__wdioAsyncErr__' in result) {
       throw new Error((result as { __wdioAsyncErr__: string }).__wdioAsyncErr__);
     }
-    return result;
+    // See the withImplementation note above — the wire result is the callback's return.
+    return result as ReturnType<typeof callbackFn>;
   };
 
   return mock;


### PR DESCRIPTION
## Summary

Fixes #339 — applies the three corrections (already made for RN in #337 / `304e7bab`) to the source service type modules, plus one more instance of the same family found in the sweep.

| Defect | Where | Fix |
|---|---|---|
| `withImplementation` discards its inferred generic (`Promise<unknown>`) | tauri, electron | `Promise<ReturnValue>` |
| `getMockImplementation(): AbstractFn` non-nullable — vitest returns `undefined` when no impl is set (runtime `TypeError` TS never flagged) | tauri, electron, dioxus, electrobun | `AbstractFn \| undefined` |
| Dead `execute(script, options)` overload — subsumed by the rest-args overload with `InnerArguments = []` | tauri only | removed |
| `mockReturnThis(): Promise<unknown>` where every sibling returns its mock type | electron (sweep finding) | `Promise<ElectronFunctionMock>` |

dioxus/electrobun have no `withImplementation` and single `execute` signatures — only the nullability fix applies there. `native-spy` already modelled `getMockImplementation` correctly (`T | undefined`); this aligns `native-types` with that reality.

## Service fallout (part of the fix)

Tightening `withImplementation` exposed four implementation sites returning the wire result as `unknown` (tauri `mock.ts` ×2, electron `mock.ts` + `mockFactory.ts`). The wire result **is** the callback's serialized return value — TS just can't connect an assigned arrow's body to the contextual generic — so each site asserts back via `ReturnType<typeof callbackFn>`. (Electron's sites initially appeared green due to a stale turbo-cached `native-types` build.)

## Verification

- Full-repo `pnpm typecheck` clean (25 tasks)
- Tests green across native-types + all four services (15 tasks)
- Types-only at the package boundary — no runtime behavior change

Release note: intended for the upcoming `@wdio/native-types` patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)