### PR TITLE
chore: update releasekit to v0.30.2

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -306,7 +306,7 @@ jobs:
       - name: Run ReleaseKit
         id: releasekit
         if: ${{ inputs.standing_pr_number == '' }}
-        uses: goosewobbler/releasekit@v0.30.1
+        uses: goosewobbler/releasekit@v0.30.2
         with:
           mode: release
           node-version: '24'
@@ -336,7 +336,7 @@ jobs:
       - name: Run ReleaseKit (standing PR publish)
         id: releasekit-standing
         if: ${{ inputs.standing_pr_number != '' }}
-        uses: goosewobbler/releasekit@v0.30.1
+        uses: goosewobbler/releasekit@v0.30.2
         with:
           mode: standing-pr-publish
           node-version: '24'

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -43,7 +43,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update standing release PR
-        uses: goosewobbler/releasekit@v0.30.1
+        uses: goosewobbler/releasekit@v0.30.2
         with:
           mode: standing-pr-update
           node-version: '24'

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release Preview
-        uses: goosewobbler/releasekit@v0.30.1
+        uses: goosewobbler/releasekit@v0.30.2
         with:
           node-version: '24'
           mode: preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Run ReleaseKit Gate
         id: gate
-        uses: goosewobbler/releasekit@v0.30.1
+        uses: goosewobbler/releasekit@v0.30.2
         with:
           mode: gate
           node-version: '24'

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@biomejs/biome": "2.4.15",
     "@inquirer/prompts": "^8.4.3",
     "@octokit/rest": "^22.0.1",
-    "@releasekit/release": "^0.30.1",
+    "@releasekit/release": "^0.30.2",
     "@types/node": "^25.9.1",
     "@types/shelljs": "^0.10.0",
     "@typescript-eslint/parser": "^8.59.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@releasekit/release':
-        specifier: ^0.30.1
-        version: 0.30.1(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        specifier: ^0.30.2
+        version: 0.30.2(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -3367,23 +3367,23 @@ packages:
       proxy-agent:
         optional: true
 
-  '@releasekit/notes@0.30.1':
-    resolution: {integrity: sha512-JVrUNRIWjSrhRyF5pkYEOlGoZ151pUB+rknNtNA0G8GyXmmhBWj1Soi6qiHkUd/AOOSbGijMvtMeHTFAIFdqfw==}
+  '@releasekit/notes@0.30.2':
+    resolution: {integrity: sha512-mtWxmBmkusNRm7aExP7jix69fD/zKV3WGK4vmJD9lFuh8knolKzjA5LyDY57P+OxzVIhR62ke2tV/pBkctV02A==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/publish@0.30.1':
-    resolution: {integrity: sha512-cBY0hJvcjIyuLueaFlbhyVdSC4nUZ5iqcOWL+6mh0mk5JiyIbPuO7xp/hm7O/p9w/XOdDJdL0ZRKkMCXgNmFBQ==}
+  '@releasekit/publish@0.30.2':
+    resolution: {integrity: sha512-LPWz/xy9fqICJrIw+k0kNrvKwqBs2GlK8gvAgqyxzr1L+KZ0eeUIq/eu41Ve+nSxIkracLmGAqLVoG4962Ausw==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/release@0.30.1':
-    resolution: {integrity: sha512-IDz19iMuXVxqYP2RHZ3ntGhBDlEM95KYStN0b8nwhMZH8TOCaSm9R6i0Nvz7rWKmkJpgUvIZh68uVzNKddteRA==}
+  '@releasekit/release@0.30.2':
+    resolution: {integrity: sha512-ema/XTYPiFQWbZNho5po3CQdXK/PCg5h5ivSFNIYAYjOpajVnFXOX7/G04mRPLi9dx1/nda1desnTloX0P9B2g==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@releasekit/version@0.30.1':
-    resolution: {integrity: sha512-GFhGWw6+Hk8wRq7FoLrSjwtatTBletVtiq9R//3hWxdn++5JGSQdIf+Pzp7fUH68h2y9t53lurh3Z2ci+IW6+w==}
+  '@releasekit/version@0.30.2':
+    resolution: {integrity: sha512-einZPU0g4MTzRTblKUjcFd2aj1jRH9kITGDYyRHr4RvUIIK8bnHOD4lXre5V2PqRzoE9IQLDsR++NFV+sMt7jQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -10993,7 +10993,7 @@ snapshots:
       modern-tar: 0.7.6
       yargs: 17.7.2
 
-  '@releasekit/notes@0.30.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@releasekit/notes@0.30.2(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@anthropic-ai/sdk': 0.104.2(zod@4.4.3)
       '@octokit/request-error': 7.1.0
@@ -11012,7 +11012,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  '@releasekit/publish@0.30.1':
+  '@releasekit/publish@0.30.2':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
@@ -11023,13 +11023,13 @@ snapshots:
       yaml: 2.9.0
       zod: 4.4.3
 
-  '@releasekit/release@0.30.1(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@releasekit/release@0.30.2(conventional-commits-parser@6.4.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@octokit/rest': 22.0.1
-      '@releasekit/notes': 0.30.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@releasekit/publish': 0.30.1
-      '@releasekit/version': 0.30.1(conventional-commits-parser@6.4.0)
+      '@releasekit/notes': 0.30.2(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@releasekit/publish': 0.30.2
+      '@releasekit/version': 0.30.2(conventional-commits-parser@6.4.0)
       chalk: 5.6.2
       commander: 14.0.3
       conventional-changelog-angular: 8.3.1
@@ -11044,7 +11044,7 @@ snapshots:
       - conventional-commits-parser
       - ws
 
-  '@releasekit/version@0.30.1(conventional-commits-parser@6.4.0)':
+  '@releasekit/version@0.30.2(conventional-commits-parser@6.4.0)':
     dependencies:
       '@manypkg/get-packages': 3.1.0
       '@types/minimatch': 5.1.2


### PR DESCRIPTION
## What

Bumps `@releasekit/release` `^0.30.1` → `^0.30.2` and the `goosewobbler/releasekit@v0.30.1` → `@v0.30.2` action ref in the 5 release workflow call-sites (via `pnpm update:releasekit`).

## Why

0.30.2 ships releasekit [#354](https://github.com/goosewobbler/releasekit/pull/354), which fixes the project-wide changelog **baseline floor** for monorepos that tag per package.

The previous floor sourced its baseline from `getLatestTag()` — bare-semver only (`v1.2.3`). All our tags are `${packageName}@v${version}`, so that lookup returned `''` and the floor collapsed back to full git history, flooding standing PR #400 with ~500 changelog entries. 0.30.2 derives the floor from the nearest reachable tag via `git describe --tags --abbrev=0` (prefix-agnostic), which here resolves to `wdio-dioxus-bridge@v1.0.0-next.2` — scoping the project-wide changelog to commits since the last release instead of all 494.

## Effect

Once merged, the next standing-PR regeneration (#400) should drop from ~500 entries to a handful.

## Notes

- Diff is purely the version bump: 5 workflow action refs, `package.json`, and the `@releasekit/*` entries in `pnpm-lock.yaml`. No other lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)