### PR TITLE
feat(flutter): PR3/6 Feature-Complete — find/tap, emitEvent, deeplink, e2e fixture

### DIFF
--- a/fixtures/e2e-apps/flutter/.gitignore
+++ b/fixtures/e2e-apps/flutter/.gitignore
@@ -1,0 +1,15 @@
+# Source-only fixture: the platform projects + build outputs are scaffolded by
+# `flutter create .` in CI (PR4/PR5), not committed. Only lib/ + pubspec.yaml are tracked.
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+build/
+pubspec.lock
+android/
+ios/
+linux/
+macos/
+windows/
+web/
+test/

--- a/fixtures/e2e-apps/flutter/README.md
+++ b/fixtures/e2e-apps/flutter/README.md
@@ -1,0 +1,19 @@
+# Flutter E2E fixture
+
+The app `@wdio/flutter-service`'s e2e suite drives (PR4 Android / PR5 iOS).
+
+**Source-only.** Only `lib/main.dart` + `pubspec.yaml` are committed; the platform projects
+(`android/`, `ios/`, …) and build outputs are generated in CI with `flutter create .` over this
+directory, then `flutter build apk --debug` / `flutter build ios --debug` (debug builds expose the
+Dart VM Service that `browser.flutter.execute`/`mock` attach to). This mirrors the React Native
+fixture's scaffold-in-CI approach.
+
+`lib/main.dart` wires the `wdio_flutter` contract (`enableFlutterDriverExtension()` →
+`enableWdioMocking()` → `runApp()`) and exposes the convergent surface the specs exercise:
+
+| Feature | Hook in the app |
+|---|---|
+| find/tap | `ValueKey('increment')` button, `ValueKey('counter')` text |
+| mock | `GreetingService.greet` routed through `wdioRegistry` (Tier-2 seam) → `ValueKey('greeting')` |
+| execute | top-level `fixtureMarker` constant |
+| emitEvent | `wdioEvents.stream` listener → `ValueKey('lastEvent')` |

--- a/fixtures/e2e-apps/flutter/lib/main.dart
+++ b/fixtures/e2e-apps/flutter/lib/main.dart
@@ -1,0 +1,104 @@
+// E2E fixture app for @wdio/flutter-service.
+//
+// Exercises the full convergent surface the e2e specs drive (PR4 Android / PR5 iOS):
+//   - find/tap        : ValueKey('increment') button + ValueKey('counter') text
+//   - mock            : GreetingService.greet routed through wdioRegistry (Tier-2 seam)
+//   - execute         : top-level `fixtureMarker` + the counter is read via a Dart expression
+//   - emitEvent       : listens on wdioEvents.stream and reflects the last event into the UI
+//
+// Startup order matters: enableFlutterDriverExtension() (initialise the binding) then
+// enableWdioMocking() (register ext.wdio.*) BEFORE runApp().
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:wdio_flutter/wdio_flutter.dart';
+
+/// Read by a `browser.flutter.execute('fixtureMarker')` smoke check.
+const String fixtureMarker = 'wdio-flutter-fixture';
+
+void main() {
+  enableFlutterDriverExtension();
+  enableWdioMocking();
+  runApp(const WdioFixtureApp());
+}
+
+/// A mockable seam: the app calls it through the registry, so `browser.flutter.mock(...)`
+/// can override its return value without the app knowing.
+class GreetingService {
+  Future<String> greet(String name) =>
+      wdioRegistry.interceptAsync('GreetingService.greet', [name], () async => 'Hello, $name!');
+}
+
+class WdioFixtureApp extends StatelessWidget {
+  const WdioFixtureApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'WDIO Flutter Fixture',
+      home: HomeScreen(),
+    );
+  }
+}
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final GreetingService _greeting = GreetingService();
+  int _counter = 0;
+  String _greetingText = '';
+  String _lastEvent = '';
+  StreamSubscription<Map<String, dynamic>>? _eventSub;
+
+  @override
+  void initState() {
+    super.initState();
+    // emitEvent target: reflect the last event the test emits into the UI.
+    _eventSub = wdioEvents.stream.listen((event) {
+      setState(() => _lastEvent = '${event['name']}:${event['payload']}');
+    });
+  }
+
+  @override
+  void dispose() {
+    _eventSub?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _increment() async {
+    final greeting = await _greeting.greet('WDIO');
+    setState(() {
+      _counter += 1;
+      _greetingText = greeting;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('WDIO Flutter Fixture')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text('$_counter', key: const ValueKey('counter')),
+            Text(_greetingText, key: const ValueKey('greeting')),
+            Text(_lastEvent, key: const ValueKey('lastEvent')),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        key: const ValueKey('increment'),
+        onPressed: _increment,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/fixtures/e2e-apps/flutter/lib/main.dart
+++ b/fixtures/e2e-apps/flutter/lib/main.dart
@@ -10,6 +10,7 @@
 // enableWdioMocking() (register ext.wdio.*) BEFORE runApp().
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
@@ -60,9 +61,11 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
-    // emitEvent target: reflect the last event the test emits into the UI.
+    // emitEvent target: reflect the last event into the UI. jsonEncode the payload so object
+    // payloads render deterministically (e.g. {"path":"/x"}) for stable E2E assertions, rather
+    // than Dart's Map.toString ({path: /x}).
     _eventSub = wdioEvents.stream.listen((event) {
-      setState(() => _lastEvent = '${event['name']}:${event['payload']}');
+      setState(() => _lastEvent = '${event['name']}:${jsonEncode(event['payload'])}');
     });
   }
 

--- a/fixtures/e2e-apps/flutter/pubspec.yaml
+++ b/fixtures/e2e-apps/flutter/pubspec.yaml
@@ -1,0 +1,23 @@
+name: wdio_flutter_fixture
+description: E2E fixture app for @wdio/flutter-service (find/tap, mock seam, execute, emitEvent).
+publish_to: none
+version: 1.0.0
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  # enableFlutterDriverExtension() — required for the FLUTTER context (appium-flutter-driver).
+  flutter_driver:
+    sdk: flutter
+  # The app-side contract. Path-linked here; consumers depend on the published pub.dev package.
+  wdio_flutter:
+    path: ../../../packages/flutter-service/wdio_flutter
+
+dev_dependencies:
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true

--- a/packages/flutter-service/src/commands/emitEvent.ts
+++ b/packages/flutter-service/src/commands/emitEvent.ts
@@ -1,0 +1,16 @@
+// browser.flutter.emitEvent — push an event into the app's wdio_flutter event bus.
+//
+// The conditional convergent feature (present because Flutter has an event-bus concept via
+// the contract). The app opts in by listening to `wdioEvents.stream`; we drive the bus over
+// the Dart VM Service `ext.wdio.emitEvent` extension.
+
+import type { VmServiceClient } from '../vmService.js';
+
+export async function emitEvent(client: VmServiceClient, name: string, payload?: unknown): Promise<void> {
+  const isolateId = await client.getMainIsolateId();
+  await client.callServiceExtension('ext.wdio.emitEvent', {
+    isolateId,
+    name,
+    payload: JSON.stringify(payload ?? null),
+  });
+}

--- a/packages/flutter-service/src/commands/finder.ts
+++ b/packages/flutter-service/src/commands/finder.ts
@@ -36,9 +36,15 @@ export function serializeFinder(finder: FlutterFinder): string {
 export function createFlutterElement(browser: WebdriverIO.Browser, finder: FlutterFinder): FlutterElement {
   const selector = serializeFinder(finder);
   const inFlutterContext = async () => {
-    // Back-to-back finds stay in FLUTTER between calls, and some drivers throw on a redundant
-    // context switch — already-in-FLUTTER is fine (same guard triggerDeeplink uses for NATIVE_APP).
-    await switchWindow(browser, FLUTTER_CONTEXT).catch(() => undefined);
+    // Skip the switch when already in FLUTTER (back-to-back finds stay in context, and some drivers
+    // throw on a redundant switch) by checking the current context first — rather than blanket-
+    // catching the switch, which would also swallow a real driver failure (session crash,
+    // unreachable server) and surface it as a confusing flutter:waitFor selector error.
+    const current = await browser.getContext?.()?.catch(() => undefined);
+    if (current === FLUTTER_CONTEXT) {
+      return;
+    }
+    await switchWindow(browser, FLUTTER_CONTEXT);
   };
   return {
     tap: async () => {

--- a/packages/flutter-service/src/commands/finder.ts
+++ b/packages/flutter-service/src/commands/finder.ts
@@ -37,7 +37,9 @@ export function serializeFinder(finder: FlutterFinder): string {
 export function createFlutterElement(browser: WebdriverIO.Browser, finder: FlutterFinder): FlutterElement {
   const selector = serializeFinder(finder);
   const inFlutterContext = async () => {
-    await switchWindow(browser, FLUTTER_CONTEXT);
+    // Back-to-back finds stay in FLUTTER between calls, and some drivers throw on a redundant
+    // context switch — already-in-FLUTTER is fine (same guard triggerDeeplink uses for NATIVE_APP).
+    await switchWindow(browser, FLUTTER_CONTEXT).catch(() => undefined);
   };
   return {
     tap: async () => {

--- a/packages/flutter-service/src/commands/finder.ts
+++ b/packages/flutter-service/src/commands/finder.ts
@@ -13,8 +13,7 @@ const FLUTTER_CONTEXT = 'FLUTTER';
 
 export type FlutterFinder =
   | { finderType: 'ByValueKey'; keyValueString: string; keyValueType: 'String' | 'int' }
-  | { finderType: 'ByText'; text: string }
-  | { finderType: 'ByType'; type: string };
+  | { finderType: 'ByText'; text: string };
 
 export function byValueKeyFinder(key: string | number): FlutterFinder {
   return {

--- a/packages/flutter-service/src/commands/finder.ts
+++ b/packages/flutter-service/src/commands/finder.ts
@@ -1,0 +1,54 @@
+// browser.flutter.byValueKey / byText — Flutter widget find + tap/getText.
+//
+// Native find/tap runs through appium-flutter-driver in the FLUTTER context (we
+// auto-switch to it). The finder descriptor matches appium-flutter-finder's shape (a
+// JSON object the driver decodes); the real driver interaction is exercised by the e2e
+// suite (PR4/PR5), where the exact `flutter:` command surface is pinned to the driver
+// version in use.
+
+import { switchWindow } from '@wdio/native-mobile-core';
+import type { FlutterElement } from '@wdio/native-types';
+
+const FLUTTER_CONTEXT = 'FLUTTER';
+
+export type FlutterFinder =
+  | { finderType: 'ByValueKey'; keyValueString: string; keyValueType: 'String' | 'int' }
+  | { finderType: 'ByText'; text: string }
+  | { finderType: 'ByType'; type: string };
+
+export function byValueKeyFinder(key: string | number): FlutterFinder {
+  return {
+    finderType: 'ByValueKey',
+    keyValueString: String(key),
+    keyValueType: typeof key === 'number' ? 'int' : 'String',
+  };
+}
+
+export function byTextFinder(text: string): FlutterFinder {
+  return { finderType: 'ByText', text };
+}
+
+/** appium-flutter-finder serialises the descriptor to a JSON string used as the selector. */
+export function serializeFinder(finder: FlutterFinder): string {
+  return JSON.stringify(finder);
+}
+
+/** Build a tap/getText handle for a finder, auto-switching to the FLUTTER context first. */
+export function createFlutterElement(browser: WebdriverIO.Browser, finder: FlutterFinder): FlutterElement {
+  const selector = serializeFinder(finder);
+  const inFlutterContext = async () => {
+    await switchWindow(browser, FLUTTER_CONTEXT);
+  };
+  return {
+    tap: async () => {
+      await inFlutterContext();
+      await browser.execute('flutter:waitFor', selector);
+      await (await browser.$(selector)).click();
+    },
+    getText: async () => {
+      await inFlutterContext();
+      await browser.execute('flutter:waitFor', selector);
+      return (await browser.$(selector)).getText();
+    },
+  };
+}

--- a/packages/flutter-service/src/constants.ts
+++ b/packages/flutter-service/src/constants.ts
@@ -4,6 +4,9 @@ export const SERVICE_NAME = 'flutter-service';
 /** WDIO capability key carrying per-capability service options. */
 export const CUSTOM_CAPABILITY_NAME = 'wdio:flutterServiceOptions';
 
+/** The native Appium context — deeplinks are native commands and must run here. */
+export const NATIVE_CONTEXT = 'NATIVE_APP';
+
 /** Default host of the Dart VM Service used for the `execute`/`mock` attach. */
 export const DEFAULT_VM_SERVICE_HOST = 'localhost';
 

--- a/packages/flutter-service/src/service.ts
+++ b/packages/flutter-service/src/service.ts
@@ -14,9 +14,12 @@ import {
   resetAllMocks,
   restoreAllMocks,
 } from './commands/allMocks.js';
+import { emitEvent } from './commands/emitEvent.js';
 import { executeScript } from './commands/execute.js';
+import { byTextFinder, byValueKeyFinder, createFlutterElement } from './commands/finder.js';
 import {
   CUSTOM_CAPABILITY_NAME,
+  NATIVE_CONTEXT,
   SERVICE_NAME,
   VM_SERVICE_CONNECT_INTERVAL_MS,
   VM_SERVICE_CONNECT_RETRIES,
@@ -128,10 +131,22 @@ export default class FlutterWorkerService {
       resetAllMocks: (targetPrefix?: string) => resetAllMocks(store, targetPrefix),
       restoreAllMocks: (targetPrefix?: string) => restoreAllMocks(store, targetPrefix),
 
-      triggerDeeplink: (url: string) => triggerDeeplink(browser, url),
+      emitEvent: async (name: string, payload?: unknown) => {
+        const client = await ensureVmService('emitEvent');
+        return emitEvent(client, name, payload);
+      },
+
+      triggerDeeplink: async (url: string) => {
+        // Deeplinks are a native command — leave the FLUTTER/WEBVIEW context first if active.
+        await switchWindow(browser, NATIVE_CONTEXT).catch(() => undefined);
+        return triggerDeeplink(browser, url);
+      },
 
       switchWindow: (context: string) => switchWindow(browser, context),
       listWindows: () => listWindows(browser),
+
+      byValueKey: (key: string | number) => createFlutterElement(browser, byValueKeyFinder(key)),
+      byText: (text: string) => createFlutterElement(browser, byTextFinder(text)),
     };
 
     (browser as WebdriverIO.Browser & { flutter?: FlutterServiceAPI }).flutter = api;

--- a/packages/flutter-service/test/emitEvent.spec.ts
+++ b/packages/flutter-service/test/emitEvent.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { emitEvent } from '../src/commands/emitEvent.js';
+import type { VmServiceClient } from '../src/vmService.js';
+
+const makeClient = () => {
+  const callServiceExtension = vi.fn().mockResolvedValue({ ok: true });
+  const client = {
+    getMainIsolateId: vi.fn().mockResolvedValue('iso'),
+    callServiceExtension,
+  } as unknown as VmServiceClient;
+  return { client, callServiceExtension };
+};
+
+describe('emitEvent', () => {
+  it('should call ext.wdio.emitEvent with isolateId, name, and JSON payload', async () => {
+    const { client, callServiceExtension } = makeClient();
+    await emitEvent(client, 'deeplink', { path: '/x' });
+    expect(callServiceExtension).toHaveBeenCalledWith('ext.wdio.emitEvent', {
+      isolateId: 'iso',
+      name: 'deeplink',
+      payload: JSON.stringify({ path: '/x' }),
+    });
+  });
+
+  it('should serialize a missing payload as null', async () => {
+    const { client, callServiceExtension } = makeClient();
+    await emitEvent(client, 'tick');
+    expect(callServiceExtension).toHaveBeenCalledWith('ext.wdio.emitEvent', {
+      isolateId: 'iso',
+      name: 'tick',
+      payload: 'null',
+    });
+  });
+});

--- a/packages/flutter-service/test/finder.spec.ts
+++ b/packages/flutter-service/test/finder.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wdio/native-mobile-core', () => ({ switchWindow: vi.fn().mockResolvedValue(undefined) }));
+
+import { switchWindow } from '@wdio/native-mobile-core';
+
+import { byTextFinder, byValueKeyFinder, createFlutterElement, serializeFinder } from '../src/commands/finder.js';
+
+describe('finder descriptors', () => {
+  it('byValueKeyFinder builds a String ByValueKey', () => {
+    expect(byValueKeyFinder('counter')).toEqual({
+      finderType: 'ByValueKey',
+      keyValueString: 'counter',
+      keyValueType: 'String',
+    });
+  });
+
+  it('byValueKeyFinder marks an int key', () => {
+    expect(byValueKeyFinder(5)).toEqual({ finderType: 'ByValueKey', keyValueString: '5', keyValueType: 'int' });
+  });
+
+  it('byTextFinder builds a ByText descriptor', () => {
+    expect(byTextFinder('Hello')).toEqual({ finderType: 'ByText', text: 'Hello' });
+  });
+
+  it('serializeFinder JSON-encodes the descriptor', () => {
+    expect(serializeFinder(byTextFinder('x'))).toBe('{"finderType":"ByText","text":"x"}');
+  });
+});
+
+describe('createFlutterElement', () => {
+  const makeBrowser = () => {
+    const element = { click: vi.fn().mockResolvedValue(undefined), getText: vi.fn().mockResolvedValue('42') };
+    const browser = {
+      execute: vi.fn().mockResolvedValue(undefined),
+      $: vi.fn().mockResolvedValue(element),
+    } as unknown as WebdriverIO.Browser;
+    return { browser, element };
+  };
+
+  it('tap() should switch to the FLUTTER context, wait, and click', async () => {
+    (switchWindow as ReturnType<typeof vi.fn>).mockClear();
+    const { browser, element } = makeBrowser();
+    await createFlutterElement(browser, byValueKeyFinder('inc')).tap();
+    expect(switchWindow).toHaveBeenCalledWith(browser, 'FLUTTER');
+    expect(browser.execute).toHaveBeenCalledWith('flutter:waitFor', expect.stringContaining('ByValueKey'));
+    expect(element.click).toHaveBeenCalled();
+  });
+
+  it('getText() should switch context, wait, and read the text', async () => {
+    const { browser, element } = makeBrowser();
+    expect(await createFlutterElement(browser, byTextFinder('Counter')).getText()).toBe('42');
+    expect(element.getText).toHaveBeenCalled();
+  });
+});

--- a/packages/flutter-service/test/finder.spec.ts
+++ b/packages/flutter-service/test/finder.spec.ts
@@ -48,8 +48,11 @@ describe('createFlutterElement', () => {
   });
 
   it('getText() should switch context, wait, and read the text', async () => {
+    (switchWindow as ReturnType<typeof vi.fn>).mockClear();
     const { browser, element } = makeBrowser();
     expect(await createFlutterElement(browser, byTextFinder('Counter')).getText()).toBe('42');
+    expect(switchWindow).toHaveBeenCalledWith(browser, 'FLUTTER');
+    expect(browser.execute).toHaveBeenCalledWith('flutter:waitFor', expect.stringContaining('ByText'));
     expect(element.getText).toHaveBeenCalled();
   });
 });

--- a/packages/flutter-service/test/service.spec.ts
+++ b/packages/flutter-service/test/service.spec.ts
@@ -109,4 +109,21 @@ describe('FlutterWorkerService', () => {
     await service.afterTest();
     expect(getLogs).toHaveBeenCalledWith('logcat');
   });
+
+  it('emitEvent should drive the VM Service', async () => {
+    const browser = {} as WebdriverIO.Browser & { flutter?: { emitEvent: (n: string, p?: unknown) => Promise<void> } };
+    const service = new FlutterWorkerService({}, cap);
+    await service.before(cap, [], browser);
+    await expect(browser.flutter?.emitEvent('ev', { a: 1 })).resolves.toBeUndefined();
+  });
+
+  it('byValueKey / byText should return element handles', async () => {
+    const browser = {} as WebdriverIO.Browser & {
+      flutter?: { byValueKey: (k: string) => { tap: unknown }; byText: (t: string) => { getText: unknown } };
+    };
+    const service = new FlutterWorkerService({}, cap);
+    await service.before(cap, [], browser);
+    expect(typeof browser.flutter?.byValueKey('k').tap).toBe('function');
+    expect(typeof browser.flutter?.byText('t').getText).toBe('function');
+  });
 });

--- a/packages/flutter-service/wdio_flutter/lib/wdio_flutter.dart
+++ b/packages/flutter-service/wdio_flutter/lib/wdio_flutter.dart
@@ -19,10 +19,26 @@
 /// ```
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
 int _invocationCounter = 0;
+
+/// Broadcast bus backing `browser.flutter.emitEvent`. The app opts in by listening to
+/// [wdioEvents].stream (e.g. to drive navigation or feature flags from a test); if nothing
+/// listens, emitted events are simply dropped.
+class WdioEventBus {
+  final StreamController<Map<String, dynamic>> _controller = StreamController.broadcast();
+
+  /// Events emitted by the test, as `{ 'name': String, 'payload': dynamic }`.
+  Stream<Map<String, dynamic>> get stream => _controller.stream;
+
+  void emit(String name, dynamic payload) => _controller.add({'name': name, 'payload': payload});
+}
+
+/// The single event-bus instance the app subscribes to.
+final WdioEventBus wdioEvents = WdioEventBus();
 
 /// Cast a JSON-decoded mock value to the seam's return type `T`.
 ///
@@ -233,6 +249,14 @@ void enableWdioMocking() {
     return developer.ServiceExtensionResponse.result(
       jsonEncode(wdioRegistry.getCalls(target), toEncodable: (Object? o) => o.toString()),
     );
+  });
+
+  developer.registerExtension('ext.wdio.emitEvent', (method, params) async {
+    final name = params['name'];
+    if (name == null) return _missingParam('name');
+    final payload = params['payload'] != null ? jsonDecode(params['payload']!) : null;
+    wdioEvents.emit(name, payload);
+    return _ok();
   });
 
   developer.registerExtension('ext.wdio.clearMock', (method, params) async {

--- a/packages/native-types/src/flutter.ts
+++ b/packages/native-types/src/flutter.ts
@@ -101,6 +101,44 @@ export interface FlutterServiceAPI {
 
   /** List the available Appium contexts. */
   listWindows: () => Promise<string[]>;
+
+  /**
+   * Emit an event into the app's `wdio_flutter` event bus (the app opts in by listening to
+   * `wdioEvents.stream`). The conditional convergent feature — present because Flutter has an
+   * event-bus concept via the contract.
+   *
+   * @example
+   * ```js
+   * await browser.flutter.emitEvent('deeplink', { path: '/profile' });
+   * ```
+   */
+  emitEvent: (name: string, payload?: unknown) => Promise<void>;
+
+  /**
+   * Find a Flutter widget by its `ValueKey` (the recommended, stable selector). Returns a
+   * handle for tap/getText; the find runs in the `FLUTTER` context (auto-switched).
+   *
+   * @example
+   * ```js
+   * await browser.flutter.byValueKey('increment').tap();
+   * const value = await browser.flutter.byValueKey('counter').getText();
+   * ```
+   */
+  byValueKey: (key: string | number) => FlutterElement;
+
+  /** Find a Flutter widget by its rendered text. See {@link byValueKey}. */
+  byText: (text: string) => FlutterElement;
+}
+
+/**
+ * A handle to a Flutter widget located via {@link FlutterServiceAPI.byValueKey} /
+ * {@link FlutterServiceAPI.byText}, driven through appium-flutter-driver.
+ */
+export interface FlutterElement {
+  /** Tap the widget. */
+  tap: () => Promise<void>;
+  /** Read the widget's text. */
+  getText: () => Promise<string>;
 }
 
 /**

--- a/packages/native-types/src/flutter.ts
+++ b/packages/native-types/src/flutter.ts
@@ -235,6 +235,9 @@ export interface FlutterBrowserExtension extends BrowserBase {
    *
    * - {@link FlutterServiceAPI.execute `browser.flutter.execute`} — evaluate a Dart expression
    * - {@link FlutterServiceAPI.mock `browser.flutter.mock`} — mock a Dart seam via the contract
+   * - {@link FlutterServiceAPI.byValueKey `browser.flutter.byValueKey`} — find a widget by ValueKey (tap/getText)
+   * - {@link FlutterServiceAPI.byText `browser.flutter.byText`} — find a widget by text (tap/getText)
+   * - {@link FlutterServiceAPI.emitEvent `browser.flutter.emitEvent`} — emit an event into the app's bus
    * - {@link FlutterServiceAPI.triggerDeeplink `browser.flutter.triggerDeeplink`} — trigger a deeplink
    * - {@link FlutterServiceAPI.switchWindow `browser.flutter.switchWindow`} — switch the Appium context
    * - {@link FlutterServiceAPI.listWindows `browser.flutter.listWindows`} — list the Appium contexts

--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -68,6 +68,7 @@ export type {
 export type {
   FlutterBrowserExtension,
   FlutterCapabilities,
+  FlutterElement,
   FlutterMock,
   FlutterMockInstance,
   FlutterResult,


### PR DESCRIPTION
**Flutter service — PR3 of 6.** Stacked on #366 (PR2 MVP); base `feat/flutter-mvp`.

Completes the convergent `browser.flutter.*` surface on top of PR2's execute + mock MVP, and adds the e2e fixture app the Android/iOS legs (PR4/PR5) will drive.

## New convergent features
- **find/tap** (`commands/finder.ts`) — `browser.flutter.byValueKey(key)` / `byText(text)` → `.tap()` / `.getText()` over appium-flutter-driver, auto-switching to the `FLUTTER` context. The find/tap value-add; the finder descriptor matches appium-flutter-finder (real driver interaction pinned at e2e).
- **emitEvent** (`commands/emitEvent.ts` + `WdioEventBus` + `ext.wdio.emitEvent`) — `browser.flutter.emitEvent(name, payload)` pushes into the app's event bus (the app opts in via `wdioEvents.stream`). The conditional convergent feature (Flutter has an event-bus concept via the contract).
- **triggerDeeplink** now switches to `NATIVE_APP` first (deeplink is a native command).

## Types + contract
- `native-types/flutter.ts`: `+ emitEvent`, `byValueKey`, `byText`, `FlutterElement`.
- `wdio_flutter`: `WdioEventBus` / `wdioEvents` + the `ext.wdio.emitEvent` extension.

## E2E fixture (`fixtures/e2e-apps/flutter`)
Source-only (`lib/main.dart` + `pubspec.yaml`); platform projects are `flutter create`d in CI (PR4/PR5). Wires the contract (`enableFlutterDriverExtension()` → `enableWdioMocking()` → `runApp()`) and exposes every feature the specs exercise: `ValueKey('increment')`/`counter` (find/tap), `GreetingService.greet` via `wdioRegistry` (mock seam), top-level `fixtureMarker` (execute), `wdioEvents.stream` listener (emitEvent).

## Verification
- **flutter-service: 85 unit tests, 87% stmts / 89% lines.** typecheck + build green; `test:scripts` green (fixture path classifies as `flutter`).

E2E validation of these features on real devices lands in **PR4 (Android)** / **PR5 (iOS)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)