### PR TITLE
fix(ci): bump inter-job app artifact retention from 1 → 3 days

### DIFF
--- a/.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
@@ -102,5 +102,5 @@ jobs:
         with:
           name: electrobun-e2e-bundle-${{ runner.os }}-${{ runner.arch }}
           path: ${{ runner.temp }}/electrobun-e2e-bundle.tgz
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error

--- a/.github/workflows/_ci-build-electrobun-package-app.reusable.yml
+++ b/.github/workflows/_ci-build-electrobun-package-app.reusable.yml
@@ -98,5 +98,5 @@ jobs:
         with:
           name: electrobun-package-app-${{ runner.os }}-${{ runner.arch }}
           path: ${{ runner.temp }}/electrobun-package-app.tgz
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error

--- a/.github/workflows/_ci-build-flutter-ios-app.reusable.yml
+++ b/.github/workflows/_ci-build-flutter-ios-app.reusable.yml
@@ -82,6 +82,6 @@ jobs:
           # The tarball, not the raw .app dir, so symlinks/exec bits survive. overwrite handles a
           # full re-run that rebuilds (the run_id-only name otherwise collides).
           path: flutter-ios-app.tar.gz
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error
           overwrite: true

--- a/.github/workflows/_ci-build-react-native-ios-app.reusable.yml
+++ b/.github/workflows/_ci-build-react-native-ios-app.reusable.yml
@@ -139,6 +139,6 @@ jobs:
           # never re-uploaded. overwrite handles a full re-run that does rebuild.
           name: rn-ios-app-${{ inputs.new-arch && 'new' || 'old' }}-arch-${{ github.run_id }}
           path: rn-ios-app.tar.gz
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error
           overwrite: true


### PR DESCRIPTION
## Root cause

Four build workflows upload inter-job app artifacts with `retention-days: 1`. These artifacts are keyed by `run_id` (not `run_attempt`) so a `--failed` rerun finds them without the build job re-running. But if the retry happens more than ~24 hours after the original run the artifact has already expired.

Observed in #397: original run created 2026-06-13, retried 2026-06-15 (2 days later) — `flutter-ios-app-27452156013` not found.

## Fix

Raise `retention-days: 1 → 3` on all four inter-job app artifact uploads:

| Workflow | Artifact |
|---|---|
| `_ci-build-flutter-ios-app.reusable.yml` | `flutter-ios-app-<run_id>` |
| `_ci-build-react-native-ios-app.reusable.yml` | `rn-ios-app-*-arch-<run_id>` |
| `_ci-build-electrobun-e2e-app.reusable.yml` | `electrobun-e2e-bundle-<os>-<arch>` |
| `_ci-build-electrobun-package-app.reusable.yml` | `electrobun-package-app-<os>-<arch>` |

3 days covers a long-weekend retry without meaningful storage cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)