### PR TITLE
perf(react-native-e2e-ios): cut macOS runner cost — caching + queue priority

### DIFF
--- a/.github/workflows/_ci-build-rn-ios-app.reusable.yml
+++ b/.github/workflows/_ci-build-rn-ios-app.reusable.yml
@@ -1,0 +1,137 @@
+name: Build RN iOS E2E App
+# Description: Scaffolds the React Native project, installs CocoaPods, and runs xcodebuild
+# to produce the simulator .app. Extracted from _ci-e2e-react-native-ios so it can run
+# in parallel with the package build (needs: [detect-changes] only, no build dep).
+# The E2E job downloads the .app artifact and only needs a JS scaffold + Metro.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Runner OS (macos-latest)'
+        required: true
+        type: string
+      node-version:
+        description: 'Node.js version'
+        required: true
+        type: string
+      rn-version:
+        description: 'React Native version to scaffold the native project with'
+        type: string
+        default: '0.76.5'
+      rn-cli-version:
+        description: '@react-native-community/cli major to scaffold with (pinned to match rn-version)'
+        type: string
+        default: '15'
+      new-arch:
+        description: 'Build the fixture with the New Architecture (Fabric/bridgeless) enabled'
+        type: boolean
+        default: false
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  RN_BUILD_DIR: ${{ github.workspace }}/rn-build
+
+jobs:
+  build:
+    name: Build .app
+    runs-on: ${{ inputs.os }}
+    # Cap a stuck xcodebuild/CocoaPods rather than holding a scarce macOS runner for the 6h default.
+    timeout-minutes: 40
+    steps:
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: 🛠️ Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      # Shared with the E2E job so the re-scaffold gets a cache hit and skips the npm
+      # download entirely — the tarball content is identical for the same pinned version.
+      - name: 💾 Restore npm download cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-rn-${{ inputs.rn-version }}-v1
+
+      - name: 💾 Restore CocoaPods cache
+        id: pods-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RN_BUILD_DIR }}/ios/Pods
+          key: rn-cocoapods-${{ inputs.rn-version }}-${{ inputs.new-arch && 'new' || 'old' }}-arch-v1
+
+      # Scaffold a complete RN project at the pinned version so CocoaPods can install for
+      # iOS, then overlay the fixture's App.tsx. The fixture App only imports react-native
+      # core, so the stock template builds it unmodified.
+      - name: 🏗️ Scaffold native project
+        shell: bash
+        env:
+          RN_VERSION: ${{ inputs.rn-version }}
+          RN_CLI_VERSION: ${{ inputs.rn-cli-version }}
+        run: |
+          set -euo pipefail
+          npx --yes "@react-native-community/cli@$RN_CLI_VERSION" init ReactNativeE2EApp \
+            --version "$RN_VERSION" --directory "$RN_BUILD_DIR" --skip-git-init --pm npm --install-pods false
+          cp fixtures/e2e-apps/react-native/App.tsx "$RN_BUILD_DIR/App.tsx"
+
+      - name: 🏗️ Install CocoaPods
+        if: steps.pods-cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          NEW_ARCH: ${{ inputs.new-arch }}
+        run: |
+          set -euo pipefail
+          # Select the RN architecture for this leg (mirrors Android) — BOTH old (Paper) and new
+          # (Fabric/bridgeless, the RN 0.76 default) are required gates. RCT_NEW_ARCH_ENABLED at
+          # pod-install time picks the arch; under Fabric the tree/Hermes register slightly later
+          # but the spec mount-waits + the service's Hermes connect-retry absorb it.
+          NEW_ARCH_FLAG=$([ "$NEW_ARCH" = "true" ] && echo 1 || echo 0)
+          ( cd "$RN_BUILD_DIR/ios" && RCT_NEW_ARCH_ENABLED="$NEW_ARCH_FLAG" pod install )
+          # NOTE: there is no reliable Podfile.lock-level arch assertion on iOS (unlike Android's
+          # gradle.properties grep). RN 0.76 vendors the Fabric pods (React-Fabric, hermes-engine,
+          # …) into Podfile.lock for BOTH archs — RCT_NEW_ARCH_ENABLED is a build-time flag, not a
+          # pod-set difference — so pod presence can't discriminate old vs new. The E2E run itself
+          # is the validation (Fabric renders/behaves differently at runtime).
+
+      - name: 📱 Build iOS app for the simulator
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$RN_BUILD_DIR/ios"
+          # xcbeautify only prettifies output and isn't guaranteed on the runner image; pipe
+          # through `(xcbeautify || cat)` so a missing tool can't SIGPIPE-kill xcodebuild, and
+          # rely on pipefail to surface a real xcodebuild failure (not the later "app not found").
+          xcodebuild \
+            -workspace ReactNativeE2EApp.xcworkspace \
+            -scheme ReactNativeE2EApp \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO 2>&1 | (xcbeautify || cat)
+          APP_PATH="$RN_BUILD_DIR/ios/build/Build/Products/Debug-iphonesimulator/ReactNativeE2EApp.app"
+          test -d "$APP_PATH" || { echo "::error::iOS .app not found at $APP_PATH"; exit 1; }
+          # Tar the bundle (preserves the simulator .app's symlinks + exec bits, which a raw
+          # artifact upload would mangle) so the E2E job can install it verbatim.
+          tar -czf "$GITHUB_WORKSPACE/rn-ios-app.tar.gz" -C "$(dirname "$APP_PATH")" ReactNativeE2EApp.app
+
+      - name: 📦 Upload built .app
+        uses: actions/upload-artifact@v7
+        with:
+          # Keyed by run_id only (NOT run_attempt): `gh run rerun --failed` re-runs the failed Run
+          # job but NOT this Build job (it passed), so the artifact keeps its original name — a
+          # run_attempt suffix would leave the retried Run job looking for an artifact that was
+          # never re-uploaded. overwrite handles a full re-run that does rebuild.
+          name: rn-ios-app-${{ inputs.new-arch && 'new' || 'old' }}-arch-${{ github.run_id }}
+          path: rn-ios-app.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/_ci-build-rn-ios-app.reusable.yml
+++ b/.github/workflows/_ci-build-rn-ios-app.reusable.yml
@@ -62,16 +62,12 @@ jobs:
           path: ~/.npm
           key: npm-rn-${{ inputs.rn-version }}-v1
 
-      - name: 💾 Restore CocoaPods cache
-        id: pods-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.RN_BUILD_DIR }}/ios/Pods
-          key: rn-cocoapods-${{ inputs.rn-version }}-${{ inputs.new-arch && 'new' || 'old' }}-arch-v1
-
       # Scaffold a complete RN project at the pinned version so CocoaPods can install for
       # iOS, then overlay the fixture's App.tsx. The fixture App only imports react-native
       # core, so the stock template builds it unmodified.
+      # IMPORTANT: the CocoaPods cache restore must come AFTER this step — actions/cache
+      # creates parent directories on restore, so restoring ios/Pods/ before scaffold would
+      # create a non-empty $RN_BUILD_DIR that makes npx init abort with "directory exists".
       - name: 🏗️ Scaffold native project
         shell: bash
         env:
@@ -82,6 +78,13 @@ jobs:
           npx --yes "@react-native-community/cli@$RN_CLI_VERSION" init ReactNativeE2EApp \
             --version "$RN_VERSION" --directory "$RN_BUILD_DIR" --skip-git-init --pm npm --install-pods false
           cp fixtures/e2e-apps/react-native/App.tsx "$RN_BUILD_DIR/App.tsx"
+
+      - name: 💾 Restore CocoaPods cache
+        id: pods-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RN_BUILD_DIR }}/ios/Pods
+          key: rn-cocoapods-${{ inputs.rn-version }}-${{ inputs.new-arch && 'new' || 'old' }}-arch-v1
 
       - name: 🏗️ Install CocoaPods
         if: steps.pods-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -1,13 +1,13 @@
 name: E2E Tests - React Native (iOS)
-# Description: iOS-simulator E2E for @wdio/react-native-service. Split into a BUILD job
-# (scaffold + CocoaPods + xcodebuild → upload the .app) and an E2E job (re-scaffold the JS for
-# Metro, download the .app, drive it on a fresh runner). The split keeps the heavy xcodebuild
-# OFF the E2E runner: when both shared one runner, appium-xcuitest's session-create (its
-# `xcrun --show-sdk-version` SDK probe + the WebDriverAgent build) was starved by the
-# just-finished xcodebuild and timed out at 15s. A debug .app loads its JS from Metro at
-# runtime, so the E2E job's freshly-scaffolded project (same pinned RN version + App.tsx)
-# serves a compatible bundle; the simulator shares the host loopback, so no adb-reverse
-# equivalent is needed.
+# Description: iOS-simulator E2E for @wdio/react-native-service. The .app is built by a
+# sibling CI job (_ci-build-rn-ios-app) that runs in parallel with the package build; this
+# workflow downloads that artifact, re-scaffolds JS for Metro (no CocoaPods/xcodebuild), and
+# drives the simulator. The split keeps the heavy xcodebuild OFF the E2E runner: when both
+# shared one runner, appium-xcuitest's session-create (its `xcrun --show-sdk-version` SDK probe
+# + the WebDriverAgent build) was starved by the just-finished xcodebuild and timed out at 15s.
+# A debug .app loads its JS from Metro at runtime, so the freshly-scaffolded project (same
+# pinned RN version + App.tsx) serves a compatible bundle; the simulator shares the host
+# loopback, so no adb-reverse equivalent is needed.
 
 permissions:
   contents: read
@@ -63,85 +63,8 @@ env:
   RN_WDA_DD: ${{ github.workspace }}/wda_dd
 
 jobs:
-  build:
-    name: Build .app
-    runs-on: ${{ inputs.os }}
-    # Cap a stuck xcodebuild/CocoaPods rather than holding a scarce macOS runner for the 6h default.
-    timeout-minutes: 40
-    steps:
-      - name: 👷 Checkout Repository
-        uses: actions/checkout@v6
-        with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-
-      - name: 🛠️ Setup Development Environment
-        uses: ./.github/workflows/actions/setup-workspace
-        with:
-          node-version: ${{ inputs.node-version }}
-
-      # Scaffold a complete RN project at the pinned version (with CocoaPods installed for
-      # iOS), then overlay the fixture's App.tsx. The fixture App only imports react-native
-      # core, so the stock template builds it unmodified.
-      - name: 🏗️ Scaffold native project + CocoaPods
-        shell: bash
-        env:
-          RN_VERSION: ${{ inputs.rn-version }}
-          RN_CLI_VERSION: ${{ inputs.rn-cli-version }}
-          NEW_ARCH: ${{ inputs.new-arch }}
-        run: |
-          set -euo pipefail
-          npx --yes "@react-native-community/cli@$RN_CLI_VERSION" init ReactNativeE2EApp \
-            --version "$RN_VERSION" --directory "$RN_BUILD_DIR" --skip-git-init --pm npm --install-pods false
-          cp fixtures/e2e-apps/react-native/App.tsx "$RN_BUILD_DIR/App.tsx"
-          # Select the RN architecture for this leg (mirrors Android) — BOTH old (Paper) and new
-          # (Fabric/bridgeless, the RN 0.76 default) are required gates. RCT_NEW_ARCH_ENABLED at
-          # pod-install time picks the arch; under Fabric the tree/Hermes register slightly later
-          # but the spec mount-waits + the service's Hermes connect-retry absorb it.
-          NEW_ARCH_FLAG=$([ "$NEW_ARCH" = "true" ] && echo 1 || echo 0)
-          ( cd "$RN_BUILD_DIR/ios" && RCT_NEW_ARCH_ENABLED="$NEW_ARCH_FLAG" pod install )
-          # NOTE: there is no reliable Podfile.lock-level arch assertion on iOS (unlike Android's
-          # gradle.properties grep). RN 0.76 vendors the Fabric pods (React-Fabric, hermes-engine,
-          # …) into Podfile.lock for BOTH archs — RCT_NEW_ARCH_ENABLED is a build-time flag, not a
-          # pod-set difference — so pod presence can't discriminate old vs new. The E2E run itself
-          # is the validation (Fabric renders/behaves differently at runtime).
-
-      - name: 📱 Build iOS app for the simulator
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd "$RN_BUILD_DIR/ios"
-          # xcbeautify only prettifies output and isn't guaranteed on the runner image; pipe
-          # through `(xcbeautify || cat)` so a missing tool can't SIGPIPE-kill xcodebuild, and
-          # rely on pipefail to surface a real xcodebuild failure (not the later "app not found").
-          xcodebuild \
-            -workspace ReactNativeE2EApp.xcworkspace \
-            -scheme ReactNativeE2EApp \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -derivedDataPath build \
-            CODE_SIGNING_ALLOWED=NO 2>&1 | (xcbeautify || cat)
-          APP_PATH="$RN_BUILD_DIR/ios/build/Build/Products/Debug-iphonesimulator/ReactNativeE2EApp.app"
-          test -d "$APP_PATH" || { echo "::error::iOS .app not found at $APP_PATH"; exit 1; }
-          # Tar the bundle (preserves the simulator .app's symlinks + exec bits, which a raw
-          # artifact upload would mangle) so the E2E job can install it verbatim.
-          tar -czf "$GITHUB_WORKSPACE/rn-ios-app.tar.gz" -C "$(dirname "$APP_PATH")" ReactNativeE2EApp.app
-
-      - name: 📦 Upload built .app
-        uses: actions/upload-artifact@v7
-        with:
-          # Keyed by run_id only (NOT run_attempt): `gh run rerun --failed` re-runs the failed Run
-          # job but NOT this Build job (it passed), so the artifact keeps its original name — a
-          # run_attempt suffix would leave the retried Run job looking for an artifact that was
-          # never re-uploaded. overwrite handles a full re-run that does rebuild.
-          name: rn-ios-app-${{ inputs.new-arch && 'new' || 'old' }}-arch-${{ github.run_id }}
-          path: rn-ios-app.tar.gz
-          retention-days: 1
-          if-no-files-found: error
-          overwrite: true
-
-  e2e:
+  run:
     name: Run
-    needs: build
     runs-on: ${{ inputs.os }}
     # Cap a hung Appium/WDA session (a stuck session-create can otherwise idle the macOS runner for
     # the 6h default). Generous over a normal pass (~16-24 min) but well under the default.
@@ -184,6 +107,14 @@ jobs:
           APP_PATH="$GITHUB_WORKSPACE/rn-app/ReactNativeE2EApp.app"
           test -d "$APP_PATH" || { echo "::error::unpacked .app not found at $APP_PATH"; exit 1; }
           echo "RN_APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
+
+      # Keyed identically to the build job's npm cache so the first fetch is already warm —
+      # the cli init downloads the same tarballs for the same pinned RN version.
+      - name: 💾 Restore npm download cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-rn-${{ inputs.rn-version }}-v1
 
       # Metro is JS-only — re-scaffold the project here (without CocoaPods/xcodebuild) so the
       # heavy native build stays in the build job. A debug .app loads its bundle from Metro at
@@ -243,6 +174,16 @@ jobs:
             pnpm --filter @repo/e2e exec appium driver install xcuitest
           fi
 
+      # WDA DerivedData is keyed on e2e/package.json (appium-xcuitest-driver pin). A cache hit
+      # skips the multi-minute xcodebuild entirely; the graded sessions still read this path via
+      # appium:derivedDataPath + usePrebuiltWDA.
+      - name: 💾 Restore WDA DerivedData cache
+        id: wda-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RN_WDA_DD }}
+          key: wda-dd-${{ runner.os }}-${{ hashFiles('e2e/package.json') }}-v1
+
       # Pre-build WebDriverAgent deterministically with a plain xcodebuild (no appium session, so no
       # socket fragility — it runs to completion). appium-xcuitest otherwise compiles WDA (several
       # minutes) on the first graded session, and under WDIO's undici client that long POST /session
@@ -250,6 +191,7 @@ jobs:
       # shared derivedDataPath that the graded run reads (appium:derivedDataPath + usePrebuiltWDA)
       # means the graded sessions skip the build and are fast.
       - name: 🏎️ Pre-build WebDriverAgent
+        if: steps.wda-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -174,15 +174,16 @@ jobs:
             pnpm --filter @repo/e2e exec appium driver install xcuitest
           fi
 
-      # WDA DerivedData is keyed on e2e/package.json (appium-xcuitest-driver pin). A cache hit
-      # skips the multi-minute xcodebuild entirely; the graded sessions still read this path via
-      # appium:derivedDataPath + usePrebuiltWDA.
+      # WDA DerivedData is keyed on e2e/package.json (xcuitest driver pin) AND the runner
+      # image version. ImageVersion is set automatically on GitHub-hosted macOS runners and
+      # encodes the Xcode major — a stale DerivedData compiled against a previous SDK causes
+      # cryptic E2E failures rather than a clean miss-and-rebuild.
       - name: 💾 Restore WDA DerivedData cache
         id: wda-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.RN_WDA_DD }}
-          key: wda-dd-${{ runner.os }}-${{ hashFiles('e2e/package.json') }}-v1
+          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v1
 
       # Pre-build WebDriverAgent deterministically with a plain xcodebuild (no appium session, so no
       # socket fragility — it runs to completion). appium-xcuitest otherwise compiles WDA (several

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -793,12 +793,31 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
 
+  # Build the RN iOS .app ahead of (and in parallel with) the Linux package build. The native
+  # xcodebuild + CocoaPods step is the dominant cost on the iOS leg; decoupling it from `build`
+  # means the macOS runner starts as soon as detect-changes finishes instead of waiting for the
+  # Linux package build to complete.
+  build-rn-ios-e2e-app-macos:
+    name: Build RN iOS E2E App - ${{ matrix.arch }}-arch
+    needs: [detect-changes]
+    if: fromJSON(needs.detect-changes.outputs.runs)['react-native'] && needs.detect-changes.outputs.run_lint_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['old', 'new']
+    uses: ./.github/workflows/_ci-build-rn-ios-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      node-version: '24'
+      new-arch: ${{ matrix.arch == 'new' }}
+
   # React Native — iOS simulator E2E (the fast-follow to the Android leg). macOS runner;
   # appium-xcuitest builds WebDriverAgent at session time (no signing on the sim).
   # Required gate (see ci-status).
   e2e-react-native-ios-macos:
     name: E2E - React Native [iOS] - ${{ matrix.test-type }} (${{ matrix.arch }}-arch)
-    needs: [detect-changes, build]
+    needs: [detect-changes, build, build-rn-ios-e2e-app-macos]
     if: fromJSON(needs.detect-changes.outputs.runs)['react-native'] && needs.detect-changes.outputs.run_lint_only != 'true'
     strategy:
       fail-fast: false
@@ -1082,6 +1101,7 @@ jobs:
       # React Native — Android emulator + iOS simulator E2E are required gates.
       - e2e-react-native-linux
       - e2e-react-native-ios-macos
+      - build-rn-ios-e2e-app-macos
       - e2e-electrobun-windows
       - package-electron-matrix
       - package-tauri-linux


### PR DESCRIPTION
## Summary

Addresses #361. Three changes targeting the iOS E2E legs (~35-40 min → ~15-20 min warm):

- **Queue priority (Option E)**: Extract `.app` build into its own `build-rn-ios-e2e-app-macos` job (`needs: [detect-changes]` only) so xcodebuild runs in parallel with the Linux package build instead of after it. The E2E job still explicitly gates on both `build` (dist) and `build-rn-ios-e2e-app-macos` (artifact) — no stale-dist race.
- **CocoaPods cache**: `ios/Pods` keyed by `rn-version + arch`; `pod install` step skipped on cache hit.
- **WDA DerivedData cache**: `$RN_WDA_DD` keyed by `hashFiles('e2e/package.json')` (xcuitest driver pin); the ~8-min `xcodebuild build-for-testing` is skipped on hits. Pre-build step gated on `cache-hit != 'true'`.
- **npm download cache**: `~/.npm` keyed by `rn-version`, shared between the build and E2E jobs — both `npx init` invocations are fast after the first run.

## Files changed

| File | Change |
|------|--------|
| `_ci-build-rn-ios-app.reusable.yml` | New — extracted `.app` build (no dist dependency) + npm + CocoaPods caches |
| `_ci-e2e-react-native-ios.reusable.yml` | `build` job removed; `run` job gets npm + WDA caches |
| `ci.yml` | New `build-rn-ios-e2e-app-macos` matrix job; `e2e-react-native-ios-macos` updated `needs`; `ci-status` updated |

## Test plan

- [ ] CI green on this PR (both old-arch and new-arch legs)
- [ ] Confirm `build-rn-ios-e2e-app-macos` starts before `build` completes on a broad-change PR (e.g. touching `ci.yml`)
- [ ] Confirm second run shows cache hits for CocoaPods, WDA, and npm in the step logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)