### PR TITLE
docs: plan @wdio/mobile-service convergence; correct ROADMAP release status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 - **React Native** - `@wdio/react-native-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via Appium (UiAutomator2/XCUITest); `execute` + `mock` via Hermes CDP (debug/Metro build); full mock, deeplink, context switching, logs, multiremote)
 - **Flutter** - `@wdio/flutter-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (Dart expression) + `mock` (Tier-2 cooperative `wdio_flutter` Dart contract) via the Dart VM Service (debug/profile build); full mock, deeplink, context switching, logs, multiremote). Built on `@wdio/native-mobile-core`.
 
-**Planned:** Capacitor, Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
+**Planned:** the generic `@wdio/mobile-service` base (ships ahead of Capacitor; React Native & Flutter converge onto it), then Capacitor and Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@
 
 ## Planned Support
 
-- **Capacitor** - Ionic's cross-platform mobile framework
+- **`@wdio/mobile-service`** - Zero-config Appium base for any native app (plain native, NativeScript, MAUI, Capacitor shells); the shared layer React Native & Flutter build on. Targeted ahead of Capacitor, which extends it.
+- **Capacitor** - Ionic's cross-platform mobile framework (extends `@wdio/mobile-service`)
 - **Neutralino** - Lightweight desktop applications
 
 See [ROADMAP.md](./ROADMAP.md) for detailed sequencing, os support, and timelines.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,7 +161,7 @@ The following frameworks were evaluated and excluded from the roadmap:
 | NW.js | Declining popularity, overlaps with Electron |
 | Cordova / PhoneGap | Deprecated (2020), replaced by Capacitor |
 | Qt / QML | Native rendering — no WebDriver fit |
-| .NET MAUI | Native UI, platform-specific drivers required |
+| .NET MAUI | No *dedicated* service planned (native UI needs no framework-specific channel) — but native MAUI apps are drivable via the generic [`@wdio/mobile-service`](#shared-mobile-infrastructure) over Appium (UiAutomator2 / XCUITest) |
 | Blazor | Standard web needs no service; Hybrid WebView context switching unreliable |
 | Wails | Go webview, no established automation patterns |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,38 +1,49 @@
 # Roadmap
 
-This document outlines the planned services and their development sequencing for the WebdriverIO Desktop & Mobile Testing project.
+This document outlines the released services and the development sequencing for planned ones in the WebdriverIO Desktop & Mobile Testing project.
 
-## Current Services (Available)
+## Released Services
 
-### [@wdio/electron-service](./packages/electron-service) - v10.x
-**Status:** 🚧 Pre-release (migrated from legacy repo)\
+Published packages, grouped by release maturity. Status reflects the npm dist-tag, not just "exists on npm".
+
+### ✅ Stable (`latest`)
+
+#### [@wdio/electron-service](./packages/electron-service) — v10.x
 **Platforms:** Windows, macOS, Linux\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/electron-service)](https://npmjs.com/package/@wdio/electron-service)
 
-### [@wdio/tauri-service](./packages/tauri-service) - v1.x
-**Status:** 🚧 Pre-release\
+#### [@wdio/tauri-service](./packages/tauri-service) — v1.x
 **Platforms:** Windows, macOS, Linux\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/tauri-service)](https://npmjs.com/package/@wdio/tauri-service)
 
-### [@wdio/dioxus-service](./packages/dioxus-service) - v1.x
-**Status:** 🚧 Pre-release\
-**Platforms:** Windows, macOS, Linux (`'embedded'` provider); Windows only for `'external'` in v1\
+### 🚧 Pre-release (`next`, `1.0.0-next.x`)
+
+> Feature-complete services published on the `next` dist-tag while the API and CI stabilise toward `1.0`.
+
+#### [@wdio/dioxus-service](./packages/dioxus-service) — v1.0.0-next
+**Platforms:** Windows, macOS, Linux (`'embedded'` provider); Windows only for `'external'`\
+**Highlights:** Wry webview → CDP (shared patterns with the Tauri service); `execute`, mocking, log forwarding, browser mode, multiremote, standalone session.\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/dioxus-service)](https://npmjs.com/package/@wdio/dioxus-service)
 
-### [@wdio/electrobun-service](./packages/electrobun-service) - v0.1.x
-**Status:** 🧪 Experimental (`0.x`) — macOS (CEF) + Windows (native WebView2); Linux upstream-blocked\
-**Platforms:** macOS, Windows\
-[![npm downloads](https://img.shields.io/npm/dm/@wdio/electrobun-service)](https://npmjs.com/package/@wdio/electrobun-service)
-
-### [@wdio/react-native-service](./packages/react-native-service) - v1.0.0-next.x
-**Status:** 🧪 Pre-release (`1.0.0-next.x`) — complete feature surface on Android + iOS\
+#### [@wdio/react-native-service](./packages/react-native-service) — v1.0.0-next
 **Platforms:** Android, iOS\
+**Highlights:** native find/tap via Appium (UiAutomator2 / XCUITest); `execute` + `mock` via Hermes CDP (debug/Metro build); deeplink, context switching, log capture, multiremote/DeviceManager. Established the shared `@wdio/native-mobile-core` mobile scaffold.\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/react-native-service)](https://npmjs.com/package/@wdio/react-native-service)
 
-### [@wdio/flutter-service](./packages/flutter-service) - v1.0.0-next.x
-**Status:** 🧪 Pre-release (`1.0.0-next.x`) — complete feature surface on Android + iOS\
+#### [@wdio/flutter-service](./packages/flutter-service) — v1.0.0-next
 **Platforms:** Android, iOS\
+**Highlights:** native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (a Dart expression) + `mock` (the cooperative [`wdio_flutter`](./packages/flutter-service/wdio_flutter) Dart contract) via the Dart VM Service (debug/profile build); deeplink, context switching, log capture, multiremote/DeviceManager. Built on `@wdio/native-mobile-core`.\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/flutter-service)](https://npmjs.com/package/@wdio/flutter-service)
+
+### 🧪 Experimental (`0.x`)
+
+> Feature surface limited by upstream gaps; not yet at parity with the services above.
+
+#### [@wdio/electrobun-service](./packages/electrobun-service) — v0.1.x
+**Platforms:** macOS 14+ (CEF), Windows 11+ (WebView2); Linux blocked upstream\
+**Highlights:** drives two renderers — **macOS via CEF** (CDP) and **Windows via the native WebView2** (Chromium over CDP, no CEF) — the latter also running the multi-window suite that CEF can't on CI.\
+**Caveats:** **Linux** blocked upstream (CEF serves no `/json`; the WebKitGTK renderer needs upstream W3C-WebDriver automation — [electrobun#467](https://github.com/blackboardsh/electrobun/issues/467)); **deeplink on Windows** and **deeplink/multiremote on the macOS CEF path** are upstream-blocked. Each upstream fix re-enables a platform/feature, graduating toward `1.0` at full parity. Tracked in [#317](https://github.com/webdriverio/desktop-mobile/issues/317) (non-CEF) + [#320](https://github.com/webdriverio/desktop-mobile/issues/320) (CEF). See the [package README](./packages/electrobun-service).\
+[![npm downloads](https://img.shields.io/npm/dm/@wdio/electrobun-service)](https://npmjs.com/package/@wdio/electrobun-service)
 
 ---
 
@@ -47,39 +58,52 @@ The roadmap above is scoped to *new framework support*. Capability-level feature
 
 ---
 
+## Shared Mobile Infrastructure
+
+The mobile services (React Native, Flutter, and future Capacitor) share a common Appium layer in `@wdio/native-mobile-core`. Two tracks harden and generalise it.
+
+| Track | Status | Notes |
+|---|---|---|
+| **Zero-config mobile setup** | 📋 Planned | Chromedriver-style auto-management: opt-in Appium driver install + version matrix, per-worker realm-port allocation, cap-default derivation, and a fail-fast preflight doctor. Shared [#378](https://github.com/webdriverio/desktop-mobile/issues/378) + Flutter [#405](https://github.com/webdriverio/desktop-mobile/issues/405) + React Native [#406](https://github.com/webdriverio/desktop-mobile/issues/406). |
+| **Generic `@wdio/mobile-service`** | 📋 Planned | A publishable mobile service for any Appium-drivable app (plain native, NativeScript, MAUI, Capacitor shells): native find/tap, deeplink, context switching, logs, multiremote — without a framework realm. React Native and Flutter converge onto it as thin extensions that add only their JS/Dart `execute`/`mock`. Design: [spec](./agent-os/specs/20260618-mobile-service-convergence/spec.md). |
+
+Composition stays two-entry — `services: ['appium', '<framework>']`; the shared layer is inherited, not listed separately. See the [design spec](./agent-os/specs/20260618-mobile-service-convergence/spec.md) for the full model.
+
+**Sequencing:** the zero-config setup-automation track is in flight now (pre-release hardening of the mobile services). The generic `@wdio/mobile-service` + the React Native / Flutter convergence onto it is targeted **Q4 2026, ahead of Capacitor** — Capacitor is its first consumer and extends it rather than re-implementing the mobile scaffold.
+
+---
+
 ## Framework Compatibility Analysis
 
 The table below quantifies the key factors used to prioritise and sequence planned services. GitHub stars serve as a proxy for ecosystem size and developer interest; automation driver maturity indicates how production-ready the underlying test infrastructure is; and pattern reuse scores how much existing service code can be directly leveraged. Stars are approximate as of early 2026.
 
 | Framework | Type | GitHub Stars | Automation Driver | Driver Maturity | Pattern Reuse vs Existing Services | Key Dependencies | Relative Integration Complexity |
 |---|---|---|---|---|---|---|---|
-| **Electron** *(existing)* | Desktop | ~120k | Chrome DevTools Protocol (CDP) | ✅ Proven | — | Chromium, Node.js | — |
-| **Tauri** *(existing)* | Desktop | ~100k | tauri-driver + CDP | ✅ Proven | — | Wry, Rust toolchain | — |
-| **Dioxus** *(existing)* | Desktop | ~34k | Wry webview → CDP (shared with Tauri) | ✅ Implemented | High — same Wry/CDP patterns as Tauri service | Wry maturity, Dioxus desktop stability | Low–Medium |
-| **React Native** | Mobile | ~121k | Appium (XCUITest / UiAutomator2) | ✅ Proven | Establishes mobile scaffold | Appium server stability, XCUITest / UiAutomator2 | Medium |
-| **Flutter** | Mobile | ~175k | Appium Flutter Driver | ✅ Production-ready | Reuses React Native mobile scaffold | Appium Flutter Driver maintenance, Dart VM | Medium |
+| **Electron** *(released)* | Desktop | ~120k | Chrome DevTools Protocol (CDP) | ✅ Proven | — | Chromium, Node.js | — |
+| **Tauri** *(released)* | Desktop | ~100k | tauri-driver + CDP | ✅ Proven | — | Wry, Rust toolchain | — |
+| **Dioxus** *(released)* | Desktop | ~34k | Wry webview → CDP (shared with Tauri) | ✅ Implemented | High — same Wry/CDP patterns as Tauri service | Wry maturity, Dioxus desktop stability | Low–Medium |
+| **React Native** *(released)* | Mobile | ~121k | Appium (XCUITest / UiAutomator2) | ✅ Proven | Establishes mobile scaffold | Appium server stability, XCUITest / UiAutomator2 | Medium |
+| **Flutter** *(released)* | Mobile | ~175k | Appium Flutter Driver | ✅ Production-ready | Reuses React Native mobile scaffold | Appium Flutter Driver maintenance, Dart VM | Medium |
+| **Electrobun** *(released)* | Desktop | ~11.7k | Native CDP (port 9222 by convention) | 🟡 Emerging | Medium — CDP attach patterns from Electron service; no driver process | Bun runtime, system webviews, OOPIF (per-tab) target routing | Medium |
 | **Ionic / Capacitor** | Mobile | ~52k / ~15k | Appium WebView context switching | ✅ Proven | Reuses mobile scaffold; pure WebView — zero new complexity | Appium server, native WebView availability | Low |
-| **Electrobun** | Desktop | ~11.7k | Native CDP (port 9222 by convention) | 🟡 Emerging | Medium — CDP attach patterns from Electron service; no driver process | Bun runtime, system webviews, OOPIF (per-tab) target routing | Medium |
 | **Neutralino** | Desktop | ~7.9k | System webview → CDP (devtools endpoint) | 🟡 Emerging | Medium — similar endpoint detection to Electron service | System webview (WebView2 / WebKitGTK) | Low |
 | **Dioxus Mobile** | Mobile | *(same repo)* | Cargo Mobile 2 — experimental | 🔴 Early-stage | Reuses mobile scaffold + Dioxus desktop learnings | Cargo Mobile 2 maturity, platform bridge stability | High |
-| **React Native Desktop** | Desktop | *(same repo)* | Less mature than mobile counterpart | 🟡 Emerging | Leverages Phase 2 mobile experience | React Native Desktop renderer maturity | Medium–High |
+| **React Native Desktop** | Desktop | *(same repo)* | Less mature than mobile counterpart | 🟡 Emerging | Leverages React Native mobile experience | React Native Desktop renderer maturity | Medium–High |
 
 ---
 
 ## Planned Services
 
-### Phase 2: React Native Mobile — ✅ Shipped (Android + iOS, `1.0.0-next.x`)
+Forward sequence, ordered by target window. Targets are aspirational (see the disclaimer at the end).
 
-**Platforms:** Android (UiAutomator2), iOS (XCUITest)\
-**Highlights:** native find/tap via Appium; `execute` + `mock` via Hermes CDP (debug/Metro build); deeplink, context switching, log capture, multiremote/DeviceManager. Establishes the mobile scaffold for Phase 3 (Flutter) and Phase 4 (Capacitor).
+### Generic Mobile Service — targeted Q4 2026
+**Priority:** High — unlocks Capacitor and any native / other-framework app
 
-### Phase 3: Flutter Mobile — ✅ Shipped (Android + iOS, `1.0.0-next.x`)
-[`@wdio/flutter-service`](./packages/flutter-service) — see the [package README](./packages/flutter-service/README.md).
+Promote the shared `@wdio/native-mobile-core` layer into a concrete, publishable `@wdio/mobile-service` for any Appium-drivable app (plain native, NativeScript, MAUI, Capacitor shells), and converge React Native + Flutter onto it as thin extensions that add only their JS/Dart realm. See [Shared Mobile Infrastructure](#shared-mobile-infrastructure) and the [design spec](./agent-os/specs/20260618-mobile-service-convergence/spec.md).
 
-**Highlights:** native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (a Dart expression) + `mock` (the cooperative [`wdio_flutter`](./packages/flutter-service/wdio_flutter) Dart contract) via the Dart VM Service (debug/profile build); deeplink, context switching, log capture, multiremote/DeviceManager. Built on the `@wdio/native-mobile-core` layer extracted from React Native — the shared mobile scaffold Phase 4 (Capacitor) will reuse.
-
-### Phase 4: Capacitor Mobile (Q1 2027)
-**Priority:** Medium - Ionic ecosystem coverage
+### Capacitor Mobile — Q1 2027
+**Priority:** Medium — Ionic ecosystem coverage\
+**Prerequisite:** extends the generic [`@wdio/mobile-service`](#shared-mobile-infrastructure) base — Capacitor is its first consumer, not a re-implementation of the mobile scaffold.
 
 **Target Platforms:** iOS, Android
 
@@ -87,43 +111,13 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Ionic's 1M+ app ecosystem
 - Pure WebView pattern (zero new complexity)
 - Replaces deprecated Cordova/PhoneGap
-- Perfect mobile scaffold consumer
 
 **Technical approach:**
 - Standard Appium WebView context switching
 - appPackage/appActivity capabilities
 
-### Phase 5: Electrobun Desktop — ✅ Shipped — macOS (CEF) + Windows (WebView2)
-**Priority:** Medium - Emerging TypeScript-first desktop framework
-
-> **Status:** `@wdio/electrobun-service` drives two renderers: **macOS via CEF** (CDP) and
-> **Windows via the native WebView2** (Chromium over CDP, no CEF) — the latter also runs the
-> multi-window suite, which CEF can't on CI. **Linux** remains blocked: CEF serves no `/json`
-> there, and the native WebKitGTK renderer needs upstream W3C-WebDriver automation
-> ([blackboardsh/electrobun#467](https://github.com/blackboardsh/electrobun/issues/467)).
-> **Deeplink on Windows** is upstream-blocked (electrobun registers URL schemes + wires
-> `open-url` macOS-only). Pre-1.0 by design — each fix re-enables a platform/feature,
-> graduating to `1.0` at full parity. Tracked in
-> [#317](https://github.com/webdriverio/desktop-mobile/issues/317) (non-CEF) +
-> [#320](https://github.com/webdriverio/desktop-mobile/issues/320) (CEF). The original plan follows.
-
-**Target Platforms:** macOS 14+ (CEF) + Windows 11+ (WebView2) shipped; Linux (Ubuntu 22.04+) blocked upstream
-
-**Why Electrobun:**
-- Growing momentum in the lightweight desktop space (~12MB bundles, sub-50ms startup)
-- TypeScript-first authoring with Bun runtime, no Node.js requirement
-- System webview model aligns with Tauri/Dioxus patterns
-- MIT-licensed; v1 line shipped, APIs still stabilizing
-
-**Technical approach:**
-- Direct CDP attachment via WebSocket on the underlying webview's debugger port (the third-party [agent-electrobun](https://github.com/Ataraxy-Labs/agent-electrobun) CLI defaults to 9222 for Electrobun apps; the WDIO service will define its own override mechanism rather than rely on a built-in Electrobun env var)
-- No external driver process — connect like Electron, not Tauri
-- Multi-target session management for OOPIF webviews (shell vs per-tab CDP targets, classified by URL path)
-- Observation/input-only protocol calls — no `Page.navigate` on attach (would destroy app state)
-- Reuse `@wdio/electron-cdp-bridge` patterns; likely add a sibling bridge with multi-target routing
-
-### Phase 6: Neutralino Desktop (Q3 2027)
-**Priority:** Low - Niche use case
+### Neutralino Desktop — Q3 2027
+**Priority:** Low — Niche use case
 
 **Target Platforms:** Windows, macOS, Linux
 
@@ -138,8 +132,8 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Electron service patterns (devtools endpoint detection)
 - Standard WebdriverIO parallelization
 
-### Phase 7: Dioxus Mobile Experimental (Q4 2027)
-**Priority:** Low - Experimental platform
+### Dioxus Mobile (Experimental) — Q4 2027
+**Priority:** Low — Experimental platform
 
 **Target Platforms:** iOS, Android (experimental)
 
@@ -148,17 +142,15 @@ The table below quantifies the key factors used to prioritise and sequence plann
 - Reuses established mobile scaffold
 - Completes Rust ecosystem coverage
 
-### Phase 8: React Native Desktop (Q1 2028)
-**Priority:** Low - Desktop expansion
+### React Native Desktop — Q1 2028
+**Priority:** Low — Desktop expansion
 
 **Target Platforms:** Windows, macOS, Linux
 
 **Why later:**
 - Less mature than React Native mobile
 - Lower demand vs mobile priorities
-- Leverages Phase 2 mobile experience
-
-
+- Leverages the React Native mobile experience
 
 ## Not Planned
 

--- a/agent-os/specs/20260618-mobile-service-convergence/spec.md
+++ b/agent-os/specs/20260618-mobile-service-convergence/spec.md
@@ -84,7 +84,8 @@ JS/Dart realm (`execute`/`mock`).
 - A concrete `MobileService` **worker base** wires the shared API once; framework workers extend it
   and install only their realm-backed commands.
 - API-type segregation: `MobileService` exposes native/deeplink/context/log/find APIs; the
-  framework services widen the surface with `execute`/`mock`/`emitEvent`.
+  framework services widen the surface with their realm-backed commands — `execute`, `mock`, and the
+  existing `emitEvent` event-bus command (RN and Flutter already expose all three today).
 - Inheritance is one extra level vs today (core lib → concrete service → framework service). The
   alternative — composition (framework worker holds a `MobileService` instance) — is acceptable if a
   3-level class chain proves awkward; decide during implementation.
@@ -137,6 +138,5 @@ JS/Dart realm (`execute`/`mock`).
 ## Open Questions
 
 - Upstream driver-install/doctor to `@wdio/appium-service`, or keep them in `native-mobile-core`?
-- Does the generic service ship before, alongside, or after the Capacitor service?
 - Versioning: a `@wdio/mobile-service` `1.0` line vs the RN/Flutter `1.0.0-next.x` lines.
 - Inheritance vs composition for the worker base (decide at implementation).

--- a/agent-os/specs/20260618-mobile-service-convergence/spec.md
+++ b/agent-os/specs/20260618-mobile-service-convergence/spec.md
@@ -1,0 +1,142 @@
+# Specification: Generic `@wdio/mobile-service` & Mobile-Service Convergence
+
+> **Status:** 📋 Planned (design) — 2026-06-18
+>
+> **Companion work (tracked as issues, not restated here):**
+> - [#378](https://github.com/webdriverio/desktop-mobile/issues/378) — shared mobile setup automation in `@wdio/native-mobile-core`
+> - [#405](https://github.com/webdriverio/desktop-mobile/issues/405) — Flutter zero-config (`dartVmServicePort`)
+> - [#406](https://github.com/webdriverio/desktop-mobile/issues/406) — React Native Metro/Hermes
+>
+> This spec is **focused** on the generic service + the convergence refactor. The setup-automation
+> mechanics (Tier 1/2/3) live in the issues above and are referenced, not duplicated.
+>
+> **Depends on** the setup-automation track landing in `@wdio/native-mobile-core` first.
+
+---
+
+## Goal
+
+Promote the framework-agnostic mobile layer (`@wdio/native-mobile-core`) into a concrete,
+publishable **`@wdio/mobile-service`** usable for any Appium-drivable app, and converge the
+React Native and Flutter services onto it as **thin extensions** that add only their
+JS/Dart realm (`execute`/`mock`).
+
+## User Stories
+
+- As a native-app (Kotlin/Swift) tester, I want a zero-config WebdriverIO mobile service so I get
+  Appium driver install, device boot, and a preflight doctor without hand-wiring a custom service.
+- As a NativeScript / .NET MAUI / Capacitor-shell tester, I want the same mobile service to drive my
+  app via Appium, since I have no framework-specific JS/Dart realm to mock.
+- As a maintainer, I want RN and Flutter to share one concrete mobile base so the shared API
+  (deeplink, context switching, logs, multiremote) is defined once and reviewed in one place.
+- As a future-framework author (Capacitor), I want to extend a stable generic base rather than
+  re-implement the mobile scaffold.
+
+## Background & Motivation
+
+- **`native-mobile-core` is already framework-agnostic, but it is a *library*** (a base launcher +
+  standalone helper functions), not a service a user can name in `services: [...]`. A generic
+  `@wdio/mobile-service` is its first concrete, publishable face.
+- **`@wdio/appium-service` is strictly server-lifecycle** — it spawns/waits/kills the Appium server,
+  picks the server port (`get-port`, default 4723), and injects connection caps only
+  (`protocol`/`hostname`/`path`/`port`). It does **no** driver install, **no** device management,
+  **no** cap derivation, and **no** doctoring (evidence: `wdio-appium-service/src/launcher.ts`). A
+  mobile service is therefore **complementary**, not duplicative.
+- **RN and Flutter already diverge on shared helpers** — `react-native-service` imports
+  `switchContext`/`listContexts`/`triggerDeeplink` from its **local** `./commands/*`, while
+  `flutter-service` imports the same-named helpers from `@wdio/native-mobile-core`. A concrete base
+  removes that drift and serves the service-API-convergence goal directly.
+- **RN is already "generic + Hermes."** RN drives native UI with UiAutomator2/XCUITest — the same
+  drivers a plain native app uses — and only adds the Hermes channel for `execute`/`mock`. Flutter is
+  the outlier: it swaps the Appium driver (`automationName: 'Flutter'`) and adds the Dart VM. So the
+  generic base composes almost literally under RN, and under Flutter once the launcher allows an
+  `automationName` override (which it should regardless).
+
+## Scope
+
+### In scope
+- **`@wdio/mobile-service`** — a concrete launcher (consuming the #378 setup automation) + a
+  `MobileService` worker exposing the shared API: deeplink, context switching, device logs, native
+  find/tap via Appium, multiremote/DeviceManager.
+- **Convergence** — `react-native-service` and `flutter-service` extend the concrete base and add
+  **only** their realm bridge (Hermes / Dart VM) plus framework specifics (Flutter `automationName`,
+  finders).
+- **The `execute`/`mock` dividing line** — a generic native app has no JS/Dart realm, so the generic
+  service omits realm-level `execute`/`mock`; API types are segregated so it does not advertise them.
+- **Foreign-cap no-op guard** — each service ignores caps that are not its own (by
+  `automationName` / custom-capability marker), the prerequisite for mixed multiremote fleets.
+
+### Out of scope
+- The setup-automation mechanics (Tier 1/2/3) — see #378/#405/#406.
+- Webview-context `execute` for Capacitor — a future Capacitor-service concern, not part of the generic base.
+- Any change to `@wdio/appium-service`'s server-lifecycle responsibilities.
+
+## Architecture
+
+```
+@wdio/native-mobile-core (library)
+  └─ @wdio/mobile-service            launcher: #378 setup automation
+                                     worker:   MobileService (shared API)
+       ├─ @wdio/react-native-service  + Hermes realm (execute/mock); native driver unchanged
+       └─ @wdio/flutter-service       + Dart VM realm (execute/mock); automationName 'Flutter'
+```
+
+- A concrete `MobileService` **worker base** wires the shared API once; framework workers extend it
+  and install only their realm-backed commands.
+- API-type segregation: `MobileService` exposes native/deeplink/context/log/find APIs; the
+  framework services widen the surface with `execute`/`mock`/`emitEvent`.
+- Inheritance is one extra level vs today (core lib → concrete service → framework service). The
+  alternative — composition (framework worker holds a `MobileService` instance) — is acceptable if a
+  3-level class chain proves awkward; decide during implementation.
+
+## Composition / Configuration Model
+
+| Config | Meaning | Verdict |
+|---|---|---|
+| `['appium', '<framework>']` | appium server explicit; mobile layer inherited inside the framework service | ✅ Recommended (= today's model) |
+| `['appium', 'mobile-service']` | standalone generic native testing | ✅ Supported |
+| `['<framework>']` | framework auto-manages the appium server *when local* | 🟡 Future polish (more magic; appium-service already no-ops on cloud caps) |
+| `['appium', 'mobile-service', '<framework>']` | both register the shared layer | ❌ Double-registration |
+
+- **The shared layer is inherited, not listed.** Listing `mobile-service` next to a framework service
+  double-registers the launcher/worker (device claimed twice, caps mutated twice, doctor run twice).
+- **`appium` stays explicit** so cloud/remote (BrowserStack, Sauce, remote Appium) is a clean swap:
+  omit `appium-service`, set connection caps. The framework service *validates* presence (per #378
+  Tier 2) rather than forcing a local server.
+- **Multiple framework entries** are correct only for a genuinely **mixed multiremote fleet**
+  (some Flutter, some RN, some native) — and only if the foreign-cap no-op guard holds.
+
+## Relationship to `@wdio/appium-service` (and an upstream question)
+
+- **No overlap with appium-service's current scope.** Compose, don't duplicate; never spawn the
+  Appium server or pick the server port from the mobile service. The device-side realm ports #378
+  allocates (`dartVmServicePort`, Metro) are a different concern — no conflict.
+- **Defer to WDIO core's existing `browser.*` mobile commands** (~49 of them: `tap`, `swipe`,
+  `switchContext`, `getContexts`, `launchApp`, `lock`, …) rather than re-wrapping them. The mobile
+  service's value is setup automation + the normalized, cross-service-consistent API shape + deeplink
+  fallback + log forwarding.
+- **Open strategic question:** driver auto-install + the version matrix + the doctor are generic
+  enough to benefit *every* Appium user. They are a candidate to **propose upstream into
+  `@wdio/appium-service`** rather than maintain in parallel in `native-mobile-core`. This is a
+  maintainer (Wim) conversation, aligned with the project's peer-coordination outreach approach.
+
+## Sequencing
+
+1. **Setup-automation track lands** in `native-mobile-core` (#378 → #405/#406).
+2. **Extract the concrete `MobileService` worker base; converge RN + Flutter.** This is the
+   highest-leverage step and is worth doing *even if a standalone generic service is not published* —
+   it removes the existing RN/Flutter divergence.
+3. **Publish `@wdio/mobile-service`** (generic native) — the base that Capacitor extends.
+4. **Distill the converged mobile archetype back into the `add-native-service` skill**
+   (`.claude/skills/add-native-service/` — the Mobile archetype + `plumbing-mobile.md`): a new mobile
+   framework should extend `@wdio/mobile-service` rather than clone RN/Flutter. This is an **output of
+   completion, not a prerequisite** — the skill encodes *proven* patterns, so it is updated only once
+   the base ships and is validated, never against the not-yet-existent abstraction (same reason the
+   skill was revised only after React Native shipped). **Required deliverable** of this work.
+
+## Open Questions
+
+- Upstream driver-install/doctor to `@wdio/appium-service`, or keep them in `native-mobile-core`?
+- Does the generic service ship before, alongside, or after the Capacitor service?
+- Versioning: a `@wdio/mobile-service` `1.0` line vs the RN/Flutter `1.0.0-next.x` lines.
+- Inheritance vs composition for the worker base (decide at implementation).


### PR DESCRIPTION
## What

Planning docs for a generic `@wdio/mobile-service` and a correction pass on the ROADMAP's release-status taxonomy. **Docs/spec only — no code changes.**

### New design spec
- `agent-os/specs/20260618-mobile-service-convergence/spec.md` — promote the framework-agnostic `@wdio/native-mobile-core` into a concrete, publishable `@wdio/mobile-service` (for any Appium-drivable app: plain native, NativeScript, MAUI, Capacitor shells), with React Native and Flutter converging onto it as thin extensions that add only their JS/Dart `execute`/`mock`.
- Focused on the service + convergence; the setup-automation mechanics stay in their issues (#378 / #405 / #406) and are referenced, not duplicated.
- Captures the evidence that `@wdio/appium-service` is server-lifecycle-only (so a mobile service is complementary, not duplicative), the two-entry composition model (`services: ['appium', '<framework>']` — shared layer inherited, not listed), and the open question of upstreaming driver-install/doctor into appium-service.
- Includes updating the `add-native-service` skill as a **completion deliverable** (done after the service ships, never against a not-yet-existent abstraction).

### ROADMAP rework
- New **Shared Mobile Infrastructure** section (zero-config setup automation + the generic mobile service), sequenced **ahead of Capacitor**.
- Corrected the release-status taxonomy to match reality (`package.json` + dist-tags): **Stable** (`latest`) = Electron, Tauri; **Pre-release** (`next`) = Dioxus, React Native, Flutter; **Experimental** (`0.x`) = Electrobun. Previously five entries were mislabeled "✅ Shipped" and Electron/Tauri were mislabeled "Pre-release".
- Retired the phase numbers (they encoded an original plan that reality diverged from — e.g. Electrobun released before Capacitor) in favour of a status-tiered "Released Services" list and a target-ordered "Planned Services" list.

### README + AGENTS
- Mention `@wdio/mobile-service` alongside Capacitor (it ships ahead of and is the base for Capacitor).

## Why
Issue #378 was rewritten and split (→ #405/#406); this captures the architecture decision (generic service + convergence) as a spec, surfaces it on the ROADMAP, and fixes the ROADMAP's inaccurate "Shipped" status labels in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)