### PR TITLE
feat(react-native-service): MVP — MetroBridge + execute + mock + launcher + service + session

### DIFF
--- a/packages/react-native-service/package.json
+++ b/packages/react-native-service/package.json
@@ -48,7 +48,10 @@
   },
   "dependencies": {
     "@wdio/native-cdp-bridge": "workspace:*",
+    "@wdio/native-core": "workspace:*",
     "@wdio/native-types": "workspace:*",
+    "@wdio/native-utils": "workspace:*",
+    "@wdio/types": "catalog:default",
     "tslib": "^2.8.1",
     "webdriverio": "catalog:default"
   },

--- a/packages/react-native-service/package.json
+++ b/packages/react-native-service/package.json
@@ -53,7 +53,8 @@
     "@wdio/native-utils": "workspace:*",
     "@wdio/types": "catalog:default",
     "tslib": "^2.8.1",
-    "webdriverio": "catalog:default"
+    "webdriverio": "catalog:default",
+    "@wdio/native-spy": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/packages/react-native-service/src/capabilities.ts
+++ b/packages/react-native-service/src/capabilities.ts
@@ -1,0 +1,33 @@
+import { unsupportedPlatform } from './errors.js';
+import type { ReactNativeCapabilities, ReactNativeServiceOptions } from './types.js';
+
+const AUTOMATION_NAME = { android: 'UiAutomator2', ios: 'XCUITest' } as const;
+
+/**
+ * Resolve the Appium automation name + app capability for a React Native session
+ * and validate the platform.
+ *
+ * Gated on the **capability's** platform (`platformName`, or the service `platform`
+ * option) — never `process.platform`: a single host drives either OS over Appium,
+ * and keeping the discriminator on the capability lets tests exercise both branches.
+ * Mutates `capability` in place (the WDIO launcher hands the service the live caps).
+ *
+ * @returns the normalised platform (`'android'` | `'ios'`)
+ * @throws {@link unsupportedPlatform} (a `SevereServiceError`) for anything else.
+ */
+export function prepareReactNativeCapability(
+  capability: ReactNativeCapabilities,
+  options: ReactNativeServiceOptions = {},
+): 'android' | 'ios' {
+  const platformName = (capability as { platformName?: string }).platformName ?? options.platform;
+  const platform = platformName?.toLowerCase();
+  if (platform !== 'android' && platform !== 'ios') {
+    throw unsupportedPlatform(platformName ?? '(unset)');
+  }
+
+  capability['appium:automationName'] ??= AUTOMATION_NAME[platform];
+  if (options.appBinaryPath && !capability['appium:app']) {
+    capability['appium:app'] = options.appBinaryPath;
+  }
+  return platform;
+}

--- a/packages/react-native-service/src/commands/execute.ts
+++ b/packages/react-native-service/src/commands/execute.ts
@@ -1,0 +1,133 @@
+// browser.reactNative.execute implementation.
+//
+// React Native's `execute`/`mock` run in the app's Hermes JS realm over the CDP
+// bridge's `Runtime.evaluate` (Metro inspector-proxy). A string-built async IIFE
+// is built from the user's function source, with args inlined as JSON literals.
+// The realm itself (`globalThis` in Hermes — `nativeModuleProxy`, `HermesInternal`)
+// is passed as the callback's first argument.
+//
+// Invariant: only `Runtime.evaluate` — never `Page.navigate`.
+
+import type { CdpBridge } from '@wdio/native-cdp-bridge';
+import type { ReactNativeAPIs } from '@wdio/native-types';
+import { hasSemicolonOutsideQuotes } from '@wdio/native-utils';
+
+interface RemoteObject {
+  type?: string;
+  value?: unknown;
+  description?: string;
+}
+
+interface EvaluateResponse {
+  result?: RemoteObject;
+  exceptionDetails?: {
+    text?: string;
+    exception?: { description?: string; value?: unknown };
+  };
+}
+
+/**
+ * Serialise a value to a JS literal for inlining into evaluated source, rejecting
+ * anything `JSON.stringify` would silently drop or choke on.
+ *
+ * @param context - caller label for the error message (e.g. `browser.reactNative.execute`).
+ * @param index - optional positional index appended to the error message.
+ */
+export function jsonLiteral(value: unknown, context: string, index?: number): string {
+  const at = index === undefined ? '' : ` at index ${index}`;
+  // JSON.stringify(fn)/JSON.stringify(symbol) returns `undefined` rather than
+  // throwing — that would silently drop the value, so reject it up front.
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    throw new Error(
+      `${context}${at} is not JSON-serialisable ` +
+        `(a ${typeof value} cannot be inlined into the evaluated source; JSON.stringify would silently drop it).`,
+    );
+  }
+  try {
+    // Escape JS line terminators (legal raw in JSON since ES2019) and `<` before
+    // inlining the JSON.stringify output into evaluated source — a regex guard
+    // alone does not clear CodeQL js/bad-code-sanitization for this sink.
+    return (JSON.stringify(value) ?? 'undefined')
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029')
+      .replace(/</g, '\\u003C');
+  } catch (err) {
+    throw new Error(
+      `${context}${at} is not JSON-serialisable ` +
+        '(values are inlined into the evaluated source via JSON.stringify). This usually means a ' +
+        `circular reference, a BigInt, or a function. Underlying error: ${(err as Error).message}`,
+    );
+  }
+}
+
+function inlineArgs(args: unknown[]): string {
+  return args.map((arg, index) => jsonLiteral(arg, 'browser.reactNative.execute argument', index)).join(', ');
+}
+
+const STATEMENT_KEYWORD = /^(const|let|var|if|for|while|switch|throw|try|do|return)(?=[^\w$]|$)/;
+
+/**
+ * Wrap a string script for `Runtime.evaluate`, mirroring the convergent execute
+ * surface: a statement-style script (leading `return`/`const`/… or multiple
+ * statements) becomes a function body; anything else is treated as an expression
+ * and returned. So `return 42`, `const x = …; return x`, and bare `1 + 2` all
+ * yield their value.
+ */
+function wrapStringScript(script: string): string {
+  const trimmed = script.trim();
+  if (STATEMENT_KEYWORD.test(trimmed) || hasSemicolonOutsideQuotes(trimmed)) {
+    return `(async function () { ${script} })()`;
+  }
+  return `(async function () { return (${script}); })()`;
+}
+
+/**
+ * Evaluate a raw JS expression in the Hermes realm and return its
+ * (returned-by-value) result. Centralises `Runtime.evaluate` + exception handling
+ * for `execute` and the mock layer.
+ */
+export async function evaluateInRealm<ReturnValue>(
+  bridge: CdpBridge,
+  expression: string,
+  context = 'browser.reactNative.execute',
+): Promise<ReturnValue> {
+  const response = (await bridge.send('Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  })) as EvaluateResponse;
+
+  if (response.exceptionDetails) {
+    const detail =
+      response.exceptionDetails.exception?.description ?? response.exceptionDetails.text ?? 'Unknown evaluation error';
+    throw new Error(`${context} failed: ${detail}`);
+  }
+
+  return response.result?.value as ReturnValue;
+}
+
+/**
+ * Run a user function (or raw expression string) in the app's Hermes realm and
+ * return its (JSON-serialisable) result.
+ *
+ * Function form: the source is wrapped in an async IIFE that passes the Hermes
+ * realm (`globalThis`) as the first arg, then the inlined user args. String form:
+ * wrapped via `wrapStringScript` so both a bare expression and a statement body
+ * return their value.
+ */
+export async function executeScript<ReturnValue, InnerArguments extends unknown[] = unknown[]>(
+  bridge: CdpBridge,
+  script: string | ((rn: ReactNativeAPIs, ...args: InnerArguments) => ReturnValue),
+  ...args: InnerArguments
+): Promise<ReturnValue> {
+  const expression =
+    typeof script === 'function'
+      ? `(async () => {
+          const userFn = (${script.toString()});
+          const rn = globalThis;
+          return await userFn(rn, ${inlineArgs(args)});
+        })()`
+      : wrapStringScript(script);
+
+  return evaluateInRealm<ReturnValue>(bridge, expression);
+}

--- a/packages/react-native-service/src/constants.ts
+++ b/packages/react-native-service/src/constants.ts
@@ -1,3 +1,9 @@
+/** Logger namespace for this service (`createLogger(SERVICE_NAME, '<module>')`). */
+export const SERVICE_NAME = 'react-native-service';
+
+/** WDIO capability key carrying per-capability service options. */
+export const CUSTOM_CAPABILITY_NAME = 'wdio:reactNativeServiceOptions';
+
 /** Default host of the Metro inspector-proxy used for the Hermes CDP attach. */
 export const DEFAULT_METRO_HOST = 'localhost';
 

--- a/packages/react-native-service/src/errors.ts
+++ b/packages/react-native-service/src/errors.ts
@@ -1,0 +1,36 @@
+// Error helpers for the React Native service.
+//
+// `SevereServiceError` (re-exported from webdriverio) tells the WDIO runner the
+// failure is non-recoverable and the run should abort — used when a capability
+// fundamentally can't work, e.g. it targets a platform the service doesn't support.
+
+import { SevereServiceError } from 'webdriverio';
+
+export { SevereServiceError };
+
+/**
+ * Thrown by the launcher when a capability targets a platform the service does
+ * not support. React Native automation runs on Android (UiAutomator2) and iOS
+ * (XCUITest) only.
+ */
+export function unsupportedPlatform(platform: string): Error {
+  return new SevereServiceError(
+    `@wdio/react-native-service supports Android and iOS only (received platformName: '${platform}'). ` +
+      "Set platformName to 'Android' or 'iOS' in your capabilities.",
+  );
+}
+
+/**
+ * Returned (rejected) when `execute`/`mock` is used but the app's Hermes
+ * inspector is not reachable through Metro. These features need a debug/Metro
+ * build with the Hermes engine and the inspector-proxy running; native find/tap
+ * works without it.
+ */
+export function hermesUnavailable(host: string, port: number): Error {
+  return new Error(
+    `Could not reach the React Native Hermes inspector via Metro at ${host}:${port}. ` +
+      'browser.reactNative.execute / mock require a debug (Metro) build with the Hermes engine and ' +
+      'the Metro inspector-proxy running. Start Metro and ensure the app is foregrounded ' +
+      '(Android also needs `adb reverse tcp:<port> tcp:<port>`).',
+  );
+}

--- a/packages/react-native-service/src/index.ts
+++ b/packages/react-native-service/src/index.ts
@@ -1,15 +1,14 @@
-// @wdio/react-native-service — WebdriverIO service for testing React Native apps.
+// @wdio/react-native-service entry point.
 //
-// PR1 (Foundation): the @wdio/native-cdp-bridge consumption layer — Hermes target
-// selection behind Metro's inspector-proxy and the Fusebox `Origin` wiring. The
-// launcher/worker service, the full Metro/Hermes attach (adb reverse + foreground
-// guard), `execute` and `mock` land in subsequent PRs.
+// - Default export: the worker-side service (registered automatically by the
+//   WDIO test runner via `services: ['@wdio/react-native-service']`).
+// - Named `launcher` export: the main-process launch service (auto-detected by
+//   the runner via the standard WDIO service convention).
 //
 // The bare import pulls in @wdio/native-types' ambient module augmentation so
 // `browser.reactNative.*` and `wdio:reactNativeServiceOptions` are typed for
-// consumers. Only the config-time types are re-exported (mirroring the sibling
-// services) — the API/mock types reach users through the augmentation, not a
-// direct import.
+// consumers. Only config-time types are re-exported (mirroring the sibling
+// services) — the API/mock types reach users through the augmentation.
 import '@wdio/native-types';
 
 export type {
@@ -17,6 +16,6 @@ export type {
   ReactNativeServiceGlobalOptions,
   ReactNativeServiceOptions,
 } from '@wdio/native-types';
-export * from './constants.js';
-export * from './hermesBridge.js';
-export * from './hermesTarget.js';
+export { default as launcher } from './launcher.js';
+export { default } from './service.js';
+export { cleanup as cleanupWdioSession, createReactNativeCapabilities, init as startWdioSession } from './session.js';

--- a/packages/react-native-service/src/innerRecorder.ts
+++ b/packages/react-native-service/src/innerRecorder.ts
@@ -1,0 +1,248 @@
+// Inner-recorder script builders for the React Native mock layer.
+//
+// `browser.reactNative.mock` targets a *dotted path to a function in the Hermes
+// JS realm* (e.g. 'nativeModuleProxy.Clipboard.getString'). These builders return
+// JS expression strings evaluated in the app's Hermes global via Runtime.evaluate
+// (see commands/execute.ts#evaluateInRealm). They never navigate the page.
+//
+// All recorders live under globalThis.__WDIO_RN_MOCKS__, keyed by target path.
+// Each entry preserves the original function so mockRestore puts it back exactly.
+// The recorder is a vitest-shaped spy; call/result history is read back one-way
+// into the outer mock via buildReadCallDataScript.
+//
+// The string semantics here are only exercised end-to-end against a real Metro/
+// Hermes target — unit tests assert the *expressions* emitted, not in-realm behaviour.
+
+import type { InnerMockSetterMethod } from './mockTypes.js';
+
+const REGISTRY = 'globalThis.__WDIO_RN_MOCKS__';
+
+// A mock target is a dotted path of JS identifiers (`nativeModuleProxy.Clipboard.getString`).
+// The VALID_TARGET guard rejects anything else (clear errors + defense-in-depth: a target
+// that passes can't carry a quote, backslash, newline, or line/paragraph separator).
+const VALID_TARGET = /^[A-Za-z_$][A-Za-z0-9_$]*(\.[A-Za-z_$][A-Za-z0-9_$]*)*$/;
+
+/** JS-source literal of a validated target path, safe to inline as an object key / string arg. */
+function pathLiteral(target: string): string {
+  if (!VALID_TARGET.test(target)) {
+    throw new Error(
+      `browser.reactNative.mock target ${JSON.stringify(target)} is not a valid dotted property path ` +
+        `(expected identifiers separated by dots, e.g. 'nativeModuleProxy.Clipboard.getString').`,
+    );
+  }
+  // The \`${key}\` interpolations below land in a JS *source* string (Runtime.evaluate).
+  // JSON.stringify leaves U+2028/U+2029 raw; escape them plus '<' for the source context.
+  // The VALID_TARGET guard already makes these no-ops, but this is the escaping CodeQL's
+  // js/bad-code-sanitization recognises (a regex .test() guard alone does not clear it).
+  return JSON.stringify(target)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+    .replace(/</g, '\\x3C');
+}
+
+const SETUP = `
+  if (!${REGISTRY}) { ${REGISTRY} = {}; }
+  var __rnReg = ${REGISTRY};
+  if (!__rnReg.__callId) { __rnReg.__callId = 0; }
+  if (!__rnReg.__createSpy) {
+    var NOT_SET = {};
+    __rnReg.__createSpy = function() {
+      var _defaultImpl;
+      var _implQueue = [];
+      var _defaultReturnValue = NOT_SET;
+      var _defaultResolvedValue = NOT_SET;
+      var _defaultRejectedValue = NOT_SET;
+      var _returnThis = false;
+      var _calls = [];
+      var _results = [];
+      var _invocationCallOrder = [];
+      function spy() {
+        var args = Array.prototype.slice.call(arguments);
+        _calls.push(args);
+        _invocationCallOrder.push(__rnReg.__callId++);
+        var impl = _implQueue.length > 0 ? _implQueue.shift() : _defaultImpl;
+        if (impl !== null && impl !== undefined && typeof impl === 'object' && impl.__wdioType) {
+          if (impl.__wdioType === 'resolve') {
+            _results.push({ type: 'return', value: impl.__wdioVal });
+            return Promise.resolve(impl.__wdioVal);
+          }
+          _results.push({ type: 'throw', value: impl.__wdioVal });
+          return Promise.reject(impl.__wdioVal);
+        }
+        if (impl !== undefined) {
+          try {
+            var val = impl.apply(this, args);
+            _results.push({ type: 'return', value: val });
+            return val;
+          } catch (e) {
+            _results.push({ type: 'throw', value: e });
+            throw e;
+          }
+        } else if (_defaultRejectedValue !== NOT_SET) {
+          _results.push({ type: 'throw', value: _defaultRejectedValue });
+          return Promise.reject(_defaultRejectedValue);
+        } else if (_defaultResolvedValue !== NOT_SET) {
+          _results.push({ type: 'return', value: _defaultResolvedValue });
+          return Promise.resolve(_defaultResolvedValue);
+        } else if (_returnThis) {
+          _results.push({ type: 'return', value: this });
+          return this;
+        } else if (_defaultReturnValue !== NOT_SET) {
+          _results.push({ type: 'return', value: _defaultReturnValue });
+          return _defaultReturnValue;
+        } else {
+          _results.push({ type: 'return', value: undefined });
+          return undefined;
+        }
+      }
+      spy.__isWdioSpy = true;
+      spy.mock = { calls: _calls, results: _results, invocationCallOrder: _invocationCallOrder };
+      spy.mockImplementation = function(fn) {
+        _defaultImpl = fn; _defaultReturnValue = NOT_SET; _defaultResolvedValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockImplementationOnce = function(fn) { _implQueue.push(fn); return spy; };
+      spy.mockReturnValue = function(v) {
+        _defaultImpl = undefined; _defaultReturnValue = v; _defaultResolvedValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockReturnValueOnce = function(v) { _implQueue.push(function() { return v; }); return spy; };
+      spy.mockResolvedValue = function(v) {
+        _defaultImpl = undefined; _defaultResolvedValue = v; _defaultReturnValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockResolvedValueOnce = function(v) { _implQueue.push({ __wdioType: 'resolve', __wdioVal: v }); return spy; };
+      spy.mockRejectedValue = function(v) {
+        _defaultImpl = undefined; _defaultRejectedValue = v; _defaultReturnValue = NOT_SET;
+        _defaultResolvedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      spy.mockRejectedValueOnce = function(v) { _implQueue.push({ __wdioType: 'reject', __wdioVal: v }); return spy; };
+      spy.mockReturnThis = function() {
+        _returnThis = true; _defaultReturnValue = NOT_SET; _defaultResolvedValue = NOT_SET;
+        _defaultRejectedValue = NOT_SET; _defaultImpl = undefined; return spy;
+      };
+      spy.mockClear = function() {
+        _calls.length = 0; _results.length = 0; _invocationCallOrder.length = 0; return spy;
+      };
+      spy.mockReset = function() {
+        spy.mockClear();
+        _implQueue = []; _defaultImpl = undefined; _defaultReturnValue = NOT_SET;
+        _defaultResolvedValue = NOT_SET; _defaultRejectedValue = NOT_SET; _returnThis = false; return spy;
+      };
+      return spy;
+    };
+  }`;
+
+const RESOLVE_PATH = `
+    var __resolve = function(path) {
+      var parts = path.split('.');
+      var parent = globalThis;
+      for (var i = 0; i < parts.length - 1; i++) {
+        if (parent == null) { return undefined; }
+        parent = parent[parts[i]];
+      }
+      if (parent == null) { return undefined; }
+      return { parent: parent, key: parts[parts.length - 1] };
+    };`;
+
+export function buildInstallScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {${SETUP}${RESOLVE_PATH}
+    var existing = __rnReg[${key}];
+    if (existing) { return; }
+    var loc = __resolve(${key});
+    if (!loc) {
+      throw new Error('browser.reactNative.mock target ' + ${key} + ' could not be resolved: a parent on the path is undefined.');
+    }
+    var original = loc.parent[loc.key];
+    if (typeof original !== 'function') {
+      throw new Error('browser.reactNative.mock target ' + ${key} + ' is not a function (got ' + typeof original + ').');
+    }
+    var spy = __rnReg.__createSpy();
+    __rnReg[${key}] = { spy: spy, original: original, parent: loc.parent, key: loc.key };
+    loc.parent[loc.key] = spy;
+  })()`;
+}
+
+export function buildReadCallDataScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (!entry || !entry.spy || !entry.spy.mock) { return { calls: [], results: [], invocationCallOrder: [] }; }
+    var m = entry.spy.mock;
+    var makeSafe = function() {
+      var seen = [];
+      return function(_k, v) {
+        if (v instanceof Error) { return { __wdioError: true, name: v.name, message: v.message, stack: v.stack }; }
+        if (typeof v === 'function') { return '[Function]'; }
+        if (v && typeof v === 'object') {
+          if (seen.indexOf(v) !== -1) { return '[Circular]'; }
+          seen.push(v);
+        }
+        return v;
+      };
+    };
+    return {
+      calls: JSON.parse(JSON.stringify(m.calls || [], makeSafe())),
+      results: JSON.parse(JSON.stringify(m.results || [], makeSafe())),
+      invocationCallOrder: JSON.parse(JSON.stringify(m.invocationCallOrder || [])),
+    };
+  })()`;
+}
+
+export function buildSetImplementationScript(target: string, source: string, once = false): string {
+  const key = pathLiteral(target);
+  const method = once ? 'mockImplementationOnce' : 'mockImplementation';
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.${method}((${source})); }
+  })()`;
+}
+
+export function buildSetValueScript(target: string, method: InnerMockSetterMethod, valueLiteral: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (!entry || !entry.spy) { return; }
+    var _v = ${valueLiteral};
+    var arg = _v;
+    if (_v && typeof _v === 'object' && _v.__wdioError === true) {
+      arg = new Error(_v.message);
+      if (_v.name) { arg.name = _v.name; }
+      if (_v.stack) { arg.stack = _v.stack; }
+    }
+    entry.spy.${method}(arg);
+  })()`;
+}
+
+export function buildClearScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.mockClear(); }
+  })()`;
+}
+
+export function buildResetScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.mockReset(); }
+  })()`;
+}
+
+export function buildRestoreScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (!entry) { return; }
+    if (entry.parent) { entry.parent[entry.key] = entry.original; }
+    delete reg[${key}];
+  })()`;
+}

--- a/packages/react-native-service/src/innerRecorder.ts
+++ b/packages/react-native-service/src/innerRecorder.ts
@@ -236,6 +236,15 @@ export function buildResetScript(target: string): string {
   })()`;
 }
 
+export function buildReturnThisScript(target: string): string {
+  const key = pathLiteral(target);
+  return `(function() {
+    var reg = ${REGISTRY};
+    var entry = reg && reg[${key}];
+    if (entry && entry.spy) { entry.spy.mockReturnThis(); }
+  })()`;
+}
+
 export function buildRestoreScript(target: string): string {
   const key = pathLiteral(target);
   return `(function() {

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -1,0 +1,55 @@
+import { BaseLauncher } from '@wdio/native-core';
+import { createLogger } from '@wdio/native-utils';
+import type { Options } from '@wdio/types';
+
+import { prepareReactNativeCapability } from './capabilities.js';
+import { SERVICE_NAME } from './constants.js';
+import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
+import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from './types.js';
+
+const log = createLogger(SERVICE_NAME, 'launcher');
+
+/**
+ * Main-process launcher for `@wdio/react-native-service`.
+ *
+ * React Native is an Appium-driven service: WDIO creates the Appium session, so
+ * the launcher does **not** spawn a driver or the app. Its `onPrepare` job is
+ * capability mutation — resolve each capability's platform to its Appium
+ * `automationName` (UiAutomator2 / XCUITest), map a service `appBinaryPath` onto
+ * `appium:app`, and reject an unsupported platform with a `SevereServiceError`.
+ *
+ * It extends `BaseLauncher` to share `@wdio/native-core`'s infra and to host the
+ * per-worker device allocation (`onWorkerStart`) that lands with the device manager.
+ */
+export default class ReactNativeLaunchService extends BaseLauncher {
+  constructor(
+    private options: ReactNativeServiceGlobalOptions,
+    _capabilities: ReactNativeCapabilities,
+    _config: Options.Testrunner,
+  ) {
+    super();
+    log.debug('ReactNativeLaunchService initialised');
+  }
+
+  async onPrepare(
+    _config: Options.Testrunner,
+    capabilities: ReactNativeCapabilities[] | Record<string, { capabilities: ReactNativeCapabilities }>,
+  ): Promise<void> {
+    const capsList = normaliseCaps(capabilities);
+    for (const cap of capsList) {
+      const options = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
+      const platform = prepareReactNativeCapability(cap, options);
+      log.info(`Prepared ${platform} capability (automationName: ${cap['appium:automationName']})`);
+    }
+  }
+}
+
+/** Flatten WDIO's array-of-caps or multiremote object into a flat capability list. */
+function normaliseCaps(
+  capabilities: ReactNativeCapabilities[] | Record<string, { capabilities: ReactNativeCapabilities }>,
+): ReactNativeCapabilities[] {
+  if (Array.isArray(capabilities)) {
+    return capabilities;
+  }
+  return Object.values(capabilities).map((entry) => entry.capabilities);
+}

--- a/packages/react-native-service/src/metroBridge.ts
+++ b/packages/react-native-service/src/metroBridge.ts
@@ -1,0 +1,89 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { CdpBridge } from '@wdio/native-cdp-bridge';
+import { createLogger } from '@wdio/native-utils';
+
+import { DEFAULT_METRO_HOST, DEFAULT_METRO_PORT, SERVICE_NAME } from './constants.js';
+import { createHermesBridge, type HermesBridgeOptions } from './hermesBridge.js';
+
+const log = createLogger(SERVICE_NAME, 'bridge');
+const execFileAsync = promisify(execFile);
+
+/** Forwards the device's Metro port to the host so the app↔Metro link (and thus the
+ *  Hermes inspector target) exists. Injectable for tests / a custom adb path. */
+export type AdbReverse = (port: number) => Promise<void>;
+
+const defaultAdbReverse: AdbReverse = async (port) => {
+  await execFileAsync('adb', ['reverse', `tcp:${port}`, `tcp:${port}`]);
+};
+
+export interface MetroBridgeOptions extends HermesBridgeOptions {
+  /** Target platform; `android` triggers the best-effort `adb reverse` step. */
+  platform?: 'android' | 'ios';
+  /** Override the adb-reverse runner (tests / custom adb path). */
+  adbReverse?: AdbReverse;
+}
+
+/**
+ * Lifecycle wrapper around the single-target Hermes {@link CdpBridge}.
+ *
+ * Establishes the Android `adb reverse` link, connects lazily, and can reconnect
+ * after the Hermes inspector drops (e.g. when the app is backgrounded — the spike
+ * showed backgrounding suspends the inspector and the target disappears). The
+ * `execute`/`mock` commands drive the underlying bridge via {@link bridge}.
+ */
+export class MetroBridge {
+  #bridge: CdpBridge | undefined;
+  readonly #options: MetroBridgeOptions;
+  readonly #port: number;
+  readonly #adbReverse: AdbReverse;
+
+  constructor(options: MetroBridgeOptions = {}) {
+    this.#options = { host: options.host ?? DEFAULT_METRO_HOST, port: options.port ?? DEFAULT_METRO_PORT, ...options };
+    this.#port = this.#options.port ?? DEFAULT_METRO_PORT;
+    this.#adbReverse = options.adbReverse ?? defaultAdbReverse;
+  }
+
+  get connected(): boolean {
+    return this.#bridge !== undefined;
+  }
+
+  /** The live Hermes bridge. Throws if {@link connect} hasn't run. */
+  get bridge(): CdpBridge {
+    if (!this.#bridge) {
+      throw new Error('Metro bridge is not connected — call connect() first.');
+    }
+    return this.#bridge;
+  }
+
+  /** Connect to the Hermes inspector (idempotent). Android runs `adb reverse` first. */
+  async connect(): Promise<void> {
+    if (this.#bridge) {
+      return;
+    }
+    if (this.#options.platform === 'android') {
+      try {
+        await this.#adbReverse(this.#port);
+      } catch (error) {
+        log.warn(
+          `adb reverse tcp:${this.#port} failed (continuing — Metro may already be reachable): ${(error as Error).message}`,
+        );
+      }
+    }
+    const bridge = createHermesBridge(this.#options);
+    await bridge.connect();
+    this.#bridge = bridge;
+  }
+
+  /** Re-establish the connection after an inspector drop (close, then connect). */
+  async reconnect(): Promise<void> {
+    await this.close();
+    await this.connect();
+  }
+
+  async close(): Promise<void> {
+    await this.#bridge?.close();
+    this.#bridge = undefined;
+  }
+}

--- a/packages/react-native-service/src/metroBridge.ts
+++ b/packages/react-native-service/src/metroBridge.ts
@@ -40,7 +40,7 @@ export class MetroBridge {
   readonly #adbReverse: AdbReverse;
 
   constructor(options: MetroBridgeOptions = {}) {
-    this.#options = { host: options.host ?? DEFAULT_METRO_HOST, port: options.port ?? DEFAULT_METRO_PORT, ...options };
+    this.#options = { ...options, host: options.host ?? DEFAULT_METRO_HOST, port: options.port ?? DEFAULT_METRO_PORT };
     this.#port = this.#options.port ?? DEFAULT_METRO_PORT;
     this.#adbReverse = options.adbReverse ?? defaultAdbReverse;
   }

--- a/packages/react-native-service/src/mock.ts
+++ b/packages/react-native-service/src/mock.ts
@@ -1,0 +1,208 @@
+// createMock — the workhorse behind browser.reactNative.mock(target).
+//
+// A React Native mock is two cooperating objects (two-tier mock doctrine):
+//
+//   1. The "outer mock" — a vitest-flavoured fn() from @wdio/native-spy that
+//      lives in the WDIO worker. Tests inspect it via mock.mock.calls/results.
+//   2. The "inner recorder" — a spy installed over globalThis.<target> in the
+//      app's Hermes realm (innerRecorder.ts), driven over CDP Runtime.evaluate.
+//
+// `target` is a dotted path to a function in the Hermes global
+// ('nativeModuleProxy.Clipboard.getString'). User-facing setters push behaviour
+// into the inner recorder. update() reads the call history back one-way into
+// the outer mock.
+
+import type { CdpBridge } from '@wdio/native-cdp-bridge';
+import { fn as vitestFn } from '@wdio/native-spy';
+import type { AbstractFn, MockResult, ReactNativeMock } from '@wdio/native-types';
+import { createLogger } from '@wdio/native-utils';
+
+import { evaluateInRealm, jsonLiteral } from './commands/execute.js';
+import { SERVICE_NAME } from './constants.js';
+import {
+  buildClearScript,
+  buildInstallScript,
+  buildReadCallDataScript,
+  buildResetScript,
+  buildRestoreScript,
+  buildSetImplementationScript,
+  buildSetValueScript,
+} from './innerRecorder.js';
+import type { ReactNativeMockStore } from './mockStore.js';
+import type { InnerMockSetterMethod } from './mockTypes.js';
+
+const log = createLogger(SERVICE_NAME, 'bridge');
+
+interface CallData {
+  calls: unknown[][];
+  results: MockResult[];
+  invocationCallOrder: number[];
+}
+
+function reconstructErrors(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(reconstructErrors);
+  }
+  const obj = value as Record<string, unknown>;
+  if (obj.__wdioError === true) {
+    const err = new Error(typeof obj.message === 'string' ? obj.message : '');
+    if (typeof obj.name === 'string') err.name = obj.name;
+    if (typeof obj.stack === 'string') err.stack = obj.stack;
+    return err;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    out[key] = reconstructErrors(obj[key]);
+  }
+  return out;
+}
+
+function parseCallData(raw: unknown): CallData {
+  if (!raw || typeof raw !== 'object') {
+    return { calls: [], results: [], invocationCallOrder: [] };
+  }
+  const r = raw as Record<string, unknown>;
+  const calls = Array.isArray(r.calls)
+    ? (r.calls as unknown[][]).map((args) => (Array.isArray(args) ? args.map(reconstructErrors) : args) as unknown[])
+    : [];
+  const results = Array.isArray(r.results)
+    ? (r.results as MockResult[]).map((res) => ({ type: res.type, value: reconstructErrors(res.value) }))
+    : [];
+  return {
+    calls,
+    results,
+    invocationCallOrder: Array.isArray(r.invocationCallOrder) ? (r.invocationCallOrder as number[]) : [],
+  };
+}
+
+function implSource(implFn: AbstractFn, target: string): string {
+  const source = implFn.toString();
+  if (/\{\s*\[native code\]\s*\}/.test(source)) {
+    throw new Error(
+      `browser.reactNative.mock("${target}"): mockImplementation requires a function with serialisable source — ` +
+        'native or bound functions stringify to "[native code]" and cannot be evaluated in the Hermes realm',
+    );
+  }
+  try {
+    new Function(`return (${source});`);
+  } catch {
+    throw new Error(
+      `browser.reactNative.mock("${target}"): mockImplementation source is not a valid expression — ` +
+        'method shorthands lose the `function` keyword when stringified; pass a function expression or arrow function',
+    );
+  }
+  return source;
+}
+
+function valueLiteral(value: unknown, target: string): string {
+  if (value instanceof Error) {
+    return JSON.stringify({ __wdioError: true, name: value.name, message: value.message, stack: value.stack })
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029');
+  }
+  return jsonLiteral(value, `browser.reactNative.mock("${target}") value`);
+}
+
+export async function createMock(
+  target: string,
+  bridge: CdpBridge,
+  store: ReactNativeMockStore,
+): Promise<ReactNativeMock> {
+  log.debug(`[${target}] createMock — installing inner recorder`);
+  const mockContext = `browser.reactNative.mock("${target}")`;
+
+  const existing = store.getMock(target);
+  if (existing) {
+    await evaluateInRealm<void>(bridge, buildInstallScript(target), mockContext);
+    return existing;
+  }
+
+  await evaluateInRealm<void>(bridge, buildInstallScript(target), mockContext);
+
+  const outerMock = vitestFn();
+  outerMock.mockName(`reactNative.${target}`);
+  const outerMockClear = outerMock.mockClear.bind(outerMock);
+  const outerMockReset = outerMock.mockReset.bind(outerMock);
+
+  const mock = outerMock as unknown as ReactNativeMock;
+  mock.__isReactNativeMock = true;
+
+  const originalMock = outerMock.mock;
+
+  const setValue = async (method: InnerMockSetterMethod, value: unknown): Promise<ReactNativeMock> => {
+    await evaluateInRealm<void>(bridge, buildSetValueScript(target, method, valueLiteral(value, target)), mockContext);
+    return mock;
+  };
+
+  mock.update = async () => {
+    const raw = await evaluateInRealm<unknown>(bridge, buildReadCallDataScript(target), mockContext);
+    const sync = parseCallData(raw);
+    (originalMock.calls as unknown[][]).length = 0;
+    (originalMock.results as { type: string; value: unknown }[]).length = 0;
+    (originalMock.invocationCallOrder as number[]).length = 0;
+    for (let i = 0; i < sync.calls.length; i++) {
+      (originalMock.calls as unknown[][]).push(sync.calls[i]);
+      (originalMock.results as { type: string; value: unknown }[]).push(
+        sync.results[i] ?? { type: 'return', value: undefined },
+      );
+      (originalMock.invocationCallOrder as number[]).push(
+        sync.invocationCallOrder[i] ?? originalMock.invocationCallOrder.length,
+      );
+    }
+    return mock;
+  };
+
+  mock.mockImplementation = async (implFn: AbstractFn) => {
+    await evaluateInRealm<void>(bridge, buildSetImplementationScript(target, implSource(implFn, target)), mockContext);
+    return mock;
+  };
+
+  mock.mockImplementationOnce = async (implFn: AbstractFn) => {
+    await evaluateInRealm<void>(
+      bridge,
+      buildSetImplementationScript(target, implSource(implFn, target), true),
+      mockContext,
+    );
+    return mock;
+  };
+
+  mock.mockReturnValue = (value: unknown) => setValue('mockReturnValue', value);
+  mock.mockReturnValueOnce = (value: unknown) => setValue('mockReturnValueOnce', value);
+  mock.mockResolvedValue = (value: unknown) => setValue('mockResolvedValue', value);
+  mock.mockResolvedValueOnce = (value: unknown) => setValue('mockResolvedValueOnce', value);
+  mock.mockRejectedValue = (value: unknown) => setValue('mockRejectedValue', value);
+  mock.mockRejectedValueOnce = (value: unknown) => setValue('mockRejectedValueOnce', value);
+
+  mock.mockReturnThis = async () => {
+    // mockReturnThis not relevant for Hermes-realm targets; delegate to inner spy.
+    return mock;
+  };
+
+  mock.mockClear = async () => {
+    await evaluateInRealm<void>(bridge, buildClearScript(target), mockContext);
+    outerMockClear();
+    return mock;
+  };
+
+  mock.mockReset = async () => {
+    const currentName = outerMock.getMockName();
+    await evaluateInRealm<void>(bridge, buildResetScript(target), mockContext);
+    outerMockReset();
+    outerMock.mockName(currentName);
+    return mock;
+  };
+
+  mock.mockRestore = async () => {
+    await evaluateInRealm<void>(bridge, buildRestoreScript(target), mockContext);
+    outerMockReset();
+    store.deleteMock(target);
+    return mock;
+  };
+
+  store.setMock(target, mock);
+  log.debug(`[${target}] mock ready`);
+  return mock;
+}

--- a/packages/react-native-service/src/mock.ts
+++ b/packages/react-native-service/src/mock.ts
@@ -101,7 +101,8 @@ function valueLiteral(value: unknown, target: string): string {
   if (value instanceof Error) {
     return JSON.stringify({ __wdioError: true, name: value.name, message: value.message, stack: value.stack })
       .replace(/\u2028/g, '\\u2028')
-      .replace(/\u2029/g, '\\u2029');
+      .replace(/\u2029/g, '\\u2029')
+      .replace(/</g, '\\u003C');
   }
   return jsonLiteral(value, `browser.reactNative.mock("${target}") value`);
 }
@@ -114,21 +115,33 @@ export async function createMock(
   log.debug(`[${target}] createMock — installing inner recorder`);
   const mockContext = `browser.reactNative.mock("${target}")`;
 
-  const existing = store.getMock(target);
-  if (existing) {
-    await evaluateInRealm<void>(bridge, buildInstallScript(target), mockContext);
-    return existing;
-  }
-
+  // Reinstall the inner spy on the current bridge, then rewire all closures.
+  // Called at first creation AND when re-using an existing mock after MetroBridge.reconnect():
+  // the existing mock's closures pointed at the old (now-closed) CdpBridge and would throw
+  // on any subsequent call — rewiring them here keeps the outer mock's call history intact
+  // while routing all CDP operations to the new connection.
   await evaluateInRealm<void>(bridge, buildInstallScript(target), mockContext);
 
-  const outerMock = vitestFn();
-  outerMock.mockName(`reactNative.${target}`);
+  const existing = store.getMock(target);
+
+  const outerMock = existing
+    ? // Preserve the existing vitest fn() (call history, mock name).
+      (existing as unknown as { _vitestFn: ReturnType<typeof vitestFn> })._vitestFn
+    : vitestFn();
+
+  if (!existing) {
+    outerMock.mockName(`reactNative.${target}`);
+  }
+
   const outerMockClear = outerMock.mockClear.bind(outerMock);
   const outerMockReset = outerMock.mockReset.bind(outerMock);
 
-  const mock = outerMock as unknown as ReactNativeMock;
-  mock.__isReactNativeMock = true;
+  const mock = (existing ?? (outerMock as unknown as ReactNativeMock)) as ReactNativeMock;
+  if (!existing) {
+    mock.__isReactNativeMock = true;
+    // Stash the vitest fn so reconnect paths can retrieve it.
+    (mock as unknown as { _vitestFn: ReturnType<typeof vitestFn> })._vitestFn = outerMock;
+  }
 
   const originalMock = outerMock.mock;
 
@@ -177,7 +190,6 @@ export async function createMock(
   mock.mockRejectedValueOnce = (value: unknown) => setValue('mockRejectedValueOnce', value);
 
   mock.mockReturnThis = async () => {
-    // mockReturnThis not relevant for Hermes-realm targets; delegate to inner spy.
     return mock;
   };
 

--- a/packages/react-native-service/src/mock.ts
+++ b/packages/react-native-service/src/mock.ts
@@ -25,6 +25,7 @@ import {
   buildReadCallDataScript,
   buildResetScript,
   buildRestoreScript,
+  buildReturnThisScript,
   buildSetImplementationScript,
   buildSetValueScript,
 } from './innerRecorder.js';
@@ -190,6 +191,7 @@ export async function createMock(
   mock.mockRejectedValueOnce = (value: unknown) => setValue('mockRejectedValueOnce', value);
 
   mock.mockReturnThis = async () => {
+    await evaluateInRealm<void>(bridge, buildReturnThisScript(target), mockContext);
     return mock;
   };
 

--- a/packages/react-native-service/src/mock.ts
+++ b/packages/react-native-service/src/mock.ts
@@ -134,14 +134,25 @@ export async function createMock(
     outerMock.mockName(`reactNative.${target}`);
   }
 
-  const outerMockClear = outerMock.mockClear.bind(outerMock);
-  const outerMockReset = outerMock.mockReset.bind(outerMock);
+  // Capture the NATIVE vitest clear/reset. On first creation outerMock.mockClear is
+  // still native; on the reconnect path it was already overwritten with the async CDP
+  // wrapper below (mock === outerMock), so re-binding it would route mockClear/mockReset
+  // at the closed bridge and leak an unhandled rejection. Retrieve the stashed native
+  // bindings instead.
+  const outerMockClear = existing
+    ? (existing as unknown as { _nativeClear: () => void })._nativeClear
+    : outerMock.mockClear.bind(outerMock);
+  const outerMockReset = existing
+    ? (existing as unknown as { _nativeReset: () => void })._nativeReset
+    : outerMock.mockReset.bind(outerMock);
 
   const mock = (existing ?? (outerMock as unknown as ReactNativeMock)) as ReactNativeMock;
   if (!existing) {
     mock.__isReactNativeMock = true;
-    // Stash the vitest fn so reconnect paths can retrieve it.
+    // Stash the vitest fn + native clear/reset so reconnect paths can retrieve them.
     (mock as unknown as { _vitestFn: ReturnType<typeof vitestFn> })._vitestFn = outerMock;
+    (mock as unknown as { _nativeClear: () => void })._nativeClear = outerMockClear;
+    (mock as unknown as { _nativeReset: () => void })._nativeReset = outerMockReset;
   }
 
   const originalMock = outerMock.mock;

--- a/packages/react-native-service/src/mockStore.ts
+++ b/packages/react-native-service/src/mockStore.ts
@@ -1,0 +1,30 @@
+// Per-attached-bridge registry of every ReactNativeMock created against one
+// Hermes CDP session. Backs isMockFunction; clear/reset/restoreAllMocks land PR3.
+// NOT a singleton: each bridge/worker gets its own store so sessions don't cross-contaminate.
+
+import type { ReactNativeMock } from '@wdio/native-types';
+
+export class ReactNativeMockStore {
+  #mocks = new Map<string, ReactNativeMock>();
+
+  setMock(target: string, mock: ReactNativeMock): ReactNativeMock {
+    this.#mocks.set(target, mock);
+    return mock;
+  }
+
+  getMock(target: string): ReactNativeMock | undefined {
+    return this.#mocks.get(target);
+  }
+
+  getMocks(): Array<[string, ReactNativeMock]> {
+    return Array.from(this.#mocks.entries());
+  }
+
+  deleteMock(target: string): boolean {
+    return this.#mocks.delete(target);
+  }
+
+  clear(): void {
+    this.#mocks.clear();
+  }
+}

--- a/packages/react-native-service/src/mockTypes.ts
+++ b/packages/react-native-service/src/mockTypes.ts
@@ -1,0 +1,11 @@
+// Internal mock-layer types for @wdio/react-native-service. Kept local (not in
+// @wdio/native-types) because they only describe the inner-recorder transport,
+// not the public browser.reactNative.* surface.
+
+export type InnerMockSetterMethod =
+  | 'mockReturnValue'
+  | 'mockReturnValueOnce'
+  | 'mockResolvedValue'
+  | 'mockResolvedValueOnce'
+  | 'mockRejectedValue'
+  | 'mockRejectedValueOnce';

--- a/packages/react-native-service/src/service.ts
+++ b/packages/react-native-service/src/service.ts
@@ -29,17 +29,14 @@ export default class ReactNativeWorkerService {
   }
 
   async before(capabilities: ReactNativeCapabilities, _specs: string[], browser: WebdriverIO.Browser): Promise<void> {
-    const capOptions = getServiceOptionsFromCapability(
-      capabilities as { [CUSTOM_CAPABILITY_NAME]?: ReactNativeCapabilities[typeof CUSTOM_CAPABILITY_NAME] },
-    );
-    const options = mergeServiceOptions(this.options, capOptions);
-
+    // this.options already has cap options merged from the constructor; read platform
+    // directly from the capability so it's always fresh (not re-merged from this.options).
     const platform =
-      options.platform ??
+      this.options.platform ??
       ((capabilities as { platformName?: string }).platformName?.toLowerCase() as 'android' | 'ios' | undefined);
 
-    const host = options.metroHost ?? DEFAULT_METRO_HOST;
-    const port = options.metroPort ?? DEFAULT_METRO_PORT;
+    const host = this.options.metroHost ?? DEFAULT_METRO_HOST;
+    const port = this.options.metroPort ?? DEFAULT_METRO_PORT;
 
     const bridge = new MetroBridge({ platform, host, port });
     const store = new ReactNativeMockStore();

--- a/packages/react-native-service/src/service.ts
+++ b/packages/react-native-service/src/service.ts
@@ -101,6 +101,32 @@ export default class ReactNativeWorkerService {
     log.debug('browser.reactNative API installed');
   }
 
+  async beforeTest(): Promise<void> {
+    if (!this.mockStore || !this.metroBridge?.connected) {
+      return;
+    }
+    const store = this.mockStore;
+    if (this.options.clearMocks) {
+      for (const [target, mock] of store.getMocks()) {
+        await mock.mockClear();
+        log.debug(`[${target}] cleared`);
+      }
+    }
+    if (this.options.resetMocks) {
+      for (const [target, mock] of store.getMocks()) {
+        await mock.mockReset();
+        log.debug(`[${target}] reset`);
+      }
+    }
+    if (this.options.restoreMocks) {
+      const entries = [...store.getMocks()];
+      for (const [target, mock] of entries) {
+        await mock.mockRestore();
+        log.debug(`[${target}] restored`);
+      }
+    }
+  }
+
   async after(): Promise<void> {
     this.mockStore?.clear();
     await this.metroBridge?.close();

--- a/packages/react-native-service/src/service.ts
+++ b/packages/react-native-service/src/service.ts
@@ -1,0 +1,115 @@
+import type { ReactNativeServiceAPI } from '@wdio/native-types';
+import { createLogger } from '@wdio/native-utils';
+
+import { executeScript } from './commands/execute.js';
+import { CUSTOM_CAPABILITY_NAME, DEFAULT_METRO_HOST, DEFAULT_METRO_PORT, SERVICE_NAME } from './constants.js';
+import { MetroBridge } from './metroBridge.js';
+import { createMock } from './mock.js';
+import { ReactNativeMockStore } from './mockStore.js';
+import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
+import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from './types.js';
+
+const log = createLogger(SERVICE_NAME, 'service');
+
+const NOT_IMPLEMENTED_MVP = (method: string): never => {
+  throw new Error(`browser.reactNative.${method} is not available in this MVP release — it lands in a later version.`);
+};
+
+export default class ReactNativeWorkerService {
+  private options: ReactNativeServiceGlobalOptions;
+  private metroBridge: MetroBridge | undefined;
+  private mockStore: ReactNativeMockStore | undefined;
+
+  constructor(options: ReactNativeServiceGlobalOptions, capabilities: ReactNativeCapabilities) {
+    const capOptions = getServiceOptionsFromCapability(
+      capabilities as { [CUSTOM_CAPABILITY_NAME]?: ReactNativeCapabilities[typeof CUSTOM_CAPABILITY_NAME] },
+    );
+    this.options = mergeServiceOptions(options, capOptions);
+    log.debug('ReactNativeWorkerService initialised');
+  }
+
+  async before(capabilities: ReactNativeCapabilities, _specs: string[], browser: WebdriverIO.Browser): Promise<void> {
+    const capOptions = getServiceOptionsFromCapability(
+      capabilities as { [CUSTOM_CAPABILITY_NAME]?: ReactNativeCapabilities[typeof CUSTOM_CAPABILITY_NAME] },
+    );
+    const options = mergeServiceOptions(this.options, capOptions);
+
+    const platform =
+      options.platform ??
+      ((capabilities as { platformName?: string }).platformName?.toLowerCase() as 'android' | 'ios' | undefined);
+
+    const host = options.metroHost ?? DEFAULT_METRO_HOST;
+    const port = options.metroPort ?? DEFAULT_METRO_PORT;
+
+    const bridge = new MetroBridge({ platform, host, port });
+    const store = new ReactNativeMockStore();
+    this.metroBridge = bridge;
+    this.mockStore = store;
+
+    try {
+      await bridge.connect();
+      log.info(`Connected to Hermes inspector at ${host}:${port}`);
+    } catch (error) {
+      log.warn(
+        `Could not connect to Hermes inspector (${(error as Error).message}). ` +
+          'execute/mock will not be available — ensure Metro is running and the app is foregrounded.',
+      );
+    }
+
+    const api: ReactNativeServiceAPI = {
+      execute: async (script, ...args) => {
+        if (!bridge.connected) {
+          throw new Error(
+            'browser.reactNative.execute: Hermes inspector is not connected. ' +
+              'Ensure Metro is running and the app is in the foreground.',
+          );
+        }
+        return executeScript(bridge.bridge, script as unknown as string, ...(args as unknown[]));
+      },
+
+      mock: async (target: string) => {
+        if (!bridge.connected) {
+          throw new Error(
+            'browser.reactNative.mock: Hermes inspector is not connected. ' +
+              'Ensure Metro is running and the app is in the foreground.',
+          );
+        }
+        return createMock(target, bridge.bridge, store);
+      },
+
+      isMockFunction: (targetOrFn: unknown) => {
+        if (typeof targetOrFn === 'string') {
+          return store.getMock(targetOrFn) !== undefined;
+        }
+        return (
+          targetOrFn !== null &&
+          typeof targetOrFn === 'object' &&
+          (targetOrFn as { __isReactNativeMock?: boolean }).__isReactNativeMock === true
+        );
+      },
+
+      // PR3 features — stubs so the type contract is satisfied at runtime
+      clearAllMocks: () => NOT_IMPLEMENTED_MVP('clearAllMocks'),
+      resetAllMocks: () => NOT_IMPLEMENTED_MVP('resetAllMocks'),
+      restoreAllMocks: () => NOT_IMPLEMENTED_MVP('restoreAllMocks'),
+      triggerDeeplink: () => NOT_IMPLEMENTED_MVP('triggerDeeplink'),
+      switchWindow: () => NOT_IMPLEMENTED_MVP('switchWindow'),
+      listWindows: () => NOT_IMPLEMENTED_MVP('listWindows'),
+      emitEvent: () => NOT_IMPLEMENTED_MVP('emitEvent'),
+    };
+
+    (browser as WebdriverIO.Browser & { reactNative?: ReactNativeServiceAPI }).reactNative = api;
+    log.debug('browser.reactNative API installed');
+  }
+
+  async after(): Promise<void> {
+    this.mockStore?.clear();
+    await this.metroBridge?.close();
+    this.metroBridge = undefined;
+    this.mockStore = undefined;
+  }
+
+  async afterSession(): Promise<void> {
+    await this.after();
+  }
+}

--- a/packages/react-native-service/src/service.ts
+++ b/packages/react-native-service/src/service.ts
@@ -31,9 +31,11 @@ export default class ReactNativeWorkerService {
   async before(capabilities: ReactNativeCapabilities, _specs: string[], browser: WebdriverIO.Browser): Promise<void> {
     // this.options already has cap options merged from the constructor; read platform
     // directly from the capability so it's always fresh (not re-merged from this.options).
-    const platform =
-      this.options.platform ??
-      ((capabilities as { platformName?: string }).platformName?.toLowerCase() as 'android' | 'ios' | undefined);
+    // Normalise to lowercase for internal routing — the option and platformName both accept
+    // title-case per the Appium/W3C convention; MetroBridge expects lowercase.
+    const platform = (
+      this.options.platform ?? (capabilities as { platformName?: string }).platformName
+    )?.toLowerCase() as 'android' | 'ios' | undefined;
 
     const host = this.options.metroHost ?? DEFAULT_METRO_HOST;
     const port = this.options.metroPort ?? DEFAULT_METRO_PORT;

--- a/packages/react-native-service/src/serviceConfig.ts
+++ b/packages/react-native-service/src/serviceConfig.ts
@@ -1,0 +1,25 @@
+// Option resolution shared by the launcher and worker service: merge global
+// (service-level) options with per-capability options, capability taking
+// precedence, and pull the custom-capability options off a capability object.
+
+import { CUSTOM_CAPABILITY_NAME } from './constants.js';
+import type { ReactNativeServiceGlobalOptions, ReactNativeServiceOptions } from './types.js';
+
+/** Read the `wdio:reactNativeServiceOptions` block off a capability, if present. */
+export function getServiceOptionsFromCapability(
+  capability: { [CUSTOM_CAPABILITY_NAME]?: ReactNativeServiceOptions } | undefined,
+): ReactNativeServiceOptions | undefined {
+  return capability?.[CUSTOM_CAPABILITY_NAME];
+}
+
+/**
+ * Merge service-level global options with per-capability options. Capability
+ * options win on conflict, matching the precedence used across the sibling
+ * services.
+ */
+export function mergeServiceOptions(
+  globalOptions: ReactNativeServiceGlobalOptions = {},
+  capabilityOptions: ReactNativeServiceOptions | undefined,
+): ReactNativeServiceOptions {
+  return { ...globalOptions, ...capabilityOptions };
+}

--- a/packages/react-native-service/src/session.ts
+++ b/packages/react-native-service/src/session.ts
@@ -1,0 +1,116 @@
+// Standalone (`remote()`) session helpers for @wdio/react-native-service.
+//
+// Mirrors the electrobun/dioxus session API shape (createCapabilities / init / cleanup).
+// WDIO's `remote()` runs only worker-level hooks, so init() manually drives the
+// launcher's onPrepare first so capabilities are mutated (automationName/app set)
+// before the Appium session opens.
+
+import { createLogger } from '@wdio/native-utils';
+import type { Options } from '@wdio/types';
+import { remote } from 'webdriverio';
+
+import { CUSTOM_CAPABILITY_NAME, SERVICE_NAME } from './constants.js';
+import ReactNativeLaunchService from './launcher.js';
+import ReactNativeWorkerService from './service.js';
+import { mergeServiceOptions } from './serviceConfig.js';
+import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from './types.js';
+
+const log = createLogger(SERVICE_NAME, 'session');
+
+const activeLaunchers = new WeakMap<WebdriverIO.Browser, ReactNativeLaunchService>();
+const activeServices = new WeakMap<WebdriverIO.Browser, ReactNativeWorkerService>();
+
+/**
+ * Create a React Native standalone session.
+ *
+ * Drives launcher.onPrepare (capability mutation) then opens the Appium session
+ * and installs `browser.reactNative.*`. Appium itself is expected to be running;
+ * this service does not spawn it.
+ */
+export async function init(
+  capabilities: ReactNativeCapabilities,
+  globalOptions?: ReactNativeServiceGlobalOptions,
+): Promise<WebdriverIO.Browser> {
+  log.debug('Initializing React Native service in standalone mode…');
+
+  const capability = Array.isArray(capabilities) ? capabilities[0] : capabilities;
+  const testRunnerOpts = { capabilities: [] } as unknown as Options.Testrunner;
+  const launcher = new ReactNativeLaunchService(globalOptions ?? {}, capability, testRunnerOpts);
+
+  await launcher.onPrepare(testRunnerOpts, [capability]);
+
+  const browser = await remote({
+    capabilities: capability as WebdriverIO.Capabilities,
+  }).catch(async (error: Error) => {
+    log.error(`Failed to create remote session: ${error.message}`);
+    // RN launcher has no driver processes to stop on completion.
+    throw error;
+  });
+
+  activeLaunchers.set(browser, launcher);
+
+  const serviceOptions = mergeServiceOptions(globalOptions, capability[CUSTOM_CAPABILITY_NAME]);
+  const service = new ReactNativeWorkerService(serviceOptions, capability);
+  try {
+    await service.before(capability, [], browser);
+  } catch (error) {
+    await browser
+      .deleteSession()
+      .catch((e: Error) => log.warn(`deleteSession failed during service.before cleanup: ${e.message}`));
+    activeLaunchers.delete(browser);
+    throw error;
+  }
+  activeServices.set(browser, service);
+
+  log.debug('React Native standalone session initialised');
+  return browser;
+}
+
+/**
+ * Clean up a standalone React Native session created by {@link init}.
+ * A browser not created by init() is left untouched (warn + no-op).
+ */
+export async function cleanup(browser: WebdriverIO.Browser): Promise<void> {
+  log.debug('Cleaning up React Native standalone session…');
+
+  const launcher = activeLaunchers.get(browser);
+  if (!launcher) {
+    log.warn('No launcher found for this browser instance');
+    return;
+  }
+
+  const service = activeServices.get(browser);
+  try {
+    await service?.after();
+  } catch (e) {
+    log.warn(`service.after() failed during cleanup: ${(e as Error).message}`);
+  } finally {
+    activeServices.delete(browser);
+  }
+
+  try {
+    if (browser.sessionId) {
+      await browser.deleteSession();
+    }
+  } catch (e) {
+    log.warn(`Failed to delete session during cleanup: ${(e as Error).message}`);
+  }
+
+  activeLaunchers.delete(browser);
+  log.debug('React Native standalone session cleaned up');
+}
+
+/**
+ * Build a minimal ReactNativeCapabilities object for standalone use.
+ *
+ * @param options - service options; `platform` or a platformName cap is required.
+ */
+export function createReactNativeCapabilities(
+  platformName: 'Android' | 'iOS',
+  serviceOptions?: ReactNativeCapabilities['wdio:reactNativeServiceOptions'],
+): ReactNativeCapabilities {
+  return {
+    platformName,
+    [CUSTOM_CAPABILITY_NAME]: serviceOptions,
+  } as ReactNativeCapabilities;
+}

--- a/packages/react-native-service/src/types.ts
+++ b/packages/react-native-service/src/types.ts
@@ -1,0 +1,10 @@
+// Extended service options for `@wdio/react-native-service`. Builds on the shared
+// types in @wdio/native-types; kept as a thin re-export for now — diverge here
+// only when the implementation needs a field that doesn't belong on the public
+// @wdio/native-types surface.
+
+import type { ReactNativeServiceOptions as BaseReactNativeServiceOptions } from '@wdio/native-types';
+
+export type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from '@wdio/native-types';
+
+export type ReactNativeServiceOptions = BaseReactNativeServiceOptions;

--- a/packages/react-native-service/test/capabilities.spec.ts
+++ b/packages/react-native-service/test/capabilities.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { SevereServiceError } from 'webdriverio';
+import { prepareReactNativeCapability } from '../src/capabilities.js';
+import type { ReactNativeCapabilities } from '../src/types.js';
+
+const cap = (over: Record<string, unknown> = {}): ReactNativeCapabilities =>
+  ({ platformName: 'Android', ...over }) as ReactNativeCapabilities;
+
+describe('prepareReactNativeCapability', () => {
+  it('should set UiAutomator2 and return android for an Android capability', () => {
+    const c = cap({ platformName: 'Android' });
+    expect(prepareReactNativeCapability(c)).toBe('android');
+    expect(c['appium:automationName']).toBe('UiAutomator2');
+  });
+
+  it('should set XCUITest and return ios for an iOS capability', () => {
+    const c = cap({ platformName: 'iOS' });
+    expect(prepareReactNativeCapability(c)).toBe('ios');
+    expect(c['appium:automationName']).toBe('XCUITest');
+  });
+
+  it('should derive the platform from the service option when platformName is unset', () => {
+    const c = cap({ platformName: undefined });
+    expect(prepareReactNativeCapability(c, { platform: 'ios' })).toBe('ios');
+    expect(c['appium:automationName']).toBe('XCUITest');
+  });
+
+  it('should not override an automationName already set on the capability', () => {
+    const c = cap({ platformName: 'Android', 'appium:automationName': 'XCUITest' });
+    prepareReactNativeCapability(c);
+    expect(c['appium:automationName']).toBe('XCUITest');
+  });
+
+  it('should map appBinaryPath onto appium:app', () => {
+    const c = cap({ platformName: 'Android' });
+    prepareReactNativeCapability(c, { appBinaryPath: '/tmp/app.apk' });
+    expect(c['appium:app']).toBe('/tmp/app.apk');
+  });
+
+  it('should not override an explicit appium:app', () => {
+    const c = cap({ platformName: 'Android', 'appium:app': '/explicit.apk' });
+    prepareReactNativeCapability(c, { appBinaryPath: '/tmp/app.apk' });
+    expect(c['appium:app']).toBe('/explicit.apk');
+  });
+
+  it('should throw a SevereServiceError for an unsupported platform', () => {
+    const c = cap({ platformName: 'Windows' });
+    expect(() => prepareReactNativeCapability(c)).toThrow(SevereServiceError);
+    expect(() => prepareReactNativeCapability(c)).toThrow(/Android and iOS only/);
+  });
+
+  it('should throw a SevereServiceError when no platform is set', () => {
+    const c = cap({ platformName: undefined });
+    expect(() => prepareReactNativeCapability(c)).toThrow(SevereServiceError);
+  });
+});

--- a/packages/react-native-service/test/errors.spec.ts
+++ b/packages/react-native-service/test/errors.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { SevereServiceError } from 'webdriverio';
+
+import { hermesUnavailable, unsupportedPlatform } from '../src/errors.js';
+
+describe('unsupportedPlatform', () => {
+  it('should be a SevereServiceError naming the platform and supported set', () => {
+    const err = unsupportedPlatform('Windows');
+    expect(err).toBeInstanceOf(SevereServiceError);
+    expect(err.message).toContain('Windows');
+    expect(err.message).toContain('Android and iOS');
+  });
+});
+
+describe('hermesUnavailable', () => {
+  it('should be a non-severe Error naming the Metro host and port', () => {
+    const err = hermesUnavailable('localhost', 8081);
+    expect(err).toBeInstanceOf(Error);
+    // Recoverable (a debug-build/Metro prerequisite), not a run-aborting SevereServiceError.
+    expect(err).not.toBeInstanceOf(SevereServiceError);
+    expect(err.message).toContain('localhost');
+    expect(err.message).toContain('8081');
+  });
+});

--- a/packages/react-native-service/test/execute.spec.ts
+++ b/packages/react-native-service/test/execute.spec.ts
@@ -1,0 +1,72 @@
+import type { CdpBridge } from '@wdio/native-cdp-bridge';
+import { describe, expect, it, vi } from 'vitest';
+
+import { evaluateInRealm, executeScript, jsonLiteral } from '../src/commands/execute.js';
+
+type EvalParams = { expression: string; returnByValue: boolean; awaitPromise: boolean };
+
+function fakeBridge(response: unknown) {
+  const send = vi.fn(async () => response);
+  return { bridge: { send } as unknown as CdpBridge, send };
+}
+
+const lastExpression = (send: ReturnType<typeof vi.fn>): string => (send.mock.calls[0][1] as EvalParams).expression;
+
+describe('jsonLiteral', () => {
+  it('should serialise a JSON value', () => {
+    expect(jsonLiteral({ a: 1 }, 'ctx')).toBe('{"a":1}');
+  });
+
+  it('should reject a function value', () => {
+    expect(() => jsonLiteral(() => {}, 'ctx', 0)).toThrow(/not JSON-serialisable/);
+  });
+
+  it('should reject a symbol value', () => {
+    expect(() => jsonLiteral(Symbol('x'), 'ctx')).toThrow(/not JSON-serialisable/);
+  });
+
+  it('should escape JS line terminators and the less-than sign', () => {
+    expect(jsonLiteral('a\u2028b', 'ctx')).toBe('"a\\u2028b"');
+    expect(jsonLiteral('</x>', 'ctx')).toContain('\\u003C');
+  });
+});
+
+describe('evaluateInRealm', () => {
+  it('should return the evaluated value', async () => {
+    const { bridge, send } = fakeBridge({ result: { value: 7 } });
+    await expect(evaluateInRealm(bridge, '1')).resolves.toBe(7);
+    expect(send.mock.calls[0][0]).toBe('Runtime.evaluate');
+    expect(send.mock.calls[0][1]).toMatchObject({ returnByValue: true, awaitPromise: true });
+  });
+
+  it('should throw with the exception detail on a CDP exception', async () => {
+    const { bridge } = fakeBridge({ exceptionDetails: { exception: { description: 'boom' } } });
+    await expect(evaluateInRealm(bridge, 'x')).rejects.toThrow(/failed: boom/);
+  });
+});
+
+describe('executeScript', () => {
+  it('should evaluate a function and return its value', async () => {
+    const { bridge, send } = fakeBridge({ result: { value: 42 } });
+    await expect(executeScript(bridge, () => 42)).resolves.toBe(42);
+    expect(lastExpression(send)).toContain('globalThis');
+  });
+
+  it('should inline args into the evaluated source', async () => {
+    const { bridge, send } = fakeBridge({ result: { value: undefined } });
+    await executeScript(bridge, (_rn, name) => name, 'sam');
+    expect(lastExpression(send)).toContain('"sam"');
+  });
+
+  it('should wrap a bare expression string and return its value', async () => {
+    const { bridge, send } = fakeBridge({ result: { value: 3 } });
+    await expect(executeScript(bridge, '1 + 2')).resolves.toBe(3);
+    expect(lastExpression(send)).toContain('return (1 + 2)');
+  });
+
+  it('should run a statement-style string as a function body', async () => {
+    const { bridge, send } = fakeBridge({ result: { value: 5 } });
+    await executeScript(bridge, 'return 5');
+    expect(lastExpression(send)).not.toContain('return (return 5)');
+  });
+});

--- a/packages/react-native-service/test/index.spec.ts
+++ b/packages/react-native-service/test/index.spec.ts
@@ -3,14 +3,14 @@ import { describe, expect, it } from 'vitest';
 import * as rn from '../src/index.js';
 
 describe('@wdio/react-native-service exports', () => {
-  it('should expose the Metro constants', () => {
-    expect(rn.DEFAULT_METRO_HOST).toBe('localhost');
-    expect(rn.DEFAULT_METRO_PORT).toBe(8081);
+  it('should export the launcher and default worker service', () => {
+    expect(typeof rn.launcher).toBe('function');
+    expect(typeof rn.default).toBe('function');
   });
 
-  it('should expose the Hermes bridge foundation', () => {
-    expect(typeof rn.createHermesBridge).toBe('function');
-    expect(typeof rn.selectHermesTarget).toBe('function');
-    expect(typeof rn.metroOrigin).toBe('function');
+  it('should export standalone session helpers', () => {
+    expect(typeof rn.startWdioSession).toBe('function');
+    expect(typeof rn.cleanupWdioSession).toBe('function');
+    expect(typeof rn.createReactNativeCapabilities).toBe('function');
   });
 });

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -1,0 +1,61 @@
+import type { Options } from '@wdio/types';
+import { describe, expect, it, vi } from 'vitest';
+import { SevereServiceError } from 'webdriverio';
+
+// BaseLauncher carries @wdio/native-core's port/driver infra the launcher doesn't
+// use yet — stub it so onPrepare is exercised in isolation.
+vi.mock('@wdio/native-core', () => ({ BaseLauncher: class {} }));
+
+import ReactNativeLaunchService from '../src/launcher.js';
+import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from '../src/types.js';
+
+const config = {} as Options.Testrunner;
+
+const make = (options: ReactNativeServiceGlobalOptions = {}) =>
+  new ReactNativeLaunchService(options, {} as ReactNativeCapabilities, config);
+
+const cap = (over: Record<string, unknown> = {}): ReactNativeCapabilities =>
+  ({ platformName: 'Android', ...over }) as ReactNativeCapabilities;
+
+describe('ReactNativeLaunchService.onPrepare', () => {
+  it('should set UiAutomator2 on an Android capability', async () => {
+    const caps = [cap({ platformName: 'Android' })];
+    await make().onPrepare(config, caps);
+    expect(caps[0]['appium:automationName']).toBe('UiAutomator2');
+  });
+
+  it('should set XCUITest on an iOS capability', async () => {
+    const caps = [cap({ platformName: 'iOS' })];
+    await make().onPrepare(config, caps);
+    expect(caps[0]['appium:automationName']).toBe('XCUITest');
+  });
+
+  it('should prepare every capability in an array', async () => {
+    const caps = [cap({ platformName: 'Android' }), cap({ platformName: 'iOS' })];
+    await make().onPrepare(config, caps);
+    expect(caps.map((c) => c['appium:automationName'])).toEqual(['UiAutomator2', 'XCUITest']);
+  });
+
+  it('should prepare capabilities in a multiremote object', async () => {
+    const caps = { phone: { capabilities: cap({ platformName: 'Android' }) } };
+    await make().onPrepare(config, caps);
+    expect(caps.phone.capabilities['appium:automationName']).toBe('UiAutomator2');
+  });
+
+  it('should apply the service appBinaryPath to appium:app', async () => {
+    const caps = [cap({ platformName: 'Android' })];
+    await make({ appBinaryPath: '/tmp/app.apk' }).onPrepare(config, caps);
+    expect(caps[0]['appium:app']).toBe('/tmp/app.apk');
+  });
+
+  it('should derive the platform from the service option when platformName is unset', async () => {
+    const caps = [cap({ platformName: undefined })];
+    await make({ platform: 'ios' }).onPrepare(config, caps);
+    expect(caps[0]['appium:automationName']).toBe('XCUITest');
+  });
+
+  it('should throw a SevereServiceError for an unsupported platform', async () => {
+    const caps = [cap({ platformName: 'Windows' })];
+    await expect(make().onPrepare(config, caps)).rejects.toThrow(SevereServiceError);
+  });
+});

--- a/packages/react-native-service/test/metroBridge.spec.ts
+++ b/packages/react-native-service/test/metroBridge.spec.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  connect: vi.fn(async () => {}),
+  close: vi.fn(async () => {}),
+  lastOptions: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock('../src/hermesBridge.js', () => ({
+  createHermesBridge: (options: Record<string, unknown>) => {
+    h.lastOptions = options;
+    return { connect: h.connect, close: h.close, send: vi.fn() };
+  },
+}));
+
+import { MetroBridge } from '../src/metroBridge.js';
+
+beforeEach(() => {
+  h.connect.mockClear();
+  h.close.mockClear();
+  h.lastOptions = undefined;
+});
+
+describe('MetroBridge', () => {
+  it('should run adb reverse then connect on Android', async () => {
+    const adbReverse = vi.fn(async () => {});
+    const metro = new MetroBridge({ platform: 'android', port: 8081, adbReverse });
+    await metro.connect();
+    expect(adbReverse).toHaveBeenCalledWith(8081);
+    expect(h.connect).toHaveBeenCalledOnce();
+    expect(metro.connected).toBe(true);
+  });
+
+  it('should not run adb reverse on iOS', async () => {
+    const adbReverse = vi.fn(async () => {});
+    const metro = new MetroBridge({ platform: 'ios', adbReverse });
+    await metro.connect();
+    expect(adbReverse).not.toHaveBeenCalled();
+    expect(h.connect).toHaveBeenCalledOnce();
+  });
+
+  it('should continue connecting when adb reverse fails', async () => {
+    const adbReverse = vi.fn(async () => {
+      throw new Error('no device');
+    });
+    const metro = new MetroBridge({ platform: 'android', adbReverse });
+    await metro.connect();
+    expect(h.connect).toHaveBeenCalledOnce();
+    expect(metro.connected).toBe(true);
+  });
+
+  it('should be idempotent on repeated connect()', async () => {
+    const metro = new MetroBridge({ platform: 'ios', adbReverse: vi.fn(async () => {}) });
+    await metro.connect();
+    await metro.connect();
+    expect(h.connect).toHaveBeenCalledOnce();
+  });
+
+  it('should throw when the bridge is accessed before connect()', () => {
+    const metro = new MetroBridge();
+    expect(() => metro.bridge).toThrow(/not connected/);
+  });
+
+  it('should close and reset the connection', async () => {
+    const metro = new MetroBridge({ platform: 'ios', adbReverse: vi.fn(async () => {}) });
+    await metro.connect();
+    await metro.close();
+    expect(h.close).toHaveBeenCalledOnce();
+    expect(metro.connected).toBe(false);
+  });
+
+  it('should reconnect by closing then connecting again', async () => {
+    const metro = new MetroBridge({ platform: 'ios', adbReverse: vi.fn(async () => {}) });
+    await metro.connect();
+    await metro.reconnect();
+    expect(h.close).toHaveBeenCalledOnce();
+    expect(h.connect).toHaveBeenCalledTimes(2);
+    expect(metro.connected).toBe(true);
+  });
+
+  it('should default the Metro host and port', async () => {
+    const metro = new MetroBridge({ platform: 'ios', adbReverse: vi.fn(async () => {}) });
+    await metro.connect();
+    expect(h.lastOptions).toMatchObject({ host: 'localhost', port: 8081 });
+  });
+});

--- a/packages/react-native-service/test/mock.spec.ts
+++ b/packages/react-native-service/test/mock.spec.ts
@@ -1,0 +1,79 @@
+import type { CdpBridge } from '@wdio/native-cdp-bridge';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createMock } from '../src/mock.js';
+import { ReactNativeMockStore } from '../src/mockStore.js';
+
+// A fake CdpBridge whose `send` resolves normally while `open`, and rejects once
+// `close()` is called — modelling a connection that was torn down by reconnect().
+function fakeBridge() {
+  let open = true;
+  const send = vi.fn(async (_method: string, params?: { expression?: string }) => {
+    if (!open) {
+      throw new Error('WebSocket is closed');
+    }
+    // buildReadCallDataScript reads call data — return an empty-but-valid shape.
+    if (params?.expression?.includes('calls')) {
+      return { result: { value: { calls: [], results: [], invocationCallOrder: [] } } };
+    }
+    return { result: { value: undefined } };
+  });
+  return {
+    bridge: { send } as unknown as CdpBridge,
+    close: () => {
+      open = false;
+    },
+  };
+}
+
+describe('createMock', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should install an inner recorder and expose a ReactNativeMock', async () => {
+    const store = new ReactNativeMockStore();
+    const { bridge } = fakeBridge();
+    const mock = await createMock('greet', bridge, store);
+    expect(mock.__isReactNativeMock).toBe(true);
+    expect(store.getMock('greet')).toBe(mock);
+  });
+
+  it('should not leak an unhandled rejection through mockClear after reconnect', async () => {
+    const store = new ReactNativeMockStore();
+    const first = fakeBridge();
+    await createMock('greet', first.bridge, store);
+
+    // Simulate MetroBridge.reconnect(): the old bridge is closed, a new one replaces it,
+    // and createMock is called again for the same target.
+    first.close();
+    const second = fakeBridge();
+    const remock = await createMock('greet', second.bridge, store);
+
+    const rejections: unknown[] = [];
+    const onRejection = (err: unknown) => rejections.push(err);
+    process.on('unhandledRejection', onRejection);
+
+    // mockClear/mockReset must route to the NEW bridge and clear native vitest state
+    // via the stashed native bindings — never the old closed bridge.
+    await remock.mockClear();
+    await remock.mockReset();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    process.off('unhandledRejection', onRejection);
+    expect(rejections).toEqual([]);
+    expect(second.bridge.send).toHaveBeenCalled();
+  });
+
+  it('should preserve call history across a reconnect (same vitest fn)', async () => {
+    const store = new ReactNativeMockStore();
+    const first = fakeBridge();
+    const mock = await createMock('greet', first.bridge, store);
+    const vitestFn = (mock as unknown as { _vitestFn: unknown })._vitestFn;
+
+    first.close();
+    const second = fakeBridge();
+    const remock = await createMock('greet', second.bridge, store);
+    expect((remock as unknown as { _vitestFn: unknown })._vitestFn).toBe(vitestFn);
+  });
+});

--- a/packages/react-native-service/test/serviceConfig.spec.ts
+++ b/packages/react-native-service/test/serviceConfig.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { CUSTOM_CAPABILITY_NAME } from '../src/constants.js';
+import { getServiceOptionsFromCapability, mergeServiceOptions } from '../src/serviceConfig.js';
+
+describe('getServiceOptionsFromCapability', () => {
+  it('should read the service options off the custom capability key', () => {
+    const opts = { metroPort: 9000 };
+    expect(getServiceOptionsFromCapability({ [CUSTOM_CAPABILITY_NAME]: opts })).toBe(opts);
+  });
+
+  it('should return undefined when the capability has no service options', () => {
+    expect(getServiceOptionsFromCapability({})).toBeUndefined();
+    expect(getServiceOptionsFromCapability(undefined)).toBeUndefined();
+  });
+});
+
+describe('mergeServiceOptions', () => {
+  it('should let capability options win over global options', () => {
+    expect(mergeServiceOptions({ metroPort: 8081 }, { metroPort: 9000 })).toEqual({ metroPort: 9000 });
+  });
+
+  it('should merge disjoint global and capability options', () => {
+    expect(mergeServiceOptions({ metroHost: 'localhost' }, { metroPort: 9000 })).toEqual({
+      metroHost: 'localhost',
+      metroPort: 9000,
+    });
+  });
+
+  it('should default to an empty object when no options are given', () => {
+    expect(mergeServiceOptions(undefined, undefined)).toEqual({});
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1280,6 +1280,9 @@ importers:
       '@wdio/native-core':
         specifier: workspace:*
         version: link:../native-core
+      '@wdio/native-spy':
+        specifier: workspace:*
+        version: link:../native-spy
       '@wdio/native-types':
         specifier: workspace:*
         version: link:../native-types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1277,9 +1277,18 @@ importers:
       '@wdio/native-cdp-bridge':
         specifier: workspace:*
         version: link:../native-cdp-bridge
+      '@wdio/native-core':
+        specifier: workspace:*
+        version: link:../native-core
       '@wdio/native-types':
         specifier: workspace:*
         version: link:../native-types
+      '@wdio/native-utils':
+        specifier: workspace:*
+        version: link:../native-utils
+      '@wdio/types':
+        specifier: catalog:default
+        version: 9.27.1
       tslib:
         specifier: ^2.8.1
         version: 2.8.1


### PR DESCRIPTION
## React Native service — PR2 (MVP)

Stacked on PR1 (#337 — foundation). Implements the working service skeleton: capability preparation, the Hermes CDP lifecycle, `execute`, basic JS-side `mock`, the worker service, standalone session helpers, and the canonical package entry point. Targets `feat/react-native-foundation`; will be retargeted to `feat/react-native` after PR1 merges.

### What lands in PR2

| Module | What it does |
|---|---|
| `capabilities.ts` | `prepareReactNativeCapability` — platform → `automationName` UiAutomator2/XCUITest, `appBinaryPath` → `appium:app`; `SevereServiceError` on unsupported platform. Gated on the capability's `platformName`, not `process.platform`. |
| `serviceConfig.ts` | `getServiceOptionsFromCapability` / `mergeServiceOptions` (capability options win) |
| `launcher.ts` | `ReactNativeLaunchService extends BaseLauncher`; `onPrepare` iterates array + multiremote caps. No Appium spawn — WDIO owns the session. |
| `metroBridge.ts` | `MetroBridge` wraps `createHermesBridge` with the worker lifecycle: best-effort `adb reverse`, lazy idempotent connect, `reconnect()` for inspector drops. |
| `commands/execute.ts` | `executeScript` → `Runtime.evaluate`; `jsonLiteral` escapes U+2028/U+2029/`<` (CodeQL `js/bad-code-sanitization` safe from first commit). |
| `innerRecorder.ts` | CDP script builders over `globalThis.__WDIO_RN_MOCKS__` (adapted from electrobun — `window→globalThis`). |
| `mock.ts` / `mockStore.ts` / `mockTypes.ts` | `createMock` outer vitest fn() + inner recorder; basic mock(). Full clear/reset/restore is PR3. |
| `service.ts` | `ReactNativeWorkerService`; `before()` connects bridge + installs `browser.reactNative.{execute,mock,isMockFunction}`; PR3 stubs throw clearly; `after/afterSession` teardown. |
| `session.ts` | `createReactNativeCapabilities`, `startWdioSession`, `cleanupWdioSession` standalone helpers. |
| `index.ts` | Bare `import '@wdio/native-types'`; `default`=service, named `launcher`, session re-exports; curated config-type exports only (no internals leak). |

### Test coverage
57 unit tests across 9 spec files: platform × `SevereServiceError` matrix, `adb reverse` gating + failure tolerance, `MetroBridge` lifecycle, `jsonLiteral` CodeQL escaping, `execute` serialisation + exception handling, error shape validation.

### Scope note
`clearAllMocks`/`resetAllMocks`/`restoreAllMocks`, `triggerDeeplink`, `switchWindow`/`listWindows`, `emitEvent`, device manager + multiremote, iOS parity, e2e fixture app — all land in **PR3** (Feature Complete). The PR3 stubs in `service.ts` throw a clear "not available in this MVP" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)