### PR TITLE
fix(electrobun): pin msedgedriver to the WebView2 runtime version (Windows flake)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 - **Electron** - `@wdio/electron-service` (v10.x)
 - **Tauri** - `@wdio/tauri-service` (v1.x)
 - **Dioxus** - `@wdio/dioxus-service` (v1.x)
-- **Electrobun** - `@wdio/electrobun-service` (v0.1.x — **macOS-only**, requires the CEF renderer; Linux/Windows + multiremote/multi-window/deeplink are upstream-blocked, see the package README)
+- **Electrobun** - `@wdio/electrobun-service` (v0.1.x — **macOS** via CEF + **Windows** via the native WebView2 renderer (CDP), incl. multi-window/multiremote; **Linux** upstream-blocked, and deeplink/multiremote blocked on the macOS CEF path — see the package README)
 
 **Planned:** React Native, Flutter, Capacitor, Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
   </div>
 </h4>
 
-[`@wdio/electrobun-service`](./packages/electrobun-service) - Electrobun desktop applications — **experimental**, **macOS only** (`0.x`), requires the CEF renderer. Linux/Windows plus multiremote / multi-window / deeplink are upstream-blocked ([#317](https://github.com/webdriverio/desktop-mobile/issues/317)). See the [package README](./packages/electrobun-service).
+[`@wdio/electrobun-service`](./packages/electrobun-service) - Electrobun desktop applications — **experimental** (`0.x`): **macOS** (CEF) and **Windows** (native WebView2 — Chromium over CDP, including multi-window + multiremote). **Linux** is upstream-blocked, and deeplink/multiremote remain blocked on the macOS CEF path ([#317](https://github.com/webdriverio/desktop-mobile/issues/317), [#320](https://github.com/webdriverio/desktop-mobile/issues/320)). See the [package README](./packages/electrobun-service).
 
 ## Planned Support
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -41,7 +41,7 @@ fixtures/e2e-apps/
 ├── electron-script/        # Electron app (script mode)
 ├── tauri/                  # Tauri app
 ├── dioxus/                 # Dioxus app
-└── electrobun/             # Electrobun app (CEF renderer)
+└── electrobun/             # Electrobun app (CEF on macOS / native WebView2 on Windows)
 ```
 
 ## Running E2E Tests

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -24,7 +24,7 @@ e2e/
 │   │   ├── api.spec.ts
 │   │   ├── mock.spec.ts
 │   │   └── ...
-│   └── electrobun/         # Electrobun E2E tests (macOS-only; CI runs the `standard` suite)
+│   └── electrobun/         # Electrobun E2E tests (macOS CEF: `standard`; Windows WebView2: standard+window+multiremote)
 │       ├── api.spec.ts
 │       └── ...
 ├── lib/                    # Shared test utilities

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -145,9 +145,10 @@ const baseCapability: ElectrobunCapability = {
   // CEF (macOS) bundles Chromium 147 (147.0.7727.118); pin the driver to that major
   // so WDIO doesn't fetch the latest (148+), which refuses to attach with "only
   // supports Chrome version N". Matching the major is what matters (spike
-  // RESEARCH_FINDINGS §2). Bump alongside the Electrobun/CEF pin. On Windows the
-  // WebView2 (Edge) path omits this so WDIO/edgedriver match the runner's installed
-  // Edge/WebView2 runtime instead. It also forces CLASSIC WebDriver: Edge defaults to
+  // RESEARCH_FINDINGS §2). Bump alongside the Electrobun/CEF pin. The Windows WebView2 path
+  // omits this — the launcher pins browserVersion to the detected WebView2 *runtime* version
+  // instead, since msedgedriver must match the runtime (which can lag the Edge browser WDIO
+  // would otherwise auto-match). It also forces CLASSIC WebDriver: Edge defaults to
   // WebDriver BiDi, whose session resets the app's only webview to about:blank (a
   // "BiDi-CDP Mapper" target appears and the content target vanishes), so the CDP bridge
   // finds no content. Classic attach leaves the `views://` page intact, as chromedriver

--- a/fixtures/package-tests/electrobun-app/wdio.conf.ts
+++ b/fixtures/package-tests/electrobun-app/wdio.conf.ts
@@ -75,9 +75,9 @@ const capabilities: ElectrobunCapability[] = [
     // The launcher rewrites 'electrobun' → 'chrome' (CEF/macOS) or 'MicrosoftEdge'
     // (WebView2/Windows) + sets debuggerAddress in onWorkerStart. CEF pins the Chromium major
     // (147) so WDIO doesn't fetch a newer Chromedriver that refuses to attach; the Windows
-    // WebView2/Edge path omits the pin (edgedriver matches the runner's Edge) and forces
-    // classic WebDriver — Edge's default BiDi resets the page to about:blank, hiding the
-    // content target.
+    // WebView2/Edge path omits the pin (the launcher pins browserVersion to the detected
+    // WebView2 runtime version, which msedgedriver must match) and forces classic WebDriver —
+    // Edge's default BiDi resets the page to about:blank, hiding the content target.
     browserName: 'electrobun',
     ...(process.platform === 'win32' ? { 'wdio:enforceWebDriverClassic': true } : { browserVersion: '147' }),
     'wdio:electrobunServiceOptions': electrobunServiceOptions,

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -29,26 +29,30 @@ Protocol (the launcher spawns the app binary and WebdriverIO attaches via
 Chromedriver's `debuggerAddress`). Electrobun's default webview engine differs
 per platform and only the Chromium-based ones speak CDP:
 
-| Platform | Default webview | CDP? |
-|---|---|---|
-| Windows | WebView2 (Chromium) | ✅ |
-| macOS | WKWebView (WebKit) | ❌ |
-| Linux | WebKitGTK (WebKit) | ❌ |
+| Platform | Native webview | CDP? | How the service drives it |
+|---|---|---|---|
+| Windows | WebView2 (Chromium) | ✅ | the **native WebView2** renderer directly (no CEF) |
+| macOS | WKWebView (WebKit) | ❌ | build with the **CEF** renderer (bundled Chromium) |
+| Linux | WebKitGTK (WebKit) | ❌ | unsupported (CEF serves no `/json`; WebKitGTK automation is upstream-blocked) |
 
-So the service requires the app under test to be built with Electrobun's **CEF
-renderer**:
+So the renderer the app must be built with is **per platform** — CEF on macOS, the native
+WebView2 on Windows:
 
 ```ts
 // electrobun.config.ts
 export default {
   build: {
+    // macOS: WKWebView can't be driven, so build with CEF.
     mac: { bundleCEF: true, defaultRenderer: 'cef' },
+    // Windows: the native WebView2 renderer speaks CDP directly — no CEF (this is the default).
+    win: { bundleCEF: false, defaultRenderer: 'native' },
   },
 };
 ```
 
-Apps built with the default WebKit renderer are an explicit, documented
-unsupported configuration — the launcher fails fast with a clear error.
+On **macOS**, an app built with the default WKWebView renderer is an explicit, documented
+unsupported configuration — the launcher fails fast with a clear error. On **Windows**, a CEF
+build is likewise unsupported (CEF can't create its profile there); use the native renderer.
 
 ## Quick start
 
@@ -58,11 +62,13 @@ export const config = {
   services: ['electrobun'],
   capabilities: [
     {
-      // The launcher rewrites this to 'chrome' + sets the CDP debuggerAddress.
+      // The launcher rewrites this to 'chrome'/'MicrosoftEdge' + sets the CDP debuggerAddress.
       browserName: 'electrobun',
-      // Pin Chromedriver to the CEF Chromium major (147 for current Electrobun).
+      // macOS/CEF: pin Chromedriver to the CEF Chromium major (147 for current Electrobun).
+      // On Windows, omit this — the launcher pins msedgedriver to the WebView2 runtime version.
       browserVersion: '147',
       'wdio:electrobunServiceOptions': {
+        // macOS: the .app bundle; Windows: the built `…\bin\launcher.exe`.
         appBinaryPath: '/path/to/build/<env>/MyApp.app',
       },
     },
@@ -77,7 +83,7 @@ const title = await browser.electrobun.execute(() => document.title);
 expect(title).toBe('My App');
 ```
 
-## Supported surface (macOS)
+## Supported surface (macOS + Windows)
 
 | Feature | Status |
 |---|---|

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -7,12 +7,14 @@ It mirrors the surface of the sibling services (`@wdio/electron-service`,
 `@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
 Vitest-style mocking, log capture, browser mode, and standalone sessions.
 
-> **Status: `0.1.0` — macOS-only, pre-1.0.** This is a `0.x` release because the
-> CEF renderer Electrobun apps must be built with cannot currently be driven on
-> Linux/Windows, and multiremote/multi-window/deeplink are blocked by the same
-> upstream limitation. See [Known limitations](#known-limitations). `1.0` is
-> reserved for full parity once those gaps are filled
-> ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) tracks the work).
+> **Status: `0.1.0`, pre-1.0 — macOS (CEF) + Windows (native WebView2).** Windows uses the
+> native WebView2 (Chromium) renderer over CDP — no CEF — and runs multi-window + multiremote.
+> This is still a `0.x` release because **Linux** isn't yet drivable (CEF serves no `/json` off
+> macOS; the native WebKitGTK renderer needs upstream automation support), and on the **macOS
+> CEF** path multiremote/deeplink remain blocked by an upstream limitation. See
+> [Known limitations](#known-limitations). `1.0` is reserved for full parity once those gaps are
+> filled ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) +
+> [#320](https://github.com/webdriverio/desktop-mobile/issues/320) track the work).
 
 ## Installation
 

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -134,6 +134,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
     // WebView2 (Windows) only: detect the installed runtime version once so the loop can pin
     // msedgedriver to it (see the per-cap note below). Off Windows this is skipped.
     const webview2Version = process.platform === 'win32' ? detectWebView2RuntimeVersion() : undefined;
+    let warnedNoWebView2Version = false;
     this.resolvedApps = [];
     for (const cap of capsList) {
       const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
@@ -155,10 +156,20 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       (cap as { browserName?: string }).browserName = transport === 'webview2' ? 'MicrosoftEdge' : 'chrome';
       // The WebView2 runtime can lag the Edge browser WDIO auto-matches; a mismatched
       // msedgedriver then refuses to attach ("only supports Microsoft Edge version N"). Pin the
-      // driver to the runtime version instead, respecting any user-set browserVersion.
-      if (transport === 'webview2' && webview2Version) {
+      // driver to the runtime version instead, respecting any user-set browserVersion. If the
+      // runtime version couldn't be detected, warn once so the at-risk auto-match is traceable.
+      if (transport === 'webview2') {
         const versioned = cap as { browserVersion?: string };
-        versioned.browserVersion ??= webview2Version;
+        if (webview2Version) {
+          versioned.browserVersion ??= webview2Version;
+        } else if (!warnedNoWebView2Version) {
+          warnedNoWebView2Version = true;
+          log.warn(
+            "Could not detect the installed WebView2 runtime version — falling back to WDIO's " +
+              'Edge-browser driver auto-match. If the runtime lags the Edge browser, msedgedriver may ' +
+              'refuse to attach ("session not created: only supports Microsoft Edge version N").',
+          );
+        }
       }
     }
     log.info(`Native mode prepared ${this.resolvedApps.length} Electrobun app(s)`);

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -16,18 +16,27 @@ const log = createLogger(SERVICE_NAME, 'launcher');
 /**
  * Main-process launcher for `@wdio/electrobun-service`.
  *
- * Electrobun is a CDP-attach framework: the launcher spawns the app binary and
- * the worker attaches over CDP through Chromedriver (`debuggerAddress`). It
- * extends `BaseLauncher` to reuse `@wdio/native-core`'s port/process/log infra.
+ * Electrobun is a CDP-attach framework: the launcher spawns the app binary and the worker
+ * attaches over CDP via `debuggerAddress`. It extends `BaseLauncher` to reuse
+ * `@wdio/native-core`'s port/process/log infra. The CDP transport is per platform
+ * (see `resolveTransport`):
+ *  - **macOS → CEF** (Chromium), driven by **chromedriver** (`browserName: 'chrome'`,
+ *    `goog:chromeOptions.debuggerAddress`). Single-instance (`maxInstances=1`): CEF can't
+ *    isolate the forced `persist:default` profile per worker, so we do NOT redirect the cache
+ *    root (no `CFFIXED_USER_HOME`, no per-worker `--user-data-dir`) — CEF uses its own
+ *    `root_cache_path`.
+ *  - **Windows → native WebView2** (Edge-based Chromium), driven by **msedgedriver**
+ *    (`browserName: 'MicrosoftEdge'`, `ms:edgeOptions.debuggerAddress`). Isolates per instance
+ *    (its own `LOCALAPPDATA` data root), so parallel workers + multiremote work.
+ *  - **Linux** has no CDP/automation surface yet → unsupported (fail fast). See the
+ *    implementation plan "Framework gaps".
  *
- * 0.x is macOS-only + single-instance (`maxInstances=1`): CEF can't isolate the
- * forced `persist:default` profile per worker, so we do NOT redirect the cache root
- * (no `CFFIXED_USER_HOME`, no per-worker `--user-data-dir`) — CEF uses its own
- * `root_cache_path`. See the implementation plan "Framework gaps". Native-mode flow:
- *  - `onPrepare`: resolve + CEF-verify each app bundle, force `browserName: 'chrome'`.
- *  - `onWorkerStart`: allocate a port; spawn the app (the spawn path clones the bundle
- *    and pins the port into the clone's build.json); wait for CEF to serve `/json`;
- *    set `goog:chromeOptions.debuggerAddress`.
+ * Native-mode flow:
+ *  - `onPrepare`: resolve each bundle + pick its transport; CEF-verify (CEF only); force
+ *    `browserName`; pin the driver to the WebView2 runtime version (WebView2 only).
+ *  - `onWorkerStart`: allocate a port; spawn the app — CEF clones the bundle and pins the port
+ *    into the clone's `build.json`, WebView2 injects `--remote-debugging-port` via env — wait
+ *    for `/json`, then set the `debuggerAddress`.
  *  - `onComplete`: kill spawned apps + clean temp dirs.
  */
 export default class ElectrobunLaunchService extends BaseLauncher {

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -9,6 +9,7 @@ import { type ElectrobunAppProcess, spawnElectrobunApp, stopElectrobunApp, waitF
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
 import { resolveTransport } from './transport.js';
 import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './types.js';
+import { detectWebView2RuntimeVersion } from './webview2Version.js';
 
 const log = createLogger(SERVICE_NAME, 'launcher');
 
@@ -130,6 +131,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
     // Native mode: resolve each bundle, pick its CDP transport, force chrome capability.
     // The spawn (CEF clone+port-pin, or WebView2 env-var injection) happens in
     // onWorkerStart so each worker gets a freshly allocated port.
+    // WebView2 (Windows) only: detect the installed runtime version once so the loop can pin
+    // msedgedriver to it (see the per-cap note below). Off Windows this is skipped.
+    const webview2Version = process.platform === 'win32' ? detectWebView2RuntimeVersion() : undefined;
     this.resolvedApps = [];
     for (const cap of capsList) {
       const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
@@ -149,6 +153,13 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       // which chromedriver rejects as an "unrecognized Chrome version"), so it must be
       // driven by msedgedriver → browserName 'MicrosoftEdge' (WDIO provisions edgedriver).
       (cap as { browserName?: string }).browserName = transport === 'webview2' ? 'MicrosoftEdge' : 'chrome';
+      // The WebView2 runtime can lag the Edge browser WDIO auto-matches; a mismatched
+      // msedgedriver then refuses to attach ("only supports Microsoft Edge version N"). Pin the
+      // driver to the runtime version instead, respecting any user-set browserVersion.
+      if (transport === 'webview2' && webview2Version) {
+        const versioned = cap as { browserVersion?: string };
+        versioned.browserVersion ??= webview2Version;
+      }
     }
     log.info(`Native mode prepared ${this.resolvedApps.length} Electrobun app(s)`);
   }

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -171,7 +171,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
         const versioned = cap as { browserVersion?: string };
         if (webview2Version) {
           versioned.browserVersion ??= webview2Version;
-        } else if (!warnedNoWebView2Version) {
+        } else if (versioned.browserVersion === undefined && !warnedNoWebView2Version) {
+          // Only warn when we'd actually fall back to auto-match — not when the user pinned
+          // browserVersion themselves (then there's no fallback and nothing at risk).
           warnedNoWebView2Version = true;
           log.warn(
             "Could not detect the installed WebView2 runtime version — falling back to WDIO's " +

--- a/packages/electrobun-service/src/webview2Version.ts
+++ b/packages/electrobun-service/src/webview2Version.ts
@@ -1,0 +1,68 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from './constants.js';
+
+const log = createLogger(SERVICE_NAME, 'launcher');
+
+const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;
+
+/**
+ * Detect the installed Evergreen **WebView2 runtime** version on Windows.
+ *
+ * WDIO auto-provisions msedgedriver to match the Edge **browser** (`msedge.exe`), but an
+ * Electrobun app renders with the WebView2 **runtime** — a separate Evergreen install that can
+ * lag the browser by a release. When they diverge (browser 149, runtime 148) the driver refuses
+ * to attach (`session not created: … only supports Microsoft Edge version 149`). Returning the
+ * runtime version lets the launcher pin `browserVersion` so the driver matches what it actually
+ * drives, instead of whatever the runner's browser/`latest` happens to be.
+ *
+ * The runtime installs versioned dirs under `…\Microsoft\EdgeWebView\Application\<version>\`
+ * (each holding `msedgewebview2.exe`). Returns the newest valid version, or `undefined` when not
+ * found (the caller then falls back to WDIO's browser auto-match — i.e. today's behaviour).
+ */
+export function detectWebView2RuntimeVersion(): string | undefined {
+  const bases = [process.env['ProgramFiles(x86)'], process.env.ProgramFiles, process.env.LOCALAPPDATA].filter(
+    (base): base is string => Boolean(base),
+  );
+
+  let best: string | undefined;
+  for (const base of bases) {
+    const appDir = join(base, 'Microsoft', 'EdgeWebView', 'Application');
+    if (!existsSync(appDir)) {
+      continue;
+    }
+    let entries: string[];
+    try {
+      entries = readdirSync(appDir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (VERSION_DIR.test(entry) && existsSync(join(appDir, entry, 'msedgewebview2.exe'))) {
+        if (best === undefined || compareVersions(entry, best) > 0) {
+          best = entry;
+        }
+      }
+    }
+  }
+
+  if (best) {
+    log.debug(`Detected WebView2 runtime version ${best}`);
+  }
+  return best;
+}
+
+/** Numeric compare of two `a.b.c.d` version strings. Returns >0 when `a` is newer. */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 4; i++) {
+    if (pa[i] !== pb[i]) {
+      return pa[i] - pb[i];
+    }
+  }
+  return 0;
+}

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -232,6 +232,27 @@ describe('ElectrobunLaunchService', () => {
       expect(logMocks.warn).toHaveBeenCalledWith(expect.stringContaining('WebView2 runtime version'));
     });
 
+    it('should NOT warn when runtime detection fails but the user pinned browserVersion', async () => {
+      setPlatform('win32');
+      vi.mocked(detectWebView2RuntimeVersion).mockReturnValueOnce(undefined);
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce({
+        binaryPath: 'C:/apps/Demo/bin/launcher.exe',
+        bundlePath: 'C:/apps/Demo',
+        resourcesDir: 'C:/apps/Demo/Resources',
+        buildJsonPath: 'C:/apps/Demo/Resources/build.json',
+        renderer: 'native',
+      });
+      const launcher = makeLauncher({ appBinaryPath: 'C:/apps/Demo/bin/launcher.exe' });
+      const cap: ElectrobunCapabilities = {};
+      (cap as { browserVersion?: string }).browserVersion = '150.0.1';
+
+      await launcher.onPrepare(baseConfig, [cap]);
+
+      // User pinned the version → no auto-match fallback, so no (spurious) warning.
+      expect((cap as { browserVersion?: string }).browserVersion).toBe('150.0.1');
+      expect(logMocks.warn).not.toHaveBeenCalledWith(expect.stringContaining('WebView2 runtime version'));
+    });
+
     it('should propagate a missing-appBinaryPath SevereServiceError from resolution', async () => {
       vi.mocked(resolveElectrobunApp).mockImplementationOnce(() => {
         throw new SevereServiceError('@wdio/electrobun-service requires an explicit appBinaryPath in native mode.');

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -43,6 +43,10 @@ vi.mock('../src/nativeMode.js', () => ({
   waitForCdpReady: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../src/webview2Version.js', () => ({
+  detectWebView2RuntimeVersion: vi.fn(() => '148.0.3967.83'),
+}));
+
 import { resolveElectrobunApp, verifyCefRenderer, writeRemoteDebuggingPort } from '../src/electrobunConfig.js';
 import ElectrobunLaunchService from '../src/launcher.js';
 import { spawnElectrobunApp, stopElectrobunApp } from '../src/nativeMode.js';
@@ -167,6 +171,25 @@ describe('ElectrobunLaunchService', () => {
       await launcher.onPrepare({ maxInstances: 2 } as Parameters<typeof launcher.onPrepare>[0], caps);
 
       expect(logMocks.warn).not.toHaveBeenCalledWith(expect.stringContaining('maxInstances'));
+    });
+
+    it('should pin browserVersion to the WebView2 runtime version on the Windows WebView2 path', async () => {
+      setPlatform('win32');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce({
+        binaryPath: 'C:/apps/Demo/bin/launcher.exe',
+        bundlePath: 'C:/apps/Demo',
+        resourcesDir: 'C:/apps/Demo/Resources',
+        buildJsonPath: 'C:/apps/Demo/Resources/build.json',
+        renderer: 'native',
+      });
+      const launcher = makeLauncher({ appBinaryPath: 'C:/apps/Demo/bin/launcher.exe' });
+      const cap: ElectrobunCapabilities = {};
+
+      await launcher.onPrepare(baseConfig, [cap]);
+
+      expect((cap as { browserName?: string }).browserName).toBe('MicrosoftEdge');
+      // Pinned to the detected runtime version (mocked), not WDIO's Edge-browser auto-match.
+      expect((cap as { browserVersion?: string }).browserVersion).toBe('148.0.3967.83');
     });
 
     it('should propagate a missing-appBinaryPath SevereServiceError from resolution', async () => {

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -59,8 +59,8 @@ function makeLauncher(options: ElectrobunServiceGlobalOptions): ElectrobunLaunch
   return new ElectrobunLaunchService(options, {} as ElectrobunCapabilities, baseConfig);
 }
 
-// Native mode is macOS-only (0.x), so default every test to darwin; the platform-guard
-// tests below override to linux/win32. Restored after each test.
+// Tests default to darwin (the CEF path); the platform-guard and Windows/WebView2 tests
+// override to linux/win32. Restored after each test.
 const originalPlatform = process.platform;
 function setPlatform(value: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', { value, writable: true, configurable: true });

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -51,6 +51,7 @@ import { resolveElectrobunApp, verifyCefRenderer, writeRemoteDebuggingPort } fro
 import ElectrobunLaunchService from '../src/launcher.js';
 import { spawnElectrobunApp, stopElectrobunApp } from '../src/nativeMode.js';
 import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions } from '../src/types.js';
+import { detectWebView2RuntimeVersion } from '../src/webview2Version.js';
 
 const baseConfig = {} as Parameters<ElectrobunLaunchService['onPrepare']>[0];
 
@@ -190,6 +191,45 @@ describe('ElectrobunLaunchService', () => {
       expect((cap as { browserName?: string }).browserName).toBe('MicrosoftEdge');
       // Pinned to the detected runtime version (mocked), not WDIO's Edge-browser auto-match.
       expect((cap as { browserVersion?: string }).browserVersion).toBe('148.0.3967.83');
+    });
+
+    it('should NOT override a user-set browserVersion on the WebView2 path (??= preserves it)', async () => {
+      setPlatform('win32');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce({
+        binaryPath: 'C:/apps/Demo/bin/launcher.exe',
+        bundlePath: 'C:/apps/Demo',
+        resourcesDir: 'C:/apps/Demo/Resources',
+        buildJsonPath: 'C:/apps/Demo/Resources/build.json',
+        renderer: 'native',
+      });
+      const launcher = makeLauncher({ appBinaryPath: 'C:/apps/Demo/bin/launcher.exe' });
+      const cap: ElectrobunCapabilities = {};
+      (cap as { browserVersion?: string }).browserVersion = '150.0.1';
+
+      await launcher.onPrepare(baseConfig, [cap]);
+
+      // The user's pin wins over the detected runtime version (mocked 148.0.3967.83).
+      expect((cap as { browserVersion?: string }).browserVersion).toBe('150.0.1');
+    });
+
+    it('should warn and fall back to auto-match when the WebView2 runtime version is undetectable', async () => {
+      setPlatform('win32');
+      vi.mocked(detectWebView2RuntimeVersion).mockReturnValueOnce(undefined);
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce({
+        binaryPath: 'C:/apps/Demo/bin/launcher.exe',
+        bundlePath: 'C:/apps/Demo',
+        resourcesDir: 'C:/apps/Demo/Resources',
+        buildJsonPath: 'C:/apps/Demo/Resources/build.json',
+        renderer: 'native',
+      });
+      const launcher = makeLauncher({ appBinaryPath: 'C:/apps/Demo/bin/launcher.exe' });
+      const cap: ElectrobunCapabilities = {};
+
+      await launcher.onPrepare(baseConfig, [cap]);
+
+      // No version pinned → WDIO auto-matches; the warn makes that traceable in CI logs.
+      expect((cap as { browserVersion?: string }).browserVersion).toBeUndefined();
+      expect(logMocks.warn).toHaveBeenCalledWith(expect.stringContaining('WebView2 runtime version'));
     });
 
     it('should propagate a missing-appBinaryPath SevereServiceError from resolution', async () => {

--- a/packages/electrobun-service/test/webview2Version.spec.ts
+++ b/packages/electrobun-service/test/webview2Version.spec.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsMocks = vi.hoisted(() => ({ existsSync: vi.fn(), readdirSync: vi.fn() }));
+vi.mock('node:fs', () => ({ existsSync: fsMocks.existsSync, readdirSync: fsMocks.readdirSync }));
+vi.mock('@wdio/native-utils', () => ({
+  createLogger: () => ({ trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { detectWebView2RuntimeVersion } from '../src/webview2Version.js';
+
+describe('detectWebView2RuntimeVersion', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Only ProgramFiles(x86) set, so the test is independent of the host OS's real env.
+    process.env = { ...originalEnv, 'ProgramFiles(x86)': 'C:\\Program Files (x86)' };
+    delete process.env.ProgramFiles;
+    delete process.env.LOCALAPPDATA;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns the newest version dir that holds msedgewebview2.exe', () => {
+    fsMocks.existsSync.mockImplementation((p: string) => p.includes('EdgeWebView'));
+    fsMocks.readdirSync.mockReturnValue(['148.0.3967.83', '149.0.4000.1', 'not-a-version', 'BHO']);
+
+    // Newest by numeric compare, ignoring the non-version entries.
+    expect(detectWebView2RuntimeVersion()).toBe('149.0.4000.1');
+  });
+
+  it('ignores a version dir without msedgewebview2.exe', () => {
+    fsMocks.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith('Application')) {
+        return true;
+      }
+      if (p.includes('149.0.4000.1')) {
+        return false; // newer dir present but missing the runtime exe
+      }
+      return p.endsWith('msedgewebview2.exe');
+    });
+    fsMocks.readdirSync.mockReturnValue(['148.0.3967.83', '149.0.4000.1']);
+
+    expect(detectWebView2RuntimeVersion()).toBe('148.0.3967.83');
+  });
+
+  it('returns undefined when the runtime is not installed', () => {
+    fsMocks.existsSync.mockReturnValue(false);
+
+    expect(detectWebView2RuntimeVersion()).toBeUndefined();
+  });
+
+  it('returns undefined when no base paths are set (e.g. non-Windows)', () => {
+    process.env = { ...originalEnv };
+    delete process.env['ProgramFiles(x86)'];
+    delete process.env.ProgramFiles;
+    delete process.env.LOCALAPPDATA;
+    fsMocks.existsSync.mockReturnValue(true);
+
+    expect(detectWebView2RuntimeVersion()).toBeUndefined();
+    expect(fsMocks.existsSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/native-cdp-bridge/README.md
+++ b/packages/native-cdp-bridge/README.md
@@ -9,7 +9,7 @@ Shared Chrome DevTools Protocol (CDP) bridge for WebdriverIO native-app services
 
 Consumers:
 
-- `@wdio/electrobun-service` — `MultiTargetCdpBridge` (CEF, one target per window; supplies the CEF classifier).
+- `@wdio/electrobun-service` — `MultiTargetCdpBridge` (CEF on macOS / native WebView2 on Windows, one target per window; supplies the target classifier).
 - `@wdio/react-native-service` — `CdpBridge` (single Hermes target via Metro's inspector-proxy; supplies a Hermes `selectTarget` + `origin`).
 - `@wdio/electron-service` — migrating to `CdpBridge` (single-target).
 


### PR DESCRIPTION
## Problem

The Windows WebView2 legs (e2e + package-test) intermittently fail on `main`:

> session not created: cannot connect to microsoft edge at 127.0.0.1:&lt;port&gt;
> This version of Microsoft Edge WebDriver only supports Microsoft Edge version 149

WDIO auto-provisions msedgedriver to match the Edge **browser** (`msedge.exe`), but an Electrobun app renders with the WebView2 **runtime** — a separate Evergreen install that can lag the browser by a release. When Edge stable rolled 148→149 the driver became 149 while the runner's WebView2 runtime stayed 148, so it refused to attach. Green at merge (versions aligned), and it recurs every Edge release cycle. Already observed on `main` (merge `88b22760`, the `multiremote` leg).

## Fix

Detect the installed WebView2 **runtime** version (`…\Microsoft\EdgeWebView\Application\<version>`) in the launcher and pin `browserVersion` to it for the `webview2` transport, so msedgedriver matches what it actually drives. Falls back to WDIO's auto-match when the runtime isn't detected (no regression).

- `webview2Version.ts` (new): `detectWebView2RuntimeVersion()` + unit tests.
- launcher: pins `browserVersion` for the WebView2 transport (respects a user-set value).
- conf comments corrected; **181 unit tests green**.

Also drops stale `0.1.0 — macOS-only` doc framing (the first publish was delayed, so `0.1.0` bundles the Windows WebView2 work; #317/#320 updated).

Refs #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)