### PR TITLE
feat(native-mobile-core): shared mobile setup automation (chromedriver-style zero-config DX) (#378)

### DIFF
--- a/.github/workflows/_ci-smoke-autoinstall-driver.reusable.yml
+++ b/.github/workflows/_ci-smoke-autoinstall-driver.reusable.yml
@@ -1,0 +1,42 @@
+name: Mobile Setup-Automation Smoke
+# Description: Verifies @wdio/native-mobile-core's `autoInstallDriver` actually installs an
+# Appium driver. The e2e/package-test envs carry the drivers as node_modules deps (which
+# Appium loads ahead of APPIUM_HOME), so `ensureAppiumDriver` no-ops there — this job is the
+# only place the real install path runs. The script builds a clean dir with appium only +
+# a fresh APPIUM_HOME, then asserts the driver is installed (issue #378).
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  smoke:
+    name: autoInstallDriver
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: 🛠️ Setup Development Environment
+        uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: '24'
+
+      # The smoke imports the built dist of @wdio/native-mobile-core.
+      - name: 🏗️ Build @wdio/native-mobile-core
+        run: pnpm turbo run build --filter=@wdio/native-mobile-core
+        shell: bash
+
+      - name: 🔌 Smoke autoInstallDriver
+        run: pnpm run smoke:autoinstall-driver
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,16 @@ jobs:
     uses: ./.github/workflows/_ci-lint.reusable.yml
     secrets: inherit
 
+  # Verify @wdio/native-mobile-core's autoInstallDriver actually installs an Appium driver.
+  # Only runs when shared mobile infra changes (native-* packages) — the e2e drivers shadow
+  # APPIUM_HOME, so this clean-env job is the only place the real install path runs.
+  setup-automation-smoke:
+    name: Mobile Setup-Automation Smoke
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_shared_changes == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-smoke-autoinstall-driver.reusable.yml
+    secrets: inherit
+
   # Run unit tests - skip when only docs changed
   unit-matrix:
     name: Unit [${{ matrix.display-name }}]

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",
     "test:integration": "turbo run test:integration",
+    "smoke:autoinstall-driver": "node ./scripts/smoke-appium-autoinstall.ts",
     "test:package": "node ./scripts/test-package.ts",
     "test:package:electron": "pnpx cross-env DEBUG=@wdio/electron-service node ./scripts/test-package.ts --service=electron",
     "test:package:electron:browser": "pnpx cross-env DEBUG=@wdio/electron-service node ./scripts/test-package.ts --service=electron --mode=browser",

--- a/packages/flutter-service/src/launcher.ts
+++ b/packages/flutter-service/src/launcher.ts
@@ -21,4 +21,16 @@ export default class FlutterLaunchService extends MobileBaseLauncher<FlutterServ
   protected mutateCapability(cap: FlutterCapabilities, options: FlutterServiceGlobalOptions): 'android' | 'ios' {
     return prepareFlutterCapability(cap, options);
   }
+
+  // appium-flutter-driver registers as automationName `Flutter` on both platforms (it wraps
+  // uiautomator2/xcuitest internally), so a single driver covers Android and iOS.
+  protected requiredDrivers(_platform: 'android' | 'ios'): string[] {
+    return ['flutter'];
+  }
+
+  // Stamp a free per-worker Dart VM Service port so execute/mock are zero-config (the worker
+  // reads appium:dartVmServicePort as the discovery fast-path, skipping the log scrape).
+  protected portCapKey(): string | undefined {
+    return 'appium:dartVmServicePort';
+  }
 }

--- a/packages/flutter-service/test/launcher.spec.ts
+++ b/packages/flutter-service/test/launcher.spec.ts
@@ -2,16 +2,22 @@ import type { Options } from '@wdio/types';
 import { describe, expect, it, vi } from 'vitest';
 import { SevereServiceError } from 'webdriverio';
 
-// BaseLauncher (via native-mobile-core's MobileBaseLauncher) carries port/driver infra
-// Flutter doesn't use — stub it so the launcher is exercised in isolation.
-vi.mock('@wdio/native-core', () => ({ BaseLauncher: class {} }));
+// BaseLauncher (via native-mobile-core's MobileBaseLauncher) carries the PortManager the
+// Flutter launcher uses to allocate a dartVmServicePort — stub it with a minimal allocator.
+vi.mock('@wdio/native-core', () => ({
+  BaseLauncher: class {
+    private _next = 9000;
+    portManager = { allocatePort: async () => this._next++, releasePort: () => {} };
+  },
+}));
 
 import FlutterLaunchService from '../src/launcher.js';
 import type { FlutterCapabilities, FlutterServiceGlobalOptions } from '../src/types.js';
 
 const config = {} as Options.Testrunner;
+// doctor: 'off' keeps onPrepare hermetic — the iOS doctor path shells out to xcrun.
 const make = (options: FlutterServiceGlobalOptions = {}) =>
-  new FlutterLaunchService(options, {} as FlutterCapabilities, config);
+  new FlutterLaunchService({ doctor: 'off', ...options }, {} as FlutterCapabilities, config);
 const cap = (over: Record<string, unknown> = {}): FlutterCapabilities =>
   ({ platformName: 'Android', ...over }) as FlutterCapabilities;
 

--- a/packages/flutter-service/test/launcher.spec.ts
+++ b/packages/flutter-service/test/launcher.spec.ts
@@ -15,9 +15,9 @@ import FlutterLaunchService from '../src/launcher.js';
 import type { FlutterCapabilities, FlutterServiceGlobalOptions } from '../src/types.js';
 
 const config = {} as Options.Testrunner;
-// doctor: 'off' keeps onPrepare hermetic — the iOS doctor path shells out to xcrun.
+// doctor: false keeps onPrepare hermetic — the iOS doctor path shells out to xcrun.
 const make = (options: FlutterServiceGlobalOptions = {}) =>
-  new FlutterLaunchService({ doctor: 'off', ...options }, {} as FlutterCapabilities, config);
+  new FlutterLaunchService({ doctor: false, ...options }, {} as FlutterCapabilities, config);
 const cap = (over: Record<string, unknown> = {}): FlutterCapabilities =>
   ({ platformName: 'Android', ...over }) as FlutterCapabilities;
 

--- a/packages/native-mobile-core/src/appiumDriverManager.ts
+++ b/packages/native-mobile-core/src/appiumDriverManager.ts
@@ -1,0 +1,189 @@
+// Chromedriver-style Appium driver auto-management.
+//
+// `@wdio/electron-service` resolves a chromedriver matched to the browser with zero user
+// config; the mobile analog is ensuring the Appium driver a service needs is installed,
+// at a version known-good for the running Appium *server* major (see `versionMatrix.ts`).
+//
+// Opt-in (`autoInstallDriver`, default off — CI manages drivers explicitly and may lack
+// network/permissions) and idempotent (an already-installed driver is a no-op). Modeled on
+// `@wdio/tauri-service`'s `driverManager.ts` (`ensureTauriDriver`): PATH/node_modules
+// detection, `Result<>` returns, `spawn` for the install.
+
+import { execFileSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createLogger, Err, Ok, type Result } from '@wdio/native-utils';
+import { type DriverSpec, driverSpecFor, supportedAppiumMajors } from './versionMatrix.js';
+
+const log = createLogger('native-mobile-core', 'launcher');
+
+export interface AppiumDriverInstallSuccess {
+  name: string;
+  method: 'found' | 'installed' | 'skipped';
+}
+
+export type AppiumDriverInstallResult = Result<AppiumDriverInstallSuccess, Error>;
+
+export interface EnsureAppiumDriverOptions {
+  /** Opt-in gate — when falsy, ensure is a no-op (`'skipped'`). Default off. */
+  autoInstallDriver?: boolean;
+  /** Escape hatch: override the matrix npm source (e.g. a published fork). */
+  source?: string;
+}
+
+const isWindows = process.platform === 'win32';
+
+/**
+ * Resolve the `appium` CLI. Prefer the project-local `node_modules/.bin/appium` (the
+ * `@wdio/appium-service` dependency), falling back to PATH — Appium loads `node_modules`
+ * drivers ahead of `APPIUM_HOME`, so the local binary is also the one that sees them.
+ */
+export function resolveAppiumBin(): string {
+  const localBins = isWindows
+    ? [join(process.cwd(), 'node_modules', '.bin', 'appium.cmd'), join(process.cwd(), 'node_modules', '.bin', 'appium.exe')]
+    : [join(process.cwd(), 'node_modules', '.bin', 'appium')];
+  for (const bin of localBins) {
+    if (existsSync(bin)) {
+      return bin;
+    }
+  }
+  return 'appium';
+}
+
+/** Parse `appium --version` output (a bare semver line) into its major. */
+export function getAppiumVersion(): { raw: string; major: number } | undefined {
+  try {
+    const raw = execFileSync(resolveAppiumBin(), ['--version'], { encoding: 'utf8', stdio: 'pipe' }).trim();
+    const match = raw.match(/(\d+)\.\d+\.\d+/);
+    if (!match) {
+      return undefined;
+    }
+    return { raw: match[0], major: Number.parseInt(match[1], 10) };
+  } catch {
+    return undefined;
+  }
+}
+
+export function isAppiumAvailable(): boolean {
+  return getAppiumVersion() !== undefined;
+}
+
+/** Extract installed driver short-names from `appium driver list --installed --json` output. */
+export function parseInstalledDrivers(json: string): string[] {
+  // `--json` prints a single JSON object keyed by driver short-name; tolerate leading log noise.
+  const start = json.indexOf('{');
+  if (start === -1) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(json.slice(start)) as Record<string, unknown>;
+    return Object.keys(parsed);
+  } catch {
+    return [];
+  }
+}
+
+let installedCache: string[] | undefined;
+
+/** Installed Appium drivers (short-names), cached per-process — the idempotency check. */
+export function listInstalledDrivers(): string[] {
+  if (installedCache) {
+    return installedCache;
+  }
+  try {
+    const out = execFileSync(resolveAppiumBin(), ['driver', 'list', '--installed', '--json'], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    installedCache = parseInstalledDrivers(out);
+  } catch (error) {
+    log.debug(`Could not list installed Appium drivers: ${(error as Error).message}`);
+    installedCache = [];
+  }
+  return installedCache;
+}
+
+/** Clear the installed-driver cache (after an install, or for tests). */
+export function resetInstalledCache(): void {
+  installedCache = undefined;
+}
+
+/** Install a driver via `appium driver install --source=npm <source>@<version>`. */
+export function installAppiumDriver(spec: DriverSpec): Promise<void> {
+  log.info(`Installing Appium driver '${spec.name}' (${spec.source}@${spec.version})...`);
+  return new Promise((resolve, reject) => {
+    const proc = spawn(resolveAppiumBin(), ['driver', 'install', '--source=npm', `${spec.source}@${spec.version}`], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+    let stderr = '';
+    proc.stdout?.on('data', (d: Buffer) => log.debug(d.toString().trim()));
+    proc.stderr?.on('data', (d: Buffer) => {
+      stderr += d.toString();
+      log.debug(d.toString().trim());
+    });
+    proc.on('close', (code) => {
+      if (code === 0) {
+        log.info(`Installed Appium driver '${spec.name}'.`);
+        resolve();
+      } else {
+        reject(new Error(`appium driver install ${spec.name} failed with code ${code}: ${stderr.trim()}`));
+      }
+    });
+    proc.on('error', (error) => reject(new Error(`Failed to spawn appium driver install: ${error.message}`)));
+  });
+}
+
+/**
+ * Ensure the Appium driver `name` is installed at a version known-good for the running
+ * Appium server major. Opt-in via `autoInstallDriver`; idempotent.
+ *
+ *   1. `autoInstallDriver` off            → Ok({ method: 'skipped' })
+ *   2. `appium` not resolvable            → Err (clear message)
+ *   3. driver already installed           → Ok({ method: 'found' })
+ *   4. no matrix entry for (name, major)  → Err (update the matrix)
+ *   5. install                            → Ok({ method: 'installed' }) | Err
+ */
+export async function ensureAppiumDriver(
+  name: string,
+  options: EnsureAppiumDriverOptions = {},
+): Promise<AppiumDriverInstallResult> {
+  if (!options.autoInstallDriver) {
+    return Ok({ name, method: 'skipped' });
+  }
+
+  const appium = getAppiumVersion();
+  if (!appium) {
+    return Err(
+      new Error(
+        `Cannot auto-install the '${name}' Appium driver: the 'appium' CLI is not resolvable. ` +
+          'Add @wdio/appium-service (which brings appium) to your project, or install drivers manually.',
+      ),
+    );
+  }
+
+  if (listInstalledDrivers().includes(name)) {
+    log.debug(`Appium driver '${name}' already installed.`);
+    return Ok({ name, method: 'found' });
+  }
+
+  const spec = driverSpecFor(name, appium.major);
+  if (!spec) {
+    return Err(
+      new Error(
+        `No known-good version for Appium driver '${name}' on Appium ${appium.raw} (major ${appium.major}). ` +
+          `The version matrix covers Appium major(s): ${supportedAppiumMajors().join(', ')}. ` +
+          'Install the driver manually or update APPIUM_MATRIX.',
+      ),
+    );
+  }
+
+  const effectiveSpec = options.source ? { ...spec, source: options.source } : spec;
+  try {
+    await installAppiumDriver(effectiveSpec);
+    resetInstalledCache();
+    return Ok({ name, method: 'installed' });
+  } catch (error) {
+    return Err(error instanceof Error ? error : new Error(String(error)));
+  }
+}

--- a/packages/native-mobile-core/src/appiumDriverManager.ts
+++ b/packages/native-mobile-core/src/appiumDriverManager.ts
@@ -40,7 +40,10 @@ const isWindows = process.platform === 'win32';
  */
 export function resolveAppiumBin(): string {
   const localBins = isWindows
-    ? [join(process.cwd(), 'node_modules', '.bin', 'appium.cmd'), join(process.cwd(), 'node_modules', '.bin', 'appium.exe')]
+    ? [
+        join(process.cwd(), 'node_modules', '.bin', 'appium.cmd'),
+        join(process.cwd(), 'node_modules', '.bin', 'appium.exe'),
+      ]
     : [join(process.cwd(), 'node_modules', '.bin', 'appium')];
   for (const bin of localBins) {
     if (existsSync(bin)) {

--- a/packages/native-mobile-core/src/appiumDriverManager.ts
+++ b/packages/native-mobile-core/src/appiumDriverManager.ts
@@ -131,12 +131,15 @@ export function installAppiumDriver(spec: DriverSpec, timeoutMs: number = DEFAUL
       stderr += d.toString();
       log.debug(d.toString().trim());
     });
-    proc.on('close', (code) => {
+    proc.on('close', (code, signal) => {
       if (code === 0) {
         log.info(`Installed Appium driver '${spec.name}'.`);
         resolve();
       } else {
-        reject(new Error(`appium driver install ${spec.name} failed with code ${code}: ${stderr.trim()}`));
+        // The timeout above kills the spawn by signal, leaving code null — report the signal
+        // so the failure reads as a timeout-kill rather than the opaque "failed with code null".
+        const reason = signal ? `signal ${signal}` : `code ${code}`;
+        reject(new Error(`appium driver install ${spec.name} failed with ${reason}: ${stderr.trim()}`));
       }
     });
     proc.on('error', (error) => reject(new Error(`Failed to spawn appium driver install: ${error.message}`)));

--- a/packages/native-mobile-core/src/appiumDriverManager.ts
+++ b/packages/native-mobile-core/src/appiumDriverManager.ts
@@ -29,7 +29,11 @@ export interface EnsureAppiumDriverOptions {
   autoInstallDriver?: boolean;
   /** Escape hatch: override the matrix npm source (e.g. a published fork). */
   source?: string;
+  /** Hard cap on the `appium driver install` spawn — killed past this so onPrepare can't hang. Default 5 min. */
+  timeoutMs?: number;
 }
+
+const DEFAULT_INSTALL_TIMEOUT_MS = 300000;
 
 const isWindows = process.platform === 'win32';
 
@@ -112,12 +116,14 @@ export function resetInstalledCache(): void {
 }
 
 /** Install a driver via `appium driver install --source=npm <source>@<version>`. */
-export function installAppiumDriver(spec: DriverSpec): Promise<void> {
+export function installAppiumDriver(spec: DriverSpec, timeoutMs: number = DEFAULT_INSTALL_TIMEOUT_MS): Promise<void> {
   log.info(`Installing Appium driver '${spec.name}' (${spec.source}@${spec.version})...`);
   return new Promise((resolve, reject) => {
     const proc = spawn(resolveAppiumBin(), ['driver', 'install', '--source=npm', `${spec.source}@${spec.version}`], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: process.env,
+      // Hard cap: a slow registry / TLS stall would otherwise block onPrepare forever.
+      timeout: timeoutMs,
     });
     let stderr = '';
     proc.stdout?.on('data', (d: Buffer) => log.debug(d.toString().trim()));
@@ -183,7 +189,7 @@ export async function ensureAppiumDriver(
 
   const effectiveSpec = options.source ? { ...spec, source: options.source } : spec;
   try {
-    await installAppiumDriver(effectiveSpec);
+    await installAppiumDriver(effectiveSpec, options.timeoutMs);
     resetInstalledCache();
     return Ok({ name, method: 'installed' });
   } catch (error) {

--- a/packages/native-mobile-core/src/deviceManager.ts
+++ b/packages/native-mobile-core/src/deviceManager.ts
@@ -86,3 +86,35 @@ export class DeviceManager {
     }
   }
 }
+
+/**
+ * Apply robustness + iOS-launch cap defaults, **only when the user hasn't set them** (an
+ * explicit cap always wins — same contract as `applyToCapability`). The iOS timeout/headless
+ * values mirror the proven e2e config: without them a real user hits the exact cryptic
+ * appium-xcuitest timeout this exists to kill.
+ *
+ * Deliberately omits `appium:noReset`: its value trades app-state isolation for speed in a
+ * way that should be the user's explicit choice, and the repo's e2e suite doesn't rely on it.
+ */
+export function applyBootCapDefaults(capability: Record<string, unknown>, platform: 'android' | 'ios'): void {
+  const setIfUnset = (key: string, value: unknown) => {
+    if (capability[key] === undefined) {
+      capability[key] = value;
+    }
+  };
+
+  if (platform === 'android') {
+    // Auto-dismiss runtime-permission dialogs that otherwise block the UI tree.
+    setIfUnset('appium:autoGrantPermissions', true);
+    return;
+  }
+
+  // iOS: generous ceilings for a cold WDA build / slow sim boot; tighten by pinning a
+  // prebuilt WDA (derivedDataPath + usePrebuiltWDA) yourself. isHeadless only in CI —
+  // a local run wants the visible Simulator window.
+  setIfUnset('appium:wdaLaunchTimeout', 720000);
+  setIfUnset('appium:simulatorStartupTimeout', 240000);
+  if (process.env.CI) {
+    setIfUnset('appium:isHeadless', true);
+  }
+}

--- a/packages/native-mobile-core/src/doctor.ts
+++ b/packages/native-mobile-core/src/doctor.ts
@@ -17,11 +17,14 @@ import { SevereServiceError } from './errors.js';
 /** A single preflight check. May return one or many results, sync or async. */
 export type DoctorCheck = () => DiagnosticResult | DiagnosticResult[] | Promise<DiagnosticResult | DiagnosticResult[]>;
 
-/** Severity assigned to a failing check. `'warn'` logs; `'error'` can abort under `'strict'`. */
+/** Severity assigned to a failing check. `'warn'` logs; `'error'` can abort under strict mode. */
 export type Severity = 'warn' | 'error';
 
-/** `'off'` skips the doctor entirely, `'warn'` logs only, `'strict'` aborts on any error. */
-export type DoctorMode = 'off' | 'warn' | 'strict';
+/**
+ * User-facing doctor config: `false` skips it; `true` (or omitted) runs the checks and logs
+ * warnings; `{ strict: true }` aborts the run (`SevereServiceError`) on any error-level check.
+ */
+export type DoctorConfig = boolean | { strict?: boolean };
 
 const isWindows = process.platform === 'win32';
 
@@ -118,9 +121,20 @@ export interface DoctorOptions {
   failFast?: boolean;
 }
 
-/** Translate a {@link DoctorMode} option into the `failFast` flag (`'off'` → run no checks). */
-export function failFastForMode(mode: DoctorMode | undefined): boolean {
-  return mode === 'strict';
+/**
+ * Resolve a {@link DoctorConfig} into whether to run the checks and whether to fail-fast.
+ *   - `false`            → don't run
+ *   - `true` / undefined → run, warn-only (default)
+ *   - `{ strict }`       → run; abort on an error-level finding when `strict` is true
+ */
+export function resolveDoctor(config: DoctorConfig | undefined): { run: boolean; failFast: boolean } {
+  if (config === false) {
+    return { run: false, failFast: false };
+  }
+  if (config === true || config === undefined) {
+    return { run: true, failFast: false };
+  }
+  return { run: true, failFast: config.strict === true };
 }
 
 /**

--- a/packages/native-mobile-core/src/doctor.ts
+++ b/packages/native-mobile-core/src/doctor.ts
@@ -26,7 +26,10 @@ export type DoctorMode = 'off' | 'warn' | 'strict';
 const isWindows = process.platform === 'win32';
 
 /** Check that `cmd` resolves on PATH (`which`/`where`). */
-export function checkCommandOnPath(cmd: string, opts: { category?: string; severity?: Severity; hint?: string } = {}): DoctorCheck {
+export function checkCommandOnPath(
+  cmd: string,
+  opts: { category?: string; severity?: Severity; hint?: string } = {},
+): DoctorCheck {
   const category = opts.category ?? cmd;
   const severity = opts.severity ?? 'error';
   return () => {

--- a/packages/native-mobile-core/src/doctor.ts
+++ b/packages/native-mobile-core/src/doctor.ts
@@ -1,0 +1,152 @@
+// Preflight "doctor" framework for mobile services (mirrors appium-doctor).
+//
+// The heavy toolchains a mobile run needs (Android SDK/adb, JDK, Flutter SDK, Xcode) are
+// multi-GB and can't be fetched on demand, and the app is the user's own build — so we
+// validate in `onPrepare` and fail fast with an actionable message instead of leaving the
+// user with a cryptic Appium timeout. This module owns the framework (check type + runner +
+// fail-fast policy); each service plugs in its own checks.
+//
+// Builds on `@wdio/native-utils`' `DiagnosticResult` / `formatDiagnosticResults` (the same
+// primitives `@wdio/electron-service` composes) rather than a new result shape.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { type DiagnosticResult, formatDiagnosticResults } from '@wdio/native-utils';
+import { SevereServiceError } from './errors.js';
+
+/** A single preflight check. May return one or many results, sync or async. */
+export type DoctorCheck = () => DiagnosticResult | DiagnosticResult[] | Promise<DiagnosticResult | DiagnosticResult[]>;
+
+/** Severity assigned to a failing check. `'warn'` logs; `'error'` can abort under `'strict'`. */
+export type Severity = 'warn' | 'error';
+
+/** `'off'` skips the doctor entirely, `'warn'` logs only, `'strict'` aborts on any error. */
+export type DoctorMode = 'off' | 'warn' | 'strict';
+
+const isWindows = process.platform === 'win32';
+
+/** Check that `cmd` resolves on PATH (`which`/`where`). */
+export function checkCommandOnPath(cmd: string, opts: { category?: string; severity?: Severity; hint?: string } = {}): DoctorCheck {
+  const category = opts.category ?? cmd;
+  const severity = opts.severity ?? 'error';
+  return () => {
+    try {
+      const out = execFileSync(isWindows ? 'where' : 'which', [cmd], { encoding: 'utf8', stdio: 'pipe' }).trim();
+      const path = out.split('\n')[0]?.trim();
+      if (path) {
+        return { category, status: 'ok', message: path };
+      }
+    } catch {
+      // fall through to the failure result
+    }
+    return {
+      category,
+      status: severity,
+      message: `'${cmd}' not found on PATH`,
+      details: opts.hint,
+    };
+  };
+}
+
+/** Check that a filesystem path exists (e.g. the app binary). */
+export function checkPathExists(path: string, category: string, severity: Severity = 'error'): DoctorCheck {
+  return () =>
+    existsSync(path)
+      ? { category, status: 'ok', message: path }
+      : { category, status: severity, message: `does not exist: ${path}` };
+}
+
+/**
+ * Check that an app build is debug/profile (not release) using a service-supplied detector.
+ * Release builds don't expose the JS/Dart realm (`execute`/`mock`), so this defaults to
+ * `'warn'` — the detector is heuristic and false positives shouldn't abort a run.
+ */
+export function checkBuildIsDebug(
+  appPath: string,
+  detector: (appPath: string) => 'debug' | 'profile' | 'release' | 'unknown',
+  opts: { category?: string; severity?: Severity } = {},
+): DoctorCheck {
+  const category = opts.category ?? 'App build';
+  return () => {
+    const kind = detector(appPath);
+    if (kind === 'debug' || kind === 'profile') {
+      return { category, status: 'ok', message: `${kind} build` };
+    }
+    if (kind === 'release') {
+      return {
+        category,
+        status: opts.severity ?? 'warn',
+        message: 'release build',
+        details: 'execute/mock need a debug or profile build that exposes the JS/Dart realm.',
+      };
+    }
+    return { category, status: 'warn', message: 'could not determine build type' };
+  };
+}
+
+/** Check that the Appium server service is configured in `services` (Tier 2.6). */
+export function checkAppiumServiceConfigured(services: unknown): DoctorCheck {
+  return () => {
+    const names = new Set<string>();
+    if (Array.isArray(services)) {
+      for (const entry of services) {
+        const name = Array.isArray(entry) ? entry[0] : entry;
+        if (typeof name === 'string') {
+          names.add(name);
+        }
+      }
+    }
+    const present = names.has('appium') || names.has('@wdio/appium-service');
+    return present
+      ? { category: 'Appium server', status: 'ok', message: '@wdio/appium-service configured' }
+      : {
+          category: 'Appium server',
+          status: 'warn',
+          message: '@wdio/appium-service not found in services',
+          details: "Add 'appium' to your wdio.conf services unless you run a standalone/remote Appium server.",
+        };
+  };
+}
+
+export interface DoctorOptions {
+  /** Logger namespace (the consuming service). */
+  serviceName: string;
+  /** When true, any `error`-status result throws `SevereServiceError`. Default false. */
+  failFast?: boolean;
+}
+
+/** Translate a {@link DoctorMode} option into the `failFast` flag (`'off'` → run no checks). */
+export function failFastForMode(mode: DoctorMode | undefined): boolean {
+  return mode === 'strict';
+}
+
+/**
+ * Run all checks, log via `formatDiagnosticResults`, and — only when `failFast` — throw
+ * `SevereServiceError` aggregating every `error`-status result. A thrown/rejected check is
+ * itself recorded as an `error` result (so one bad check can't crash the whole preflight).
+ */
+export async function runDoctor(checks: DoctorCheck[], opts: DoctorOptions): Promise<DiagnosticResult[]> {
+  const results: DiagnosticResult[] = [];
+  for (const check of checks) {
+    try {
+      const r = await check();
+      results.push(...(Array.isArray(r) ? r : [r]));
+    } catch (error) {
+      results.push({ category: 'Doctor', status: 'error', message: `check threw: ${(error as Error).message}` });
+    }
+  }
+
+  formatDiagnosticResults(results, opts.serviceName);
+
+  if (opts.failFast) {
+    const errors = results.filter((r) => r.status === 'error');
+    if (errors.length > 0) {
+      throw new SevereServiceError(
+        `${opts.serviceName} preflight failed:\n` +
+          errors.map((e) => `  - ${e.category}: ${e.message}${e.details ? ` (${e.details})` : ''}`).join('\n'),
+      );
+    }
+  }
+
+  return results;
+}

--- a/packages/native-mobile-core/src/index.ts
+++ b/packages/native-mobile-core/src/index.ts
@@ -14,6 +14,7 @@ export {
   installAppiumDriver,
   isAppiumAvailable,
   listInstalledDrivers,
+  resetInstalledCache,
 } from './appiumDriverManager.js';
 export type { MobileCapabilityConfig, MobileCapabilityOptions, MutableMobileCapability } from './capabilities.js';
 export { prepareMobileCapability } from './capabilities.js';

--- a/packages/native-mobile-core/src/index.ts
+++ b/packages/native-mobile-core/src/index.ts
@@ -22,13 +22,13 @@ export type { LogEntry } from './deviceLogs.js';
 export { collectDeviceLogs, forwardDeviceLogs } from './deviceLogs.js';
 export type { DeviceDescriptor } from './deviceManager.js';
 export { applyBootCapDefaults, DeviceManager } from './deviceManager.js';
-export type { DoctorCheck, DoctorMode, DoctorOptions, Severity } from './doctor.js';
+export type { DoctorCheck, DoctorConfig, DoctorOptions, Severity } from './doctor.js';
 export {
   checkAppiumServiceConfigured,
   checkBuildIsDebug,
   checkCommandOnPath,
   checkPathExists,
-  failFastForMode,
+  resolveDoctor,
   runDoctor,
 } from './doctor.js';
 export { SevereServiceError, unsupportedPlatform } from './errors.js';

--- a/packages/native-mobile-core/src/index.ts
+++ b/packages/native-mobile-core/src/index.ts
@@ -20,7 +20,7 @@ export { prepareMobileCapability } from './capabilities.js';
 export type { LogEntry } from './deviceLogs.js';
 export { collectDeviceLogs, forwardDeviceLogs } from './deviceLogs.js';
 export type { DeviceDescriptor } from './deviceManager.js';
-export { DeviceManager } from './deviceManager.js';
+export { applyBootCapDefaults, DeviceManager } from './deviceManager.js';
 export type { DoctorCheck, DoctorMode, DoctorOptions, Severity } from './doctor.js';
 export {
   checkAppiumServiceConfigured,
@@ -31,6 +31,8 @@ export {
   runDoctor,
 } from './doctor.js';
 export { SevereServiceError, unsupportedPlatform } from './errors.js';
+export type { PrebuildWdaOptions } from './iosSetup.js';
+export { pickIosUdid, prebuildWda, resolveIosUdid, resolveWdaProject, warmUpXcodeToolchain } from './iosSetup.js';
 export type { MobileLauncherOptions } from './launcher.js';
 export { flattenCaps, MobileBaseLauncher } from './launcher.js';
 export { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';

--- a/packages/native-mobile-core/src/index.ts
+++ b/packages/native-mobile-core/src/index.ts
@@ -3,12 +3,33 @@
 // Flutter's Dart VM Service) stays in each service package; everything here is the
 // framework-agnostic Appium layer.
 
+export type {
+  AppiumDriverInstallResult,
+  AppiumDriverInstallSuccess,
+  EnsureAppiumDriverOptions,
+} from './appiumDriverManager.js';
+export {
+  ensureAppiumDriver,
+  getAppiumVersion,
+  installAppiumDriver,
+  isAppiumAvailable,
+  listInstalledDrivers,
+} from './appiumDriverManager.js';
 export type { MobileCapabilityConfig, MobileCapabilityOptions, MutableMobileCapability } from './capabilities.js';
 export { prepareMobileCapability } from './capabilities.js';
 export type { LogEntry } from './deviceLogs.js';
 export { collectDeviceLogs, forwardDeviceLogs } from './deviceLogs.js';
 export type { DeviceDescriptor } from './deviceManager.js';
 export { DeviceManager } from './deviceManager.js';
+export type { DoctorCheck, DoctorMode, DoctorOptions, Severity } from './doctor.js';
+export {
+  checkAppiumServiceConfigured,
+  checkBuildIsDebug,
+  checkCommandOnPath,
+  checkPathExists,
+  failFastForMode,
+  runDoctor,
+} from './doctor.js';
 export { SevereServiceError, unsupportedPlatform } from './errors.js';
 export type { MobileLauncherOptions } from './launcher.js';
 export { flattenCaps, MobileBaseLauncher } from './launcher.js';
@@ -18,3 +39,5 @@ export { createMobileSession } from './session.js';
 export { listContexts, switchContext } from './switchContext.js';
 export type { DeeplinkCapKeys } from './triggerDeeplink.js';
 export { triggerDeeplink } from './triggerDeeplink.js';
+export type { AppiumCompat, DriverSpec } from './versionMatrix.js';
+export { APPIUM_MATRIX, driverSpecFor, supportedAppiumMajors } from './versionMatrix.js';

--- a/packages/native-mobile-core/src/iosSetup.ts
+++ b/packages/native-mobile-core/src/iosSetup.ts
@@ -14,7 +14,7 @@ import { createLogger, type DiagnosticResult, Err, Ok, type Result } from '@wdio
 
 const log = createLogger('native-mobile-core', 'launcher');
 
-const isMac = process.platform === 'darwin';
+const isMac = () => process.platform === 'darwin';
 
 interface SimctlDevice {
   udid: string;
@@ -63,7 +63,7 @@ export function pickIosUdid(simctlJson: string, deviceName: string, platformVers
 
 /** Resolve the exact simulator UDID for a device name (macOS only). */
 export function resolveIosUdid(deviceName: string, platformVersion?: string): string | undefined {
-  if (!isMac) {
+  if (!isMac()) {
     return undefined;
   }
   try {
@@ -84,7 +84,7 @@ export function resolveIosUdid(deviceName: string, platformVersion?: string): st
  * toolchain as a clear diagnostic instead of appium-xcuitest's internal SDK-probe timeout.
  */
 export function warmUpXcodeToolchain(): DiagnosticResult[] {
-  if (!isMac) {
+  if (!isMac()) {
     return [];
   }
   const results: DiagnosticResult[] = [];
@@ -143,7 +143,7 @@ export interface PrebuildWdaOptions {
  * normal per-session build.
  */
 export async function prebuildWda(opts: PrebuildWdaOptions): Promise<Result<{ derivedDataPath: string }, Error>> {
-  if (!isMac) {
+  if (!isMac()) {
     return Err(new Error('WDA pre-build is macOS-only'));
   }
   const project = resolveWdaProject();

--- a/packages/native-mobile-core/src/iosSetup.ts
+++ b/packages/native-mobile-core/src/iosSetup.ts
@@ -117,23 +117,40 @@ export function warmUpXcodeToolchain(): DiagnosticResult[] {
   return results;
 }
 
-/** Locate WebDriverAgent.xcodeproj shipped inside appium-xcuitest-driver. */
+/** Locate WebDriverAgent.xcodeproj shipped with appium-xcuitest-driver. */
 export function resolveWdaProject(): string | undefined {
+  // Resolve from the project root (where the driver is installed), not this package's tree.
+  const req = createRequire(join(process.cwd(), 'noop.js'));
+  // Hoisted (npm / Yarn / pnpm-with-hoisting): appium-webdriveragent is lifted to a
+  // node_modules root, so resolve it directly first.
   try {
-    // Resolve from the project root (where the driver is installed), not this package's tree.
-    const req = createRequire(join(process.cwd(), 'noop.js'));
+    const wdaPkg = req.resolve('appium-webdriveragent/package.json');
+    const proj = join(dirname(wdaPkg), 'WebDriverAgent.xcodeproj');
+    if (existsSync(proj)) {
+      return proj;
+    }
+  } catch {
+    // fall through to the nested layout
+  }
+  // Nested (pnpm isolated): under the xcuitest driver's own node_modules.
+  try {
     const pkg = req.resolve('appium-xcuitest-driver/package.json');
     const proj = join(dirname(pkg), 'node_modules', 'appium-webdriveragent', 'WebDriverAgent.xcodeproj');
-    return existsSync(proj) ? proj : undefined;
+    if (existsSync(proj)) {
+      return proj;
+    }
   } catch {
-    return undefined;
+    // not found
   }
+  return undefined;
 }
 
 export interface PrebuildWdaOptions {
   /** DerivedData directory to cache the build into (reused via usePrebuiltWDA). */
   derivedDataPath: string;
   isHeadless?: boolean;
+  /** Hard ceiling on the xcodebuild — killed past this so onPrepare can't hang. Default 15 min. */
+  timeoutMs?: number;
 }
 
 /**
@@ -168,7 +185,9 @@ export async function prebuildWda(opts: PrebuildWdaOptions): Promise<Result<{ de
         opts.derivedDataPath,
         'CODE_SIGNING_ALLOWED=NO',
       ],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
+      // timeout kills xcodebuild past the ceiling (a cold toolchain / stale sim lock / a
+      // permission dialog can otherwise block onPrepare indefinitely).
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: opts.timeoutMs ?? 900000 },
     );
     proc.stdout?.on('data', (d: Buffer) => log.debug(d.toString().trim()));
     proc.stderr?.on('data', (d: Buffer) => log.debug(d.toString().trim()));

--- a/packages/native-mobile-core/src/iosSetup.ts
+++ b/packages/native-mobile-core/src/iosSetup.ts
@@ -1,0 +1,175 @@
+// iOS shared launch path — used by both RN-iOS and Flutter-iOS (both drive the XCUITest
+// native shell). Smooths the exact cold-toolchain failure modes that otherwise surface as a
+// cryptic Appium timeout: ambiguous simulator UDID, a cold Xcode SDK probe, and a
+// per-session WebDriverAgent build.
+//
+// All macOS-only; every helper is a no-op / empty result off darwin so it's safe to call
+// unconditionally from the shared launcher.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { createLogger, type DiagnosticResult, Err, Ok, type Result } from '@wdio/native-utils';
+
+const log = createLogger('native-mobile-core', 'launcher');
+
+const isMac = process.platform === 'darwin';
+
+interface SimctlDevice {
+  udid: string;
+  name: string;
+  state?: string;
+  isAvailable?: boolean;
+}
+
+/** Numeric sort key for a simctl runtime identifier, e.g. `…SimRuntime.iOS-17-4` → 17.4. */
+function runtimeVersion(runtimeId: string): number {
+  const m = runtimeId.match(/iOS-(\d+)(?:-(\d+))?/i);
+  if (!m) {
+    return 0;
+  }
+  return Number.parseInt(m[1], 10) + Number.parseInt(m[2] ?? '0', 10) / 1000;
+}
+
+/**
+ * Pick the exact UDID for `deviceName` from `xcrun simctl list devices --json` output,
+ * preferring the newest runtime (and a matching `platformVersion` when given). Avoids the
+ * duplicate-device-name ambiguity where Appium boots a different instance than expected.
+ * Exported for testing.
+ */
+export function pickIosUdid(simctlJson: string, deviceName: string, platformVersion?: string): string | undefined {
+  let parsed: { devices?: Record<string, SimctlDevice[]> };
+  try {
+    parsed = JSON.parse(simctlJson);
+  } catch {
+    return undefined;
+  }
+  const byRuntime = parsed.devices ?? {};
+  const runtimes = Object.keys(byRuntime).sort((a, b) => runtimeVersion(b) - runtimeVersion(a));
+  for (const runtime of runtimes) {
+    if (platformVersion && !runtime.includes(`iOS-${platformVersion.replace(/\./g, '-')}`)) {
+      continue;
+    }
+    const match = byRuntime[runtime].find(
+      (d) => d.name === deviceName && d.isAvailable !== false,
+    );
+    if (match) {
+      return match.udid;
+    }
+  }
+  return undefined;
+}
+
+/** Resolve the exact simulator UDID for a device name (macOS only). */
+export function resolveIosUdid(deviceName: string, platformVersion?: string): string | undefined {
+  if (!isMac) {
+    return undefined;
+  }
+  try {
+    const json = execFileSync('xcrun', ['simctl', 'list', 'devices', 'available', '--json'], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 30000,
+    });
+    return pickIosUdid(json, deviceName, platformVersion);
+  } catch (error) {
+    log.debug(`resolveIosUdid failed: ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+/**
+ * Pre-resolve the Xcode SDK and simulator list before the session, surfacing a broken/cold
+ * toolchain as a clear diagnostic instead of appium-xcuitest's internal SDK-probe timeout.
+ */
+export function warmUpXcodeToolchain(): DiagnosticResult[] {
+  if (!isMac) {
+    return [];
+  }
+  const results: DiagnosticResult[] = [];
+  try {
+    const sdk = execFileSync('xcrun', ['--sdk', 'iphonesimulator', '--show-sdk-version'], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 30000,
+    }).trim();
+    results.push({ category: 'iOS SDK', status: 'ok', message: `iphonesimulator ${sdk}` });
+  } catch (error) {
+    results.push({
+      category: 'iOS SDK',
+      status: 'error',
+      message: 'xcrun SDK probe failed',
+      details: `Install Xcode + command-line tools (xcode-select --install). ${(error as Error).message}`,
+    });
+  }
+  try {
+    execFileSync('xcrun', ['simctl', 'list', 'devices'], { stdio: 'ignore', timeout: 30000 });
+    results.push({ category: 'iOS Simulators', status: 'ok', message: 'simctl reachable' });
+  } catch (error) {
+    results.push({
+      category: 'iOS Simulators',
+      status: 'warn',
+      message: 'simctl list failed',
+      details: (error as Error).message,
+    });
+  }
+  return results;
+}
+
+/** Locate WebDriverAgent.xcodeproj shipped inside appium-xcuitest-driver. */
+export function resolveWdaProject(): string | undefined {
+  try {
+    // Resolve from the project root (where the driver is installed), not this package's tree.
+    const req = createRequire(join(process.cwd(), 'noop.js'));
+    const pkg = req.resolve('appium-xcuitest-driver/package.json');
+    const proj = join(dirname(pkg), 'node_modules', 'appium-webdriveragent', 'WebDriverAgent.xcodeproj');
+    return existsSync(proj) ? proj : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface PrebuildWdaOptions {
+  /** DerivedData directory to cache the build into (reused via usePrebuiltWDA). */
+  derivedDataPath: string;
+  isHeadless?: boolean;
+}
+
+/**
+ * Pre-build WebDriverAgent (`xcodebuild build-for-testing`) outside the session so the first
+ * session just launches a cached WDA — no multi-minute per-session compile, no socket timeout.
+ * Best-effort, macOS-only, opt-in: returns `Err` (never throws) so a failure degrades to the
+ * normal per-session build.
+ */
+export async function prebuildWda(opts: PrebuildWdaOptions): Promise<Result<{ derivedDataPath: string }, Error>> {
+  if (!isMac) {
+    return Err(new Error('WDA pre-build is macOS-only'));
+  }
+  const project = resolveWdaProject();
+  if (!project) {
+    return Err(new Error('Could not locate appium-webdriveragent (is appium-xcuitest-driver installed?)'));
+  }
+  log.info('Pre-building WebDriverAgent (one-time; cached in derivedDataPath)...');
+  try {
+    execFileSync(
+      'xcodebuild',
+      [
+        'build-for-testing',
+        '-project',
+        project,
+        '-scheme',
+        'WebDriverAgentRunner',
+        '-destination',
+        'generic/platform=iOS Simulator',
+        '-derivedDataPath',
+        opts.derivedDataPath,
+        'CODE_SIGNING_ALLOWED=NO',
+      ],
+      { stdio: 'pipe', timeout: 900000 },
+    );
+    return Ok({ derivedDataPath: opts.derivedDataPath });
+  } catch (error) {
+    return Err(error instanceof Error ? error : new Error(String(error)));
+  }
+}

--- a/packages/native-mobile-core/src/iosSetup.ts
+++ b/packages/native-mobile-core/src/iosSetup.ts
@@ -6,7 +6,7 @@
 // All macOS-only; every helper is a no-op / empty result off darwin so it's safe to call
 // unconditionally from the shared launcher.
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
@@ -45,15 +45,15 @@ export function pickIosUdid(simctlJson: string, deviceName: string, platformVers
   } catch {
     return undefined;
   }
+  // A JS config can set platformVersion as a number (e.g. 17.4), so coerce before string ops.
+  const pv = platformVersion === undefined ? undefined : String(platformVersion);
   const byRuntime = parsed.devices ?? {};
   const runtimes = Object.keys(byRuntime).sort((a, b) => runtimeVersion(b) - runtimeVersion(a));
   for (const runtime of runtimes) {
-    if (platformVersion && !runtime.includes(`iOS-${platformVersion.replace(/\./g, '-')}`)) {
+    if (pv && !runtime.includes(`iOS-${pv.replace(/\./g, '-')}`)) {
       continue;
     }
-    const match = byRuntime[runtime].find(
-      (d) => d.name === deviceName && d.isAvailable !== false,
-    );
+    const match = byRuntime[runtime].find((d) => d.name === deviceName && d.isAvailable !== false);
     if (match) {
       return match.udid;
     }
@@ -151,8 +151,10 @@ export async function prebuildWda(opts: PrebuildWdaOptions): Promise<Result<{ de
     return Err(new Error('Could not locate appium-webdriveragent (is appium-xcuitest-driver installed?)'));
   }
   log.info('Pre-building WebDriverAgent (one-time; cached in derivedDataPath)...');
-  try {
-    execFileSync(
+  // spawn (not execFileSync) so the long xcodebuild doesn't block the event loop — keeps
+  // logging/SIGINT live and lets progress stream.
+  return new Promise((resolve) => {
+    const proc = spawn(
       'xcodebuild',
       [
         'build-for-testing',
@@ -166,10 +168,17 @@ export async function prebuildWda(opts: PrebuildWdaOptions): Promise<Result<{ de
         opts.derivedDataPath,
         'CODE_SIGNING_ALLOWED=NO',
       ],
-      { stdio: 'pipe', timeout: 900000 },
+      { stdio: ['ignore', 'pipe', 'pipe'] },
     );
-    return Ok({ derivedDataPath: opts.derivedDataPath });
-  } catch (error) {
-    return Err(error instanceof Error ? error : new Error(String(error)));
-  }
+    proc.stdout?.on('data', (d: Buffer) => log.debug(d.toString().trim()));
+    proc.stderr?.on('data', (d: Buffer) => log.debug(d.toString().trim()));
+    proc.on('close', (code) => {
+      resolve(
+        code === 0
+          ? Ok({ derivedDataPath: opts.derivedDataPath })
+          : Err(new Error(`xcodebuild exited with code ${code}`)),
+      );
+    });
+    proc.on('error', (error) => resolve(Err(error)));
+  });
 }

--- a/packages/native-mobile-core/src/launcher.ts
+++ b/packages/native-mobile-core/src/launcher.ts
@@ -17,7 +17,7 @@ import { createLogger } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
 
 import { ensureAppiumDriver } from './appiumDriverManager.js';
-import { type DeviceDescriptor, DeviceManager } from './deviceManager.js';
+import { applyBootCapDefaults, type DeviceDescriptor, DeviceManager } from './deviceManager.js';
 import {
   checkAppiumServiceConfigured,
   type DoctorCheck,
@@ -25,6 +25,7 @@ import {
   failFastForMode,
   runDoctor,
 } from './doctor.js';
+import { resolveIosUdid, warmUpXcodeToolchain } from './iosSetup.js';
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
 
 /** The option fields the base launcher reads; service options extend this. */
@@ -101,8 +102,14 @@ export abstract class MobileBaseLauncher<
    * Service-specific preflight checks. Override and spread `super.doctorChecks(...)` to keep
    * the shared checks. Runs in the launcher (main process) during `onPrepare`.
    */
-  protected doctorChecks(config: Options.Testrunner, _platforms: Set<'android' | 'ios'>): DoctorCheck[] {
-    return [checkAppiumServiceConfigured(config.services)];
+  protected doctorChecks(config: Options.Testrunner, platforms: Set<'android' | 'ios'>): DoctorCheck[] {
+    const checks: DoctorCheck[] = [checkAppiumServiceConfigured(config.services)];
+    if (platforms.has('ios')) {
+      // Warm the Xcode toolchain (SDK + simctl) so a cold/broken setup fails clearly here
+      // rather than as appium-xcuitest's internal SDK-probe timeout. No-op off macOS.
+      checks.push(() => warmUpXcodeToolchain());
+    }
+    return checks;
   }
 
   async onPrepare(
@@ -179,9 +186,21 @@ export abstract class MobileBaseLauncher<
       );
       const platform = options.platform?.toLowerCase() ?? cap.platformName?.toLowerCase();
 
-      if (device && (platform === 'android' || platform === 'ios')) {
-        DeviceManager.applyToCapability(c, device, platform);
-        this.log.info(`Worker ${cid}: applied device ${JSON.stringify(device)} for ${platform}`);
+      if (platform === 'android' || platform === 'ios') {
+        if (device) {
+          DeviceManager.applyToCapability(c, device, platform);
+          this.log.info(`Worker ${cid}: applied device ${JSON.stringify(device)} for ${platform}`);
+        }
+        // iOS: resolve the exact simulator UDID from deviceName when not already pinned, so a
+        // duplicate device name across runtimes can't boot a different instance than intended.
+        if (platform === 'ios' && c['appium:udid'] === undefined && typeof c['appium:deviceName'] === 'string') {
+          const udid = resolveIosUdid(c['appium:deviceName'] as string, c['appium:platformVersion'] as string | undefined);
+          if (udid) {
+            c['appium:udid'] = udid;
+            this.log.info(`Worker ${cid}: resolved iOS udid ${udid} for '${c['appium:deviceName']}'`);
+          }
+        }
+        applyBootCapDefaults(c, platform);
       }
 
       // Per-cap realm port — one distinct free port per instance, only when the user

--- a/packages/native-mobile-core/src/launcher.ts
+++ b/packages/native-mobile-core/src/launcher.ts
@@ -21,8 +21,8 @@ import { applyBootCapDefaults, type DeviceDescriptor, DeviceManager } from './de
 import {
   checkAppiumServiceConfigured,
   type DoctorCheck,
-  type DoctorMode,
-  failFastForMode,
+  type DoctorConfig,
+  resolveDoctor,
   runDoctor,
 } from './doctor.js';
 import { resolveIosUdid, warmUpXcodeToolchain } from './iosSetup.js';
@@ -34,8 +34,11 @@ export interface MobileLauncherOptions {
   devices?: DeviceDescriptor[];
   /** Opt-in: auto-install the service's required Appium drivers in `onPrepare`. Default off. */
   autoInstallDriver?: boolean;
-  /** Preflight doctor mode: `'off'` | `'warn'` (default) | `'strict'` (abort on error). */
-  doctor?: DoctorMode;
+  /**
+   * Preflight doctor: `false` skips it, `true`/omitted runs the checks (warn), `{ strict: true }`
+   * aborts the run on an error-level check.
+   */
+  doctor?: DoctorConfig;
 }
 
 /** WDIO hands the launcher one of three capability shapes; normalise to a flat list. */
@@ -150,11 +153,12 @@ export abstract class MobileBaseLauncher<
       }
     }
 
-    // Preflight doctor — fail-fast only under doctor: 'strict'.
-    if (this.options.doctor !== 'off') {
+    // Preflight doctor — fail-fast only under doctor: { strict: true }.
+    const { run: runTheDoctor, failFast } = resolveDoctor(this.options.doctor);
+    if (runTheDoctor) {
       await runDoctor(this.doctorChecks(config, platforms), {
         serviceName: this.logNamespace,
-        failFast: failFastForMode(this.options.doctor),
+        failFast,
       });
     }
   }

--- a/packages/native-mobile-core/src/launcher.ts
+++ b/packages/native-mobile-core/src/launcher.ts
@@ -215,7 +215,10 @@ export abstract class MobileBaseLauncher<
     }
 
     if (allocated.length > 0) {
-      this.#allocatedPorts.set(cid, allocated);
+      // Merge (don't overwrite): if onWorkerStart ever fires twice for the same cid, a
+      // replace would drop the earlier ports from the map and leak them past onWorkerEnd.
+      const existing = this.#allocatedPorts.get(cid) ?? [];
+      this.#allocatedPorts.set(cid, [...existing, ...allocated]);
     }
   }
 

--- a/packages/native-mobile-core/src/launcher.ts
+++ b/packages/native-mobile-core/src/launcher.ts
@@ -180,10 +180,7 @@ export abstract class MobileBaseLauncher<
     // the pool to allocate N devices per cid, which it doesn't do yet.
     for (const cap of caps) {
       const c = cap as unknown as Record<string, unknown>;
-      const options = mergeServiceOptions(
-        this.options,
-        getServiceOptionsFromCapability<TOptions>(c, this.capKey),
-      );
+      const options = mergeServiceOptions(this.options, getServiceOptionsFromCapability<TOptions>(c, this.capKey));
       const platform = options.platform?.toLowerCase() ?? cap.platformName?.toLowerCase();
 
       if (platform === 'android' || platform === 'ios') {
@@ -194,7 +191,10 @@ export abstract class MobileBaseLauncher<
         // iOS: resolve the exact simulator UDID from deviceName when not already pinned, so a
         // duplicate device name across runtimes can't boot a different instance than intended.
         if (platform === 'ios' && c['appium:udid'] === undefined && typeof c['appium:deviceName'] === 'string') {
-          const udid = resolveIosUdid(c['appium:deviceName'] as string, c['appium:platformVersion'] as string | undefined);
+          const udid = resolveIosUdid(
+            c['appium:deviceName'] as string,
+            c['appium:platformVersion'] as string | undefined,
+          );
           if (udid) {
             c['appium:udid'] = udid;
             this.log.info(`Worker ${cid}: resolved iOS udid ${udid} for '${c['appium:deviceName']}'`);

--- a/packages/native-mobile-core/src/launcher.ts
+++ b/packages/native-mobile-core/src/launcher.ts
@@ -2,21 +2,39 @@
 //
 // Mobile services don't spawn a driver or the app — WDIO + @wdio/appium-service
 // create the Appium session, which launches the app from capabilities. So this base
-// only mutates capabilities and allocates devices from a round-robin pool. The single
-// per-framework seam is `mutateCapability` (set automationName etc.). Subclasses
-// (React Native, Flutter) implement it and pass their capKey + log namespace up.
+// mutates capabilities, allocates devices from a round-robin pool, and (opt-in) drives
+// the chromedriver-style setup automation: ensuring the required Appium drivers are
+// installed, allocating a per-worker realm port, and running a preflight doctor.
+//
+// Per-framework seams the subclasses (React Native, Flutter) implement:
+//   - `mutateCapability` — set automationName etc. and return the platform.
+//   - `requiredDrivers`   — which Appium drivers this service needs per platform.
+//   - `portCapKey`        — the capability key to stamp a per-worker realm port into.
+//   - `doctorChecks`      — service-specific preflight checks (optional override).
 
 import { BaseLauncher } from '@wdio/native-core';
 import { createLogger } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
 
+import { ensureAppiumDriver } from './appiumDriverManager.js';
 import { type DeviceDescriptor, DeviceManager } from './deviceManager.js';
+import {
+  checkAppiumServiceConfigured,
+  type DoctorCheck,
+  type DoctorMode,
+  failFastForMode,
+  runDoctor,
+} from './doctor.js';
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
 
 /** The option fields the base launcher reads; service options extend this. */
 export interface MobileLauncherOptions {
   platform?: string;
   devices?: DeviceDescriptor[];
+  /** Opt-in: auto-install the service's required Appium drivers in `onPrepare`. Default off. */
+  autoInstallDriver?: boolean;
+  /** Preflight doctor mode: `'off'` | `'warn'` (default) | `'strict'` (abort on error). */
+  doctor?: DoctorMode;
 }
 
 /** WDIO hands the launcher one of three capability shapes; normalise to a flat list. */
@@ -42,6 +60,8 @@ export abstract class MobileBaseLauncher<
 > extends BaseLauncher {
   protected deviceManager: DeviceManager;
   protected log: ReturnType<typeof createLogger>;
+  // Per-worker realm ports allocated via the PortManager seam, released on worker end.
+  #allocatedPorts = new Map<string, number[]>();
 
   /**
    * @param options - the service global options.
@@ -51,9 +71,11 @@ export abstract class MobileBaseLauncher<
   constructor(
     protected options: TOptions,
     protected capKey: string,
-    logNamespace: string,
+    protected logNamespace: string,
   ) {
-    super();
+    // Secondary (realm) ports only — the Appium server port is @wdio/appium-service's (4723).
+    // Base at 8200 to stay clear of 4444 (WDIO), 4723 (Appium) and 8081 (Metro).
+    super({ basePort: 8200, baseNativePort: 8300 });
     this.deviceManager = new DeviceManager(options.devices ?? []);
     this.log = createLogger(logNamespace, 'launcher');
     this.log.debug(`Mobile launcher initialised (device pool: ${this.deviceManager.size})`);
@@ -66,21 +88,67 @@ export abstract class MobileBaseLauncher<
    */
   protected abstract mutateCapability(cap: TCap, options: TOptions): 'android' | 'ios';
 
+  /** The Appium driver short-names this service needs for `platform` (e.g. `['uiautomator2']`). */
+  protected abstract requiredDrivers(platform: 'android' | 'ios'): string[];
+
+  /**
+   * The capability key a per-worker realm port is stamped into (Flutter
+   * `'appium:dartVmServicePort'`), or `undefined` when the service uses no allocated port.
+   */
+  protected abstract portCapKey(): string | undefined;
+
+  /**
+   * Service-specific preflight checks. Override and spread `super.doctorChecks(...)` to keep
+   * the shared checks. Runs in the launcher (main process) during `onPrepare`.
+   */
+  protected doctorChecks(config: Options.Testrunner, _platforms: Set<'android' | 'ios'>): DoctorCheck[] {
+    return [checkAppiumServiceConfigured(config.services)];
+  }
+
   async onPrepare(
-    _config: Options.Testrunner,
+    config: Options.Testrunner,
     capabilities: TCap[] | Record<string, { capabilities: TCap }>,
   ): Promise<void> {
+    const platforms = new Set<'android' | 'ios'>();
     for (const cap of flattenCaps<TCap>(capabilities)) {
       const options = mergeServiceOptions(
         this.options,
         getServiceOptionsFromCapability<TOptions>(cap as Record<string, unknown>, this.capKey),
       );
       const platform = this.mutateCapability(cap, options);
+      platforms.add(platform);
       // Read automationName back after mutateCapability sets it — confirms which driver was
       // selected at a glance, especially when a per-capability appium:automationName overrides
       // the framework default.
       const automationName = (cap as { 'appium:automationName'?: string })['appium:automationName'];
       this.log.info(`Prepared ${platform} capability (automationName: ${automationName})`);
+    }
+
+    // Driver auto-install — opt-in, idempotent, once per launcher (not per worker).
+    if (this.options.autoInstallDriver) {
+      const names = new Set<string>();
+      for (const platform of platforms) {
+        for (const name of this.requiredDrivers(platform)) {
+          names.add(name);
+        }
+      }
+      for (const name of names) {
+        const result = await ensureAppiumDriver(name, { autoInstallDriver: true });
+        if (result.ok) {
+          this.log.info(`Appium driver '${name}': ${result.value.method}`);
+        } else {
+          // Non-fatal: a missing driver surfaces as a clear doctor/Appium error downstream.
+          this.log.warn(`Appium driver '${name}' not ensured: ${result.error.message}`);
+        }
+      }
+    }
+
+    // Preflight doctor — fail-fast only under doctor: 'strict'.
+    if (this.options.doctor !== 'off') {
+      await runDoctor(this.doctorChecks(config, platforms), {
+        serviceName: this.logNamespace,
+        failFast: failFastForMode(this.options.doctor),
+      });
     }
   }
 
@@ -97,27 +165,49 @@ export abstract class MobileBaseLauncher<
     }
 
     const device = this.deviceManager.claim(cid);
-    if (!device) {
-      return;
-    }
+    const portKey = this.portCapKey();
+    const allocated: number[] = [];
 
     // One device per worker (the pool's contract). A multiremote worker shares that one
     // device across its instances — distinct-device-per-instance multiremote would need
     // the pool to allocate N devices per cid, which it doesn't do yet.
     for (const cap of caps) {
+      const c = cap as unknown as Record<string, unknown>;
       const options = mergeServiceOptions(
         this.options,
-        getServiceOptionsFromCapability<TOptions>(cap as Record<string, unknown>, this.capKey),
+        getServiceOptionsFromCapability<TOptions>(c, this.capKey),
       );
       const platform = options.platform?.toLowerCase() ?? cap.platformName?.toLowerCase();
-      if (platform === 'android' || platform === 'ios') {
-        DeviceManager.applyToCapability(cap as unknown as Record<string, unknown>, device, platform);
+
+      if (device && (platform === 'android' || platform === 'ios')) {
+        DeviceManager.applyToCapability(c, device, platform);
         this.log.info(`Worker ${cid}: applied device ${JSON.stringify(device)} for ${platform}`);
       }
+
+      // Per-cap realm port — one distinct free port per instance, only when the user
+      // hasn't pinned it. PortManager excludes already-used ports, so multiremote
+      // instances never collide.
+      if (portKey && c[portKey] === undefined) {
+        const port = await this.portManager.allocatePort();
+        c[portKey] = port;
+        allocated.push(port);
+        this.log.info(`Worker ${cid}: allocated ${portKey}=${port}`);
+      }
+    }
+
+    if (allocated.length > 0) {
+      this.#allocatedPorts.set(cid, allocated);
     }
   }
 
   async onWorkerEnd(cid: string): Promise<void> {
     this.deviceManager.release(cid);
+    const ports = this.#allocatedPorts.get(cid);
+    if (ports) {
+      for (const port of ports) {
+        this.portManager.releasePort(port);
+      }
+      this.#allocatedPorts.delete(cid);
+    }
   }
 }

--- a/packages/native-mobile-core/src/versionMatrix.ts
+++ b/packages/native-mobile-core/src/versionMatrix.ts
@@ -1,0 +1,44 @@
+// Known-good Appium server↔driver version matrix (the chromedriver-vs-Chrome analog).
+//
+// Appium drivers pin to the Appium *server* major, so `ensureAppiumDriver` installs the
+// matrix-specified driver version for the detected server major rather than letting npm
+// resolution drift. Keep these ranges in sync with `e2e/package.json` — a unit test
+// guards the drift. Add a new row (not a new range on an existing row) when supporting a
+// new Appium major.
+
+export interface DriverSpec {
+  /** Appium driver short-name (the registry key + automationName lineage), e.g. `'uiautomator2'`. */
+  name: string;
+  /** npm package the driver ships as, e.g. `'appium-uiautomator2-driver'`. */
+  source: string;
+  /** Known-good version range for the owning Appium server major (an npm-installable spec). */
+  version: string;
+}
+
+export interface AppiumCompat {
+  /** Appium server major this row applies to. */
+  appiumMajor: number;
+  /** Drivers keyed by short-name. */
+  drivers: Record<string, DriverSpec>;
+}
+
+export const APPIUM_MATRIX: AppiumCompat[] = [
+  {
+    appiumMajor: 3,
+    drivers: {
+      uiautomator2: { name: 'uiautomator2', source: 'appium-uiautomator2-driver', version: '^7.6.0' },
+      xcuitest: { name: 'xcuitest', source: 'appium-xcuitest-driver', version: '^11.9.0' },
+      flutter: { name: 'flutter', source: 'appium-flutter-driver', version: '^3.7.0' },
+    },
+  },
+];
+
+/** Resolve the known-good {@link DriverSpec} for a driver short-name under an Appium server major. */
+export function driverSpecFor(name: string, appiumMajor: number): DriverSpec | undefined {
+  return APPIUM_MATRIX.find((row) => row.appiumMajor === appiumMajor)?.drivers[name];
+}
+
+/** The Appium server majors the matrix knows about (for clear error messages). */
+export function supportedAppiumMajors(): number[] {
+  return APPIUM_MATRIX.map((row) => row.appiumMajor);
+}

--- a/packages/native-mobile-core/test/appiumDriverManager.spec.ts
+++ b/packages/native-mobile-core/test/appiumDriverManager.spec.ts
@@ -110,7 +110,8 @@ describe('ensureAppiumDriver', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       expect.any(String),
       ['driver', 'install', '--source=npm', 'appium-flutter-driver@^3.7.0'],
-      expect.any(Object),
+      // a timeout caps the install so a slow registry can't hang onPrepare
+      expect.objectContaining({ timeout: 300000 }),
     );
   });
 

--- a/packages/native-mobile-core/test/appiumDriverManager.spec.ts
+++ b/packages/native-mobile-core/test/appiumDriverManager.spec.ts
@@ -1,0 +1,138 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: vi.fn() }));
+vi.mock('node:fs', () => ({ existsSync: vi.fn(() => false) }));
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return { ...actual, createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) };
+});
+
+import { execFileSync, spawn } from 'node:child_process';
+import {
+  ensureAppiumDriver,
+  getAppiumVersion,
+  parseInstalledDrivers,
+  resetInstalledCache,
+} from '../src/appiumDriverManager.js';
+
+const execMock = vi.mocked(execFileSync);
+const spawnMock = vi.mocked(spawn);
+
+/** A fake child process that emits `close` with `code` on the next tick. */
+function fakeProc(code = 0, stderr = '') {
+  const proc = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  queueMicrotask(() => {
+    if (stderr) {
+      proc.stderr.emit('data', Buffer.from(stderr));
+    }
+    proc.emit('close', code);
+  });
+  return proc as unknown as ReturnType<typeof spawn>;
+}
+
+/** Wire execFileSync: `appium --version` → version, `driver list` → installed JSON. */
+function mockAppium(version: string | null, installed: string[]) {
+  execMock.mockImplementation((_bin, args) => {
+    const a = args as string[];
+    if (a.includes('--version')) {
+      if (version === null) {
+        throw new Error('appium not found');
+      }
+      return version;
+    }
+    if (a.includes('list')) {
+      return JSON.stringify(Object.fromEntries(installed.map((n) => [n, {}])));
+    }
+    return '';
+  });
+}
+
+afterEach(() => {
+  resetInstalledCache();
+  vi.clearAllMocks();
+});
+
+describe('parseInstalledDrivers', () => {
+  it('should extract driver names and tolerate leading log noise', () => {
+    expect(parseInstalledDrivers('log line\n{"uiautomator2":{},"xcuitest":{}}')).toEqual(['uiautomator2', 'xcuitest']);
+    expect(parseInstalledDrivers('garbage')).toEqual([]);
+  });
+});
+
+describe('getAppiumVersion', () => {
+  it('should parse the major from a bare semver line', () => {
+    mockAppium('3.5.0\n', []);
+    expect(getAppiumVersion()).toEqual({ raw: '3.5.0', major: 3 });
+  });
+
+  it('should return undefined when appium is missing', () => {
+    mockAppium(null, []);
+    expect(getAppiumVersion()).toBeUndefined();
+  });
+});
+
+describe('ensureAppiumDriver', () => {
+  it('should be a no-op when autoInstallDriver is off', async () => {
+    const r = await ensureAppiumDriver('uiautomator2', { autoInstallDriver: false });
+    expect(r).toEqual({ ok: true, value: { name: 'uiautomator2', method: 'skipped' } });
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('should error clearly when appium is not resolvable', async () => {
+    mockAppium(null, []);
+    const r = await ensureAppiumDriver('uiautomator2', { autoInstallDriver: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.message).toMatch(/appium' CLI is not resolvable/);
+    }
+  });
+
+  it('should be idempotent — found when already installed (no install)', async () => {
+    mockAppium('3.5.0', ['uiautomator2']);
+    const r = await ensureAppiumDriver('uiautomator2', { autoInstallDriver: true });
+    expect(r).toMatchObject({ ok: true, value: { method: 'found' } });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should error when the matrix has no entry for the Appium major', async () => {
+    mockAppium('99.0.0', []);
+    const r = await ensureAppiumDriver('uiautomator2', { autoInstallDriver: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.message).toMatch(/No known-good version/);
+    }
+  });
+
+  it('should install the matrix-pinned driver on success', async () => {
+    mockAppium('3.5.0', []);
+    spawnMock.mockReturnValueOnce(fakeProc(0));
+    const r = await ensureAppiumDriver('flutter', { autoInstallDriver: true });
+    expect(r).toMatchObject({ ok: true, value: { method: 'installed' } });
+    expect(spawnMock).toHaveBeenCalledWith(
+      expect.any(String),
+      ['driver', 'install', '--source=npm', 'appium-flutter-driver@^3.7.0'],
+      expect.any(Object),
+    );
+  });
+
+  it('should return Err when the install process exits non-zero', async () => {
+    mockAppium('3.5.0', []);
+    spawnMock.mockReturnValueOnce(fakeProc(1, 'boom'));
+    const r = await ensureAppiumDriver('xcuitest', { autoInstallDriver: true });
+    expect(r.ok).toBe(false);
+  });
+
+  it('should honour a source override for the install spec', async () => {
+    mockAppium('3.5.0', []);
+    spawnMock.mockReturnValueOnce(fakeProc(0));
+    await ensureAppiumDriver('flutter', { autoInstallDriver: true, source: '@goosewobbler/appium-flutter-driver' });
+    expect(spawnMock).toHaveBeenCalledWith(
+      expect.any(String),
+      ['driver', 'install', '--source=npm', '@goosewobbler/appium-flutter-driver@^3.7.0'],
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/native-mobile-core/test/appiumDriverManager.spec.ts
+++ b/packages/native-mobile-core/test/appiumDriverManager.spec.ts
@@ -19,8 +19,8 @@ import {
 const execMock = vi.mocked(execFileSync);
 const spawnMock = vi.mocked(spawn);
 
-/** A fake child process that emits `close` with `code` on the next tick. */
-function fakeProc(code = 0, stderr = '') {
+/** A fake child process that emits `close` with `code` (and optional `signal`) on the next tick. */
+function fakeProc(code: number | null = 0, stderr = '', signal?: NodeJS.Signals) {
   const proc = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
   proc.stdout = new EventEmitter();
   proc.stderr = new EventEmitter();
@@ -28,7 +28,7 @@ function fakeProc(code = 0, stderr = '') {
     if (stderr) {
       proc.stderr.emit('data', Buffer.from(stderr));
     }
-    proc.emit('close', code);
+    proc.emit('close', code, signal);
   });
   return proc as unknown as ReturnType<typeof spawn>;
 }
@@ -120,6 +120,15 @@ describe('ensureAppiumDriver', () => {
     spawnMock.mockReturnValueOnce(fakeProc(1, 'boom'));
     const r = await ensureAppiumDriver('xcuitest', { autoInstallDriver: true });
     expect(r.ok).toBe(false);
+  });
+
+  it('should report the kill signal (not "code null") when the install is timed out', async () => {
+    mockAppium('3.5.0', []);
+    // A timeout-kill closes with code null + a signal; the message must name the signal.
+    spawnMock.mockReturnValueOnce(fakeProc(null, '', 'SIGTERM'));
+    const r = await ensureAppiumDriver('xcuitest', { autoInstallDriver: true });
+    expect(r.ok).toBe(false);
+    expect(r.ok ? '' : r.error.message).toMatch(/signal SIGTERM/);
   });
 
   it('should honour a source override for the install spec', async () => {

--- a/packages/native-mobile-core/test/appiumDriverManager.spec.ts
+++ b/packages/native-mobile-core/test/appiumDriverManager.spec.ts
@@ -85,9 +85,7 @@ describe('ensureAppiumDriver', () => {
     mockAppium(null, []);
     const r = await ensureAppiumDriver('uiautomator2', { autoInstallDriver: true });
     expect(r.ok).toBe(false);
-    if (!r.ok) {
-      expect(r.error.message).toMatch(/appium' CLI is not resolvable/);
-    }
+    expect(r.ok ? '' : r.error.message).toMatch(/appium' CLI is not resolvable/);
   });
 
   it('should be idempotent — found when already installed (no install)', async () => {
@@ -101,9 +99,7 @@ describe('ensureAppiumDriver', () => {
     mockAppium('99.0.0', []);
     const r = await ensureAppiumDriver('uiautomator2', { autoInstallDriver: true });
     expect(r.ok).toBe(false);
-    if (!r.ok) {
-      expect(r.error.message).toMatch(/No known-good version/);
-    }
+    expect(r.ok ? '' : r.error.message).toMatch(/No known-good version/);
   });
 
   it('should install the matrix-pinned driver on success', async () => {

--- a/packages/native-mobile-core/test/deviceManager.spec.ts
+++ b/packages/native-mobile-core/test/deviceManager.spec.ts
@@ -6,7 +6,8 @@ vi.mock('@wdio/native-utils', async (importOriginal) => {
   return { ...actual, createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() }) };
 });
 
-import { DeviceManager } from '../src/deviceManager.js';
+import { afterEach } from 'vitest';
+import { applyBootCapDefaults, DeviceManager } from '../src/deviceManager.js';
 
 describe('DeviceManager', () => {
   it('should return undefined when the pool is empty', () => {
@@ -52,5 +53,56 @@ describe('DeviceManager', () => {
     const cap: Record<string, unknown> = {};
     DeviceManager.applyToCapability(cap, { iOSUdid: 'ABC-123' }, 'ios');
     expect(cap['appium:udid']).toBe('ABC-123');
+  });
+});
+
+describe('applyBootCapDefaults', () => {
+  const origCI = process.env.CI;
+  afterEach(() => {
+    if (origCI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = origCI;
+    }
+  });
+
+  it('should set autoGrantPermissions for Android', () => {
+    const cap: Record<string, unknown> = {};
+    applyBootCapDefaults(cap, 'android');
+    expect(cap['appium:autoGrantPermissions']).toBe(true);
+  });
+
+  it('should set the iOS WDA/sim timeout defaults', () => {
+    const cap: Record<string, unknown> = {};
+    applyBootCapDefaults(cap, 'ios');
+    expect(cap['appium:wdaLaunchTimeout']).toBe(720000);
+    expect(cap['appium:simulatorStartupTimeout']).toBe(240000);
+  });
+
+  it('should set isHeadless only in CI', () => {
+    process.env.CI = 'true';
+    const ci: Record<string, unknown> = {};
+    applyBootCapDefaults(ci, 'ios');
+    expect(ci['appium:isHeadless']).toBe(true);
+
+    delete process.env.CI;
+    const local: Record<string, unknown> = {};
+    applyBootCapDefaults(local, 'ios');
+    expect(local['appium:isHeadless']).toBeUndefined();
+  });
+
+  it('should never override an explicit user cap', () => {
+    const cap: Record<string, unknown> = { 'appium:wdaLaunchTimeout': 1, 'appium:autoGrantPermissions': false };
+    applyBootCapDefaults(cap, 'ios');
+    applyBootCapDefaults(cap, 'android');
+    expect(cap['appium:wdaLaunchTimeout']).toBe(1);
+    expect(cap['appium:autoGrantPermissions']).toBe(false);
+  });
+
+  it('should not set noReset (left to the user)', () => {
+    const cap: Record<string, unknown> = {};
+    applyBootCapDefaults(cap, 'android');
+    applyBootCapDefaults(cap, 'ios');
+    expect(cap['appium:noReset']).toBeUndefined();
   });
 });

--- a/packages/native-mobile-core/test/doctor.spec.ts
+++ b/packages/native-mobile-core/test/doctor.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+vi.mock('node:fs', () => ({ existsSync: vi.fn() }));
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import {
+  checkAppiumServiceConfigured,
+  checkBuildIsDebug,
+  checkCommandOnPath,
+  checkPathExists,
+  failFastForMode,
+  runDoctor,
+} from '../src/doctor.js';
+
+const execMock = vi.mocked(execFileSync);
+const existsMock = vi.mocked(existsSync);
+
+describe('doctor builders', () => {
+  it('should report ok when a command is found and error when missing', async () => {
+    execMock.mockReturnValueOnce('/usr/bin/flutter\n');
+    expect(await checkCommandOnPath('flutter')()).toMatchObject({ status: 'ok', category: 'flutter' });
+
+    execMock.mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+    expect(await checkCommandOnPath('flutter', { hint: 'install it' })()).toMatchObject({
+      status: 'error',
+      details: 'install it',
+    });
+  });
+
+  it('should honour a warn severity when configured', async () => {
+    execMock.mockImplementationOnce(() => {
+      throw new Error('nope');
+    });
+    expect(await checkCommandOnPath('adb', { severity: 'warn' })()).toMatchObject({ status: 'warn' });
+  });
+
+  it('should report ok when the path exists and error when missing', async () => {
+    existsMock.mockReturnValueOnce(true);
+    expect(await checkPathExists('/app', 'App')()).toMatchObject({ status: 'ok' });
+    existsMock.mockReturnValueOnce(false);
+    expect(await checkPathExists('/app', 'App')()).toMatchObject({ status: 'error' });
+  });
+
+  it('should report ok for debug/profile and warn for release/unknown', async () => {
+    expect(await checkBuildIsDebug('/a', () => 'debug')()).toMatchObject({ status: 'ok' });
+    expect(await checkBuildIsDebug('/a', () => 'release')()).toMatchObject({ status: 'warn' });
+    expect(await checkBuildIsDebug('/a', () => 'unknown')()).toMatchObject({ status: 'warn' });
+  });
+
+  it('should report ok when appium is in services and warn when absent', async () => {
+    expect(await checkAppiumServiceConfigured(['appium', 'flutter'])()).toMatchObject({ status: 'ok' });
+    expect(await checkAppiumServiceConfigured([['@wdio/appium-service', {}]])()).toMatchObject({ status: 'ok' });
+    expect(await checkAppiumServiceConfigured(['flutter'])()).toMatchObject({ status: 'warn' });
+    expect(await checkAppiumServiceConfigured(undefined)()).toMatchObject({ status: 'warn' });
+  });
+});
+
+describe('runDoctor', () => {
+  const ok = () => ({ category: 'A', status: 'ok' as const, message: 'fine' });
+  const err = () => ({ category: 'B', status: 'error' as const, message: 'broken' });
+
+  it('should not throw on error when failFast is false', async () => {
+    const results = await runDoctor([ok, err], { serviceName: 'svc', failFast: false });
+    expect(results).toHaveLength(2);
+  });
+
+  it('should throw SevereServiceError on error when failFast', async () => {
+    await expect(runDoctor([ok, err], { serviceName: 'svc', failFast: true })).rejects.toThrow(/broken/);
+  });
+
+  it('should not throw under failFast when there are no errors', async () => {
+    await expect(runDoctor([ok], { serviceName: 'svc', failFast: true })).resolves.toHaveLength(1);
+  });
+
+  it('should record a thrown check as an error result rather than crashing', async () => {
+    const boom = () => {
+      throw new Error('kaboom');
+    };
+    const results = await runDoctor([boom], { serviceName: 'svc', failFast: false });
+    expect(results[0]).toMatchObject({ status: 'error', message: expect.stringContaining('kaboom') });
+  });
+
+  it('should map only strict to failFast true', () => {
+    expect(failFastForMode('strict')).toBe(true);
+    expect(failFastForMode('warn')).toBe(false);
+    expect(failFastForMode(undefined)).toBe(false);
+  });
+});

--- a/packages/native-mobile-core/test/doctor.spec.ts
+++ b/packages/native-mobile-core/test/doctor.spec.ts
@@ -10,7 +10,7 @@ import {
   checkBuildIsDebug,
   checkCommandOnPath,
   checkPathExists,
-  failFastForMode,
+  resolveDoctor,
   runDoctor,
 } from '../src/doctor.js';
 
@@ -84,9 +84,12 @@ describe('runDoctor', () => {
     expect(results[0]).toMatchObject({ status: 'error', message: expect.stringContaining('kaboom') });
   });
 
-  it('should map only strict to failFast true', () => {
-    expect(failFastForMode('strict')).toBe(true);
-    expect(failFastForMode('warn')).toBe(false);
-    expect(failFastForMode(undefined)).toBe(false);
+  it('should resolve doctor config to run/failFast', () => {
+    expect(resolveDoctor(undefined)).toEqual({ run: true, failFast: false });
+    expect(resolveDoctor(true)).toEqual({ run: true, failFast: false });
+    expect(resolveDoctor(false)).toEqual({ run: false, failFast: false });
+    expect(resolveDoctor({})).toEqual({ run: true, failFast: false });
+    expect(resolveDoctor({ strict: false })).toEqual({ run: true, failFast: false });
+    expect(resolveDoctor({ strict: true })).toEqual({ run: true, failFast: true });
   });
 });

--- a/packages/native-mobile-core/test/iosSetup.spec.ts
+++ b/packages/native-mobile-core/test/iosSetup.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+vi.mock('node:fs', () => ({ existsSync: vi.fn() }));
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return { ...actual, createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) };
+});
+
+import { execFileSync } from 'node:child_process';
+import { pickIosUdid, prebuildWda, resolveIosUdid, warmUpXcodeToolchain } from '../src/iosSetup.js';
+
+const execMock = vi.mocked(execFileSync);
+const origPlatform = process.platform;
+const setPlatform = (p: NodeJS.Platform) =>
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+afterEach(() => {
+  setPlatform(origPlatform);
+  vi.clearAllMocks();
+});
+
+const simctl = JSON.stringify({
+  devices: {
+    'com.apple.CoreSimulator.SimRuntime.iOS-16-4': [{ udid: 'OLD', name: 'iPhone 16', isAvailable: true }],
+    'com.apple.CoreSimulator.SimRuntime.iOS-17-5': [{ udid: 'NEW', name: 'iPhone 16', isAvailable: true }],
+  },
+});
+
+describe('pickIosUdid', () => {
+  it('should prefer the newest runtime for a duplicate device name', () => {
+    expect(pickIosUdid(simctl, 'iPhone 16')).toBe('NEW');
+  });
+
+  it('should honour an explicit platformVersion', () => {
+    expect(pickIosUdid(simctl, 'iPhone 16', '16.4')).toBe('OLD');
+  });
+
+  it('should skip unavailable devices and unmatched names', () => {
+    const json = JSON.stringify({
+      devices: {
+        'com.apple.CoreSimulator.SimRuntime.iOS-17-5': [{ udid: 'X', name: 'iPhone 16', isAvailable: false }],
+      },
+    });
+    expect(pickIosUdid(json, 'iPhone 16')).toBeUndefined();
+    expect(pickIosUdid(simctl, 'iPad')).toBeUndefined();
+  });
+
+  it('should return undefined on invalid JSON', () => {
+    expect(pickIosUdid('not json', 'iPhone 16')).toBeUndefined();
+  });
+});
+
+describe('resolveIosUdid', () => {
+  it('should return undefined off macOS without shelling out', () => {
+    setPlatform('linux');
+    expect(resolveIosUdid('iPhone 16')).toBeUndefined();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('should resolve via simctl on macOS', () => {
+    setPlatform('darwin');
+    execMock.mockReturnValueOnce(simctl);
+    expect(resolveIosUdid('iPhone 16')).toBe('NEW');
+  });
+
+  it('should return undefined when simctl throws', () => {
+    setPlatform('darwin');
+    execMock.mockImplementationOnce(() => {
+      throw new Error('xcrun missing');
+    });
+    expect(resolveIosUdid('iPhone 16')).toBeUndefined();
+  });
+});
+
+describe('warmUpXcodeToolchain', () => {
+  it('should be empty off macOS', () => {
+    setPlatform('linux');
+    expect(warmUpXcodeToolchain()).toEqual([]);
+  });
+
+  it('should report an error result when the SDK probe fails', () => {
+    setPlatform('darwin');
+    execMock
+      .mockImplementationOnce(() => {
+        throw new Error('no sdk');
+      })
+      .mockReturnValueOnce('' as never);
+    const results = warmUpXcodeToolchain();
+    expect(results.find((r) => r.category === 'iOS SDK')).toMatchObject({ status: 'error' });
+  });
+});
+
+describe('prebuildWda', () => {
+  it('should return Err off macOS', async () => {
+    setPlatform('linux');
+    const r = await prebuildWda({ derivedDataPath: '/tmp/dd' });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/native-mobile-core/test/launcher.spec.ts
+++ b/packages/native-mobile-core/test/launcher.spec.ts
@@ -145,6 +145,20 @@ describe('MobileBaseLauncher device stamping', () => {
     expect(c['appium:udid']).toBe('a');
   });
 
+  it('should stamp the device udid onto a multiremote capability object', async () => {
+    // A multiremote run hands onWorkerStart { instance: { capabilities } }, not an array,
+    // so the device must land on the nested capability — not silently dropped.
+    const caps = { phone: { capabilities: cap() } };
+    await withDevices().onWorkerStart('0-0', caps as unknown as Record<string, unknown>);
+    expect(caps.phone.capabilities['appium:udid']).toBe('a');
+  });
+
+  it('should release a claimed device without throwing on worker end', async () => {
+    const l = withDevices();
+    await l.onWorkerStart('0-0', cap());
+    await expect(l.onWorkerEnd('0-0')).resolves.toBeUndefined();
+  });
+
   it('should advance the device cursor per worker', async () => {
     const l = withDevices();
     const a = cap();

--- a/packages/native-mobile-core/test/launcher.spec.ts
+++ b/packages/native-mobile-core/test/launcher.spec.ts
@@ -111,6 +111,20 @@ describe('MobileBaseLauncher.onPrepare', () => {
     expect(names).toEqual(['uiautomator2', 'xcuitest']);
   });
 
+  it('should mutate a multiremote object and build platforms from it (driver-ensure not skipped)', async () => {
+    // Integrated multiremote path: a `{ instance: { capabilities } }` shape must unwrap to the
+    // inner caps, so both get mutated AND `platforms` is non-empty (else driver-ensure + doctor
+    // would silently no-op on a multiremote config).
+    const caps = {
+      phone: { capabilities: cap({ platformName: 'Android' }) },
+      tablet: { capabilities: cap({ platformName: 'iOS' }) },
+    };
+    await new TestLauncher({ autoInstallDriver: true }).onPrepare(config, caps);
+    expect(caps.phone.capabilities['appium:automationName']).toBe('UiAutomator2');
+    expect(caps.tablet.capabilities['appium:automationName']).toBe('XCUITest');
+    expect(ensureSpy.mock.calls.map((c) => c[0]).sort()).toEqual(['uiautomator2', 'xcuitest']);
+  });
+
   it('should not throw under the default warn doctor mode', async () => {
     await expect(new TestLauncher().onPrepare(config, [cap()])).resolves.toBeUndefined();
   });

--- a/packages/native-mobile-core/test/launcher.spec.ts
+++ b/packages/native-mobile-core/test/launcher.spec.ts
@@ -32,7 +32,7 @@ interface TestOptions {
   platform?: string;
   devices?: Array<{ udid?: string }>;
   autoInstallDriver?: boolean;
-  doctor?: 'off' | 'warn' | 'strict';
+  doctor?: boolean | { strict?: boolean };
 }
 interface TestCap {
   platformName?: string;
@@ -123,16 +123,16 @@ describe('MobileBaseLauncher doctor fail-fast', () => {
     }
   }
 
-  it('should throw under strict mode when a check errors', async () => {
-    await expect(new StrictLauncher({ doctor: 'strict' }).onPrepare(config, [cap()])).rejects.toThrow(/bad/);
+  it('should throw under { strict: true } when a check errors', async () => {
+    await expect(new StrictLauncher({ doctor: { strict: true } }).onPrepare(config, [cap()])).rejects.toThrow(/bad/);
   });
 
-  it('should only log under warn mode', async () => {
-    await expect(new StrictLauncher({ doctor: 'warn' }).onPrepare(config, [cap()])).resolves.toBeUndefined();
+  it('should only log when run without strict (doctor: true)', async () => {
+    await expect(new StrictLauncher({ doctor: true }).onPrepare(config, [cap()])).resolves.toBeUndefined();
   });
 
-  it('should skip checks entirely under off mode', async () => {
-    await expect(new StrictLauncher({ doctor: 'off' }).onPrepare(config, [cap()])).resolves.toBeUndefined();
+  it('should skip checks entirely when doctor: false', async () => {
+    await expect(new StrictLauncher({ doctor: false }).onPrepare(config, [cap()])).resolves.toBeUndefined();
   });
 });
 

--- a/packages/native-mobile-core/test/launcher.spec.ts
+++ b/packages/native-mobile-core/test/launcher.spec.ts
@@ -1,19 +1,44 @@
 import type { Options } from '@wdio/types';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-// BaseLauncher carries @wdio/native-core's port/driver infra mobile services don't use — stub it.
-vi.mock('@wdio/native-core', () => ({ BaseLauncher: class {} }));
+// Stub BaseLauncher (native-core's port/driver infra) with a minimal allocating PortManager.
+const releaseSpy = vi.hoisted(() => vi.fn());
+vi.mock('@wdio/native-core', () => ({
+  BaseLauncher: class {
+    private _next = 9000;
+    portManager = {
+      allocatePort: async () => this._next++,
+      releasePort: releaseSpy,
+    };
+  },
+}));
 
+// Keep onPrepare from shelling out to `appium` / `xcrun`.
+const ensureSpy = vi.hoisted(() => vi.fn(async () => ({ ok: true, value: { name: 'x', method: 'skipped' as const } })));
+vi.mock('../src/appiumDriverManager.js', () => ({ ensureAppiumDriver: ensureSpy }));
+vi.mock('../src/iosSetup.js', () => ({
+  resolveIosUdid: vi.fn(() => undefined),
+  warmUpXcodeToolchain: vi.fn(() => []),
+}));
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return { ...actual, createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) };
+});
+
+import type { DoctorCheck } from '../src/doctor.js';
 import { flattenCaps, MobileBaseLauncher } from '../src/launcher.js';
 
 interface TestOptions {
   platform?: string;
   devices?: Array<{ udid?: string }>;
+  autoInstallDriver?: boolean;
+  doctor?: 'off' | 'warn' | 'strict';
 }
 interface TestCap {
   platformName?: string;
   'appium:automationName'?: string;
   'appium:udid'?: string;
+  'appium:dartVmServicePort'?: number;
 }
 
 class TestLauncher extends MobileBaseLauncher<TestOptions, TestCap> {
@@ -28,20 +53,33 @@ class TestLauncher extends MobileBaseLauncher<TestOptions, TestCap> {
     cap['appium:automationName'] = p === 'android' ? 'UiAutomator2' : 'XCUITest';
     return p;
   }
+  protected requiredDrivers(platform: 'android' | 'ios'): string[] {
+    return platform === 'android' ? ['uiautomator2'] : ['xcuitest'];
+  }
+  protected portCapKey(): string | undefined {
+    return undefined;
+  }
+}
+
+// A launcher that stamps a per-cap realm port (the Flutter shape).
+class PortLauncher extends TestLauncher {
+  protected portCapKey(): string | undefined {
+    return 'appium:dartVmServicePort';
+  }
 }
 
 const config = {} as Options.Testrunner;
 const cap = (over: Record<string, unknown> = {}): TestCap => ({ platformName: 'Android', ...over });
 
+afterEach(() => vi.clearAllMocks());
+
 describe('flattenCaps', () => {
   it('should pass an array of caps through', () => {
     expect(flattenCaps([cap(), cap()])).toHaveLength(2);
   });
-
   it('should unwrap a multiremote { instance: { capabilities } } object', () => {
     expect(flattenCaps({ phone: { capabilities: cap() } })).toEqual([cap()]);
   });
-
   it('should wrap a single bare capability', () => {
     const c = cap();
     expect(flattenCaps(c as unknown as Record<string, unknown>)).toEqual([c]);
@@ -55,30 +93,56 @@ describe('MobileBaseLauncher.onPrepare', () => {
     expect(caps.map((c) => c['appium:automationName'])).toEqual(['UiAutomator2', 'XCUITest']);
   });
 
-  it('should mutate a multiremote capability object', async () => {
-    const caps = { phone: { capabilities: cap({ platformName: 'Android' }) } };
-    await new TestLauncher().onPrepare(config, caps);
-    expect(caps.phone.capabilities['appium:automationName']).toBe('UiAutomator2');
-  });
-
   it('should reject when the subclass rejects an unsupported platform', async () => {
     await expect(new TestLauncher().onPrepare(config, [cap({ platformName: 'Windows' })])).rejects.toThrow();
   });
+
+  it('should not auto-install drivers by default', async () => {
+    await new TestLauncher().onPrepare(config, [cap()]);
+    expect(ensureSpy).not.toHaveBeenCalled();
+  });
+
+  it('should ensure the union of required drivers once when autoInstallDriver is on', async () => {
+    await new TestLauncher({ autoInstallDriver: true }).onPrepare(config, [
+      cap({ platformName: 'Android' }),
+      cap({ platformName: 'iOS' }),
+    ]);
+    const names = ensureSpy.mock.calls.map((c) => c[0]).sort();
+    expect(names).toEqual(['uiautomator2', 'xcuitest']);
+  });
+
+  it('should not throw under the default warn doctor mode', async () => {
+    await expect(new TestLauncher().onPrepare(config, [cap()])).resolves.toBeUndefined();
+  });
 });
 
-describe('MobileBaseLauncher.onWorkerStart / onWorkerEnd', () => {
+describe('MobileBaseLauncher doctor fail-fast', () => {
+  class StrictLauncher extends TestLauncher {
+    protected doctorChecks(): DoctorCheck[] {
+      return [() => ({ category: 'X', status: 'error', message: 'bad' })];
+    }
+  }
+
+  it('should throw under strict mode when a check errors', async () => {
+    await expect(new StrictLauncher({ doctor: 'strict' }).onPrepare(config, [cap()])).rejects.toThrow(/bad/);
+  });
+
+  it('should only log under warn mode', async () => {
+    await expect(new StrictLauncher({ doctor: 'warn' }).onPrepare(config, [cap()])).resolves.toBeUndefined();
+  });
+
+  it('should skip checks entirely under off mode', async () => {
+    await expect(new StrictLauncher({ doctor: 'off' }).onPrepare(config, [cap()])).resolves.toBeUndefined();
+  });
+});
+
+describe('MobileBaseLauncher device stamping', () => {
   const withDevices = () => new TestLauncher({ devices: [{ udid: 'a' }, { udid: 'b' }] });
 
   it('should stamp the claimed device udid onto a bare capability', async () => {
     const c = cap();
     await withDevices().onWorkerStart('0-0', c);
     expect(c['appium:udid']).toBe('a');
-  });
-
-  it('should stamp onto a multiremote capability object', async () => {
-    const caps = { phone: { capabilities: cap() } };
-    await withDevices().onWorkerStart('0-0', caps as unknown as Record<string, unknown>);
-    expect(caps.phone.capabilities['appium:udid']).toBe('a');
   });
 
   it('should advance the device cursor per worker', async () => {
@@ -100,9 +164,43 @@ describe('MobileBaseLauncher.onWorkerStart / onWorkerEnd', () => {
     await expect(withDevices().onWorkerStart('0-0', undefined)).resolves.toBeUndefined();
   });
 
-  it('should release a claimed device without throwing', async () => {
-    const l = withDevices();
-    await l.onWorkerStart('0-0', cap());
-    expect(() => l.onWorkerEnd('0-0')).not.toThrow();
+  it('should apply Android boot-cap defaults', async () => {
+    const c = cap();
+    await new TestLauncher().onWorkerStart('0-0', c);
+    expect((c as Record<string, unknown>)['appium:autoGrantPermissions']).toBe(true);
+  });
+});
+
+describe('MobileBaseLauncher port seam', () => {
+  it('should stamp a free realm port per cap and release it on worker end', async () => {
+    const l = new PortLauncher();
+    const c = cap();
+    await l.onWorkerStart('0-0', c);
+    const port = c['appium:dartVmServicePort'];
+    expect(typeof port).toBe('number');
+    await l.onWorkerEnd('0-0');
+    expect(releaseSpy).toHaveBeenCalledWith(port);
+  });
+
+  it('should not overwrite a user-pinned port', async () => {
+    const c = cap({ 'appium:dartVmServicePort': 5555 });
+    await new PortLauncher().onWorkerStart('0-0', c);
+    expect(c['appium:dartVmServicePort']).toBe(5555);
+  });
+
+  it('should allocate distinct ports per multiremote instance', async () => {
+    const caps = { a: { capabilities: cap() }, b: { capabilities: cap() } };
+    await new PortLauncher().onWorkerStart('0-0', caps as unknown as Record<string, unknown>);
+    const pa = caps.a.capabilities['appium:dartVmServicePort'];
+    const pb = caps.b.capabilities['appium:dartVmServicePort'];
+    expect(pa).not.toBe(pb);
+  });
+
+  it('should do nothing for a launcher without a port cap key', async () => {
+    const c = cap();
+    const l = new TestLauncher();
+    await l.onWorkerStart('0-0', c);
+    await l.onWorkerEnd('0-0');
+    expect(releaseSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/native-mobile-core/test/launcher.spec.ts
+++ b/packages/native-mobile-core/test/launcher.spec.ts
@@ -202,6 +202,17 @@ describe('MobileBaseLauncher port seam', () => {
     expect(c['appium:dartVmServicePort']).toBe(5555);
   });
 
+  it('should release every port when onWorkerStart fires twice for one cid (no leak)', async () => {
+    const l = new PortLauncher();
+    const a = cap();
+    const b = cap();
+    await l.onWorkerStart('0-0', a);
+    await l.onWorkerStart('0-0', b);
+    await l.onWorkerEnd('0-0');
+    expect(releaseSpy).toHaveBeenCalledWith(a['appium:dartVmServicePort']);
+    expect(releaseSpy).toHaveBeenCalledWith(b['appium:dartVmServicePort']);
+  });
+
   it('should allocate distinct ports per multiremote instance', async () => {
     const caps = { a: { capabilities: cap() }, b: { capabilities: cap() } };
     await new PortLauncher().onWorkerStart('0-0', caps as unknown as Record<string, unknown>);

--- a/packages/native-mobile-core/test/versionMatrix.spec.ts
+++ b/packages/native-mobile-core/test/versionMatrix.spec.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { APPIUM_MATRIX, driverSpecFor, supportedAppiumMajors } from '../src/versionMatrix.js';
+
+describe('versionMatrix', () => {
+  it('should resolve a known driver spec for the supported Appium major', () => {
+    expect(driverSpecFor('uiautomator2', 3)).toEqual({
+      name: 'uiautomator2',
+      source: 'appium-uiautomator2-driver',
+      version: '^7.6.0',
+    });
+    expect(driverSpecFor('flutter', 3)?.source).toBe('appium-flutter-driver');
+  });
+
+  it('should return undefined for an unknown driver or unsupported major', () => {
+    expect(driverSpecFor('uiautomator2', 99)).toBeUndefined();
+    expect(driverSpecFor('nope', 3)).toBeUndefined();
+  });
+
+  it('should report the supported Appium majors', () => {
+    expect(supportedAppiumMajors()).toContain(3);
+  });
+
+  // Drift guard: the matrix must track the ranges e2e actually installs against, so a bump
+  // in e2e that the matrix misses fails here rather than silently installing a stale driver.
+  it('should match the driver version ranges pinned in e2e/package.json', () => {
+    const e2ePkg = JSON.parse(readFileSync(new URL('../../../e2e/package.json', import.meta.url), 'utf8'));
+    const dev = e2ePkg.devDependencies as Record<string, string>;
+    const row = APPIUM_MATRIX.find((r) => r.appiumMajor === 3);
+    expect(row).toBeDefined();
+    for (const spec of Object.values(row?.drivers ?? {})) {
+      expect(dev[spec.source]).toBe(spec.version);
+    }
+  });
+});

--- a/packages/native-types/src/flutter.ts
+++ b/packages/native-types/src/flutter.ts
@@ -189,11 +189,12 @@ export interface FlutterServiceOptions extends LogCaptureConfig, MockLifecycleCo
    */
   autoInstallDriver?: boolean;
   /**
-   * Preflight doctor mode. `'off'` skips checks, `'warn'` logs actionable warnings,
-   * `'strict'` aborts the run (`SevereServiceError`) on any error-level check.
-   * @default 'warn'
+   * Preflight doctor. `false` skips the checks; `true` (the default) runs them and logs
+   * actionable warnings; `{ strict: true }` aborts the run (`SevereServiceError`) on any
+   * error-level check.
+   * @default true
    */
-  doctor?: 'off' | 'warn' | 'strict';
+  doctor?: boolean | { strict?: boolean };
 }
 
 /**

--- a/packages/native-types/src/flutter.ts
+++ b/packages/native-types/src/flutter.ts
@@ -181,6 +181,19 @@ export interface FlutterServiceOptions extends LogCaptureConfig, MockLifecycleCo
   appBinaryPath?: string;
   /** Device pool for parallel workers / multiremote. */
   devices?: Array<{ udid?: string; avd?: string; iOSUdid?: string }>;
+  /**
+   * Opt-in: auto-install the `flutter` Appium driver (appium-flutter-driver) in the
+   * launcher, at a version known-good for the running Appium server major. Idempotent;
+   * a no-op when the driver is already installed.
+   * @default false
+   */
+  autoInstallDriver?: boolean;
+  /**
+   * Preflight doctor mode. `'off'` skips checks, `'warn'` logs actionable warnings,
+   * `'strict'` aborts the run (`SevereServiceError`) on any error-level check.
+   * @default 'warn'
+   */
+  doctor?: 'off' | 'warn' | 'strict';
 }
 
 /**

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -297,6 +297,19 @@ export interface ReactNativeServiceOptions extends LogCaptureConfig, MockLifecyc
    * Omit (or leave empty) for single-device runs — Appium picks the device.
    */
   devices?: Array<{ udid?: string; avd?: string; iOSUdid?: string }>;
+  /**
+   * Opt-in: auto-install the required Appium drivers (`uiautomator2` / `xcuitest`) in the
+   * launcher, at a version known-good for the running Appium server major. Idempotent;
+   * a no-op when the driver is already installed.
+   * @default false
+   */
+  autoInstallDriver?: boolean;
+  /**
+   * Preflight doctor mode. `'off'` skips checks, `'warn'` logs actionable warnings,
+   * `'strict'` aborts the run (`SevereServiceError`) on any error-level check.
+   * @default 'warn'
+   */
+  doctor?: 'off' | 'warn' | 'strict';
 }
 
 /**

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -305,11 +305,12 @@ export interface ReactNativeServiceOptions extends LogCaptureConfig, MockLifecyc
    */
   autoInstallDriver?: boolean;
   /**
-   * Preflight doctor mode. `'off'` skips checks, `'warn'` logs actionable warnings,
-   * `'strict'` aborts the run (`SevereServiceError`) on any error-level check.
-   * @default 'warn'
+   * Preflight doctor. `false` skips the checks; `true` (the default) runs them and logs
+   * actionable warnings; `{ strict: true }` aborts the run (`SevereServiceError`) on any
+   * error-level check.
+   * @default true
    */
-  doctor?: 'off' | 'warn' | 'strict';
+  doctor?: boolean | { strict?: boolean };
 }
 
 /**

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -31,4 +31,14 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
   ): 'android' | 'ios' {
     return prepareReactNativeCapability(cap, options);
   }
+
+  protected requiredDrivers(platform: 'android' | 'ios'): string[] {
+    return platform === 'android' ? ['uiautomator2'] : ['xcuitest'];
+  }
+
+  // RN connects to a single shared Metro on a fixed port (default 8081), not a per-cap
+  // allocated realm port — so there's no capability for the base launcher to stamp.
+  protected portCapKey(): string | undefined {
+    return undefined;
+  }
 }

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -11,8 +11,9 @@ import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from '.
 
 const config = {} as Options.Testrunner;
 
+// doctor: 'off' keeps onPrepare hermetic — the iOS doctor path shells out to xcrun.
 const make = (options: ReactNativeServiceGlobalOptions = {}) =>
-  new ReactNativeLaunchService(options, {} as ReactNativeCapabilities, config);
+  new ReactNativeLaunchService({ doctor: 'off', ...options }, {} as ReactNativeCapabilities, config);
 
 const cap = (over: Record<string, unknown> = {}): ReactNativeCapabilities =>
   ({ platformName: 'Android', ...over }) as ReactNativeCapabilities;

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -11,9 +11,9 @@ import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from '.
 
 const config = {} as Options.Testrunner;
 
-// doctor: 'off' keeps onPrepare hermetic — the iOS doctor path shells out to xcrun.
+// doctor: false keeps onPrepare hermetic — the iOS doctor path shells out to xcrun.
 const make = (options: ReactNativeServiceGlobalOptions = {}) =>
-  new ReactNativeLaunchService({ doctor: 'off', ...options }, {} as ReactNativeCapabilities, config);
+  new ReactNativeLaunchService({ doctor: false, ...options }, {} as ReactNativeCapabilities, config);
 
 const cap = (over: Record<string, unknown> = {}): ReactNativeCapabilities =>
   ({ platformName: 'Android', ...over }) as ReactNativeCapabilities;

--- a/scripts/smoke-appium-autoinstall.ts
+++ b/scripts/smoke-appium-autoinstall.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Clean-env smoke for `autoInstallDriver` (issue #378).
+ *
+ * The e2e/package-test envs have the Appium drivers as `node_modules` deps, and Appium loads
+ * those ahead of `APPIUM_HOME` — so there `ensureAppiumDriver` always reports `'found'` and the
+ * install path is never exercised. This smoke creates a clean dir with ONLY `appium` installed
+ * (no driver) and a fresh `APPIUM_HOME`, then asserts `ensureAppiumDriver(..., {
+ * autoInstallDriver: true })` actually installs the driver and it shows up afterwards.
+ *
+ * Run via `pnpm run smoke:autoinstall-driver` (needs `@wdio/native-mobile-core` built).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DRIVER = 'uiautomator2';
+const APPIUM_SPEC = 'appium@^3.5.0';
+
+/** The slice of `@wdio/native-mobile-core` this smoke uses. */
+interface NativeMobileCore {
+  ensureAppiumDriver: (
+    name: string,
+    opts: { autoInstallDriver?: boolean; source?: string },
+  ) => Promise<{ ok: true; value: { name: string; method: string } } | { ok: false; error: Error }>;
+  listInstalledDrivers: () => string[];
+  resetInstalledCache: () => void;
+}
+
+function fail(message: string): never {
+  console.error(`❌ autoInstallDriver smoke failed: ${message}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  // Import the built dist by path (not the package name): @wdio/native-mobile-core isn't a
+  // root dependency, and the dist only exists after the smoke job's build step — so a
+  // compile-time-resolved import would also break `typecheck:scripts` in the lint job.
+  const distUrl = pathToFileURL(
+    join(import.meta.dirname, '..', 'packages', 'native-mobile-core', 'dist', 'esm', 'index.js'),
+  ).href;
+  const { ensureAppiumDriver, listInstalledDrivers, resetInstalledCache } = (await import(distUrl)) as NativeMobileCore;
+
+  const work = mkdtempSync(join(tmpdir(), 'autoinstall-smoke-'));
+  process.env.APPIUM_HOME = mkdtempSync(join(tmpdir(), 'appium-home-'));
+
+  // Clean dir with ONLY appium — no driver in node_modules to shadow APPIUM_HOME.
+  writeFileSync(join(work, 'package.json'), JSON.stringify({ name: 'autoinstall-driver-smoke', private: true }));
+  console.log(`Installing ${APPIUM_SPEC} into a clean dir (${work})...`);
+  execFileSync('npm', ['install', APPIUM_SPEC, '--no-audit', '--no-fund', '--loglevel', 'error'], {
+    cwd: work,
+    stdio: 'inherit',
+  });
+
+  // ensureAppiumDriver resolves the appium CLI + driver list from process.cwd().
+  process.chdir(work);
+
+  resetInstalledCache();
+  if (listInstalledDrivers().includes(DRIVER)) {
+    fail(`precondition: '${DRIVER}' already present in a fresh APPIUM_HOME`);
+  }
+
+  const result = await ensureAppiumDriver(DRIVER, { autoInstallDriver: true });
+  if (!result.ok) {
+    fail(`ensureAppiumDriver returned Err: ${result.error.message}`);
+  }
+  if (result.value.method !== 'installed') {
+    fail(`expected method 'installed', got '${result.value.method}'`);
+  }
+
+  resetInstalledCache();
+  if (!listInstalledDrivers().includes(DRIVER)) {
+    fail(`'${DRIVER}' not present after install`);
+  }
+
+  console.log(`✅ autoInstallDriver smoke: '${DRIVER}' installed via ensureAppiumDriver`);
+}
+
+main().catch((error) => fail(error instanceof Error ? error.message : String(error)));


### PR DESCRIPTION
Closes #378.

Shared chromedriver-style setup-automation mechanism in `@wdio/native-mobile-core` that React Native, Flutter, and future Capacitor/Neutralino all inherit. **All opt-in and non-disruptive by default** (existing CI is untouched).

## Tier 1 — parity mechanism
- **`ensureAppiumDriver(name, opts)`** + static **Appium-server↔driver version matrix** (`versionMatrix.ts`), modeled on `@wdio/tauri-service`'s `ensureTauriDriver`: opt-in `autoInstallDriver` (default off), idempotent (skips when already installed via `appium driver list --installed`), installs the matrix-pinned known-good version for the detected Appium **major**. A unit test guards drift against `e2e/package.json`.
- **Per-worker port seam** — activates the inherited (previously unused) `PortManager` on `MobileBaseLauncher`. Subclasses declare `portCapKey()`; the launcher allocates a free realm port per cap (stamp-if-unset, multiremote-safe) and releases it on worker end. Base ports moved to 8200/8300 (clear of 4444/4723/8081).
- **Preflight doctor** (`doctor.ts`) extending `@wdio/native-utils`' `DiagnosticResult`/`formatDiagnosticResults`: check builders (`checkCommandOnPath`, `checkPathExists`, `checkBuildIsDebug`, `checkAppiumServiceConfigured`) + `runDoctor` with a `doctor: 'off' | 'warn' | 'strict'` policy (fail-fast `SevereServiceError` only under `strict`).

## Tier 2 — cap-default derivation
- **`applyBootCapDefaults`** (apply-only-if-unset): `appium:autoGrantPermissions` (Android); iOS `wdaLaunchTimeout`/`simulatorStartupTimeout`/`isHeadless` (the proven e2e values that kill the cryptic appium-xcuitest cold-toolchain timeout). Deliberately omits `appium:noReset` (reset-vs-speed is the user's call).
- **`iosSetup.ts`**: `resolveIosUdid` (newest-runtime — avoids the duplicate-name boot of the wrong sim, the #359 root cause), `warmUpXcodeToolchain` (pre-resolve SDK + simctl), `prebuildWda` (optional `xcodebuild build-for-testing`, best-effort/macOS-guarded/`Result`).
- Appium-server-presence check via `config.services`.

## Seams + options
New abstract seams `requiredDrivers`/`portCapKey` implemented in both service launchers; `autoInstallDriver`/`doctor` options added to the RN + Flutter option types.

## Tests
103 native-mobile-core tests (driver manager, version matrix + drift guard, doctor, port seam, iOS setup, boot-cap defaults); RN/Flutter launcher specs updated for the new seams. Typecheck + lint + detect-changes guard all green.

Framework-specific halves: Flutter #405, React Native #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)