### PR TITLE
fix(dioxus): getTitle reads OS window title instead of document.title

### DIFF
--- a/packages/dioxus-embedded-driver/src/server/handlers/navigation.rs
+++ b/packages/dioxus-embedded-driver/src/server/handlers/navigation.rs
@@ -62,12 +62,20 @@ pub async fn get_url(
 
 /// GET `/session/{session_id}/title`
 pub async fn get_title(
-  State(state): State<Arc<AppState>>,
-  Path(session_id): Path<String>,
+  _state: State<Arc<AppState>>,
+  _session_id: Path<String>,
 ) -> WebDriverResult {
-  let timeout = script_timeout(&state, &session_id).await?;
-  let result = eval("return document.title".to_string(), timeout).await?;
-  Ok(WebDriverResponse::success(result))
+  // Dioxus apps set the OS window title via document::Title / WindowBuilder::with_title,
+  // never touching document.title. Read from the bridge's window-state registry instead,
+  // preferring the focused window and falling back to the first registered window.
+  let states = wdio_dioxus_bridge::window_state::get_window_states();
+  let title = states
+    .iter()
+    .find(|w| w.is_focused)
+    .or_else(|| states.first())
+    .map(|w| w.title.as_str())
+    .unwrap_or_default();
+  Ok(WebDriverResponse::success(serde_json::json!(title)))
 }
 
 /// POST `/session/{session_id}/back`

--- a/packages/dioxus-embedded-driver/src/server/handlers/navigation.rs
+++ b/packages/dioxus-embedded-driver/src/server/handlers/navigation.rs
@@ -62,16 +62,17 @@ pub async fn get_url(
 
 /// GET `/session/{session_id}/title`
 pub async fn get_title(
-  _state: State<Arc<AppState>>,
-  _session_id: Path<String>,
+  State(state): State<Arc<AppState>>,
+  Path(session_id): Path<String>,
 ) -> WebDriverResult {
   // Dioxus apps set the OS window title via document::Title / WindowBuilder::with_title,
-  // never touching document.title. Read from the bridge's window-state registry instead,
-  // preferring the focused window and falling back to the first registered window.
+  // never touching document.title. Read from the bridge's window-state registry instead.
+  let current_window = state.sessions.read().await.get(&session_id)?.current_window.clone();
   let states = wdio_dioxus_bridge::window_state::get_window_states();
   let title = states
     .iter()
-    .find(|w| w.is_focused)
+    .find(|w| w.label == current_window)
+    .or_else(|| states.iter().find(|w| w.is_focused))
     .or_else(|| states.first())
     .map(|w| w.title.as_str())
     .unwrap_or_default();


### PR DESCRIPTION
## Summary

- `browser.getTitle()` on a Dioxus app previously returned `"Dioxus app"` (the `document.title` default) because the embedded driver's Get Title handler was reading `document.title`, which Dioxus desktop never sets
- Dioxus apps set the OS window title via `document::Title` or `WindowBuilder::with_title`; `document.title` stays at the framework's placeholder
- Fix: read the title from the bridge's `window_state` registry (same source as `listWindows`), preferring the focused window, falling back to the first registered window

Closes #408

## Test plan

- [ ] `cargo check` passes on `packages/dioxus-embedded-driver`
- [ ] Manual: `browser.getTitle()` returns the app's configured title (e.g. `"WDIO Dioxus E2E App"`) against the downstream example app
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)