### PR TITLE
feat(flutter): PR6/6 Ship — docs, package-test, release wiring + pub.dev

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       scope:
-        description: 'Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, cdp-bridge, shared) — controls build and toolchain steps'
+        description: 'Release scope (electron, tauri, dioxus, electrobun, flutter, native-mobile-core, utils, types, spy, core, cdp-bridge, shared) — controls build and toolchain steps'
         required: true
         type: string
     secrets:
@@ -96,6 +96,15 @@ jobs:
           sudo apt-get install -y libayatana-appindicator3-dev || true
           sudo apt-get install -y libsoup3-dev || true
 
+      # Flutter SDK only for the wdio_flutter pub.dev publish below (the @wdio/flutter-service npm
+      # package is plain TS). SHA-pinned third-party action — secrets: inherit gives secret access.
+      - name: Setup Flutter
+        if: ${{ contains(inputs.scope, 'flutter') }}
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: '3.35.6'
+          channel: stable
+
       - name: Compute target packages from scope
         id: targets
         run: |
@@ -128,6 +137,12 @@ jobs:
               ;;
             cdp-bridge)
               echo "packages=@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
+              ;;
+            native-mobile-core)
+              echo "packages=@wdio/native-mobile-core" >> "$GITHUB_OUTPUT"
+              ;;
+            flutter)
+              echo "packages=@wdio/flutter-service" >> "$GITHUB_OUTPUT"
               ;;
             shared)
               echo "packages=@wdio/native-utils,@wdio/native-types,@wdio/native-spy,@wdio/native-core,@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
@@ -216,6 +231,12 @@ jobs:
             cdp-bridge)
               pnpm turbo run build --filter='@wdio/native-cdp-bridge...'
               ;;
+            native-mobile-core)
+              pnpm turbo run build --filter='@wdio/native-mobile-core...'
+              ;;
+            flutter)
+              pnpm turbo run build --filter='@wdio/flutter-service...'
+              ;;
             shared)
               pnpm turbo run build \
                 --filter='@wdio/native-types...' \
@@ -279,3 +300,28 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
           OLLAMA_API_KEY: ${{ secrets.ollama_api_key }}
+
+      # Publish the wdio_flutter Dart contract to pub.dev alongside the npm @wdio/flutter-service
+      # release — they version together but live in separate ecosystems (pub.dev / npm). Uses
+      # pub.dev's GitHub-Actions automated publishing over OIDC (id-token: write is granted above);
+      # REQUIRES the pub.dev package's "Automated publishing" to be configured to trust this repo +
+      # workflow first. ReleaseKit bumps the npm package.json only, so keep
+      # wdio_flutter/pubspec.yaml's version in sync with the @wdio/flutter-service line by hand
+      # before a release. dry_run validates packaging without publishing.
+      - name: Publish wdio_flutter to pub.dev
+        if: ${{ contains(inputs.scope, 'flutter') }}
+        working-directory: packages/flutter-service/wdio_flutter
+        shell: bash
+        run: |
+          set -euo pipefail
+          flutter pub get
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "Dry run — validating the wdio_flutter package without publishing."
+            flutter pub publish --dry-run
+          elif [ "${{ steps.params.outputs.stable }}" = "true" ]; then
+            flutter pub publish --force
+          else
+            # pubspec.yaml carries a stable version; publishing it on an npm -next.N prerelease would
+            # burn the 1.0.0 slot before the real release. wdio_flutter publishes on the stable line.
+            echo "Prerelease release — skipping pub.dev publish (wdio_flutter publishes on stable)."
+          fi

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -96,15 +96,6 @@ jobs:
           sudo apt-get install -y libayatana-appindicator3-dev || true
           sudo apt-get install -y libsoup3-dev || true
 
-      # Flutter SDK only for the wdio_flutter pub.dev publish below (the @wdio/flutter-service npm
-      # package is plain TS). SHA-pinned third-party action — secrets: inherit gives secret access.
-      - name: Setup Flutter
-        if: ${{ contains(inputs.scope, 'flutter') }}
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
-        with:
-          flutter-version: '3.35.6'
-          channel: stable
-
       - name: Compute target packages from scope
         id: targets
         run: |
@@ -301,27 +292,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
           OLLAMA_API_KEY: ${{ secrets.ollama_api_key }}
 
-      # Publish the wdio_flutter Dart contract to pub.dev alongside the npm @wdio/flutter-service
-      # release — they version together but live in separate ecosystems (pub.dev / npm). Uses
-      # pub.dev's GitHub-Actions automated publishing over OIDC (id-token: write is granted above);
-      # REQUIRES the pub.dev package's "Automated publishing" to be configured to trust this repo +
-      # workflow first. ReleaseKit bumps the npm package.json only, so keep
-      # wdio_flutter/pubspec.yaml's version in sync with the @wdio/flutter-service line by hand
-      # before a release. dry_run validates packaging without publishing.
-      - name: Publish wdio_flutter to pub.dev
-        if: ${{ contains(inputs.scope, 'flutter') }}
-        working-directory: packages/flutter-service/wdio_flutter
-        shell: bash
-        run: |
-          set -euo pipefail
-          flutter pub get
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "Dry run — validating the wdio_flutter package without publishing."
-            flutter pub publish --dry-run
-          elif [ "${{ steps.params.outputs.stable }}" = "true" ]; then
-            flutter pub publish --force
-          else
-            # pubspec.yaml carries a stable version; publishing it on an npm -next.N prerelease would
-            # burn the 1.0.0 slot before the real release. wdio_flutter publishes on the stable line.
-            echo "Prerelease release — skipping pub.dev publish (wdio_flutter publishes on stable)."
-          fi
+      # The wdio_flutter Dart contract (packages/flutter-service/wdio_flutter) publishes to pub.dev
+      # as part of the `flutter` scope. This is handled inside ReleaseKit — peer to its npm +
+      # crates.io publishing — rather than a bespoke step here, so the pubspec.yaml version bumps in
+      # lockstep with the @wdio/flutter-service npm line. Tracked: goosewobbler/releasekit#285.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: "Release scope (electron, tauri, dioxus, electrobun, utils, types, spy, core, cdp-bridge, shared)"
+        description: "Release scope (electron, tauri, dioxus, electrobun, flutter, native-mobile-core, utils, types, spy, core, cdp-bridge, shared)"
         required: true
         type: choice
         options:
@@ -18,10 +18,12 @@ on:
           - spy
           - core
           - cdp-bridge
+          - native-mobile-core
           - electron
           - tauri
           - dioxus
           - electrobun
+          - flutter
         default: shared
       bump:
         description: "Version increment"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 - **Dioxus** - `@wdio/dioxus-service` (v1.x)
 - **Electrobun** - `@wdio/electrobun-service` (v0.1.x — **macOS** via CEF + **Windows** via the native WebView2 renderer (CDP), incl. multi-window/multiremote; **Linux** upstream-blocked, and deeplink/multiremote blocked on the macOS CEF path — see the package README)
 - **React Native** - `@wdio/react-native-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via Appium (UiAutomator2/XCUITest); `execute` + `mock` via Hermes CDP (debug/Metro build); full mock, deeplink, context switching, logs, multiremote)
+- **Flutter** - `@wdio/flutter-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (Dart expression) + `mock` (Tier-2 cooperative `wdio_flutter` Dart contract) via the Dart VM Service (debug/profile build); full mock, deeplink, context switching, logs, multiremote). Built on `@wdio/native-mobile-core`.
 
-**Planned:** Flutter, Capacitor, Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
+**Planned:** Capacitor, Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
 
 ## Tech Stack
 
@@ -36,6 +37,8 @@ packages/
 ├── dioxus-service/         # Dioxus WDIO service
 ├── electrobun-service/     # Electrobun WDIO service
 ├── react-native-service/   # React Native WDIO service (Android + iOS via Appium + Hermes CDP)
+├── flutter-service/        # Flutter WDIO service (Android + iOS via appium-flutter-driver + Dart VM Service); nested wdio_flutter Dart contract
+├── native-mobile-core/     # Shared Appium-mobile layer (DeviceManager, MobileBaseLauncher, session/caps/deeplink/contexts/logs) — RN + Flutter
 ├── tauri-plugin/           # Tauri v2 plugin (Rust + JS)
 ├── dioxus-bridge/          # Dioxus bridge crate (Rust) — IPC, mocking, log forwarding
 ├── dioxus-embedded-driver/ # Dioxus in-process WebDriver server (Rust)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@
 
 [`@wdio/react-native-service`](./packages/react-native-service) - React Native mobile applications — **Android + iOS**. Native find/tap via Appium (UiAutomator2 / XCUITest); `execute` and `mock` via Hermes CDP (debug/Metro build). See the [package README](./packages/react-native-service).
 
+<h4>
+  <div>
+    <a href="https://www.npmjs.com/package/@wdio/flutter-service"><img src="https://img.shields.io/badge/@wdio-flutter--service-027DFD?labelColor=1a1a1a&style=plastic" alt="npm package" /></a>
+    <a href="https://www.npmjs.com/package/@wdio/flutter-service"><img src="https://img.shields.io/npm/v/@wdio/flutter-service" alt="npm version" /></a>
+    <a href="https://www.npmjs.com/package/@wdio/flutter-service"><img src="https://img.shields.io/npm/dw/@wdio/flutter-service" alt="npm downloads" /></a>
+  </div>
+</h4>
+
+[`@wdio/flutter-service`](./packages/flutter-service) - Flutter mobile applications — **Android + iOS**. Native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (a Dart expression) and `mock` (the cooperative [`wdio_flutter`](./packages/flutter-service/wdio_flutter) contract) via the Dart VM Service (debug/profile build). See the [package README](./packages/flutter-service).
+
 > Early (`0.x`) support — scope is limited and the surface may change as upstream gaps are resolved. Not yet at parity with the frameworks above.
 
 <h4>
@@ -90,7 +100,6 @@
 
 ## Planned Support
 
-- **Flutter** - Google's UI toolkit for mobile and beyond
 - **Capacitor** - Ionic's cross-platform mobile framework
 - **Neutralino** - Lightweight desktop applications
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,11 @@ This document outlines the planned services and their development sequencing for
 **Platforms:** Android, iOS\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/react-native-service)](https://npmjs.com/package/@wdio/react-native-service)
 
+### [@wdio/flutter-service](./packages/flutter-service) - v1.0.0-next.x
+**Status:** 🧪 Pre-release (`1.0.0-next.x`) — complete feature surface on Android + iOS\
+**Platforms:** Android, iOS\
+[![npm downloads](https://img.shields.io/npm/dm/@wdio/flutter-service)](https://npmjs.com/package/@wdio/flutter-service)
+
 ---
 
 ## Cross-cutting Capabilities
@@ -68,20 +73,10 @@ The table below quantifies the key factors used to prioritise and sequence plann
 **Platforms:** Android (UiAutomator2), iOS (XCUITest)\
 **Highlights:** native find/tap via Appium; `execute` + `mock` via Hermes CDP (debug/Metro build); deeplink, context switching, log capture, multiremote/DeviceManager. Establishes the mobile scaffold for Phase 3 (Flutter) and Phase 4 (Capacitor).
 
-### Phase 3: Flutter Mobile (Q4 2026)
-**Priority:** Medium - Mobile testing completion
+### Phase 3: Flutter Mobile — ✅ Shipped (Android + iOS, `1.0.0-next.x`)
+[`@wdio/flutter-service`](./packages/flutter-service) — see the [package README](./packages/flutter-service/README.md).
 
-**Target Platforms:** iOS, Android
-
-**Why Flutter:**
-- Google backing and strong mobile presence
-- Production-ready Appium Flutter Driver
-- Complements React Native mobile coverage
-- Reuses mobile scaffold
-
-**Technical approach:**
-- Appium Flutter Driver integration
-- Standard WebdriverIO Appium patterns
+**Highlights:** native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (a Dart expression) + `mock` (the cooperative [`wdio_flutter`](./packages/flutter-service/wdio_flutter) Dart contract) via the Dart VM Service (debug/profile build); deeplink, context switching, log capture, multiremote/DeviceManager. Built on the `@wdio/native-mobile-core` layer extracted from React Native — the shared mobile scaffold Phase 4 (Capacitor) will reuse.
 
 ### Phase 4: Capacitor Mobile (Q1 2027)
 **Priority:** Medium - Ionic ecosystem coverage

--- a/fixtures/package-tests/flutter-app/package.json
+++ b/fixtures/package-tests/flutter-app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "flutter-app-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "wdio run wdio.conf.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.3",
+    "@wdio/appium-service": "9.27.1",
+    "@wdio/cli": "9.27.1",
+    "@wdio/globals": "9.27.1",
+    "@wdio/local-runner": "9.27.1",
+    "@wdio/mocha-framework": "9.27.1",
+    "@wdio/native-types": "workspace:*",
+    "@wdio/flutter-service": "workspace:*",
+    "@wdio/spec-reporter": "9.27.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/fixtures/package-tests/flutter-app/test/smoke.spec.ts
+++ b/fixtures/package-tests/flutter-app/test/smoke.spec.ts
@@ -1,0 +1,28 @@
+import { browser, expect } from '@wdio/globals';
+
+// Package-install smoke test: confirms the installed @wdio/flutter-service tarball exposes the
+// expected browser.flutter.* API surface.
+//
+// Requires: a running Appium server + a device / emulator with the fixture app pre-installed;
+// set FLUTTER_APP_PATH and optionally FLUTTER_PLATFORM, FLUTTER_DEVICE_NAME. The full feature
+// matrix lives in e2e/test/flutter/.
+describe('@wdio/flutter-service package install', () => {
+  it('should install the browser.flutter API surface', async () => {
+    expect(typeof browser.flutter.execute).toBe('function');
+    expect(typeof browser.flutter.mock).toBe('function');
+    expect(typeof browser.flutter.clearAllMocks).toBe('function');
+    expect(typeof browser.flutter.resetAllMocks).toBe('function');
+    expect(typeof browser.flutter.restoreAllMocks).toBe('function');
+    expect(typeof browser.flutter.isMockFunction).toBe('function');
+    expect(typeof browser.flutter.triggerDeeplink).toBe('function');
+    expect(typeof browser.flutter.switchWindow).toBe('function');
+    expect(typeof browser.flutter.emitEvent).toBe('function');
+    expect(typeof browser.flutter.byValueKey).toBe('function');
+    expect(typeof browser.flutter.byText).toBe('function');
+  });
+
+  it('should evaluate a Dart expression via the VM Service', async () => {
+    const isFlutter = await browser.flutter.execute<boolean>('WidgetsBinding.instance != null');
+    expect(isFlutter).toBe(true);
+  });
+});

--- a/fixtures/package-tests/flutter-app/tsconfig.json
+++ b/fixtures/package-tests/flutter-app/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "wdio.conf.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/fixtures/package-tests/flutter-app/wdio.conf.ts
+++ b/fixtures/package-tests/flutter-app/wdio.conf.ts
@@ -1,0 +1,70 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { FlutterCapabilities, FlutterServiceOptions } from '@wdio/native-types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Set FLUTTER_APP_PATH to your built debug APK (Android) or .app bundle (iOS).
+// Without it the config throws a descriptive error on startup.
+const appPath = process.env.FLUTTER_APP_PATH;
+if (!appPath) {
+  throw new Error(
+    'FLUTTER_APP_PATH is not set. Point it at a built Flutter debug app:\n' +
+      '  Android: build/app/outputs/flutter-apk/app-debug.apk\n' +
+      '  iOS:     build/ios/iphonesimulator/Runner.app',
+  );
+}
+
+// Select platform from FLUTTER_PLATFORM (defaults to Android).
+const rawPlatform = (process.env.FLUTTER_PLATFORM ?? 'android').toLowerCase();
+if (rawPlatform !== 'android' && rawPlatform !== 'ios') {
+  throw new Error(`FLUTTER_PLATFORM must be 'android' or 'ios', got: ${rawPlatform}`);
+}
+const platform = rawPlatform as 'android' | 'ios';
+
+const flutterServiceOptions: FlutterServiceOptions = {
+  captureBackendLogs: true,
+};
+
+const capabilities: FlutterCapabilities[] = [
+  {
+    platformName: platform === 'ios' ? 'iOS' : 'Android',
+    'appium:automationName': 'Flutter',
+    'appium:deviceName': process.env.FLUTTER_DEVICE_NAME ?? (platform === 'ios' ? 'iPhone 16' : 'emulator-5554'),
+    'appium:app': appPath,
+    'wdio:flutterServiceOptions': flutterServiceOptions,
+  },
+];
+
+export const config = {
+  runner: 'local',
+  specs: ['./test/**/*.spec.ts'],
+  exclude: [],
+  maxInstances: 1,
+  capabilities,
+  logLevel: 'info',
+  bail: 0,
+  baseUrl: '',
+  waitforTimeout: 30000,
+  connectionRetryTimeout: 180000,
+  connectionRetryCount: 3,
+  outputDir: join(__dirname, 'logs'),
+  services: [
+    'appium',
+    [
+      'flutter',
+      {
+        ...flutterServiceOptions,
+      },
+    ],
+  ],
+  framework: 'mocha',
+  reporters: ['spec'],
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+  },
+  tsConfigPath: join(__dirname, 'tsconfig.json'),
+};

--- a/packages/flutter-service/README.md
+++ b/packages/flutter-service/README.md
@@ -1,0 +1,291 @@
+# @wdio/flutter-service
+
+WebdriverIO service for end-to-end testing [Flutter](https://flutter.dev) applications on
+**Android and iOS**.
+
+Flutter is a **self-rendered** automation target — it paints its own widgets to a canvas
+rather than composing native views. Native find/tap therefore runs over
+[appium-flutter-driver](https://github.com/appium/appium-flutter-driver) (automationName
+`Flutter`, the `FLUTTER` context), while `execute` and `mock` run in the app's **Dart isolate**
+over the [Dart VM Service](https://github.com/dart-lang/sdk/blob/main/runtime/vm/service/service.md)
+— the service opens its own JSON-RPC-over-WebSocket connection to the observatory.
+
+Mocking is **cooperative** (Dart has no runtime monkey-patch): the app opts in via the
+[`wdio_flutter`](./wdio_flutter) Dart package, routing its DI seams through a registry the service
+drives over `ext.wdio.*` service extensions.
+
+> **Status: `1.0.0-next.x` pre-release.** Both platforms ship together; the feature surface is
+> complete. `execute` and `mock` require a **debug / profile build** (the VM Service is not
+> exposed in release builds). See [Known limitations](#known-limitations).
+
+## Installation
+
+```sh
+npm install --save-dev @wdio/flutter-service
+```
+
+The service **composes with `@wdio/appium-service`** — install that too:
+
+```sh
+npm install --save-dev @wdio/appium-service
+```
+
+Native find/tap needs the Appium Flutter driver:
+
+```sh
+appium driver install --source=npm appium-flutter-driver
+```
+
+## Quick start
+
+```ts
+// wdio.conf.ts
+import type { FlutterCapabilities, FlutterServiceOptions } from '@wdio/native-types';
+
+const flutterOptions: FlutterServiceOptions = {
+  captureBackendLogs: true,
+};
+
+export const config = {
+  services: [
+    'appium',                       // starts the local Appium server
+    ['flutter', { ...flutterOptions }],
+  ],
+  capabilities: [
+    {
+      platformName: 'Android',
+      'appium:automationName': 'Flutter',
+      'appium:deviceName': 'emulator-5554',
+      'appium:app': '/path/to/app-debug.apk',
+      'wdio:flutterServiceOptions': flutterOptions,
+    } satisfies FlutterCapabilities,
+  ],
+  // ... mocha/spec config
+};
+```
+
+```ts
+// a spec
+it('should evaluate a Dart expression', async () => {
+  const isFlutter = await browser.flutter.execute<boolean>('WidgetsBinding.instance != null');
+  expect(isFlutter).toBe(true);
+});
+
+it('should tap a widget by ValueKey and read text', async () => {
+  await browser.flutter.byValueKey('increment').tap();
+  expect(await browser.flutter.byValueKey('counter').getText()).toBe('1');
+});
+
+it('should mock an app-exposed seam', async () => {
+  const greet = await browser.flutter.mock('GreetingService.greet');
+  await greet.mockReturnValue('Hello, mock!');
+  // ... exercise the app ...
+  await greet.update();
+  expect(greet.mock.calls).toHaveLength(1);
+  await browser.flutter.restoreAllMocks();
+});
+```
+
+## Build requirement
+
+`execute` and `mock` attach to the **Dart VM Service**, which is exposed only by a **debug or
+profile build** — not a release build. The app must initialise the driver extension (and, for
+mocking, the `wdio_flutter` contract) at startup, **before** `runApp()`:
+
+```dart
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:wdio_flutter/wdio_flutter.dart';
+
+void main() {
+  enableFlutterDriverExtension(); // initialises the binding + the Flutter driver channel
+  enableWdioMocking();            // registers ext.wdio.* (call AFTER, before runApp)
+  runApp(const MyApp());
+}
+```
+
+Build a debug app:
+
+- **Android**: `flutter build apk --debug`
+- **iOS** (simulator): `flutter build ios --debug --simulator`
+
+Native find/tap via appium-flutter-driver works with any debug/profile build.
+
+## Capabilities
+
+All standard [Appium capabilities](https://appium.io/docs/en/latest/guides/caps/) are supported.
+The service adds `wdio:flutterServiceOptions`:
+
+| Capability | Type | Description |
+|---|---|---|
+| `platformName` | `'Android' \| 'iOS'` | Target platform (required) |
+| `appium:automationName` | `'Flutter'` | appium-flutter-driver, both platforms |
+| `appium:deviceName` | `string` | Device name or emulator AVD name |
+| `appium:udid` | `string` | Device serial (Android) or UDID (iOS) |
+| `appium:app` | `string` | Path to the built `.apk` / `.app` |
+| `appium:dartVmServicePort` | `number` | Pin the VM Service port → skips the (up to 60s) log scrape (CI-robust) |
+| `wdio:flutterServiceOptions` | `FlutterServiceOptions` | Service options |
+
+## Service options (`FlutterServiceOptions`)
+
+```ts
+interface FlutterServiceOptions {
+  // Dart VM Service connection
+  vmServiceHost?: string;       // default: 'localhost'
+  vmServicePort?: number;       // pin the port (skips the log scrape); also via appium:dartVmServicePort
+
+  // Convenience — maps onto appium:app if not already set in the capability
+  appBinaryPath?: string;
+
+  // Device pool for parallel workers / multiremote
+  devices?: Array<{ udid?: string; avd?: string; iOSUdid?: string }>;
+
+  // Log capture
+  captureBackendLogs?: boolean; // forward logcat (Android) / syslog (iOS) to the WDIO output
+
+  // Mock lifecycle (run before each test)
+  clearMocks?: boolean;         // clear mock call history
+  resetMocks?: boolean;         // clear value + call history
+  restoreMocks?: boolean;       // remove the mock entirely
+}
+```
+
+## API (`browser.flutter.*`)
+
+### `execute(script)`
+
+Evaluate a **Dart expression** in the app's root isolate via the VM Service.
+
+> **API divergence:** unlike the other services, `script` is a **Dart expression string**, not a
+> JavaScript function — Flutter has no JS realm. The expression is evaluated against the app's
+> root library.
+
+```ts
+const counter = await browser.flutter.execute<int>('myAppState.counter');
+```
+
+### `mock(target)`
+
+Mock a Dart seam the app exposed through the `wdio_flutter` contract, addressed by its target id.
+Returns a Vitest/Jest-compatible mock instance.
+
+```ts
+const fn = await browser.flutter.mock('Analytics.track');
+await fn.mockReturnValue(null);
+// ... run the test ...
+await fn.update();            // sync call data from the app into fn.mock.calls
+expect(fn.mock.calls).toHaveLength(1);
+await browser.flutter.restoreAllMocks();
+```
+
+> **Cooperative-seam scope.** You mock the seams the app routes through `wdioRegistry`
+> (idiomatic Flutter DI), not arbitrary internals. There is no `mockImplementation` — Dart can't
+> serialise a JS closure across the boundary; use `mockReturnValue` / `mockResolvedValue` /
+> `mockRejectedValue` with serialisable values. See the [`wdio_flutter` contract](./wdio_flutter).
+
+### `clearAllMocks()` / `resetAllMocks()` / `restoreAllMocks()`
+
+Lifecycle helpers — `vi.clearAllMocks()`-equivalents over the Flutter mock registry. Also wired to
+the `clearMocks` / `resetMocks` / `restoreMocks` service options (run before each test).
+
+### `isMockFunction(targetOrFn)`
+
+Returns `true` if the argument is an active Flutter mock (or a mocked target path).
+
+### `triggerDeeplink(url)`
+
+Open a deep link in the running app via Appium's `mobile: deepLink` (switches to `NATIVE_APP`
+first).
+
+```ts
+await browser.flutter.triggerDeeplink('myapp://products/42');
+```
+
+### `switchWindow(context)` / `listWindows()`
+
+Switch between Appium contexts — `NATIVE_APP` ↔ `FLUTTER` (↔ `WEBVIEW_*` for embedded web).
+
+### `emitEvent(name, payload?)`
+
+Emit an event into the app's `wdio_flutter` event bus. The app opts in by listening to
+`wdioEvents.stream` (e.g. to drive navigation or a feature flag from a test).
+
+```ts
+await browser.flutter.emitEvent('deeplink', { path: '/profile' });
+```
+
+## Element finding
+
+Flutter paints its own widgets, so prefer the Flutter finders (they run in the `FLUTTER` context,
+auto-switched):
+
+```ts
+await browser.flutter.byValueKey('increment').tap();           // const ValueKey('increment')
+const text = await browser.flutter.byText('Submit').getText();
+```
+
+Raw [appium-flutter-driver finders](https://github.com/appium/appium-flutter-driver#finders) remain
+available via `browser.$(<json-finder>)` once in the `FLUTTER` context.
+
+## Log capture
+
+The service collects **logcat** (Android) / **syslog** (iOS) and forwards them to the WDIO test
+output. Enable via `captureBackendLogs`.
+
+## Multiremote / parallel workers
+
+Set `devices` in the service options to pool descriptors across workers:
+
+```ts
+const config = {
+  maxInstances: 2,
+  services: [
+    'appium',
+    ['flutter', {
+      devices: [{ avd: 'Pixel_8_API_35' }, { avd: 'Pixel_7_API_35' }],
+    }],
+  ],
+};
+```
+
+Each worker claims a device round-robin (and its own `adb forward` tunnel). Omit `devices` for a
+single-device run.
+
+## Standalone / session mode
+
+Use `startWdioSession` to drive sessions outside the WDIO runner:
+
+```ts
+import { startWdioSession, cleanupWdioSession } from '@wdio/flutter-service';
+
+const browser = await startWdioSession({
+  platformName: 'Android',
+  'appium:automationName': 'Flutter',
+  'appium:app': '/path/to/app-debug.apk',
+});
+try {
+  console.log(await browser.flutter.execute('1 + 1'));
+} finally {
+  await cleanupWdioSession(browser);
+}
+```
+
+## Known limitations
+
+| Area | Status |
+|---|---|
+| `execute` (Dart expression) | ✅ supported — **debug / profile build only** (VM Service) |
+| `mock` (cooperative contract) | ✅ supported — app opts in via [`wdio_flutter`](./wdio_flutter) |
+| Android | ✅ full support |
+| iOS | ✅ full support |
+| find/tap (`byValueKey` / `byText`) | ✅ via appium-flutter-driver |
+| multiremote | ✅ via the `devices` pool |
+| context switching (`NATIVE_APP` ↔ `FLUTTER`) | ✅ |
+| deeplink | ✅ via `mobile: deepLink` |
+| log capture | ✅ logcat / syslog |
+| `emitEvent` | ✅ via the `wdio_flutter` event bus |
+| `mockImplementation` | ❌ Dart can't run a serialised JS closure — use `mockReturnValue` etc. |
+| Release build `execute` / `mock` | ❌ the VM Service is not exposed in release builds |
+
+## License
+
+MIT

--- a/test/scripts/detect-changes.spec.ts
+++ b/test/scripts/detect-changes.spec.ts
@@ -89,7 +89,10 @@ describe('classifyFile', () => {
     ['e2e/wdio.flutter.conf.ts', 'flutter'],
     ['e2e/test/flutter/api.spec.ts', 'flutter'],
     ['fixtures/e2e-apps/flutter/lib/main.dart', 'flutter'],
+    ['fixtures/package-tests/flutter-app/wdio.conf.ts', 'flutter'],
     ['.github/workflows/_ci-e2e-flutter.reusable.yml', 'flutter'],
+    ['.github/workflows/_ci-e2e-flutter-ios.reusable.yml', 'flutter'],
+    ['.github/workflows/_ci-build-flutter-ios-app.reusable.yml', 'flutter'],
   ])('should classify %s as %s', (file, expected) => {
     expect(classifyFile(file, SERVICES)).toBe(expected);
   });


### PR DESCRIPTION
**Flutter service — PR6 of 6 (Ship).** Stacked on `feat/flutter-service` (the integration branch, #374); makes `@wdio/flutter-service` shippable.

## Package-test
- **`fixtures/package-tests/flutter-app/`** — ESM-only package-install smoke test (clone of the RN fixture): verifies the published `@wdio/flutter-service` composes `services: ['appium', 'flutter']` and exposes the `browser.flutter.*` surface. ESM-only because `@wdio/appium-service` + WDIO 9 core are import-only.
- **`detect-changes.spec.ts`** — classify the flutter package-test fixture + the iOS reusable workflows.

## Docs
- **`packages/flutter-service/README.md`** (new) — full service docs: Dart-VM `execute` (with the **Dart-expression divergence** called out), Tier-2 `mock` via the [`wdio_flutter`](./packages/flutter-service/wdio_flutter) contract, find/tap, deeplink, contexts, `emitEvent`, logs, multiremote, standalone.
- **`README.md`** — Flutter under Experimental Support (`1.0.0-next.x`); removed from Planned.
- **`ROADMAP.md`** — Phase 3 Flutter → ✅ Shipped.
- **`AGENTS.md`** — Flutter in Supported Frameworks + `flutter-service`/`native-mobile-core` in the layout.

## Release wiring (npm)
- **`release.yml` + `_release.reusable.yml`** — add `flutter` (`@wdio/flutter-service`) and `native-mobile-core` (`@wdio/native-mobile-core`) scopes to the dispatch options + the compute-packages/build-packages case blocks. (`native-mobile-core` + the RN-delegation rework ship via this Flutter branch, since PR1 created them here — not via the RN release.)

## pub.dev (`wdio_flutter`)
The Dart contract publishes to pub.dev as part of the `flutter` scope, but that's deferred to **ReleaseKit** (peer to its npm + crates.io publishing) rather than a bespoke workflow step — so the `pubspec.yaml` version bumps in lockstep with the npm line instead of by hand. Tracked: **goosewobbler/releasekit#285**.

Completes the 6-PR stack. 🤖 Generated with [Claude Code](https://claude.com/claude-code)