### PR TITLE
spike: CEF-on-Windows /json verification (#320) — DO NOT MERGE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,7 +773,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-type: ['standard', 'window', 'multiremote']
+        # SPIKE (#320 CEF-on-Windows): standard only — CEF is single-instance (shared
+        # root_cache_path), so window/multiremote can't run on the CEF renderer.
+        test-type: ['standard']
     uses: ./.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
     secrets: inherit
     with:

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -152,7 +152,9 @@ const baseCapability: ElectrobunCapability = {
   // "BiDi-CDP Mapper" target appears and the content target vanishes), so the CDP bridge
   // finds no content. Classic attach leaves the `views://` page intact, as chromedriver
   // does for CEF.
-  ...(process.platform === 'win32' ? { 'wdio:enforceWebDriverClassic': true } : { browserVersion: '147' }),
+  // SPIKE (#320 CEF-on-Windows): CEF on every platform → chromedriver-147 caps everywhere
+  // (NOT the WebView2/Edge classic-WebDriver path the Windows native renderer needs).
+  browserVersion: '147',
   'wdio:electrobunServiceOptions': electrobunServiceOptions,
 };
 

--- a/fixtures/e2e-apps/electrobun/electrobun.config.ts
+++ b/fixtures/e2e-apps/electrobun/electrobun.config.ts
@@ -37,10 +37,10 @@ export default {
       defaultRenderer: 'cef',
     },
     win: {
-      // Native WebView2 (Chromium) renderer — driven over CDP by @wdio/electrobun-service
-      // via an injected --remote-debugging-port. No CEF bundle on Windows.
-      bundleCEF: false,
-      defaultRenderer: 'native',
+      // SPIKE (#320 CEF-on-Windows): build CEF on Windows too, to test whether CEF serves
+      // /json there. Normally Windows is native WebView2 (bundleCEF:false/'native').
+      bundleCEF,
+      defaultRenderer: 'cef',
     },
     linux: {
       bundleCEF,

--- a/fixtures/e2e-apps/electrobun/src/bun/index.ts
+++ b/fixtures/e2e-apps/electrobun/src/bun/index.ts
@@ -17,8 +17,6 @@ import { app, BrowserWindow } from 'electrobun/bun';
 // Windows (WebView2): no persist:default race, so the second window opens immediately
 // (concurrently) rather than staggered behind dom-ready.
 
-const isWindows = process.platform === 'win32';
-
 const mainWindow = new BrowserWindow({
   title: 'WDIO Electrobun E2E — Main',
   url: 'views://mainview/index.html',
@@ -35,19 +33,16 @@ const openSecondWindow = (): void => {
   console.log('[e2e] opened second window', { second: secondWindow.id });
 };
 
-if (isWindows) {
+// SPIKE (#320 CEF-on-Windows): every platform builds CEF here, so stagger the second window
+// behind mainview's dom-ready on all platforms (the CEF workaround described above).
+let secondOpened = false;
+mainWindow.webview.on('dom-ready', () => {
+  if (secondOpened) {
+    return;
+  }
+  secondOpened = true;
   openSecondWindow();
-} else {
-  // CEF: stagger the second window behind mainview's dom-ready (see the note above).
-  let secondOpened = false;
-  mainWindow.webview.on('dom-ready', () => {
-    if (secondOpened) {
-      return;
-    }
-    secondOpened = true;
-    openSecondWindow();
-  });
-}
+});
 
 // Deeplink handler — `open wdio-electrobun://<path>` (macOS), routed via the
 // urlSchemes entry in electrobun.config.ts. Surface the URL into the main view

--- a/packages/electrobun-service/src/transport.ts
+++ b/packages/electrobun-service/src/transport.ts
@@ -30,10 +30,10 @@ export function resolveTransport(
     return 'cef';
   }
   if (platform === 'win32') {
-    // Windows drives the native WebView2 renderer; an explicit CEF build is unsupported there
-    // (it serves no /json). `readRenderer` records build.json's renderer as exactly 'cef' or
-    // 'native' (lower-cased), so match the whole value rather than a substring.
-    return renderer === 'cef' ? undefined : 'webview2';
+    // SPIKE (#320 CEF-on-Windows): route an explicit CEF build through the CEF transport to
+    // test whether CEF-on-Windows serves /json. Normally a Windows CEF build is `undefined`
+    // (unsupported). `readRenderer` records build.json's renderer as exactly 'cef' or 'native'.
+    return renderer === 'cef' ? 'cef' : 'webview2';
   }
   return undefined;
 }

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -221,7 +221,7 @@ describe('ElectrobunLaunchService', () => {
       expect(caps[0].browserName).toBe('MicrosoftEdge');
     });
 
-    it('should reject a CEF-built bundle on Windows (CEF serves no /json there)', async () => {
+    it('SPIKE (#320): should route a CEF-built bundle on Windows through the cef transport', async () => {
       setPlatform('win32');
       vi.mocked(resolveElectrobunApp).mockReturnValueOnce({
         binaryPath: 'C:/apps/Demo/bin/launcher.exe',
@@ -231,11 +231,12 @@ describe('ElectrobunLaunchService', () => {
         renderer: 'cef',
       });
       const launcher = makeLauncher({ appBinaryPath: 'C:/apps/Demo/bin/launcher.exe' });
+      const cap: ElectrobunCapabilities = {};
 
-      const error = await launcher.onPrepare(baseConfig, [{}]).catch((e: Error) => e);
-      expect(error).toBeInstanceOf(SevereServiceError);
-      expect((error as Error).message).toContain('win32');
-      expect((error as Error).message).toContain('issues/317');
+      // No longer rejected — CEF-on-Windows resolves to the cef transport (chromedriver), so
+      // onPrepare forces browserName 'chrome' instead of throwing.
+      await launcher.onPrepare(baseConfig, [cap]);
+      expect((cap as { browserName?: string }).browserName).toBe('chrome');
     });
   });
 

--- a/packages/electrobun-service/test/transport.spec.ts
+++ b/packages/electrobun-service/test/transport.spec.ts
@@ -30,8 +30,8 @@ describe('resolveTransport', () => {
     expect(resolveTransport(app(''), 'win32')).toBe('webview2');
   });
 
-  it('should return undefined on Windows for an explicit CEF build (CEF serves no /json there)', () => {
-    expect(resolveTransport(app('cef'), 'win32')).toBeUndefined();
+  it('SPIKE: should route a Windows CEF build through the cef transport (#320 verification)', () => {
+    expect(resolveTransport(app('cef'), 'win32')).toBe('cef');
   });
 
   it('should match the CEF renderer exactly, not by substring', () => {


### PR DESCRIPTION
**Throwaway spike — do not merge, do not review.** Purpose: settle empirically whether a **CEF-built app on Windows** serves a CDP `/json` endpoint (the `persist:default` profile question), which determines whether CEF-on-Windows is service-side-supportable or upstream-blocked like Linux CEF.

Routes a Windows CEF build through the existing CEF transport (normally `undefined`/unsupported): `win→bundleCEF:true` fixture, chromedriver-147 caps, always-stagger backend, `standard`-only Windows e2e matrix. macOS CEF is unchanged (control leg).

**Read the result:**
- `Build Electrobun E2E App [Windows]` green → `electrobun build` can produce a Windows CEF bundle.
- `E2E - Electrobun [Windows] - standard` green → **CEF-on-Windows serves `/json`** → supportable service-side (cheap follow-up).
- Red with "no CDP targets" / no `/json` → same `persist:default` gap as Linux CEF → upstream-blocked, fold into #466.

Refs #320.