### PR TITLE
perf(ci): re-enable pnpm store cache in setup-workspace

### DIFF
--- a/.github/workflows/actions/setup-workspace/action.yml
+++ b/.github/workflows/actions/setup-workspace/action.yml
@@ -18,9 +18,13 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        # Temporarily disable cache to ensure fresh tarball is used
-        # cache: 'pnpm'
-        # cache-dependency-path: '**/pnpm-lock.yaml'
+        # Store cache keyed on the lockfile. Safe w.r.t. the electron-builder fixtures'
+        # @wdio/utils `file:` tarball override: pnpm honors overrides only at the workspace
+        # root (which has none), so the root lockfile never references the mutable tarball —
+        # that's confined to the isolated package-test install (test-package.ts), which this
+        # cache doesn't touch.
+        cache: 'pnpm'
+        cache-dependency-path: '**/pnpm-lock.yaml'
 
     - name: 📦 Install Project Dependencies
       shell: bash


### PR DESCRIPTION
The final item from the CI review (Perf-4). `setup-workspace` runs every job's `pnpm install` with **no store cache** — re-downloading all deps from the registry on each of ~40 jobs per run. This restores the cache (`cache: 'pnpm'`), which ran fine for ~3 months before being switched off.

## Why it was off, and why re-enabling is safe

The cache was disabled in a `chore: debug` commit ("ensure fresh tarball is used") that — in the same commit — introduced the electron-builder fixtures' `@wdio/utils` → `file:../../../../wdio-utils-*.tgz` override. The disable was a shotgun aimed at a problem in a different code path.

The store cache cannot go stale on that tarball:

- **pnpm honors `pnpm.overrides` only at the workspace root**, and the root `package.json` declares none — the override lives only in the two electron-builder fixtures. So during `setup-workspace`'s root install the override is ignored; `@wdio/utils` resolves to the registry version.
- The root `pnpm-lock.yaml` therefore has **no `file:`/tarball reference** — the cache is keyed on that lockfile and holds only immutable registry packages (version + integrity).
- The patched tarball is used **only** by the isolated package-test install (`test-package.ts` copies a fixture out → *its* root override applies there). That install doesn't use this cache.

## Validation

- `actionlint` 1.7.12 clean; `action.yml` parses.
- Order is correct — `pnpm/action-setup` runs before `actions/setup-node`, so `cache: 'pnpm'` can resolve the store path.
- Real proof is the CI run (store-cache hit on subsequent runs). Revert is a one-file, 4-line change if anything regresses.

Independent of #396 (different file); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)