### PR TITLE
feat(flutter): PR5/6 E2E-iOS — Flutter iOS-simulator CI

### DIFF
--- a/.github/workflows/_ci-build-flutter-ios-app.reusable.yml
+++ b/.github/workflows/_ci-build-flutter-ios-app.reusable.yml
@@ -1,0 +1,87 @@
+name: Build Flutter iOS E2E App
+# Description: Scaffolds the Flutter iOS platform project and builds a debug .app for the
+# simulator. Split from the e2e run (mirrors the RN iOS leg) so the heavy build stays OFF the
+# e2e runner — appium-xcuitest's session-create SDK probe (xcrun, 15s timeout) is fragile when a
+# build is competing for the runner. The e2e job downloads this artifact.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Runner OS (macos-latest)'
+        required: true
+        type: string
+      node-version:
+        description: 'Node.js version'
+        required: true
+        type: string
+      flutter-version:
+        description: 'Flutter SDK version to build the fixture with'
+        type: string
+        default: '3.35.6'
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  FIXTURE_DIR: ${{ github.workspace }}/fixtures/e2e-apps/flutter
+
+jobs:
+  build:
+    name: Build .app
+    runs-on: ${{ inputs.os }}
+    # Cap a stuck Flutter/CocoaPods/xcodebuild build rather than holding a scarce macOS runner
+    # for the 6h default.
+    timeout-minutes: 60
+    steps:
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: 🛠️ Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      # Third-party action with secret access (secrets: inherit) → SHA-pinned, not a floating tag.
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ inputs.flutter-version }}
+          channel: stable
+          cache: true
+
+      # Scaffold the iOS platform project over the source-only fixture, restore our lib/main.dart +
+      # pubspec.yaml (flutter create can overwrite them), and build a debug .app for the simulator.
+      # A debug build exposes the Dart VM Service execute/mock attach to. --no-codesign: the sim
+      # doesn't require signing.
+      - name: 🏗️ Scaffold + build debug .app (simulator)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$FIXTURE_DIR"
+          flutter create --org com.wdio --project-name wdio_flutter_fixture --platforms=ios .
+          git checkout -- lib/main.dart pubspec.yaml
+          flutter pub get
+          flutter build ios --debug --simulator --no-codesign
+          APP=$(find build/ios/iphonesimulator -maxdepth 1 -name '*.app' -type d | head -1)
+          test -n "$APP" || { echo "::error::no .app under build/ios/iphonesimulator"; exit 1; }
+          # Tar the bundle (preserves the simulator .app's symlinks + exec bits, which a raw
+          # actions/upload-artifact corrupts → Appium can't install it on the sim).
+          tar -czf "$GITHUB_WORKSPACE/flutter-ios-app.tar.gz" -C "$(dirname "$APP")" "$(basename "$APP")"
+          echo "Built + tarred $APP"
+
+      - name: 📦 Upload built .app
+        uses: actions/upload-artifact@v7
+        with:
+          name: flutter-ios-app-${{ github.run_id }}
+          # The tarball, not the raw .app dir, so symlinks/exec bits survive. overwrite handles a
+          # full re-run that rebuilds (the run_id-only name otherwise collides).
+          path: flutter-ios-app.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -1,0 +1,168 @@
+name: E2E Tests - Flutter (iOS)
+# Description: iOS-simulator E2E for @wdio/flutter-service. The .app is built by the
+# build-flutter-ios-app job and downloaded here; this job boots the simulator, prebuilds
+# WebDriverAgent (appium-flutter-driver wraps appium-xcuitest on iOS), and runs the suite.
+# No Metro — a Flutter debug build is self-contained; the Dart VM Service is in-app and the
+# service discovers it from the device syslog over the simulator's shared host loopback.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Runner OS (macos-latest)'
+        required: true
+        type: string
+      node-version:
+        description: 'Node.js version'
+        required: true
+        type: string
+      test-type:
+        type: string
+        default: 'standard'
+      ios-device:
+        description: 'Simulator device name'
+        type: string
+        default: 'iPhone 16'
+      build_id:
+        type: string
+        required: false
+      artifact_size:
+        type: string
+        required: false
+      cache_key:
+        type: string
+        required: false
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  FLUTTER_WDA_DD: ${{ github.workspace }}/wda_dd
+  FLUTTER_APP_DIR: ${{ github.workspace }}/flutter-ios-app
+
+jobs:
+  run:
+    name: Run
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 60
+    steps:
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: 🛠️ Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: 📦 Download Build Artifacts
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: wdio-desktop-mobile
+          path: wdio-desktop-mobile-build
+          filename: artifact.zip
+          cache_key_prefix: wdio-desktop-build
+          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
+
+      - name: 📥 Download built .app
+        uses: actions/download-artifact@v7
+        with:
+          name: flutter-ios-app-${{ github.run_id }}
+          path: ${{ github.workspace }}/flutter-app-dl
+
+      - name: 📦 Unpack built .app
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$FLUTTER_APP_DIR"
+          tar -xzf "$GITHUB_WORKSPACE/flutter-app-dl/flutter-ios-app.tar.gz" -C "$FLUTTER_APP_DIR"
+          APP=$(find "$FLUTTER_APP_DIR" -maxdepth 1 -name '*.app' -type d | head -1)
+          test -n "$APP" || { echo "::error::unpacked .app not found under $FLUTTER_APP_DIR"; find "$FLUTTER_APP_DIR" | head -40; exit 1; }
+          echo "FLUTTER_APP_PATH=$APP" >> "$GITHUB_ENV"
+          echo "Using app: $APP"
+
+      # Warm the Xcode toolchain before the Appium session: appium-xcuitest (which the flutter
+      # driver wraps) probes the SDK with `xcrun --show-sdk-version` under a 15s timeout; the first
+      # cold invocation on a fresh runner can exceed it.
+      - name: 🔥 Warm Xcode toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcrun --sdk iphonesimulator --show-sdk-version
+          xcrun simctl list devices available >/dev/null
+
+      - name: 📲 Boot iOS simulator
+        shell: bash
+        env:
+          FLUTTER_IOS_DEVICE: ${{ inputs.ios-device }}
+        run: |
+          set -euo pipefail
+          if ! xcrun simctl boot "$FLUTTER_IOS_DEVICE" 2>/tmp/boot.err; then
+            if grep -qiE "already booted|current state: Booted" /tmp/boot.err; then
+              echo "Simulator '$FLUTTER_IOS_DEVICE' already booted"
+            else
+              echo "::error::Failed to boot simulator '$FLUTTER_IOS_DEVICE':"; cat /tmp/boot.err
+              echo "Available devices:"; xcrun simctl list devices available
+              exit 1
+            fi
+          fi
+          xcrun simctl bootstatus "$FLUTTER_IOS_DEVICE" -b || { echo "::error::Simulator '$FLUTTER_IOS_DEVICE' did not reach Booted state"; exit 1; }
+
+      - name: 🔌 Install Appium Flutter + XCUITest drivers
+        shell: bash
+        run: |
+          set -euo pipefail
+          installed=$(pnpm --filter @repo/e2e exec appium driver list --installed 2>&1 || true)
+          echo "$installed" | grep -qi xcuitest || pnpm --filter @repo/e2e exec appium driver install xcuitest
+          echo "$installed" | grep -qi flutter || pnpm --filter @repo/e2e exec appium driver install --source=npm appium-flutter-driver
+
+      # WDA DerivedData cache keyed on e2e/package.json (driver pins) + the runner image version.
+      - name: 💾 Restore WDA DerivedData cache
+        id: wda-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.FLUTTER_WDA_DD }}
+          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v1
+
+      # Pre-build WebDriverAgent deterministically (no appium session, so no socket fragility).
+      # The graded run reuses it via appium:derivedDataPath + usePrebuiltWDA, skipping the
+      # multi-minute compile on the first session (which under WDIO's undici client dropped the
+      # POST /session socket on the RN leg).
+      - name: 🏎️ Pre-build WebDriverAgent
+        if: steps.wda-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          WDA_PROJ=$(find node_modules/.pnpm -maxdepth 6 -path '*/appium-webdriveragent/WebDriverAgent.xcodeproj' -type d 2>/dev/null | head -1)
+          test -n "$WDA_PROJ" || { echo "::error::WebDriverAgent.xcodeproj not found under node_modules"; exit 1; }
+          xcodebuild build-for-testing \
+            -project "$WDA_PROJ" \
+            -scheme WebDriverAgentRunner \
+            -derivedDataPath "$FLUTTER_WDA_DD" \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO GCC_TREAT_WARNINGS_AS_ERRORS=0 2>&1 | (xcbeautify || cat)
+          test -d "$FLUTTER_WDA_DD/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app" \
+            || { echo "::error::prebuilt WDA runner not found"; exit 1; }
+
+      - name: 🧪 Run E2E on iOS simulator
+        shell: bash
+        env:
+          FLUTTER_IOS_DEVICE: ${{ inputs.ios-device }}
+        run: |
+          set -euo pipefail
+          pnpm --filter @repo/e2e run test:e2e:flutter:ios
+
+      - name: 📦 Upload Test Logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-logs-flutter-ios-${{ inputs.os }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-type }}
+          path: |
+            e2e/logs/**/*.log
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,6 +815,37 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
 
+  # Flutter iOS .app build (macOS) — split from the e2e run so the heavy build stays off the e2e
+  # runner (appium-xcuitest's SDK probe is fragile under build contention). Mirrors the RN iOS split.
+  build-flutter-ios-e2e-app-macos:
+    name: Build Flutter iOS E2E App
+    needs: [detect-changes]
+    if: fromJSON(needs.detect-changes.outputs.runs)['flutter'] && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-flutter-ios-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      node-version: '24'
+
+  # Flutter — iOS simulator E2E (fast-follow to the Android leg). Required gate (see ci-status).
+  e2e-flutter-ios-macos:
+    name: E2E - Flutter [iOS] - ${{ matrix.test-type }}
+    needs: [detect-changes, build, build-flutter-ios-e2e-app-macos]
+    if: fromJSON(needs.detect-changes.outputs.runs)['flutter'] && needs.detect-changes.outputs.run_lint_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: ['standard']
+    uses: ./.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      node-version: '24'
+      test-type: ${{ matrix.test-type }}
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
   # Build the RN iOS .app ahead of (and in parallel with) the Linux package build. The native
   # xcodebuild + CocoaPods step is the dominant cost on the iOS leg; decoupling it from `build`
   # means the macOS runner starts as soon as detect-changes finishes instead of waiting for the
@@ -1124,8 +1155,10 @@ jobs:
       - e2e-react-native-linux
       - e2e-react-native-ios-macos
       - build-rn-ios-e2e-app-macos
-      # Flutter — Android emulator E2E is a required gate (iOS simulator lands in PR5).
+      # Flutter — Android emulator + iOS simulator E2E are required gates.
       - e2e-flutter-linux
+      - e2e-flutter-ios-macos
+      - build-flutter-ios-e2e-app-macos
       - e2e-electrobun-windows
       - package-electron-matrix
       - package-tauri-linux

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -83,6 +83,10 @@ type FlutterCapability = {
   'appium:newCommandTimeout': number;
   'appium:deviceName'?: string;
   'appium:dartVmServicePort'?: number;
+  'appium:wdaLaunchTimeout'?: number;
+  'appium:simulatorStartupTimeout'?: number;
+  'appium:derivedDataPath'?: string;
+  'appium:usePrebuiltWDA'?: boolean;
   'wdio:flutterServiceOptions': FlutterServiceOptions;
 };
 
@@ -92,7 +96,20 @@ const capabilities: FlutterCapability[] = [
     'appium:automationName': 'Flutter',
     'appium:app': appPath,
     'appium:newCommandTimeout': 240,
-    ...(isIos ? { 'appium:deviceName': process.env.FLUTTER_IOS_DEVICE ?? 'iPhone 16' } : {}),
+    // iOS: appium-flutter-driver wraps appium-xcuitest, which launches WebDriverAgent. CI
+    // pre-builds WDA into FLUTTER_WDA_DD; reuse it (usePrebuiltWDA) so the first session just
+    // launches it — fast, no per-session compile (which under WDIO's undici client dropped the
+    // POST /session socket on the RN leg). Generous sim-boot ceiling for cold/slow runners.
+    ...(isIos
+      ? {
+          'appium:deviceName': process.env.FLUTTER_IOS_DEVICE ?? 'iPhone 16',
+          'appium:simulatorStartupTimeout': 240000,
+          'appium:wdaLaunchTimeout': process.env.FLUTTER_WDA_DD ? 180000 : 720000,
+          ...(process.env.FLUTTER_WDA_DD
+            ? { 'appium:derivedDataPath': process.env.FLUTTER_WDA_DD, 'appium:usePrebuiltWDA': true }
+            : {}),
+        }
+      : {}),
     'wdio:flutterServiceOptions': flutterServiceOptions,
   },
 ];
@@ -113,7 +130,10 @@ export const config = {
   specFileRetriesDeferred: false,
   baseUrl: '',
   waitforTimeout: 15000,
-  connectionRetryTimeout: 180000,
+  // iOS must exceed wdaLaunchTimeout so WDIO doesn't abort POST /session before WDA is ready;
+  // with a prebuilt WDA (CI) the session is fast, so a tighter 7-min ceiling surfaces a flaky
+  // first session quickly. Android stays tight.
+  connectionRetryTimeout: isIos ? (process.env.FLUTTER_WDA_DD ? 420000 : 900000) : 180000,
   connectionRetryCount: 0,
   // @wdio/appium-service boots Appium; @wdio/flutter-service prepares the capability
   // (automationName Flutter) and attaches the Dart VM Service for execute/mock.


### PR DESCRIPTION
**Flutter service — PR5 of 6.** Stacked on #371 (PR4 E2E-Android); base `feat/flutter-e2e-android`.

Adds the iOS-simulator E2E leg. Mirrors the RN iOS split — build the `.app` off the e2e runner + prebuild WebDriverAgent — because appium-flutter-driver wraps appium-xcuitest on iOS. ⚠️ Validated only by real iOS-simulator CI.

- **`_ci-build-flutter-ios-app.reusable.yml`** — macOS, Flutter SDK (SHA-pinned), `flutter create --platforms=ios` + `flutter build ios --debug --simulator --no-codesign`, uploads the `.app`.
- **`_ci-e2e-flutter-ios.reusable.yml`** — macOS, downloads the `.app`, warms Xcode, boots the sim, installs the `flutter` + `xcuitest` drivers, prebuilds WDA (cached `derivedDataPath`, reused via `usePrebuiltWDA`), runs the shared specs with `FLUTTER_PLATFORM=ios`. **No Metro** (self-contained build; VM service via the sim's shared loopback + syslog scrape).
- **`ci.yml`** — `build-flutter-ios-e2e-app-macos` + `e2e-flutter-ios-macos` jobs (gated on `detect-changes` `flutter`), both added to the `ci-status` required gate.
- **`wdio.flutter.conf.ts`** — iOS caps (`usePrebuiltWDA`/`derivedDataPath`, WDA/sim timeouts) + a `connectionRetryTimeout` that exceeds `wdaLaunchTimeout`.

The same `e2e/test/flutter/*` specs drive both platforms via `FLUTTER_PLATFORM`. Ship (docs, release, pub.dev) is PR6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)