### PR TITLE
docs(native-types): complete BrowserExtension JSDoc API lists

### DIFF
--- a/packages/native-types/src/dioxus.ts
+++ b/packages/native-types/src/dioxus.ts
@@ -176,7 +176,23 @@ export interface DioxusCapabilities {
   'wdio:dioxusServiceOptions'?: DioxusServiceOptions;
 }
 
+/**
+ * Browser extension for Dioxus service
+ */
 export interface DioxusBrowserExtension extends BrowserBase {
+  /**
+   * Access the WebdriverIO Dioxus Service API.
+   *
+   * - {@link DioxusServiceAPI.clearAllMocks `browser.dioxus.clearAllMocks`} - Clear the Dioxus API mock functions
+   * - {@link DioxusServiceAPI.execute `browser.dioxus.execute`} - Execute code in the Dioxus frontend context
+   * - {@link DioxusServiceAPI.isMockFunction `browser.dioxus.isMockFunction`} - Check if a value is a Dioxus mock or a command is mocked
+   * - {@link DioxusServiceAPI.listWindows `browser.dioxus.listWindows`} - List the labels of all open windows
+   * - {@link DioxusServiceAPI.mock `browser.dioxus.mock`} - Mock a function from the Dioxus API
+   * - {@link DioxusServiceAPI.resetAllMocks `browser.dioxus.resetAllMocks`} - Reset the Dioxus API mock functions
+   * - {@link DioxusServiceAPI.restoreAllMocks `browser.dioxus.restoreAllMocks`} - Restore the original Dioxus API functionality
+   * - {@link DioxusServiceAPI.switchWindow `browser.dioxus.switchWindow`} - Switch WebDriver focus to another window
+   * - {@link DioxusServiceAPI.triggerDeeplink `browser.dioxus.triggerDeeplink`} - Trigger a deeplink for testing protocol handlers
+   */
   dioxus: DioxusServiceAPI;
 }
 

--- a/packages/native-types/src/electrobun.ts
+++ b/packages/native-types/src/electrobun.ts
@@ -161,7 +161,23 @@ export interface ElectrobunCapabilities {
   'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions;
 }
 
+/**
+ * Browser extension for Electrobun service
+ */
 export interface ElectrobunBrowserExtension extends BrowserBase {
+  /**
+   * Access the WebdriverIO Electrobun Service API.
+   *
+   * - {@link ElectrobunServiceAPI.clearAllMocks `browser.electrobun.clearAllMocks`} - Clear the Electrobun API mock functions
+   * - {@link ElectrobunServiceAPI.execute `browser.electrobun.execute`} - Execute code in the Electrobun webview context
+   * - {@link ElectrobunServiceAPI.isMockFunction `browser.electrobun.isMockFunction`} - Check if a value is a Electrobun mock or a command is mocked
+   * - {@link ElectrobunServiceAPI.listWindows `browser.electrobun.listWindows`} - List the labels of all open windows
+   * - {@link ElectrobunServiceAPI.mock `browser.electrobun.mock`} - Mock a function from the Electrobun API
+   * - {@link ElectrobunServiceAPI.resetAllMocks `browser.electrobun.resetAllMocks`} - Reset the Electrobun API mock functions
+   * - {@link ElectrobunServiceAPI.restoreAllMocks `browser.electrobun.restoreAllMocks`} - Restore the original Electrobun API functionality
+   * - {@link ElectrobunServiceAPI.switchWindow `browser.electrobun.switchWindow`} - Switch WebDriver focus to another window
+   * - {@link ElectrobunServiceAPI.triggerDeeplink `browser.electrobun.triggerDeeplink`} - Trigger a deeplink for testing protocol handlers
+   */
   electrobun: ElectrobunServiceAPI;
 }
 

--- a/packages/native-types/src/electrobun.ts
+++ b/packages/native-types/src/electrobun.ts
@@ -170,7 +170,7 @@ export interface ElectrobunBrowserExtension extends BrowserBase {
    *
    * - {@link ElectrobunServiceAPI.clearAllMocks `browser.electrobun.clearAllMocks`} - Clear the Electrobun API mock functions
    * - {@link ElectrobunServiceAPI.execute `browser.electrobun.execute`} - Execute code in the Electrobun webview context
-   * - {@link ElectrobunServiceAPI.isMockFunction `browser.electrobun.isMockFunction`} - Check if a value is a Electrobun mock or a command is mocked
+   * - {@link ElectrobunServiceAPI.isMockFunction `browser.electrobun.isMockFunction`} - Check if a value is an Electrobun mock or a command is mocked
    * - {@link ElectrobunServiceAPI.listWindows `browser.electrobun.listWindows`} - List the labels of all open windows
    * - {@link ElectrobunServiceAPI.mock `browser.electrobun.mock`} - Mock a function from the Electrobun API
    * - {@link ElectrobunServiceAPI.resetAllMocks `browser.electrobun.resetAllMocks`} - Reset the Electrobun API mock functions

--- a/packages/native-types/src/tauri.ts
+++ b/packages/native-types/src/tauri.ts
@@ -422,10 +422,14 @@ export interface TauriBrowserExtension extends BrowserBase {
    * Access the WebdriverIO Tauri Service API.
    *
    * - {@link TauriServiceAPI.clearAllMocks `browser.tauri.clearAllMocks`} - Clear the Tauri API mock functions
+   * - {@link TauriServiceAPI.emitEvent `browser.tauri.emitEvent`} - Emit a Tauri event to frontend listeners
    * - {@link TauriServiceAPI.execute `browser.tauri.execute`} - Execute code in the Tauri frontend context
+   * - {@link TauriServiceAPI.isMockFunction `browser.tauri.isMockFunction`} - Check if a value is a Tauri mock or a command is mocked
+   * - {@link TauriServiceAPI.listWindows `browser.tauri.listWindows`} - List the labels of all open windows
    * - {@link TauriServiceAPI.mock `browser.tauri.mock`} - Mock a function from the Tauri API
    * - {@link TauriServiceAPI.resetAllMocks `browser.tauri.resetAllMocks`} - Reset the Tauri API mock functions
    * - {@link TauriServiceAPI.restoreAllMocks `browser.tauri.restoreAllMocks`} - Restore the original Tauri API functionality
+   * - {@link TauriServiceAPI.switchWindow `browser.tauri.switchWindow`} - Switch WebDriver focus to another window
    * - {@link TauriServiceAPI.triggerDeeplink `browser.tauri.triggerDeeplink`} - Trigger a deeplink for testing protocol handlers
    */
   tauri: TauriServiceAPI;


### PR DESCRIPTION
## Summary

Fixes #342 — completes the `*BrowserExtension` JSDoc `@link` lists so IDE hover docs cover the full `browser.<service>.*` surface, using `ElectronBrowserExtension` as the reference (RN's `3f1ee890` pattern).

| Interface | Before | After |
|---|---|---|
| `TauriBrowserExtension` | 6/10 | 10/10 (+ `emitEvent`, `isMockFunction`, `listWindows`, `switchWindow`) |
| `DioxusBrowserExtension` | none | 9/9 (full list; dioxus has no `emitEvent`) |
| `ElectrobunBrowserExtension` | none | 9/9 (full list; electrobun has no `emitEvent`) |

Method lists were derived from each `*ServiceAPI` interface's actual members rather than copied from the template — which is how the per-service differences (no `emitEvent` outside electron/tauri) stayed accurate. Lists are alphabetical; dioxus/electrobun also gain the interface-level doc comment their siblings have.

Docs-only — no type or runtime change. `@wdio/native-types` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)