### PR TITLE
fix(dioxus): preserve undefined in execute() via __wdio_value__ envelope

### DIFF
--- a/packages/dioxus-bridge/guest-js/index.ts
+++ b/packages/dioxus-bridge/guest-js/index.ts
@@ -149,7 +149,7 @@ if (typeof window.__WDIO_EMBEDDED_PORT === 'number' && !window.__WDIO_EMBEDDED_R
             error = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
           }
           try {
-            await invoke('__embedded_result', { id: cmd.id, result: result ?? null, error });
+            await invoke('__embedded_result', { id: cmd.id, result: error ? null : { __wdio_value__: result }, error });
           } catch {
             // Result delivery failed (e.g. IPC teardown during navigation).
             // Attempt once more with an error marker so the Axum oneshot

--- a/packages/dioxus-service/src/commands/execute.ts
+++ b/packages/dioxus-service/src/commands/execute.ts
@@ -75,10 +75,12 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
         }
       });
     `;
-    return (await browser.execute(wrapped)) as ReturnValue;
+    const raw = await browser.execute(wrapped);
+    return unwrapEmbeddedResult<ReturnValue>(raw);
   }
 
-  return (await browser.execute(script, ...args)) as ReturnValue;
+  const raw = await browser.execute(script, ...args);
+  return unwrapEmbeddedResult<ReturnValue>(raw);
 }
 
 /**
@@ -90,5 +92,24 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
  * Not exported from the package's public surface — only consumed by mock.ts.
  */
 export async function runInterceptorScript<T>(browser: WebdriverIO.Browser, script: string): Promise<T> {
-  return browser.execute(`return (${script})()`) as Promise<T>;
+  const raw = await browser.execute(`return (${script})()`);
+  return unwrapEmbeddedResult<T>(raw);
+}
+
+// The embedded polling loop wraps every result in { __wdio_value__: result }
+// before JSON-serialising it through the IPC channel. JSON.stringify omits
+// undefined properties, so { __wdio_value__: undefined } → {} (key absent),
+// while { __wdio_value__: null } → {"__wdio_value__":null} (key present).
+// This lets the service distinguish undefined from null — something plain
+// WebDriver cannot do because both map to JSON null.
+function unwrapEmbeddedResult<T>(raw: unknown): T {
+  if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
+    const envelope = raw as Record<string, unknown>;
+    if ('__wdio_value__' in envelope) {
+      return envelope['__wdio_value__'] as T;
+    }
+    // Key absent: the result was undefined (omitted by JSON.stringify)
+    return undefined as unknown as T;
+  }
+  return raw as T;
 }

--- a/packages/dioxus-service/test/commands/execute.spec.ts
+++ b/packages/dioxus-service/test/commands/execute.spec.ts
@@ -50,8 +50,18 @@ describe('execute command', () => {
   });
 
   it('should return the value produced by browser.execute', async () => {
-    const browser = browserStub({ hello: 'world' });
+    const browser = browserStub({ __wdio_value__: { hello: 'world' } });
     await expect(execute(browser, 'return {}')).resolves.toEqual({ hello: 'world' });
+  });
+
+  it('should return undefined when the embedded driver returns the empty envelope (undefined result)', async () => {
+    const browser = browserStub({});
+    await expect(execute(browser, 'return undefined')).resolves.toBeUndefined();
+  });
+
+  it('should return null when the embedded driver returns a null-valued envelope', async () => {
+    const browser = browserStub({ __wdio_value__: null });
+    await expect(execute(browser, 'return null')).resolves.toBeNull();
   });
 
   it('should inline multiple positional args as JSON into the wrapper', async () => {
@@ -96,8 +106,13 @@ describe('runInterceptorScript', () => {
   });
 
   it('should return the value produced by browser.execute', async () => {
-    const browser = browserStub({ calls: [['a']], results: [], invocationCallOrder: [1] });
+    const browser = browserStub({ __wdio_value__: { calls: [['a']], results: [], invocationCallOrder: [1] } });
     const result = await runInterceptorScript(browser, '(_dx) => ({ calls: [["a"]] })');
     expect(result).toEqual({ calls: [['a']], results: [], invocationCallOrder: [1] });
+  });
+
+  it('should return undefined when the embedded driver returns the empty envelope', async () => {
+    const browser = browserStub({});
+    await expect(runInterceptorScript(browser, '() => undefined')).resolves.toBeUndefined();
   });
 });

--- a/packages/dioxus-service/test/mock.spec.ts
+++ b/packages/dioxus-service/test/mock.spec.ts
@@ -118,9 +118,11 @@ describe('createMock', () => {
     vi.mocked(browser.execute)
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce({
-        calls: [['arg1']],
-        results: [{ type: 'return', value: 42 }],
-        invocationCallOrder: [1],
+        __wdio_value__: {
+          calls: [['arg1']],
+          results: [{ type: 'return', value: 42 }],
+          invocationCallOrder: [1],
+        },
       });
 
     const m = await createMock('greet', browser);
@@ -136,18 +138,22 @@ describe('createMock', () => {
       .mockResolvedValueOnce(undefined)
       // First update: two calls.
       .mockResolvedValueOnce({
-        calls: [['a'], ['b']],
-        results: [
-          { type: 'return', value: 1 },
-          { type: 'return', value: 2 },
-        ],
-        invocationCallOrder: [1, 2],
+        __wdio_value__: {
+          calls: [['a'], ['b']],
+          results: [
+            { type: 'return', value: 1 },
+            { type: 'return', value: 2 },
+          ],
+          invocationCallOrder: [1, 2],
+        },
       })
       // Second update: inner cleared, only one call now.
       .mockResolvedValueOnce({
-        calls: [['c']],
-        results: [{ type: 'return', value: 3 }],
-        invocationCallOrder: [3],
+        __wdio_value__: {
+          calls: [['c']],
+          results: [{ type: 'return', value: 3 }],
+          invocationCallOrder: [3],
+        },
       });
 
     const m = await createMock('greet', browser);


### PR DESCRIPTION
## Summary

- `browser.dioxus.execute(...)` returning `undefined` previously delivered `null` to the test; `null` and `undefined` were indistinguishable
- Root cause: the embedded polling loop coerced `result ?? null`, collapsing both to `null`
- Fix: mirror `@wdio/tauri-service`'s `__wdio_value__` envelope — wrap the result before posting it through `__embedded_result`; unwrap in `execute.ts` and `runInterceptorScript`
- Because `JSON.stringify` omits `undefined` object properties, `{ __wdio_value__: undefined }` serialises to `{}` (key absent) while `{ __wdio_value__: null }` serialises to `{"__wdio_value__":null}` (key present), making the two distinguishable on receipt
- Updated `mock.spec.ts` call-data stubs to match the new envelope shape

Closes #409

## Test plan

- [ ] `pnpm --filter @wdio/dioxus-service test` passes (all 12 execute + 11 mock tests green)
- [ ] `pnpm --filter @wdio/dioxus-bridge test` passes
- [ ] CI green
- [ ] Manual: after `resetAllMocks()`, `execute(() => invoke('cmd'))` returns `undefined`, not `null` (downstream example app mocking spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)