### PR TITLE
perf(ci): start native/CEF app builds off detect-changes, not build (re-land #395)

### DIFF
--- a/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
@@ -11,18 +11,6 @@ on:
         description: 'OS of runner'
         required: true
         type: string
-      build_id:
-        description: 'Build ID from the main build job'
-        type: string
-        required: false
-      artifact_size:
-        description: 'Size of the build artifact in bytes'
-        type: string
-        required: false
-      cache_key:
-        description: 'Cache key to use for downloading artifacts'
-        type: string
-        required: false
     outputs:
       build_id:
         description: 'Unique identifier for this build'
@@ -116,21 +104,6 @@ jobs:
         run: |
           echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
-
-      - name: 📦 Download Package Build Artifacts
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: wdio-desktop-mobile
-          path: wdio-desktop-mobile-build
-          filename: artifact.zip
-          cache_key_prefix: wdio-desktop-build
-          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
-
-      - name: 📊 Show Build Information
-        if: inputs.build_id != '' && inputs.artifact_size != ''
-        shell: bash
-        run: |
-          echo "::notice::Build artifact: ID=${{ inputs.build_id }}, Size=${{ inputs.artifact_size }} bytes"
 
       - name: 🏗️ Build Dioxus Bridge Guest JS
         run: pnpm --filter @wdio/dioxus-bridge build

--- a/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-package-app.reusable.yml
@@ -12,18 +12,6 @@ on:
         description: 'OS of runner'
         required: true
         type: string
-      build_id:
-        description: 'Build ID from the main build job'
-        type: string
-        required: false
-      artifact_size:
-        description: 'Size of the build artifact in bytes'
-        type: string
-        required: false
-      cache_key:
-        description: 'Cache key to use for downloading artifacts'
-        type: string
-        required: false
     outputs:
       build_id:
         description: 'Unique identifier for this build'
@@ -62,17 +50,6 @@ jobs:
         uses: ./.github/workflows/actions/setup-workspace
         with:
           node-version: '24'
-
-      # Download the pre-built packages from the main build job
-      # This ensures workspace dependencies (e.g. @wdio/native-spy dist/) are available
-      - name: Download Package Build Artifacts
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: wdio-desktop-mobile
-          path: wdio-desktop-mobile-build
-          filename: artifact.zip
-          cache_key_prefix: wdio-desktop-build
-          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
 
       - name: Install Rust Toolchain
         shell: bash

--- a/.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
@@ -17,18 +17,6 @@ on:
         description: 'OS of runner'
         required: true
         type: string
-      build_id:
-        description: 'Build ID from the main build job'
-        type: string
-        required: false
-      artifact_size:
-        description: 'Size of the build artifact in bytes'
-        type: string
-        required: false
-      cache_key:
-        description: 'Cache key to use for downloading artifacts'
-        type: string
-        required: false
     outputs:
       build_id:
         description: 'Unique identifier for this build'
@@ -73,21 +61,6 @@ jobs:
         run: |
           echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
-
-      - name: 📦 Download Package Build Artifacts
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: wdio-desktop-mobile
-          path: wdio-desktop-mobile-build
-          filename: artifact.zip
-          cache_key_prefix: wdio-desktop-build
-          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
-
-      - name: 📊 Show Build Information
-        if: inputs.build_id != '' && inputs.artifact_size != ''
-        shell: bash
-        run: |
-          echo "::notice::Build artifact: ID=${{ inputs.build_id }}, Size=${{ inputs.artifact_size }} bytes"
 
       # CEF download + bundle. The beta Bun/CEF toolchain is the biggest unknown in
       # this pipeline (~150MB CEF download); a failure here is most likely a

--- a/.github/workflows/_ci-build-electrobun-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-electrobun-package-app.reusable.yml
@@ -17,18 +17,6 @@ on:
         description: 'OS of runner'
         required: true
         type: string
-      build_id:
-        description: 'Build ID from the main build job'
-        type: string
-        required: false
-      artifact_size:
-        description: 'Size of the build artifact in bytes'
-        type: string
-        required: false
-      cache_key:
-        description: 'Cache key to use for downloading artifacts'
-        type: string
-        required: false
     outputs:
       build_id:
         description: 'Unique identifier for this build'
@@ -73,21 +61,6 @@ jobs:
         run: |
           echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
-
-      - name: 📦 Download Package Build Artifacts
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: wdio-desktop-mobile
-          path: wdio-desktop-mobile-build
-          filename: artifact.zip
-          cache_key_prefix: wdio-desktop-build
-          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
-
-      - name: 📊 Show Build Information
-        if: inputs.build_id != '' && inputs.artifact_size != ''
-        shell: bash
-        run: |
-          echo "::notice::Build artifact: ID=${{ inputs.build_id }}, Size=${{ inputs.artifact_size }} bytes"
 
       # CEF download + bundle (~150MB) — the beta Bun/CEF toolchain is the biggest
       # unknown here; a failure is most likely a toolchain/network issue, not a fixture

--- a/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
@@ -15,18 +15,6 @@ on:
         description: 'Build command for Tauri app (build or build:debug)'
         type: string
         default: 'build'
-      build_id:
-        description: 'Build ID from the main build job'
-        type: string
-        required: false
-      artifact_size:
-        description: 'Size of the build artifact in bytes'
-        type: string
-        required: false
-      cache_key:
-        description: 'Cache key to use for downloading artifacts'
-        type: string
-        required: false
     outputs:
       build_id:
         description: 'Unique identifier for this build'
@@ -152,24 +140,6 @@ jobs:
         run: |
           echo "build_id=$(date +%s)-${{ github.run_id }}-${{ runner.os }}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
-
-      # Download the pre-built packages from the main build job
-      # This ensures we use the same build artifacts and avoid rebuilding Node.js packages
-      - name: 📦 Download Package Build Artifacts
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: wdio-desktop-mobile
-          path: wdio-desktop-mobile-build
-          filename: artifact.zip
-          cache_key_prefix: wdio-desktop-build
-          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
-
-      # Display build information if available
-      - name: 📊 Show Build Information
-        if: inputs.build_id != '' && inputs.artifact_size != ''
-        shell: bash
-        run: |
-          echo "::notice::Build artifact: ID=${{ inputs.build_id }}, Size=${{ inputs.artifact_size }} bytes"
 
       # Build the Tauri plugin's JavaScript first
       # This is needed by the E2E app's build process (for bundling)

--- a/.github/workflows/_ci-build-tauri-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-tauri-package-app.reusable.yml
@@ -11,18 +11,6 @@ on:
         description: 'OS of runner'
         required: true
         type: string
-      build_id:
-        description: 'Build ID from the main build job'
-        type: string
-        required: false
-      artifact_size:
-        description: 'Size of the build artifact in bytes'
-        type: string
-        required: false
-      cache_key:
-        description: 'Cache key to use for downloading artifacts'
-        type: string
-        required: false
     outputs:
       build_id:
         description: 'Unique identifier for this build'
@@ -61,17 +49,6 @@ jobs:
         uses: ./.github/workflows/actions/setup-workspace
         with:
           node-version: '24'
-
-      # Download the pre-built packages from the main build job
-      # This ensures workspace dependencies (e.g. @wdio/native-spy dist/) are available
-      - name: 📦 Download Package Build Artifacts
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: wdio-desktop-mobile
-          path: wdio-desktop-mobile-build
-          filename: artifact.zip
-          cache_key_prefix: wdio-desktop-build
-          exact_cache_key: ${{ inputs.cache_key || github.run_id && format('{0}-{1}-{2}-{3}{4}', 'Linux', 'wdio-desktop-build', 'wdio-desktop-mobile', github.run_id, github.run_attempt > 1 && format('-rerun{0}', github.run_attempt) || '') || '' }}
 
       - name: 🦀 Install Rust Toolchain
         shell: bash
@@ -304,8 +281,11 @@ jobs:
             echo "gen directory does not exist, nothing to clean"
           fi
 
+      # No --only: the main build artifact is no longer downloaded (this job now starts off
+      # detect-changes, in parallel with build), so let Turbo build the app's workspace deps
+      # from source (remote-cache backed) instead of relying on the downloaded dist/.
       - name: 🏗️ Build Tauri Package Test App
-        run: pnpm exec turbo run build --filter=tauri-app-example --only
+        run: pnpm exec turbo run build --filter=tauri-app-example
         shell: bash
 
       # Debug: Check if ACL manifest was generated after build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,39 +92,30 @@ jobs:
   # Build Tauri E2E app binaries - only if Tauri tests will run
   build-tauri-e2e-app-linux:
     name: Build Tauri E2E App [Linux]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'ubuntu-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-tauri-e2e-app-windows:
     name: Build Tauri E2E App [Windows]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'windows-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-tauri-e2e-app-macos-arm:
     name: Build Tauri E2E App [macOS-ARM]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   # Build Dioxus Rust crates - only if Dioxus tests will run.
   # v1 scope: Linux only. wdio-dioxus-driver is Windows-targeted but
@@ -142,39 +133,30 @@ jobs:
   # Build Dioxus E2E app binaries - only if Dioxus tests will run
   build-dioxus-e2e-app-linux:
     name: Build Dioxus E2E App [Linux]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'ubuntu-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-dioxus-e2e-app-windows:
     name: Build Dioxus E2E App [Windows]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'windows-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-dioxus-e2e-app-macos-arm:
     name: Build Dioxus E2E App [macOS-ARM]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   # ────────────────────────────────────────────────────────────────────────
   # Electrobun E2E app — macOS (CEF bundle, no Rust crates). The CEF fixture build is
@@ -189,15 +171,12 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   build-electrobun-e2e-app-macos-arm:
     name: Build Electrobun E2E App [macOS-ARM]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   # ────────────────────────────────────────────────────────────────────────
   # Electrobun E2E app [Windows] — built with the native WebView2 renderer
@@ -207,163 +186,124 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   build-electrobun-e2e-app-windows:
     name: Build Electrobun E2E App [Windows]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
     secrets: inherit
     with:
       os: 'windows-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   # macOS (CEF) + Windows (WebView2). The package-test fixture build mirrors the e2e build
   # (Bun, tar artifact); Windows builds the native WebView2 renderer (no CEF download).
   build-electrobun-package-app-macos-arm:
     name: Build Electrobun Package Test App [macOS-ARM]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-electrobun-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-electrobun-package-app-windows:
     name: Build Electrobun Package Test App [Windows]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-electrobun-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'windows-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   # Build Dioxus package test apps - only if Dioxus package tests will run
   build-dioxus-package-app-linux:
     name: Build Dioxus Package Test App [Linux]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'ubuntu-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-dioxus-package-app-windows:
     name: Build Dioxus Package Test App [Windows]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'windows-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-dioxus-package-app-macos-arm:
     name: Build Dioxus Package Test App [macOS-ARM]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-dioxus-package-app-macos-intel:
     name: Build Dioxus Package Test App [macOS-Intel]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-15-intel'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-dioxus-package-app-linux-arm:
     name: Build Dioxus Package Test App [Linux-ARM64]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-dioxus-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'ubuntu-24.04-arm'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   # Build Tauri package test apps - only if Tauri package tests will run
   build-tauri-package-app-linux:
     name: Build Tauri Package Test App [Linux]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'ubuntu-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-tauri-package-app-windows:
     name: Build Tauri Package Test App [Windows]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'windows-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-tauri-package-app-linux-arm:
     name: Build Tauri Package Test App [Linux-ARM64]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'ubuntu-24.04-arm'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-tauri-package-app-macos-arm:
     name: Build Tauri Package Test App [macOS-ARM]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-latest'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   build-tauri-package-app-macos-intel:
     name: Build Tauri Package Test App [macOS-Intel]
-    needs: [detect-changes, build]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
     uses: ./.github/workflows/_ci-build-tauri-package-app.reusable.yml
     secrets: inherit
     with:
       os: 'macos-15-intel'
-      build_id: ${{ needs.build.outputs.build_id }}
-      artifact_size: ${{ needs.build.outputs.artifact_size }}
-      cache_key: ${{ needs.build.outputs.cache_key }}
 
   # Run package tests after unit tests to ensure the package is built correctly
   # Split Electron and Tauri tests across separate jobs for better parallelization and clarity


### PR DESCRIPTION
Re-lands #395, which was **merged but never reached `main`**: its base was the #394 branch (`ci/status-gate-and-redundant-installs`), and because that branch wasn't deleted/retargeted after #394 squash-merged, merging #395 put the commit on that stale branch instead of `main`. So `main` currently still has the old `needs: [detect-changes, build]` + artifact downloads.

This is the **exact same commit** (`7fc5bdfae`) cherry-picked cleanly onto current `main` — its hunks (build-app jobs + the 6 app-build reusables) don't overlap the Dependabot CI-gating that landed on main since, which is preserved.

## What (unchanged from #395)
Decouples the 20 Tauri/Dioxus/Electrobun e2e + package-test **app builds** from the Linux `build` job: drop `needs: build`, remove the build-artifact download (+ dead show-info step + unused `build_id/artifact_size/cache_key` inputs); drop `--only` in the Tauri package build so Turbo builds deps from source. Each leg now starts off `detect-changes`, in parallel with `build`, so the e2e/package leg start drops from `build + app-build` to `≈ app-build`. The consuming e2e/package jobs still depend on `build` directly, so a JS build failure still reds CI.

## Verified
- `actionlint` 1.7.12 clean.
- Dependabot gating preserved (`detect-changes` `if:` + `ci-status` guard).
- App-build reusables download artifact: **0**; consumers still reference `needs.build.outputs`: **88**; identical +24/−238 to #395.

To avoid the stale-base trap again, this targets `main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)