### PR TITLE
fix(react-native): re-attach mock spy on reconnect after a fast-refresh displaces the target

### DIFF
--- a/packages/react-native-service/src/innerRecorder.ts
+++ b/packages/react-native-service/src/innerRecorder.ts
@@ -168,6 +168,16 @@ export function buildInstallScript(target: string): string {
       // popImpl never landed (e.g. the bridge dropped mid-call), so a temporary implementation
       // doesn't survive the reconnect (it otherwise persisted until mockRestore).
       if (existing.spy && existing.spy.__resetImplStack) { existing.spy.__resetImplStack(); }
+      // A Fast Refresh / HMR reload can replace the object our spy was installed on, leaving the
+      // live target pointing at a fresh original — the spy would then silently stop intercepting.
+      // Re-attach the persisted spy (refreshing original/parent/key so mockRestore still works).
+      var live = __resolve(${key});
+      if (live && live.parent[live.key] !== existing.spy && typeof live.parent[live.key] === 'function') {
+        existing.original = live.parent[live.key];
+        existing.parent = live.parent;
+        existing.key = live.key;
+        live.parent[live.key] = existing.spy;
+      }
       return;
     }
     var loc = __resolve(${key});

--- a/packages/react-native-service/src/innerRecorder.ts
+++ b/packages/react-native-service/src/innerRecorder.ts
@@ -178,6 +178,12 @@ export function buildInstallScript(target: string): string {
         existing.key = live.key;
         live.parent[live.key] = existing.spy;
       }
+      // If __resolve returns undefined here (the parent path was removed by a Fast Refresh that
+      // dropped the entire module), we fall through silently — the spy stays displaced and the mock
+      // is inactive until the next full reinstall.  This asymmetry with the fresh-install path
+      // below (which throws) is intentional: throwing during a reconnect would abort the session;
+      // the silent no-op lets the session continue, and the mock self-heals once the module
+      // re-appears and the test re-runs buildInstallScript.
       return;
     }
     var loc = __resolve(${key});

--- a/packages/react-native-service/test/innerRecorder.spec.ts
+++ b/packages/react-native-service/test/innerRecorder.spec.ts
@@ -42,6 +42,21 @@ describe('inner recorder impl stack (reconnect recovery)', () => {
     exec(ctx, buildInstallScript('greet'));
     expect(call(ctx, 'greet')).toBe('set');
   });
+
+  it('should re-attach the spy on reconnect when a fast-refresh displaced the target', () => {
+    const ctx = realm({ greet: () => 'orig' });
+    exec(ctx, buildInstallScript('greet'));
+    exec(ctx, buildSetImplementationScript('greet', '() => "mocked"'));
+    expect(call(ctx, 'greet')).toBe('mocked');
+
+    // Fast Refresh replaces the target with a fresh original — the spy is now bypassed.
+    ctx.greet = () => 'fresh-orig';
+    expect(call(ctx, 'greet')).toBe('fresh-orig');
+
+    // Reconnect re-runs buildInstallScript, whose existing-entry path re-attaches the spy.
+    exec(ctx, buildInstallScript('greet'));
+    expect(call(ctx, 'greet')).toBe('mocked');
+  });
 });
 
 describe('buildEnumerateFunctionsScript (mockAll)', () => {

--- a/packages/react-native-service/test/innerRecorder.spec.ts
+++ b/packages/react-native-service/test/innerRecorder.spec.ts
@@ -5,6 +5,7 @@ import {
   buildEnumerateFunctionsScript,
   buildInstallScript,
   buildPushImplementationScript,
+  buildRestoreScript,
   buildSetImplementationScript,
 } from '../src/innerRecorder.js';
 
@@ -56,6 +57,11 @@ describe('inner recorder impl stack (reconnect recovery)', () => {
     // Reconnect re-runs buildInstallScript, whose existing-entry path re-attaches the spy.
     exec(ctx, buildInstallScript('greet'));
     expect(call(ctx, 'greet')).toBe('mocked');
+
+    // mockRestore must put back the *fresh* original recorded during re-attachment, not the
+    // stale pre-mock one — verifying that existing.original was updated above.
+    exec(ctx, buildRestoreScript('greet'));
+    expect(call(ctx, 'greet')).toBe('fresh-orig');
   });
 });
 


### PR DESCRIPTION
## What

`buildInstallScript`'s reconnect path early-returned on an existing registry entry without re-resolving the target. If a **Fast Refresh / HMR reload** replaced the object the spy was installed on, the live target then pointed at a fresh original and the mock **silently stopped intercepting** (until `mockRestore`).

Narrow in practice — the primary mock target, `nativeModuleProxy`, is a stable Hermes HostObject that Fast Refresh doesn't displace — but plain JS-object targets (e.g. `globalThis.MyModule`) across a bridge drop + reconnect were affected. Flagged as a low-priority follow-up during the #348 review.

## Fix

On the existing-entry (reconnect) path, re-resolve the target and, if it no longer points at our spy, **re-attach** it — refreshing `original`/`parent`/`key` so `mockRestore` still restores the (new) original. No-op when the spy is still in place, so it doesn't disturb the normal reconnect path.

Adds an `innerRecorder` spec exercising the displacement case (install → mock → simulate a fast-refresh swap → reconnect → spy intercepts again).

## Test plan
- `pnpm --filter @wdio/react-native-service test` — 117 pass (incl. the new case)
- `pnpm --filter @wdio/react-native-service typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)