### PR TITLE
ci: convert detect-changes classifier to TypeScript

### DIFF
--- a/.claude/skills/add-native-service/ci-and-release.md
+++ b/.claude/skills/add-native-service/ci-and-release.md
@@ -6,7 +6,7 @@ Concrete wiring for getting a new service gated in CI and published. Grounded in
 
 ### Change detection — convention-driven, no per-framework edits
 
-`_ci-detect-changes.reusable.yml` delegates classification to `scripts/detect-changes.mjs`,
+`_ci-detect-changes.reusable.yml` delegates classification to `scripts/detect-changes.ts`,
 which **discovers services from `packages/*-service` and classifies changed files by naming
 convention**. A new framework is detected automatically — there is nothing to add to the
 detect workflow — PROVIDED the framework follows the conventions:

--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -3,12 +3,13 @@ name: Detect Affected Services (Reusable)
 # Convention-driven change detection (issue #331): dorny/paths-filter is used ONLY
 # to resolve the changed-file list (its base-ref handling across pull_request and
 # push events is battle-tested); all classification lives in
-# scripts/detect-changes.mjs, which derives the service list from packages/*-service
+# scripts/detect-changes.ts, which derives the service list from packages/*-service
 # and classifies by the repo's naming conventions. Adding a service needs NO edits
 # here — only ci.yml jobs and the per-service reusable workflows.
 #
-# The classifier is plain node (no install step) and unit-tested via
-# `pnpm test:scripts` (wired into the unconditional lint job).
+# The classifier runs on bare node (no install step) — Node 24 strips its type
+# syntax natively — and is unit-tested via `pnpm test:scripts` plus typechecked via
+# `pnpm typecheck:scripts` (both wired into the unconditional lint job).
 
 permissions:
   contents: read
@@ -63,6 +64,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pin the node version: native type stripping for the classifier needs >= 23.6;
+      # the runner image carries 24, so this is a PATH switch, not a download.
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: List Changed Files
         id: changes
         uses: dorny/paths-filter@v4
@@ -77,4 +85,4 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changes.outputs.any_files }}
           FORCE_ALL: ${{ inputs.force_all }}
-        run: node scripts/detect-changes.mjs
+        run: node scripts/detect-changes.ts

--- a/.github/workflows/_ci-lint.reusable.yml
+++ b/.github/workflows/_ci-lint.reusable.yml
@@ -56,11 +56,15 @@ jobs:
         run: pnpm run format:check
         shell: bash
 
-      # Unit tests for repo tooling (scripts/), notably the CI change classifier
-      # that gates every other job — run here because lint is the one job with
-      # no `if:` gate.
+      # Unit tests + typecheck for repo tooling (scripts/), notably the CI change
+      # classifier that gates every other job — run here because lint is the one
+      # job with no `if:` gate.
       - name: 🔍 Run Scripts Tests
         run: pnpm run test:scripts
+        shell: bash
+
+      - name: 🔍 Typecheck Scripts
+        run: pnpm run typecheck:scripts
         shell: bash
 
       # Static analysis of GitHub Actions workflows. Catches schema errors,

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "update:dependencies": "pnpm catalog:update --default && pnpm catalog:update --next && pnpm up -iLr",
     "update:releasekit": "tsx ./scripts/update-releasekit.ts",
     "update:tauri": "tsx ./scripts/update-tauri-version.ts",
-    "test:scripts": "vitest run --config vitest.scripts.config.ts"
+    "test:scripts": "vitest run --config vitest.scripts.config.ts",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",

--- a/scripts/detect-changes.ts
+++ b/scripts/detect-changes.ts
@@ -8,8 +8,9 @@
  * ci.yml jobs and per-service reusable workflows (which are inherently
  * per-service).
  *
- * Plain .mjs rather than .ts: the detect job runs this before any pnpm install,
- * so it must execute on bare node.
+ * Runs on bare node (no pnpm install) in the detect job — Node 24 strips the
+ * erasable type syntax natively, so keep this file free of enums, namespaces,
+ * and parameter properties.
  *
  * Classification (first matching rule wins):
  *   - *.md anywhere            → docs (never triggers pipelines; lint runs unconditionally)
@@ -33,6 +34,18 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+
+/** 'none' | 'shared' | 'all' | 'unknown' | a service name discovered from packages/. */
+type Verdict = string;
+
+interface Classification {
+  runs: Record<string, boolean>;
+  sharedChanges: boolean;
+  lintOnly: boolean;
+  triggersAll: string[];
+  unknownFiles: string[];
+  perFile: Array<{ file: string; verdict: Verdict }>;
+}
 
 // Core CI orchestration + release workflows: changes affect every service pipeline.
 const CORE_INFRA_WORKFLOWS = new Set([
@@ -73,7 +86,7 @@ const LINT_ONLY_FILES = new Set(['biome.jsonc', 'eslint.config.js']);
 const SHARED_PACKAGE_PREFIXES = ['native-'];
 const SHARED_PACKAGES = new Set(['bundler']);
 
-export function discoverServices(repoRoot) {
+export function discoverServices(repoRoot: string): string[] {
   const packagesDir = path.join(repoRoot, 'packages');
   return fs
     .readdirSync(packagesDir)
@@ -82,11 +95,11 @@ export function discoverServices(repoRoot) {
     .sort();
 }
 
-function serviceForDir(dir, services) {
+function serviceForDir(dir: string, services: string[]): string | undefined {
   return services.find((svc) => dir === svc || dir.startsWith(`${svc}-`));
 }
 
-function serviceForToken(filename, services) {
+function serviceForToken(filename: string, services: string[]): string | undefined {
   const tokens = filename.toLowerCase().split(/[^a-z0-9]+/);
   return services.find((svc) => tokens.includes(svc));
 }
@@ -95,7 +108,7 @@ function serviceForToken(filename, services) {
  * Classify one changed file.
  * Returns: 'none' | 'shared' | 'all' | a service name.
  */
-export function classifyFile(file, services) {
+export function classifyFile(file: string, services: string[]): Verdict {
   if (file.endsWith('.md')) return 'none';
 
   const pkg = file.match(/^packages\/([^/]+)\//);
@@ -139,21 +152,21 @@ export function classifyFile(file, services) {
   return 'none';
 }
 
-export function classifyChanges(files, services, { forceAll = false } = {}) {
-  const runs = Object.fromEntries(services.map((svc) => [svc, false]));
+export function classifyChanges(files: string[], services: string[], { forceAll = false } = {}): Classification {
+  const runs: Record<string, boolean> = Object.fromEntries(services.map((svc) => [svc, false]));
   let sharedChanges = false;
   // Deliberate run-everything verdicts (core infra, cross-service scripts, shared e2e)
   // vs files no convention rule could place — both run all pipelines, but only the
   // latter signal naming-convention drift.
-  const triggersAll = [];
-  const unknownFiles = [];
+  const triggersAll: string[] = [];
+  const unknownFiles: string[] = [];
 
   if (forceAll) {
     for (const svc of services) runs[svc] = true;
     return { runs, sharedChanges: true, lintOnly: false, triggersAll, unknownFiles, perFile: [] };
   }
 
-  const perFile = [];
+  const perFile: Array<{ file: string; verdict: Verdict }> = [];
   for (const file of files) {
     const verdict = classifyFile(file, services);
     perFile.push({ file, verdict });
@@ -172,13 +185,13 @@ export function classifyChanges(files, services, { forceAll = false } = {}) {
   return { runs, sharedChanges, lintOnly, triggersAll, unknownFiles, perFile };
 }
 
-function appendFile(envVar, content) {
+function appendFile(envVar: string, content: string): void {
   const target = process.env[envVar];
   if (target) fs.appendFileSync(target, content);
 }
 
-function main() {
-  const files = JSON.parse(process.env.CHANGED_FILES || '[]');
+function main(): void {
+  const files: string[] = JSON.parse(process.env.CHANGED_FILES || '[]');
   const forceAll = process.env.FORCE_ALL === 'true';
   const services = discoverServices(process.cwd());
 

--- a/scripts/detect-changes.ts
+++ b/scripts/detect-changes.ts
@@ -218,7 +218,7 @@ function main(): void {
   if (unknownFiles.length > 0) {
     summary += '\n### ⚠️ Unclassified files (running all pipelines defensively)\n\n';
     summary += 'No naming-convention rule places these — possible convention drift. ';
-    summary += 'Either rename to match the conventions or teach `scripts/detect-changes.mjs` about them:\n\n';
+    summary += 'Either rename to match the conventions or teach `scripts/detect-changes.ts` about them:\n\n';
     for (const file of unknownFiles) summary += `- \`${file}\`\n`;
   }
   appendFile('GITHUB_STEP_SUMMARY', summary);

--- a/test/scripts/detect-changes.spec.ts
+++ b/test/scripts/detect-changes.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classifyChanges, classifyFile, discoverServices } from '../../scripts/detect-changes.mjs';
+import { classifyChanges, classifyFile, discoverServices } from '../../scripts/detect-changes.ts';
 
 const SERVICES = ['dioxus', 'electrobun', 'electron', 'tauri'];
 
@@ -62,7 +62,7 @@ describe('classifyFile', () => {
     // scripts
     ['scripts/update-tauri-version.ts', 'tauri'],
     ['scripts/test-package.ts', 'all'],
-    ['scripts/detect-changes.mjs', 'all'],
+    ['scripts/detect-changes.ts', 'all'],
     // root config
     ['package.json', 'all'],
     ['pnpm-lock.yaml', 'all'],

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "scripts/detect-changes.ts",
+    "test/scripts/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

`scripts/detect-changes.mjs` → `scripts/detect-changes.ts`, aligning the one outlier with the other 12 scripts. The `.mjs` choice existed solely for the detect job's zero-install constraint — and Node 24's native type stripping dissolves that tradeoff: the classifier stays on **bare node** (no pnpm install on the critical path of every CI run) while gaining real types.

- **Erasable-syntax-only TS** (annotations, type aliases, interfaces — no enums/namespaces/parameter properties), enforced by the `erasableSyntaxOnly` compiler flag so a future edit can't silently break native stripping
- **Detect job pins node 24** via `actions/setup-node` (PATH switch on the runner image) — deterministic stripping support instead of relying on the runner default
- **Now actually typechecked** — which none of the scripts were: new `tsconfig.scripts.json` scoped to the classifier + its tests, run as `typecheck:scripts` in the unconditional lint job next to `test:scripts`. Scoped narrowly on purpose; extending coverage to the other scripts can follow incrementally
- References updated (workflow comments, skill, the classifier's own self-classification test case)

## Verification

- `node scripts/detect-changes.ts` on bare node 24: classification output identical (docs-only → lint-only, tauri file → tauri only)
- `pnpm test:scripts`: 62 passing; `pnpm typecheck:scripts`: clean; workflows parse clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)