### PR TITLE
fix(electron): deprecate inline returnValue in mock() — use chained .mockReturnValue() (#377)

### DIFF
--- a/packages/native-types/src/electron.ts
+++ b/packages/native-types/src/electron.ts
@@ -55,6 +55,10 @@ export interface ElectronServiceAPI {
      * The inline `returnValue` argument is a legacy convenience specific to
      * Electron's two-part mock identity; all other services use the chained
      * setter as the single convergent pattern.
+     *
+     * Note: TypeScript's TS-6385 deprecation diagnostic does not fire for `@deprecated`
+     * placed on individual call signatures within an object-type overload set (verified
+     * against TS 5.9). The JSDoc text surfaces in hover tooltips but no squiggle is emitted.
      */
     (apiName: string, funcName: string, returnValue: unknown): Promise<ElectronFunctionMock>;
   };

--- a/packages/native-types/src/electron.ts
+++ b/packages/native-types/src/electron.ts
@@ -37,19 +37,26 @@ export interface ElectronServiceAPI {
    * Native mode supports two forms:
    * - `mock(className)` returns an {@link ElectronClassMock} that mocks every
    *   method of the named Electron class.
-   * - `mock(apiName, funcName, returnValue?)` mocks a single function on the
-   *   named API and returns an {@link ElectronFunctionMock}.
+   * - `mock(apiName, funcName)` mocks a single function on the named API and
+   *   returns an {@link ElectronFunctionMock}.
    *
    * Browser mode supports only `mock(channel)`; the two-argument form throws.
    *
    * @param classNameOrApiOrChannel - Electron class name, API name, or IPC channel
    * @param funcName - function name (native two-arg form only)
-   * @param returnValue - initial return value for the mocked function
    * @returns a {@link Promise} that resolves once the mock is registered
    */
   mock: {
     (className: string): Promise<ElectronClassMock>;
-    (apiName: string, funcName: string, returnValue?: unknown): Promise<ElectronFunctionMock>;
+    (apiName: string, funcName: string): Promise<ElectronFunctionMock>;
+    /**
+     * @deprecated Pass `returnValue` via the chained setter instead:
+     * `(await browser.electron.mock('api', 'fn')).mockReturnValue(value)`.
+     * The inline `returnValue` argument is a legacy convenience specific to
+     * Electron's two-part mock identity; all other services use the chained
+     * setter as the single convergent pattern.
+     */
+    (apiName: string, funcName: string, returnValue: unknown): Promise<ElectronFunctionMock>;
   };
   /**
    * Mock all functions from an Electron API.


### PR DESCRIPTION
## Summary

- Marks the 3-argument `mock(apiName, funcName, returnValue)` overload as `@deprecated` in `ElectronServiceAPI` (in `packages/native-types/src/electron.ts`)
- Promotes the 2-argument `mock(apiName, funcName)` as the canonical method-mock form; the single-arg class-mock `mock(className)` is unchanged
- Adds a deprecation comment pointing users at the chained `.mockReturnValue()` setter, which is the convergent pattern across all other services (Tauri, Dioxus, Electrobun, React Native, Flutter)
- No runtime behaviour changes — types/JSDoc only

Closes #377

## What changed

The 3-arg overload was an Electron-specific legacy convenience: because every Electron mock target needs *two* identifiers (`apiName` + `funcName`), there was room for an optional third argument to set the return value inline. No other service shares this two-part mock identity, so none of them ever grew the same convenience argument. Deprecating it here aligns Electron's public API surface with the rest of the suite.

**Before**
```ts
mock: {
  (className: string): Promise<ElectronClassMock>;
  (apiName: string, funcName: string, returnValue?: unknown): Promise<ElectronFunctionMock>;
};
```

**After**
```ts
mock: {
  (className: string): Promise<ElectronClassMock>;
  (apiName: string, funcName: string): Promise<ElectronFunctionMock>;
  /** @deprecated — use .mockReturnValue() instead */
  (apiName: string, funcName: string, returnValue: unknown): Promise<ElectronFunctionMock>;
};
```

## Test plan

- [x] `pnpm --filter @wdio/electron-service typecheck` — passes (0 errors)
- [x] `pnpm --filter @wdio/electron-service test` — 511 tests pass, 89.6% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)