### PR TITLE
ci: pack tarballs on runner — containers install tarballs, not workspace (#350)

### DIFF
--- a/.claude/skills/add-native-service/ci-and-release.md
+++ b/.claude/skills/add-native-service/ci-and-release.md
@@ -55,7 +55,9 @@ From the Dioxus equivalents (names matter — match them):
 - `_ci-build-<framework>-package-app.reusable.yml` — builds the package-test fixture.
 - `_ci-e2e-<framework>-all-providers.reusable.yml` — runs E2E across providers.
 
-Extend `_ci-package.reusable.yml` and `_ci-package-docker.reusable.yml` to accept `<framework>` in the service matrix. (CDP services skip the `-crates` workflow entirely — no Rust to build.)
+Extend `_ci-package.reusable.yml` to accept `<framework>` in the service matrix. (CDP services skip the `-crates` workflow entirely — no Rust to build.)
+
+**The per-distro Docker matrix (`_ci-package-docker-*`) is only for system-webview services.** It exists because Tauri and Dioxus render through the host's system WebView (WebKitGTK), whose libraries are named/versioned differently on each distro — that variance is exactly what the matrix tests (build + launch + driver/lib detection across Ubuntu/Debian/Arch/Fedora/Void). Services that **bundle their own renderer** (Electron's Chromium, Electrobun's CEF) behave identically across glibc distros, so they get the plain `_ci-package` test and **no** Docker matrix. Decision rule for a new service: add the Docker matrix only if the service depends on system libraries that differ across distros (a future GTK/WebKitGTK-on-Linux Flutter, Neutralino, etc.); skip it for bundled-renderer ones. Mobile services (React Native) don't apply — they target Android/iOS, not desktop Linux.
 
 ### Mobile CI — per-platform, not per-provider
 

--- a/.github/workflows/_ci-package-docker-dioxus.reusable.yml
+++ b/.github/workflows/_ci-package-docker-dioxus.reusable.yml
@@ -24,13 +24,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: '24'
+
+      - name: Build packages
+        run: pnpm turbo run build --filter=@wdio/dioxus-service... --filter=@wdio/dioxus-bridge
+
+      # Pack workspace packages to tarballs so the container only receives pre-built
+      # artefacts and does not need the full workspace toolchain (Node >=23.6 .ts
+      # execution, Turbo, etc.) -- root cause of the Node-version breakage (#350).
+      # Note: dioxus-bridge dist-js is baked into the app binary at cargo-build time
+      # via build.rs; its Rust crate stays as a path dep so the JS is still available
+      # in the workspace during the container's cargo build step.
+      - name: Pack tarballs
+        run: |
+          mkdir -p dist/tarballs
+          for pkg in dioxus-service native-core native-spy native-types native-utils; do
+            pnpm pack -C packages/$pkg --pack-destination "$(pwd)/dist/tarballs"
+          done
+          echo "Packed tarballs:"
+          ls -lh dist/tarballs/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Run tests using test.sh
         run: |
           cd fixtures/package-tests/dioxus-app/docker
-          ./test.sh ${{ inputs.distro }} test
+          TARBALLS_DIR="$(pwd)/../../../../dist/tarballs" ./test.sh ${{ inputs.distro }} test
 
       - name: Copy logs to workspace
         if: always()

--- a/.github/workflows/_ci-package-docker-tauri.reusable.yml
+++ b/.github/workflows/_ci-package-docker-tauri.reusable.yml
@@ -24,13 +24,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: '24'
+
+      - name: Build packages
+        run: pnpm turbo run build --filter=@wdio/tauri-service... --filter=@wdio/tauri-plugin
+
+      # Pack workspace packages to tarballs so the container only receives pre-built
+      # artefacts and does not need the full workspace toolchain (Node >=23.6 .ts
+      # execution, Turbo, etc.) -- root cause of the Node-version breakage (#350).
+      - name: Pack tarballs
+        run: |
+          mkdir -p dist/tarballs
+          for pkg in tauri-service tauri-plugin native-core native-spy native-types native-utils; do
+            pnpm pack -C packages/$pkg --pack-destination "$(pwd)/dist/tarballs"
+          done
+          echo "Packed tarballs:"
+          ls -lh dist/tarballs/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Run tests using test.sh
         run: |
           cd fixtures/package-tests/tauri-app/docker
-          ./test.sh ${{ inputs.distro }} test
+          TARBALLS_DIR="$(pwd)/../../../../dist/tarballs" ./test.sh ${{ inputs.distro }} test
 
       - name: Copy logs to workspace
         if: always()

--- a/fixtures/package-tests/dioxus-app/docker/README.md
+++ b/fixtures/package-tests/dioxus-app/docker/README.md
@@ -64,15 +64,22 @@ for the detailed rationale.
 ./test.sh ubuntu test
 ```
 
-1. Build the Docker image (system packages, Node 20, pnpm, Rust toolchain, WebKitGTK build deps).
-2. Mount the workspace into the container and start Xvfb.
-3. `pnpm install --frozen-lockfile`.
-4. `pnpm --filter @wdio/dioxus-service... build` (service + its workspace dependencies).
-5. `pnpm --filter @wdio/dioxus-bridge... build` — the guest-js bundle the bridge crate's
-   `build.rs` bakes into the app binary. Not a service dependency, so step 4 skips it;
-   without it the bundle silently degrades to a no-op and every bridge call times out.
-6. `cargo build` the Dioxus app — this also compiles the embedded driver and the bridge crate into the binary.
-7. `pnpm test` (WebdriverIO against the embedded driver, headless under Xvfb).
+The CI runner (Node 24, full workspace toolchain) builds the packages and packs them
+to tarballs *before* Docker starts; the container receives them via a `/tarballs`
+bind-mount and never runs the workspace toolchain itself — no `pnpm install`, Turbo, or
+`.ts` execution, which is what broke on the container's older Node (#350). Per container:
+
+1. Build the Docker image (system packages, Node 24, Rust toolchain, WebKitGTK build deps).
+2. Mount the workspace at `/workspace` and the packed tarballs at `/tarballs`; start Xvfb.
+3. Verify the bridge guest-js bundle (`packages/dioxus-bridge/dist-js/index.js`) is present —
+   the runner built it, and the bridge crate's `build.rs` bakes it into the app binary at
+   `cargo build` time. Without it the bundle silently degrades to a no-op and every bridge
+   call times out.
+4. Rewrite the fixture's `workspace:*` deps to `file:` tarball paths and `npm install`. The
+   fixture's pnpm `node_modules` (symlinks into the workspace) is cleared first — npm's
+   arborist cannot load a pnpm layout.
+5. `cargo build` the Dioxus app — this also compiles the embedded driver and the bridge crate into the binary.
+6. `npx wdio run` (WebdriverIO against the embedded driver, headless under Xvfb).
 
 There is no separate plugin-build step: unlike Tauri's JS plugin, the Dioxus bridge
 and embedded driver are Rust crates pulled in by the app's `Cargo.toml` and built by `cargo`.

--- a/fixtures/package-tests/dioxus-app/docker/arch.dockerfile
+++ b/fixtures/package-tests/dioxus-app/docker/arch.dockerfile
@@ -27,9 +27,6 @@ RUN NODE_VERSION="24.11.0" && \
     rm /tmp/node.tar.xz && \
     node --version && npm --version
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Rust toolchain — compiles the Dioxus app, the embedded WebDriver and the
 # bridge crate into the binary
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fixtures/package-tests/dioxus-app/docker/container-test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/container-test.sh
@@ -72,26 +72,39 @@ const fs = require('fs');
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const tarballs = fs.readdirSync('/tarballs').filter(f => f.endsWith('.tgz'));
 
-for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
-  if (!pkg[section]) continue;
-  for (const [name, ver] of Object.entries(pkg[section])) {
-    if (ver !== 'workspace:*') continue;
-    // Map @wdio/foo-bar -> wdio-foo-bar-*.tgz
-    const base = name.replace(/^@/, '').replace('/', '-');
-    const match = tarballs.find(t => t.startsWith(base + '-'));
-    if (!match) { console.error('No tarball found for ' + name); process.exit(1); }
-    pkg[section][name] = 'file:/tarballs/' + match;
-  }
-}
-pkg.overrides = pkg.overrides || {};
+// Build a map of @wdio/package-name -> file: path for every tarball
+const tarballMap = {};
 for (const tarball of tarballs) {
   const base = tarball.replace('.tgz', '');
   const segments = base.split('-');
   const versionIdx = segments.findIndex(s => /^\d+\.\d+/.test(s));
   if (versionIdx <= 1) continue;
   const pkgName = '@' + segments[0] + '/' + segments.slice(1, versionIdx).join('-');
-  pkg.overrides[pkgName] = 'file:/tarballs/' + tarball;
+  tarballMap[pkgName] = 'file:/tarballs/' + tarball;
 }
+
+// Patch workspace:* in all dep sections
+for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+  if (!pkg[section]) continue;
+  for (const [name, ver] of Object.entries(pkg[section])) {
+    if (ver !== 'workspace:*') continue;
+    if (!tarballMap[name]) { console.error('No tarball found for ' + name); process.exit(1); }
+    pkg[section][name] = tarballMap[name];
+  }
+}
+
+// Add ALL workspace tarballs as direct devDependencies so npm can
+// deduplicate transitive @wdio/* deps without hitting the registry.
+// (Avoids the npm arborist bug with file: in overrides.)
+pkg.devDependencies = pkg.devDependencies || {};
+for (const [name, path] of Object.entries(tarballMap)) {
+  if (!pkg.dependencies?.[name] && !pkg.devDependencies[name]) {
+    pkg.devDependencies[name] = path;
+  }
+}
+// Remove any overrides left from a previous attempt
+delete pkg.overrides;
+
 process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
 JS_EOF
 )

--- a/fixtures/package-tests/dioxus-app/docker/container-test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/container-test.sh
@@ -89,6 +89,7 @@ JS_EOF
 echo "$PATCHED_PKG" > package.json.patched
 mv package.json package.json.orig
 mv package.json.patched package.json
+trap 'mv -f package.json.orig package.json 2>/dev/null || true' EXIT
 
 npm install --prefer-offline 2>&1
 

--- a/fixtures/package-tests/dioxus-app/docker/container-test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/container-test.sh
@@ -83,6 +83,15 @@ for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
     pkg[section][name] = 'file:/tarballs/' + match;
   }
 }
+pkg.overrides = pkg.overrides || {};
+for (const tarball of tarballs) {
+  const base = tarball.replace('.tgz', '');
+  const segments = base.split('-');
+  const versionIdx = segments.findIndex(s => /^\d+\.\d+/.test(s));
+  if (versionIdx <= 1) continue;
+  const pkgName = '@' + segments[0] + '/' + segments.slice(1, versionIdx).join('-');
+  pkg.overrides[pkgName] = 'file:/tarballs/' + tarball;
+}
 process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
 JS_EOF
 )
@@ -94,7 +103,7 @@ trap 'mv -f package.json.orig package.json 2>/dev/null || true' EXIT
 npm install --prefer-offline 2>&1
 
 # Restore original package.json so the working tree stays clean for log uploads
-mv package.json package.json.installed
+rm package.json
 mv package.json.orig package.json
 
 echo '=== Building Dioxus app (compiles embedded driver + bridge) ==='

--- a/fixtures/package-tests/dioxus-app/docker/container-test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/container-test.sh
@@ -113,6 +113,15 @@ mv package.json package.json.orig
 mv package.json.patched package.json
 trap 'mv -f package.json.orig package.json 2>/dev/null || true' EXIT
 
+# This fixture is a pnpm workspace member, so the runner's `pnpm install` leaves
+# a symlinked node_modules here (entries link out to ../../../../node_modules/.pnpm
+# and ../../../../packages). The whole workspace is bind-mounted in, so npm's
+# arborist tries to load that pnpm layout and crashes on a symlink it can't
+# resolve in its own model: "Cannot destructure property 'package' of
+# 'node.target' as it is null". Clear it so npm builds node_modules purely from
+# the tarballs + registry.
+rm -rf node_modules package-lock.json
+
 npm install --prefer-offline 2>&1
 
 # Restore original package.json so the working tree stays clean for log uploads

--- a/fixtures/package-tests/dioxus-app/docker/container-test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/container-test.sh
@@ -4,12 +4,21 @@
 # /workspace and invokes this file). Kept as a separate script rather than an
 # inline `bash -c "..."` string: an unescaped double quote inside an inline
 # script silently truncates it at that quote, and the container then exits 0
-# having run nothing — CI reports a green no-op. That exact failure shipped
+# having run nothing -- CI reports a green no-op. That exact failure shipped
 # two false-positive runs of this matrix.
+#
+# Tarballs are pre-packed on the CI runner (Node 24, full workspace toolchain)
+# and bind-mounted at /tarballs. The container only needs to install them and
+# build the fixture's Rust binary -- it no longer requires the workspace
+# toolchain (pnpm install --frozen-lockfile, turbo, TS execution). (#350)
+#
+# Note: dioxus-bridge dist-js is baked into the app binary at cargo-build time
+# via build.rs (packages/dioxus-bridge/build.rs). The bridge Rust crate is
+# referenced via a workspace path dep in Cargo.toml, so dist-js/index.js is
+# already present in the bind-mounted workspace after the runner's build step.
 
 set -e
 
-export TURBO_TELEMETRY_DISABLED=1
 export DISPLAY=:99
 # No GL/WebKit env tweaks needed: the "libEGL DRI3 error" warnings under
 # Xvfb are benign (the bare-runner package test prints the same ones and
@@ -23,37 +32,79 @@ if command -v Xvfb > /dev/null; then
     sleep 2
     echo "Xvfb started with PID: $XVFB_PID"
 else
-    echo '⚠️  Xvfb not found, tests may fail'
+    echo 'Warning: Xvfb not found, tests may fail'
 fi
 
-echo '=== Installing workspace dependencies ==='
-pnpm install --frozen-lockfile
+# Verify tarballs were provided
+if [ ! -d /tarballs ] || [ -z "$(ls /tarballs/*.tgz 2>/dev/null)" ]; then
+    echo 'ERROR: /tarballs must contain pre-packed workspace tarballs.'
+    echo 'Pack them on the runner before launching the container:'
+    echo '  for pkg in dioxus-service native-core native-spy native-types native-utils; do'
+    echo '    pnpm pack -C packages/$pkg --pack-destination dist/tarballs'
+    echo '  done'
+    exit 1
+fi
 
-echo '=== Building dioxus-service and dependencies ==='
-pnpm --filter @wdio/dioxus-service... build
+echo '=== Tarballs available ==='
+ls -lh /tarballs/
 
-echo '=== Building bridge guest-js (baked into the app binary) ==='
-# Not a workspace dependency of the service, so the filtered build above
-# skips it. The bridge crate's build.rs embeds dist-js/index.js into the
-# binary and silently degrades to a no-op bundle when it is missing — the
-# app then renders fine but every bridge round-trip times out. The main CI
-# build job avoids this by building all packages; this harness must build
-# it explicitly.
-pnpm --filter "@wdio/dioxus-bridge..." build
+echo '=== Verifying bridge guest-js bundle ==='
+# The bridge crate's build.rs (packages/dioxus-bridge/build.rs) embeds
+# dist-js/index.js into the binary at cargo-build time. The CI runner builds
+# @wdio/dioxus-bridge before packing, so the file is present in the workspace.
 test -s /workspace/packages/dioxus-bridge/dist-js/index.js || {
-    echo 'ERROR: bridge guest-js bundle missing after build'; exit 1;
+    echo 'ERROR: bridge guest-js bundle missing from workspace.'
+    echo 'The runner build step should have produced packages/dioxus-bridge/dist-js/index.js.'
+    exit 1
 }
 
+echo '=== Installing workspace packages from tarballs ==='
+# Install from fixture app directory. Replace workspace:* refs in package.json
+# with file: paths to the pre-packed tarballs, then run npm install so that
+# all @wdio/* workspace packages resolve to the built artefacts rather than
+# the live workspace source.
+cd /workspace/fixtures/package-tests/dioxus-app
+
+# Rewrite workspace:* entries in package.json to file:/tarballs/<tarball>.
+# npm understands file: protocol; pnpm workspace: protocol is workspace-only.
+PATCHED_PKG=$(node - << 'JS_EOF'
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const tarballs = fs.readdirSync('/tarballs').filter(f => f.endsWith('.tgz'));
+
+for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+  if (!pkg[section]) continue;
+  for (const [name, ver] of Object.entries(pkg[section])) {
+    if (ver !== 'workspace:*') continue;
+    // Map @wdio/foo-bar -> wdio-foo-bar-*.tgz
+    const base = name.replace(/^@/, '').replace('/', '-');
+    const match = tarballs.find(t => t.startsWith(base + '-'));
+    if (!match) { console.error('No tarball found for ' + name); process.exit(1); }
+    pkg[section][name] = 'file:/tarballs/' + match;
+  }
+}
+process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
+JS_EOF
+)
+echo "$PATCHED_PKG" > package.json.patched
+mv package.json package.json.orig
+mv package.json.patched package.json
+
+npm install --prefer-offline 2>&1
+
+# Restore original package.json so the working tree stays clean for log uploads
+mv package.json package.json.installed
+mv package.json.orig package.json
+
 echo '=== Building Dioxus app (compiles embedded driver + bridge) ==='
-cd fixtures/package-tests/dioxus-app
-pnpm run build
+cargo build --manifest-path src-dioxus/Cargo.toml
 
 echo '=== Running Dioxus package test ==='
 # Capture the exit code instead of letting set -e abort here, so the
 # wdio session logs (backend/frontend tracing) are still copied out on
-# failure — that is exactly when they are needed.
+# failure -- that is exactly when they are needed.
 set +e
-pnpm test
+npx wdio run wdio.conf.ts
 TEST_EXIT=$?
 set -e
 

--- a/fixtures/package-tests/dioxus-app/docker/container-test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/container-test.sh
@@ -67,7 +67,10 @@ cd /workspace/fixtures/package-tests/dioxus-app
 
 # Rewrite workspace:* entries in package.json to file:/tarballs/<tarball>.
 # npm understands file: protocol; pnpm workspace: protocol is workspace-only.
-PATCHED_PKG=$(node - << 'JS_EOF'
+# `set -e` does NOT abort on a failed `VAR=$(cmd)` assignment, so guard the patch
+# step explicitly -- otherwise a missing-tarball exit(1) falls through and
+# resurfaces as an opaque `npm install` error instead of this clear one.
+if ! PATCHED_PKG=$(node - << 'JS_EOF'
 const fs = require('fs');
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const tarballs = fs.readdirSync('/tarballs').filter(f => f.endsWith('.tgz'));
@@ -107,7 +110,10 @@ delete pkg.overrides;
 
 process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
 JS_EOF
-)
+); then
+  echo 'ERROR: failed to rewrite package.json deps to /tarballs paths (see node error above).'
+  exit 1
+fi
 echo "$PATCHED_PKG" > package.json.patched
 mv package.json package.json.orig
 mv package.json.patched package.json

--- a/fixtures/package-tests/dioxus-app/docker/debian.dockerfile
+++ b/fixtures/package-tests/dioxus-app/docker/debian.dockerfile
@@ -23,9 +23,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Rust toolchain — compiles the Dioxus app, the embedded WebDriver and the
 # bridge crate into the binary
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fixtures/package-tests/dioxus-app/docker/fedora.dockerfile
+++ b/fixtures/package-tests/dioxus-app/docker/fedora.dockerfile
@@ -22,9 +22,6 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_24.x | bash - && \
     dnf install -y nodejs && \
     dnf clean all
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Rust toolchain — compiles the Dioxus app, the embedded WebDriver and the
 # bridge crate into the binary
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fixtures/package-tests/dioxus-app/docker/test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/test.sh
@@ -7,11 +7,41 @@
 # Example: ./test.sh void build
 # Example: ./test.sh void test
 # Example: ./test.sh void debug
+#
+# The TARBALLS_DIR env variable must point to a directory containing pre-packed
+# workspace tarballs (wdio-dioxus-service-*.tgz etc.).  In CI this is set by the
+# workflow after the runner-side "Pack tarballs" step.  Locally you can create
+# the tarballs first:
+#
+#   cd <repo-root>
+#   mkdir -p dist/tarballs
+#   for pkg in dioxus-service native-core native-spy native-types native-utils; do
+#     pnpm pack -C packages/$pkg --pack-destination "$(pwd)/dist/tarballs"
+#   done
+#   TARBALLS_DIR="$(pwd)/dist/tarballs" fixtures/package-tests/dioxus-app/docker/test.sh all test
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Validate that TARBALLS_DIR is set and non-empty before running tests
+if [ -z "${TARBALLS_DIR:-}" ]; then
+    echo "ERROR: TARBALLS_DIR is not set."
+    echo "Pack tarballs first:"
+    echo "  cd $REPO_ROOT"
+    echo "  mkdir -p dist/tarballs"
+    echo "  for pkg in dioxus-service native-core native-spy native-types native-utils; do"
+    echo "    pnpm pack -C packages/\$pkg --pack-destination \"\$(pwd)/dist/tarballs\""
+    echo "  done"
+    echo "  TARBALLS_DIR=\"\$(pwd)/dist/tarballs\" $0 \$@"
+    exit 1
+fi
+
+if [ ! -d "$TARBALLS_DIR" ]; then
+    echo "ERROR: TARBALLS_DIR '$TARBALLS_DIR' does not exist or is not a directory."
+    exit 1
+fi
 
 # Colors for output
 RED='\033[0;31m'
@@ -54,13 +84,14 @@ run_tests_in_container() {
     echo -e "${YELLOW}=== Running tests for $distro ===${NC}"
 
     # The in-container logic lives in container-test.sh (reached through the
-    # workspace bind mount) instead of an inline `bash -c` string — an
+    # workspace bind mount) instead of an inline `bash -c` string -- an
     # unescaped double quote in an inline script truncates it silently and
     # the run reports a green no-op. See the header of container-test.sh.
     docker run --rm \
         -u root \
         -v "$REPO_ROOT:/workspace" \
         -v "$log_dir:/workspace/logs-output" \
+        -v "$TARBALLS_DIR:/tarballs:ro" \
         -w /workspace \
         "dioxus-distro-test:$distro" \
         bash /workspace/fixtures/package-tests/dioxus-app/docker/container-test.sh \

--- a/fixtures/package-tests/dioxus-app/docker/test.sh
+++ b/fixtures/package-tests/dioxus-app/docker/test.sh
@@ -25,22 +25,26 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 
-# Validate that TARBALLS_DIR is set and non-empty before running tests
-if [ -z "${TARBALLS_DIR:-}" ]; then
-    echo "ERROR: TARBALLS_DIR is not set."
-    echo "Pack tarballs first:"
-    echo "  cd $REPO_ROOT"
-    echo "  mkdir -p dist/tarballs"
-    echo "  for pkg in dioxus-service native-core native-spy native-types native-utils; do"
-    echo "    pnpm pack -C packages/\$pkg --pack-destination \"\$(pwd)/dist/tarballs\""
-    echo "  done"
-    echo "  TARBALLS_DIR=\"\$(pwd)/dist/tarballs\" $0 \$@"
-    exit 1
-fi
+# Only `test` mode consumes the tarballs (it bind-mounts them into the container);
+# `build` and `debug` just build the image, so don't require TARBALLS_DIR. Mode is
+# the second positional arg (default `build`), validated in full further down.
+if [ "${2:-build}" = "test" ]; then
+    if [ -z "${TARBALLS_DIR:-}" ]; then
+        echo "ERROR: TARBALLS_DIR is not set."
+        echo "Pack tarballs first:"
+        echo "  cd $REPO_ROOT"
+        echo "  mkdir -p dist/tarballs"
+        echo "  for pkg in dioxus-service native-core native-spy native-types native-utils; do"
+        echo "    pnpm pack -C packages/\$pkg --pack-destination \"\$(pwd)/dist/tarballs\""
+        echo "  done"
+        echo "  TARBALLS_DIR=\"\$(pwd)/dist/tarballs\" $0 \$@"
+        exit 1
+    fi
 
-if [ ! -d "$TARBALLS_DIR" ]; then
-    echo "ERROR: TARBALLS_DIR '$TARBALLS_DIR' does not exist or is not a directory."
-    exit 1
+    if [ ! -d "$TARBALLS_DIR" ]; then
+        echo "ERROR: TARBALLS_DIR '$TARBALLS_DIR' does not exist or is not a directory."
+        exit 1
+    fi
 fi
 
 # Colors for output

--- a/fixtures/package-tests/dioxus-app/docker/ubuntu.dockerfile
+++ b/fixtures/package-tests/dioxus-app/docker/ubuntu.dockerfile
@@ -23,9 +23,6 @@ RUN apt-get update -qq && \
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs
 
-# Install pnpm globally as root
-RUN npm install -g pnpm
-
 # Rust toolchain — compiles the Dioxus app, the embedded WebDriver and the
 # bridge crate into the binary
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fixtures/package-tests/dioxus-app/docker/void.dockerfile
+++ b/fixtures/package-tests/dioxus-app/docker/void.dockerfile
@@ -27,9 +27,6 @@ RUN xbps-install -Syu xbps && \
         xorg-server-xvfb && \
     xbps-remove -O
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Rust toolchain — compiles the Dioxus app, the embedded WebDriver and the
 # bridge crate into the binary
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/fixtures/package-tests/tauri-app/docker/README.md
+++ b/fixtures/package-tests/tauri-app/docker/README.md
@@ -108,7 +108,7 @@ Tests if the Docker image can be built with all system dependencies:
 **What it does:**
 - Pulls base image
 - Installs system packages
-- Installs Node.js, pnpm, Rust
+- Installs Node.js, Rust
 - Installs Tauri runtime dependencies
 - Verifies critical packages are available
 
@@ -120,13 +120,12 @@ Builds the Docker image and runs the complete test suite inside:
 ```
 
 **What it does:**
-1. Build Docker image (same as `build` mode)
-2. Mount workspace into container
-3. Install pnpm workspace dependencies
-4. Build `@wdio/tauri-service` and dependencies
-5. Build `@wdio/tauri-plugin`
-6. Build Tauri example app
-7. Run WebdriverIO tests with Xvfb
+1. On the runner (Node 24, before Docker): build the `@wdio/*` packages and pack them to tarballs
+2. Build Docker image (same as `build` mode)
+3. Mount workspace at `/workspace` + tarballs at `/tarballs` into container
+4. Rewrite the fixture's `workspace:*` deps to `file:` tarball paths and `npm install` (the fixture's pnpm `node_modules` is cleared first — npm's arborist cannot load a pnpm layout)
+5. Build the Tauri example app (`build-web.ts` + `tauri build --debug`)
+6. Run WebdriverIO tests with Xvfb
 
 ### Debug Mode
 Build with verbose output and no caching:
@@ -150,9 +149,8 @@ FROM <base-image>
 # 1. Basic Requirements
 RUN <install curl, git, build-essential, xvfb>
 
-# 2. Node.js & pnpm
-RUN <install nodejs 20.x>
-RUN npm install -g pnpm
+# 2. Node.js
+RUN <install nodejs 24.x>
 
 # 3. Rust Toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -294,12 +292,11 @@ All distributions are tested using Docker containers with:
 - Official base image from distribution
 - All required development packages
 - Rust toolchain (latest stable)
-- Node.js 20.x + pnpm
+- Node.js 24.x
 
 **Build Testing:**
-- Full workspace dependency installation
-- Tauri service package build
-- Tauri example app build from source
+- Install the runner-packed `@wdio/*` tarballs with npm (no in-container workspace build)
+- Tauri example app build (web assets + `tauri build --debug`)
 - WebdriverIO test execution with Xvfb
 
 **Pass Criteria:**

--- a/fixtures/package-tests/tauri-app/docker/arch.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/arch.dockerfile
@@ -28,9 +28,6 @@ RUN NODE_VERSION="24.11.0" && \
     rm /tmp/node.tar.xz && \
     node --version && npm --version
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Install Rust toolchain (needed for tauri-driver)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -49,7 +49,10 @@ cd /workspace/fixtures/package-tests/tauri-app
 
 # Rewrite workspace:* entries in package.json to file:/tarballs/<tarball>.
 # npm understands file: protocol; pnpm workspace: protocol is workspace-only.
-PATCHED_PKG=$(node - << 'JS_EOF'
+# `set -e` does NOT abort on a failed `VAR=$(cmd)` assignment, so guard the patch
+# step explicitly -- otherwise a missing-tarball exit(1) falls through and
+# resurfaces as an opaque `npm install` error instead of this clear one.
+if ! PATCHED_PKG=$(node - << 'JS_EOF'
 const fs = require('fs');
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const tarballs = fs.readdirSync('/tarballs').filter(f => f.endsWith('.tgz'));
@@ -89,7 +92,10 @@ delete pkg.overrides;
 
 process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
 JS_EOF
-)
+); then
+  echo 'ERROR: failed to rewrite package.json deps to /tarballs paths (see node error above).'
+  exit 1
+fi
 echo "$PATCHED_PKG" > package.json.patched
 mv package.json package.json.orig
 mv package.json.patched package.json

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -65,6 +65,15 @@ for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
     pkg[section][name] = 'file:/tarballs/' + match;
   }
 }
+pkg.overrides = pkg.overrides || {};
+for (const tarball of tarballs) {
+  const base = tarball.replace('.tgz', '');
+  const segments = base.split('-');
+  const versionIdx = segments.findIndex(s => /^\d+\.\d+/.test(s));
+  if (versionIdx <= 1) continue;
+  const pkgName = '@' + segments[0] + '/' + segments.slice(1, versionIdx).join('-');
+  pkg.overrides[pkgName] = 'file:/tarballs/' + tarball;
+}
 process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
 JS_EOF
 )
@@ -76,7 +85,7 @@ trap 'mv -f package.json.orig package.json 2>/dev/null || true' EXIT
 npm install --prefer-offline 2>&1
 
 # Restore original package.json so the working tree stays clean for log uploads
-mv package.json package.json.installed
+rm package.json
 mv package.json.orig package.json
 
 echo '=== Building Tauri app ==='

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -4,12 +4,16 @@
 # /workspace and invokes this file). Kept as a separate script rather than an
 # inline `bash -c "..."` string: an unescaped double quote inside an inline
 # script silently truncates it at that quote, and the container then exits 0
-# having run nothing — CI reports a green no-op. That exact failure shipped
+# having run nothing -- CI reports a green no-op. That exact failure shipped
 # two false-positive runs of the sibling Dioxus matrix.
+#
+# Tarballs are pre-packed on the CI runner (Node 24, full workspace toolchain)
+# and bind-mounted at /tarballs. The container only needs to install them and
+# build the fixture's Rust binary -- it no longer requires the workspace
+# toolchain (pnpm install --frozen-lockfile, turbo, TS execution). (#350)
 
 set -e
 
-export TURBO_TELEMETRY_DISABLED=1
 export DISPLAY=:99
 
 echo '=== Starting Xvfb ==='
@@ -20,28 +24,75 @@ if command -v Xvfb > /dev/null; then
     sleep 2
     echo "Xvfb started with PID: $XVFB_PID"
 else
-    echo '⚠️  Xvfb not found, tests may fail'
+    echo 'Warning: Xvfb not found, tests may fail'
 fi
 
-echo '=== Installing workspace dependencies ==='
-pnpm install --frozen-lockfile
+# Verify tarballs were provided
+if [ ! -d /tarballs ] || [ -z "$(ls /tarballs/*.tgz 2>/dev/null)" ]; then
+    echo 'ERROR: /tarballs must contain pre-packed workspace tarballs.'
+    echo 'Pack them on the runner before launching the container:'
+    echo '  for pkg in tauri-service tauri-plugin native-core native-spy native-types native-utils; do'
+    echo '    pnpm pack -C packages/$pkg --pack-destination dist/tarballs'
+    echo '  done'
+    exit 1
+fi
 
-echo '=== Building tauri-service and dependencies ==='
-pnpm --filter @wdio/tauri-service... build
+echo '=== Tarballs available ==='
+ls -lh /tarballs/
 
-echo '=== Building tauri-plugin (required for app build) ==='
-pnpm --filter @wdio/tauri-plugin build
+echo '=== Installing workspace packages from tarballs ==='
+# Install from fixture app directory. Replace workspace:* refs in package.json
+# with file: paths to the pre-packed tarballs, then run npm install so that
+# all @wdio/* workspace packages resolve to the built artefacts rather than
+# the live workspace source.
+cd /workspace/fixtures/package-tests/tauri-app
+
+# Rewrite workspace:* entries in package.json to file:/tarballs/<tarball>.
+# npm understands file: protocol; pnpm workspace: protocol is workspace-only.
+PATCHED_PKG=$(node - << 'JS_EOF'
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const tarballs = fs.readdirSync('/tarballs').filter(f => f.endsWith('.tgz'));
+
+for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+  if (!pkg[section]) continue;
+  for (const [name, ver] of Object.entries(pkg[section])) {
+    if (ver !== 'workspace:*') continue;
+    // Map @wdio/foo-bar -> wdio-foo-bar-*.tgz
+    const base = name.replace(/^@/, '').replace('/', '-');
+    const match = tarballs.find(t => t.startsWith(base + '-'));
+    if (!match) { console.error('No tarball found for ' + name); process.exit(1); }
+    pkg[section][name] = 'file:/tarballs/' + match;
+  }
+}
+process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
+JS_EOF
+)
+echo "$PATCHED_PKG" > package.json.patched
+mv package.json package.json.orig
+mv package.json.patched package.json
+
+npm install --prefer-offline 2>&1
+
+# Restore original package.json so the working tree stays clean for log uploads
+mv package.json package.json.installed
+mv package.json.orig package.json
 
 echo '=== Building Tauri app ==='
-cd fixtures/package-tests/tauri-app
-pnpm run build
+# Run the build steps individually rather than via `pnpm run build`, which
+# would invoke build:js -- a workspace-filtered pnpm operation that requires
+# tsx + Node >=23.6 to execute @wdio/tauri-plugin's build script. The plugin
+# JS is already in node_modules/@wdio/tauri-plugin from the tarball install.
+# build-web.ts probes node_modules/@wdio/tauri-plugin and copies it to dist/.
+node scripts/build-web.ts
+npx tauri build --debug
 
 echo '=== Running Tauri package test ==='
 # Capture the exit code instead of letting set -e abort here, so the wdio
-# session logs are still copied out on failure — that is exactly when they
+# session logs are still copied out on failure -- that is exactly when they
 # are needed.
 set +e
-pnpm test
+npx wdio run wdio.conf.ts
 TEST_EXIT=$?
 set -e
 

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -54,26 +54,39 @@ const fs = require('fs');
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const tarballs = fs.readdirSync('/tarballs').filter(f => f.endsWith('.tgz'));
 
-for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
-  if (!pkg[section]) continue;
-  for (const [name, ver] of Object.entries(pkg[section])) {
-    if (ver !== 'workspace:*') continue;
-    // Map @wdio/foo-bar -> wdio-foo-bar-*.tgz
-    const base = name.replace(/^@/, '').replace('/', '-');
-    const match = tarballs.find(t => t.startsWith(base + '-'));
-    if (!match) { console.error('No tarball found for ' + name); process.exit(1); }
-    pkg[section][name] = 'file:/tarballs/' + match;
-  }
-}
-pkg.overrides = pkg.overrides || {};
+// Build a map of @wdio/package-name -> file: path for every tarball
+const tarballMap = {};
 for (const tarball of tarballs) {
   const base = tarball.replace('.tgz', '');
   const segments = base.split('-');
   const versionIdx = segments.findIndex(s => /^\d+\.\d+/.test(s));
   if (versionIdx <= 1) continue;
   const pkgName = '@' + segments[0] + '/' + segments.slice(1, versionIdx).join('-');
-  pkg.overrides[pkgName] = 'file:/tarballs/' + tarball;
+  tarballMap[pkgName] = 'file:/tarballs/' + tarball;
 }
+
+// Patch workspace:* in all dep sections
+for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+  if (!pkg[section]) continue;
+  for (const [name, ver] of Object.entries(pkg[section])) {
+    if (ver !== 'workspace:*') continue;
+    if (!tarballMap[name]) { console.error('No tarball found for ' + name); process.exit(1); }
+    pkg[section][name] = tarballMap[name];
+  }
+}
+
+// Add ALL workspace tarballs as direct devDependencies so npm can
+// deduplicate transitive @wdio/* deps without hitting the registry.
+// (Avoids the npm arborist bug with file: in overrides.)
+pkg.devDependencies = pkg.devDependencies || {};
+for (const [name, path] of Object.entries(tarballMap)) {
+  if (!pkg.dependencies?.[name] && !pkg.devDependencies[name]) {
+    pkg.devDependencies[name] = path;
+  }
+}
+// Remove any overrides left from a previous attempt
+delete pkg.overrides;
+
 process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');
 JS_EOF
 )

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -95,6 +95,15 @@ mv package.json package.json.orig
 mv package.json.patched package.json
 trap 'mv -f package.json.orig package.json 2>/dev/null || true' EXIT
 
+# This fixture is a pnpm workspace member, so the runner's `pnpm install` leaves
+# a symlinked node_modules here (entries link out to ../../../../node_modules/.pnpm
+# and ../../../../packages). The whole workspace is bind-mounted in, so npm's
+# arborist tries to load that pnpm layout and crashes on a symlink it can't
+# resolve in its own model: "Cannot destructure property 'package' of
+# 'node.target' as it is null". Clear it so npm builds node_modules purely from
+# the tarballs + registry.
+rm -rf node_modules package-lock.json
+
 npm install --prefer-offline 2>&1
 
 # Restore original package.json so the working tree stays clean for log uploads

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -71,6 +71,7 @@ JS_EOF
 echo "$PATCHED_PKG" > package.json.patched
 mv package.json package.json.orig
 mv package.json.patched package.json
+trap 'mv -f package.json.orig package.json 2>/dev/null || true' EXIT
 
 npm install --prefer-offline 2>&1
 
@@ -84,7 +85,7 @@ echo '=== Building Tauri app ==='
 # tsx + Node >=23.6 to execute @wdio/tauri-plugin's build script. The plugin
 # JS is already in node_modules/@wdio/tauri-plugin from the tarball install.
 # build-web.ts probes node_modules/@wdio/tauri-plugin and copies it to dist/.
-node scripts/build-web.ts
+npx tsx scripts/build-web.ts
 npx tauri build --debug
 
 echo '=== Running Tauri package test ==='

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -117,12 +117,14 @@ rm package.json
 mv package.json.orig package.json
 
 echo '=== Building Tauri app ==='
-# Run the build steps individually rather than via `pnpm run build`, which
-# would invoke build:js -- a workspace-filtered pnpm operation that requires
-# tsx + Node >=23.6 to execute @wdio/tauri-plugin's build script. The plugin
-# JS is already in node_modules/@wdio/tauri-plugin from the tarball install.
-# build-web.ts probes node_modules/@wdio/tauri-plugin and copies it to dist/.
-npx tsx scripts/build-web.ts
+# Run the build steps individually rather than via `pnpm run build`, which would
+# invoke build:js -- a workspace-filtered pnpm operation (`pnpm --filter
+# @wdio/tauri-plugin build:js`) that needs the full pnpm workspace the container
+# doesn't have. The plugin JS is already in node_modules/@wdio/tauri-plugin from the
+# tarball install, and build-web.ts probes that path and copies it into dist/.
+# build-web.ts runs under bare `node` -- the container is Node 24, which strips TS
+# natively, so no tsx is needed (matches the fixture's own `build:web` script).
+node scripts/build-web.ts
 npx tauri build --debug
 
 echo '=== Running Tauri package test ==='

--- a/fixtures/package-tests/tauri-app/docker/debian.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/debian.dockerfile
@@ -23,9 +23,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Install Rust toolchain (needed for tauri-driver)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/fixtures/package-tests/tauri-app/docker/fedora.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/fedora.dockerfile
@@ -22,9 +22,6 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_24.x | bash - && \
     dnf install -y nodejs && \
     dnf clean all
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Install Rust toolchain (needed for tauri-driver)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/fixtures/package-tests/tauri-app/docker/test.sh
+++ b/fixtures/package-tests/tauri-app/docker/test.sh
@@ -25,22 +25,26 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 
-# Validate that TARBALLS_DIR is set and non-empty before running tests
-if [ -z "${TARBALLS_DIR:-}" ]; then
-    echo "ERROR: TARBALLS_DIR is not set."
-    echo "Pack tarballs first:"
-    echo "  cd $REPO_ROOT"
-    echo "  mkdir -p dist/tarballs"
-    echo "  for pkg in tauri-service tauri-plugin native-core native-spy native-types native-utils; do"
-    echo "    pnpm pack -C packages/\$pkg --pack-destination \"\$(pwd)/dist/tarballs\""
-    echo "  done"
-    echo "  TARBALLS_DIR=\"\$(pwd)/dist/tarballs\" $0 \$@"
-    exit 1
-fi
+# Only `test` mode consumes the tarballs (it bind-mounts them into the container);
+# `build` and `debug` just build the image, so don't require TARBALLS_DIR. Mode is
+# the second positional arg (default `build`), validated in full further down.
+if [ "${2:-build}" = "test" ]; then
+    if [ -z "${TARBALLS_DIR:-}" ]; then
+        echo "ERROR: TARBALLS_DIR is not set."
+        echo "Pack tarballs first:"
+        echo "  cd $REPO_ROOT"
+        echo "  mkdir -p dist/tarballs"
+        echo "  for pkg in tauri-service tauri-plugin native-core native-spy native-types native-utils; do"
+        echo "    pnpm pack -C packages/\$pkg --pack-destination \"\$(pwd)/dist/tarballs\""
+        echo "  done"
+        echo "  TARBALLS_DIR=\"\$(pwd)/dist/tarballs\" $0 \$@"
+        exit 1
+    fi
 
-if [ ! -d "$TARBALLS_DIR" ]; then
-    echo "ERROR: TARBALLS_DIR '$TARBALLS_DIR' does not exist or is not a directory."
-    exit 1
+    if [ ! -d "$TARBALLS_DIR" ]; then
+        echo "ERROR: TARBALLS_DIR '$TARBALLS_DIR' does not exist or is not a directory."
+        exit 1
+    fi
 fi
 
 # Colors for output

--- a/fixtures/package-tests/tauri-app/docker/test.sh
+++ b/fixtures/package-tests/tauri-app/docker/test.sh
@@ -7,11 +7,41 @@
 # Example: ./test.sh void build
 # Example: ./test.sh void test
 # Example: ./test.sh void debug
+#
+# The TARBALLS_DIR env variable must point to a directory containing pre-packed
+# workspace tarballs (wdio-tauri-service-*.tgz etc.).  In CI this is set by the
+# workflow after the runner-side "Pack tarballs" step.  Locally you can create
+# the tarballs first:
+#
+#   cd <repo-root>
+#   mkdir -p dist/tarballs
+#   for pkg in tauri-service tauri-plugin native-core native-spy native-types native-utils; do
+#     pnpm pack -C packages/$pkg --pack-destination "$(pwd)/dist/tarballs"
+#   done
+#   TARBALLS_DIR="$(pwd)/dist/tarballs" fixtures/package-tests/tauri-app/docker/test.sh all test
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Validate that TARBALLS_DIR is set and non-empty before running tests
+if [ -z "${TARBALLS_DIR:-}" ]; then
+    echo "ERROR: TARBALLS_DIR is not set."
+    echo "Pack tarballs first:"
+    echo "  cd $REPO_ROOT"
+    echo "  mkdir -p dist/tarballs"
+    echo "  for pkg in tauri-service tauri-plugin native-core native-spy native-types native-utils; do"
+    echo "    pnpm pack -C packages/\$pkg --pack-destination \"\$(pwd)/dist/tarballs\""
+    echo "  done"
+    echo "  TARBALLS_DIR=\"\$(pwd)/dist/tarballs\" $0 \$@"
+    exit 1
+fi
+
+if [ ! -d "$TARBALLS_DIR" ]; then
+    echo "ERROR: TARBALLS_DIR '$TARBALLS_DIR' does not exist or is not a directory."
+    exit 1
+fi
 
 # Colors for output
 RED='\033[0;31m'
@@ -54,13 +84,14 @@ run_tests_in_container() {
     echo -e "${YELLOW}=== Running tests for $distro ===${NC}"
 
     # The in-container logic lives in container-test.sh (reached through the
-    # workspace bind mount) instead of an inline `bash -c` string — an
+    # workspace bind mount) instead of an inline `bash -c` string -- an
     # unescaped double quote in an inline script truncates it silently and
     # the run reports a green no-op. See the header of container-test.sh.
     docker run --rm \
         -u root \
         -v "$REPO_ROOT:/workspace" \
         -v "$log_dir:/workspace/logs-output" \
+        -v "$TARBALLS_DIR:/tarballs:ro" \
         -w /workspace \
         "tauri-distro-test:$distro" \
         bash /workspace/fixtures/package-tests/tauri-app/docker/container-test.sh \

--- a/fixtures/package-tests/tauri-app/docker/ubuntu.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/ubuntu.dockerfile
@@ -24,9 +24,6 @@ RUN apt-get update -qq && \
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs
 
-# Install pnpm globally as root
-RUN npm install -g pnpm
-
 # Install Rust toolchain (needed for tauri-driver)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/fixtures/package-tests/tauri-app/docker/void.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/void.dockerfile
@@ -24,9 +24,6 @@ RUN xbps-install -Syu xbps && \
         xorg-server-xvfb && \
     xbps-remove -O
 
-# Install pnpm globally
-RUN npm install -g pnpm
-
 # Install Rust toolchain (needed for tauri-driver)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/fixtures/package-tests/tauri-app/scripts/build-web.ts
+++ b/fixtures/package-tests/tauri-app/scripts/build-web.ts
@@ -8,9 +8,10 @@
  * 3. Copies the WebDriverIO Tauri plugin JavaScript to dist/plugins/
  *
  * The plugin JS location differs between environments:
- * - Monorepo:  fixtures/package-tests/tauri-app -> ../../../packages/tauri-plugin
- * - Isolated:  /tmp/.../tauri-app              -> ../packages/tauri-plugin
- * - The script tries both paths to support both environments
+ * - Monorepo:    fixtures/package-tests/tauri-app -> ../../../packages/tauri-plugin
+ * - Isolated:    /tmp/.../tauri-app              -> ../packages/tauri-plugin
+ * - Tarball CI:  node_modules/@wdio/tauri-plugin (installed from packed tarball)
+ * - The script tries all paths to support every environment
  */
 
 import { cpSync, existsSync, mkdirSync } from 'node:fs';
@@ -22,23 +23,24 @@ const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, '..');
 
 function main() {
-  console.log('🔨 Building web frontend...');
+  console.log('Building web frontend...');
 
   // Create dist directory
   const distDir = join(projectRoot, 'dist');
   mkdirSync(distDir, { recursive: true });
-  console.log('✅ Created dist directory');
+  console.log('Created dist directory');
 
   // Copy index.html
   const indexHtml = join(projectRoot, 'index.html');
   const distIndexHtml = join(distDir, 'index.html');
   cpSync(indexHtml, distIndexHtml);
-  console.log('✅ Copied index.html');
+  console.log('Copied index.html');
 
   // Copy plugin JavaScript - try multiple paths for different environments
   const pluginPaths = [
     join(projectRoot, '../../../packages/tauri-plugin/dist-js/index.js'), // Monorepo
     join(projectRoot, '../packages/tauri-plugin/dist-js/index.js'), // Isolated test environment
+    join(projectRoot, 'node_modules/@wdio/tauri-plugin/dist-js/index.js'), // Tarball install (Docker CI)
   ];
 
   let pluginCopied = false;
@@ -47,21 +49,21 @@ function main() {
       const pluginsDir = join(distDir, 'plugins');
       mkdirSync(pluginsDir, { recursive: true });
       cpSync(pluginPath, join(pluginsDir, 'wdio-plugin.js'));
-      console.log(`✅ Copied plugin JS from ${pluginPath}`);
+      console.log(`Copied plugin JS from ${pluginPath}`);
       pluginCopied = true;
       break;
     }
   }
 
   if (!pluginCopied) {
-    console.error('❌ Plugin JS not found at any of these locations:');
+    console.error('Plugin JS not found at any of these locations:');
     for (const path of pluginPaths) {
       console.error(`   - ${path}`);
     }
     process.exit(1);
   }
 
-  console.log('🎉 Web frontend build complete!');
+  console.log('Web frontend build complete!');
 }
 
 main();


### PR DESCRIPTION
## Summary

- CI runner (Node 24) now packs workspace tarballs after the build step; containers receive them via a `/tarballs` bind-mount and install with `npm` using `file:` protocol references
- Removes `pnpm install --frozen-lockfile` + workspace service builds from containers — eliminating the Node >=23.6 requirement that caused the breakage described in #350
- `workspace:*` refs in fixture `package.json` are rewritten by an inline Node script before `npm install`; original `package.json` is restored after install so the working tree stays clean for log uploads

## Changes

**CI workflows** (`_ci-package-docker-tauri.reusable.yml`, `_ci-package-docker-dioxus.reusable.yml`):
- Add `Setup Development Environment` + `Build packages` + `Pack tarballs` steps on the runner before launching Docker
- Pass `TARBALLS_DIR` to `test.sh`, which forwards it as a `/tarballs:ro` bind-mount into the container

**`container-test.sh`** (both Tauri and Dioxus):
- Replace workspace build steps with tarball verification + `npm install` with `file:` paths
- Tauri: call build steps individually (`node scripts/build-web.ts` + `npx tauri build --debug`) to bypass the `build:js` workspace-filtered step that required tsx/Node >=23.6
- Dioxus: call `cargo build` and `npx wdio run wdio.conf.ts` directly

**`test.sh`** (both): require `TARBALLS_DIR` to be set; pass it as bind-mount to `docker run`

**`build-web.ts`** (Tauri fixture): add `node_modules/@wdio/tauri-plugin` as a third probe path for the tarball-install case

## Test plan

- [ ] Verify `bash -n` syntax check passes on all modified shell scripts (done in implementation)
- [ ] Manually run `TARBALLS_DIR=... ./test.sh ubuntu test` locally after packing tarballs
- [ ] CI green on the Tauri and Dioxus docker matrix legs

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)