### PR TITLE
feat(flutter-service): zero-config execute/mock via auto VM-service setup (#405)

### DIFF
--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -74,6 +74,10 @@ const flutterServiceOptions: FlutterServiceOptions = {
   platform: isIos ? 'iOS' : 'Android',
   // Forward the device (logcat/syslog) logs into the WDIO log on each test.
   captureBackendLogs: true,
+  // Exercise the preflight doctor end-to-end (appium-service present, flutter on PATH, the
+  // fork's getVMServiceUrl present on Android, iOS toolchain warm). 'strict' makes a
+  // regression that breaks the preflight fail CI.
+  doctor: 'strict',
 };
 
 type FlutterCapability = {

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -75,9 +75,9 @@ const flutterServiceOptions: FlutterServiceOptions = {
   // Forward the device (logcat/syslog) logs into the WDIO log on each test.
   captureBackendLogs: true,
   // Exercise the preflight doctor end-to-end (appium-service present, flutter on PATH, the
-  // fork's getVMServiceUrl present on Android, iOS toolchain warm). 'strict' makes a
+  // fork's getVMServiceUrl present on Android, iOS toolchain warm). strict mode makes a
   // regression that breaks the preflight fail CI.
-  doctor: 'strict',
+  doctor: { strict: true },
 };
 
 type FlutterCapability = {

--- a/fixtures/package-tests/flutter-app/wdio.conf.ts
+++ b/fixtures/package-tests/flutter-app/wdio.conf.ts
@@ -26,6 +26,10 @@ const platform = rawPlatform as 'android' | 'ios';
 
 const flutterServiceOptions: FlutterServiceOptions = {
   captureBackendLogs: true,
+  // Type-level coverage: assert the published package exports/types the setup-automation
+  // options. Values are runtime no-ops so this stays a config-composition smoke test.
+  autoInstallDriver: false,
+  doctor: 'off',
 };
 
 const capabilities: FlutterCapabilities[] = [

--- a/fixtures/package-tests/flutter-app/wdio.conf.ts
+++ b/fixtures/package-tests/flutter-app/wdio.conf.ts
@@ -29,7 +29,7 @@ const flutterServiceOptions: FlutterServiceOptions = {
   // Type-level coverage: assert the published package exports/types the setup-automation
   // options. Values are runtime no-ops so this stays a config-composition smoke test.
   autoInstallDriver: false,
-  doctor: 'off',
+  doctor: false,
 };
 
 const capabilities: FlutterCapabilities[] = [

--- a/packages/flutter-service/README.md
+++ b/packages/flutter-service/README.md
@@ -36,18 +36,20 @@ Native find/tap needs the Appium Flutter driver:
 appium driver install --source=npm appium-flutter-driver
 ```
 
-> **`execute` / `mock` prerequisite — pin the VM Service port.** These connect to the Dart VM
-> Service, which the driver discovers by scraping the device log — a path that isn't exposed to
-> the service. Instead, **set `appium:dartVmServicePort`** (a fixed port) so the driver binds the VM
-> Service to it with auth codes disabled, giving a deterministic `ws://localhost:<port>/ws` the
-> service connects to directly.
+> **`execute` / `mock` and the VM Service port — now zero-config.** These connect to the Dart VM
+> Service on a fixed port (bound with auth codes disabled, giving a deterministic
+> `ws://localhost:<port>/ws`). The launcher **auto-allocates a free `appium:dartVmServicePort` per
+> worker**, so you no longer need to set it by hand — pin it yourself only to override. Without it,
+> find/tap/deeplink/contexts still work; only `execute`/`mock` use it.
 >
-> On **iOS** the published `appium-flutter-driver` (≥ 3.7.1) already pins the port via
-> `processArguments`. On **Android** the equivalent (a `vm-service-port` launch-intent extra) lives
-> in a [fork](https://github.com/goosewobbler/appium-flutter-driver) pending an upstream PR — until
-> it lands, Android `execute`/`mock` need that fork (to be published as
-> `@goosewobbler/appium-flutter-driver`: `appium driver install --source=npm @goosewobbler/appium-flutter-driver`).
-> Without the pin, find/tap/deeplink/contexts still work — only `execute`/`mock` need it.
+> On **iOS** the published `appium-flutter-driver` (≥ 3.7.1) honours the port via `processArguments`.
+> On **Android** the equivalent (a `vm-service-port` launch-intent extra + the `flutter:getVMServiceUrl`
+> command) lives in a [fork](https://github.com/goosewobbler/appium-flutter-driver) pending an upstream
+> PR to `appium/appium-flutter-driver` (the iOS half merged as
+> [#870](https://github.com/appium/appium-flutter-driver/pull/870)) — until it lands, Android
+> `execute`/`mock` need that fork. The preflight doctor warns if the installed driver lacks
+> `getVMServiceUrl`. Set `autoInstallDriver: true` to let the launcher install the `flutter` driver
+> for you, and `doctor: 'strict'` to fail fast on a missing toolchain.
 
 ## Quick start
 

--- a/packages/flutter-service/README.md
+++ b/packages/flutter-service/README.md
@@ -157,12 +157,60 @@ interface FlutterServiceOptions {
   // Log capture
   captureBackendLogs?: boolean; // forward logcat (Android) / syslog (iOS) to the WDIO output
 
+  // Setup automation (see "Zero-config setup automation" below)
+  autoInstallDriver?: boolean;  // install the flutter Appium driver if missing (default: false)
+  doctor?: 'off' | 'warn' | 'strict'; // preflight checks (default: 'warn')
+
   // Mock lifecycle (run before each test)
   clearMocks?: boolean;         // clear mock call history
   resetMocks?: boolean;         // clear value + call history
   restoreMocks?: boolean;       // remove the mock entirely
 }
 ```
+
+## Zero-config setup automation
+
+Like `@wdio/electron-service` (which auto-manages chromedriver), the service drives as much
+of the Appium setup as is feasible. Everything here is **opt-in and apply-if-unset** — an
+explicit capability or option you set always wins.
+
+### Auto VM-Service port
+
+The launcher **auto-allocates a free `appium:dartVmServicePort` per worker** (see the note
+under [Installation](#installation)), so `execute`/`mock` are zero-config — no manual port,
+no log scrape. Pin `vmServicePort` only to override.
+
+### `autoInstallDriver` — install the Appium driver
+
+`autoInstallDriver: true` installs the `flutter` Appium driver (appium-flutter-driver) if
+it isn't already present, at a version known-good for your Appium **server major** (from a
+maintained matrix). It's **idempotent** and **off by default** (CI usually manages drivers
+explicitly). Note it installs the **stock** driver — on Android, `execute`/`mock` still need
+the goosewobbler fork until it's upstreamed (see [Installation](#installation)); the doctor
+warns when the fork is absent.
+
+### `doctor` — preflight checks
+
+`doctor` runs fail-fast preflight validation in `onPrepare` so a misconfiguration surfaces
+as a clear message instead of a cryptic Appium timeout:
+
+| Mode | Behaviour |
+|---|---|
+| `'off'` | Skip all checks. |
+| `'warn'` *(default)* | Log actionable warnings; never abort. |
+| `'strict'` | Abort the run (`SevereServiceError`) on any error-level check. |
+
+For Flutter it checks: `@wdio/appium-service` is in `services`, `flutter` is on PATH, the
+installed `appium-flutter-driver` carries `getVMServiceUrl` (Android only), and (iOS) the
+Xcode toolchain is warm.
+
+### iOS launch caps — auto-applied
+
+On iOS the service fills in launch caps you didn't set (each only if absent): a generous
+`appium:wdaLaunchTimeout` / `appium:simulatorStartupTimeout`, `appium:isHeadless` under CI,
+and — when you give `appium:deviceName` but no `appium:udid` — it resolves the exact
+simulator UDID (preferring the newest runtime) to avoid booting a duplicate-named device.
+On Android it sets `appium:autoGrantPermissions`. Set any of these yourself to override.
 
 ## API (`browser.flutter.*`)
 

--- a/packages/flutter-service/README.md
+++ b/packages/flutter-service/README.md
@@ -49,7 +49,7 @@ appium driver install --source=npm appium-flutter-driver
 > [#870](https://github.com/appium/appium-flutter-driver/pull/870)) — until it lands, Android
 > `execute`/`mock` need that fork. The preflight doctor warns if the installed driver lacks
 > `getVMServiceUrl`. Set `autoInstallDriver: true` to let the launcher install the `flutter` driver
-> for you, and `doctor: 'strict'` to fail fast on a missing toolchain.
+> for you, and `doctor: { strict: true }` to fail fast on a missing toolchain.
 
 ## Quick start
 
@@ -159,7 +159,7 @@ interface FlutterServiceOptions {
 
   // Setup automation (see "Zero-config setup automation" below)
   autoInstallDriver?: boolean;  // install the flutter Appium driver if missing (default: false)
-  doctor?: 'off' | 'warn' | 'strict'; // preflight checks (default: 'warn')
+  doctor?: boolean | { strict?: boolean }; // preflight checks (default: true; { strict: true } aborts on error)
 
   // Mock lifecycle (run before each test)
   clearMocks?: boolean;         // clear mock call history
@@ -194,11 +194,11 @@ warns when the fork is absent.
 `doctor` runs fail-fast preflight validation in `onPrepare` so a misconfiguration surfaces
 as a clear message instead of a cryptic Appium timeout:
 
-| Mode | Behaviour |
+| `doctor` | Behaviour |
 |---|---|
-| `'off'` | Skip all checks. |
-| `'warn'` *(default)* | Log actionable warnings; never abort. |
-| `'strict'` | Abort the run (`SevereServiceError`) on any error-level check. |
+| `false` | Skip all checks. |
+| `true` *(default)*, or omitted | Run the checks; log actionable warnings; never abort. |
+| `{ strict: true }` | Run the checks; abort the run (`SevereServiceError`) on any error-level check. |
 
 For Flutter it checks: `@wdio/appium-service` is in `services`, `flutter` is on PATH, the
 installed `appium-flutter-driver` carries `getVMServiceUrl` (Android only), and (iOS) the

--- a/packages/flutter-service/src/diagnostics.ts
+++ b/packages/flutter-service/src/diagnostics.ts
@@ -25,9 +25,16 @@ export function checkFlutterOnPath(): DoctorCheck {
  */
 export function checkAppiumFlutterDriverFork(): DoctorCheck {
   return (): DiagnosticResult => {
+    const forkHint =
+      'Android execute/mock need the goosewobbler appium-flutter-driver fork (vm-service-port + ' +
+      'getVMServiceUrl) until it is upstreamed. iOS is unaffected (uses appium:dartVmServicePort directly).';
     try {
       const req = createRequire(join(process.cwd(), 'noop.js'));
       const pkg = req.resolve('appium-flutter-driver/package.json');
+      // The driver's compiled command lives at build/lib/commands/execute.js. This layout is
+      // stable across the versions we target; the check is temporary and retired once the fork
+      // lands upstream, so a future layout change just needs this path (and the catch keeps the
+      // fork hint so a drift still points the right way).
       const execJs = join(dirname(pkg), 'build', 'lib', 'commands', 'execute.js');
       const src = readFileSync(execJs, 'utf8');
       if (src.includes('getVMServiceUrl')) {
@@ -37,21 +44,28 @@ export function checkAppiumFlutterDriverFork(): DoctorCheck {
         category: 'appium-flutter-driver',
         status: 'warn',
         message: 'getVMServiceUrl not found in the installed driver',
-        details:
-          'Android execute/mock need the goosewobbler appium-flutter-driver fork (vm-service-port + ' +
-          'getVMServiceUrl) until it is upstreamed. iOS is unaffected (uses appium:dartVmServicePort directly).',
+        details: forkHint,
       };
     } catch (error) {
       return {
         category: 'appium-flutter-driver',
         status: 'warn',
         message: `could not inspect appium-flutter-driver (${(error as Error).message})`,
+        details: forkHint,
       };
     }
   };
 }
 
-/** The Flutter-specific preflight checks, in the order they should run. */
-export function flutterDoctorChecks(): DoctorCheck[] {
-  return [checkFlutterOnPath(), checkAppiumFlutterDriverFork()];
+/**
+ * The Flutter-specific preflight checks. The fork check is Android-only — the vm-service-port
+ * intent extra + getVMServiceUrl are an Android concern, so it's omitted for an iOS-only run
+ * (iOS pins the port via processArguments and isn't affected by the fork).
+ */
+export function flutterDoctorChecks(platforms: Set<'android' | 'ios'>): DoctorCheck[] {
+  const checks: DoctorCheck[] = [checkFlutterOnPath()];
+  if (platforms.has('android')) {
+    checks.push(checkAppiumFlutterDriverFork());
+  }
+  return checks;
 }

--- a/packages/flutter-service/src/diagnostics.ts
+++ b/packages/flutter-service/src/diagnostics.ts
@@ -1,0 +1,57 @@
+// Flutter-service preflight checks, composed from @wdio/native-mobile-core's doctor builders
+// and run from the launcher's onPrepare. Validates the toolchain + the one fork-specific
+// requirement that makes Android execute/mock work until it's upstreamed.
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { checkCommandOnPath, type DoctorCheck } from '@wdio/native-mobile-core';
+import type { DiagnosticResult } from '@wdio/native-utils';
+
+/** `flutter` on PATH — needed for app builds and SDK-adjacent tooling. */
+export function checkFlutterOnPath(): DoctorCheck {
+  return checkCommandOnPath('flutter', {
+    severity: 'warn',
+    hint: 'Install the Flutter SDK and ensure `flutter` is on PATH.',
+  });
+}
+
+/**
+ * Verify the installed `appium-flutter-driver` carries the `flutter:getVMServiceUrl` command.
+ * Android `execute`/`mock` need the goosewobbler fork (vm-service-port intent extra +
+ * getVMServiceUrl) until it is upstreamed/published; on the stock driver this surfaces as a
+ * clear warning rather than a silent execute/mock failure. (Delivery stays in CI — we
+ * validate, we don't mutate node_modules; see ROADMAP / the upstream PR.)
+ */
+export function checkAppiumFlutterDriverFork(): DoctorCheck {
+  return (): DiagnosticResult => {
+    try {
+      const req = createRequire(join(process.cwd(), 'noop.js'));
+      const pkg = req.resolve('appium-flutter-driver/package.json');
+      const execJs = join(dirname(pkg), 'build', 'lib', 'commands', 'execute.js');
+      const src = readFileSync(execJs, 'utf8');
+      if (src.includes('getVMServiceUrl')) {
+        return { category: 'appium-flutter-driver', status: 'ok', message: 'getVMServiceUrl present' };
+      }
+      return {
+        category: 'appium-flutter-driver',
+        status: 'warn',
+        message: 'getVMServiceUrl not found in the installed driver',
+        details:
+          'Android execute/mock need the goosewobbler appium-flutter-driver fork (vm-service-port + ' +
+          'getVMServiceUrl) until it is upstreamed. iOS is unaffected (uses appium:dartVmServicePort directly).',
+      };
+    } catch (error) {
+      return {
+        category: 'appium-flutter-driver',
+        status: 'warn',
+        message: `could not inspect appium-flutter-driver (${(error as Error).message})`,
+      };
+    }
+  };
+}
+
+/** The Flutter-specific preflight checks, in the order they should run. */
+export function flutterDoctorChecks(): DoctorCheck[] {
+  return [checkFlutterOnPath(), checkAppiumFlutterDriverFork()];
+}

--- a/packages/flutter-service/src/launcher.ts
+++ b/packages/flutter-service/src/launcher.ts
@@ -6,11 +6,12 @@
 // `MobileBaseLauncher`; this subclass supplies the one per-framework seam —
 // Flutter's automation name — via `mutateCapability`.
 
-import { MobileBaseLauncher } from '@wdio/native-mobile-core';
+import { type DoctorCheck, MobileBaseLauncher } from '@wdio/native-mobile-core';
 import type { Options } from '@wdio/types';
 
 import { prepareFlutterCapability } from './capabilities.js';
 import { CUSTOM_CAPABILITY_NAME, SERVICE_NAME } from './constants.js';
+import { flutterDoctorChecks } from './diagnostics.js';
 import type { FlutterCapabilities, FlutterServiceGlobalOptions } from './types.js';
 
 export default class FlutterLaunchService extends MobileBaseLauncher<FlutterServiceGlobalOptions, FlutterCapabilities> {
@@ -32,5 +33,9 @@ export default class FlutterLaunchService extends MobileBaseLauncher<FlutterServ
   // reads appium:dartVmServicePort as the discovery fast-path, skipping the log scrape).
   protected portCapKey(): string | undefined {
     return 'appium:dartVmServicePort';
+  }
+
+  protected doctorChecks(config: Options.Testrunner, platforms: Set<'android' | 'ios'>): DoctorCheck[] {
+    return [...super.doctorChecks(config, platforms), ...flutterDoctorChecks()];
   }
 }

--- a/packages/flutter-service/src/launcher.ts
+++ b/packages/flutter-service/src/launcher.ts
@@ -36,6 +36,6 @@ export default class FlutterLaunchService extends MobileBaseLauncher<FlutterServ
   }
 
   protected doctorChecks(config: Options.Testrunner, platforms: Set<'android' | 'ios'>): DoctorCheck[] {
-    return [...super.doctorChecks(config, platforms), ...flutterDoctorChecks()];
+    return [...super.doctorChecks(config, platforms), ...flutterDoctorChecks(platforms)];
   }
 }

--- a/packages/flutter-service/test/diagnostics.spec.ts
+++ b/packages/flutter-service/test/diagnostics.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
+vi.mock('node:module', () => ({ createRequire: () => ({ resolve: () => '/fake/appium-flutter-driver/package.json' }) }));
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { checkAppiumFlutterDriverFork, checkFlutterOnPath, flutterDoctorChecks } from '../src/diagnostics.js';
+
+const execMock = vi.mocked(execFileSync);
+const readMock = vi.mocked(readFileSync);
+
+afterEach(() => vi.clearAllMocks());
+
+describe('checkFlutterOnPath', () => {
+  it('should report ok when flutter is on PATH', async () => {
+    execMock.mockReturnValueOnce('/usr/bin/flutter\n');
+    expect(await checkFlutterOnPath()()).toMatchObject({ status: 'ok' });
+  });
+
+  it('should warn (not error) when flutter is missing', async () => {
+    execMock.mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+    expect(await checkFlutterOnPath()()).toMatchObject({ status: 'warn', category: 'flutter' });
+  });
+});
+
+describe('checkAppiumFlutterDriverFork', () => {
+  it('should report ok when getVMServiceUrl is present in the installed driver', async () => {
+    readMock.mockReturnValueOnce('exports.getVMServiceUrl = ...');
+    expect(await checkAppiumFlutterDriverFork()()).toMatchObject({ status: 'ok' });
+  });
+
+  it('should warn with the fork hint when getVMServiceUrl is absent', async () => {
+    readMock.mockReturnValueOnce('exports.execute = ...');
+    const r = await checkAppiumFlutterDriverFork()();
+    expect(r.status).toBe('warn');
+    expect(r.details).toMatch(/goosewobbler/);
+  });
+
+  it('should warn when the driver cannot be inspected', async () => {
+    readMock.mockImplementationOnce(() => {
+      throw new Error('ENOENT');
+    });
+    expect(await checkAppiumFlutterDriverFork()()).toMatchObject({ status: 'warn' });
+  });
+});
+
+describe('flutterDoctorChecks', () => {
+  it('should bundle the flutter + fork checks', () => {
+    expect(flutterDoctorChecks()).toHaveLength(2);
+  });
+});

--- a/packages/flutter-service/test/diagnostics.spec.ts
+++ b/packages/flutter-service/test/diagnostics.spec.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
 vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
-vi.mock('node:module', () => ({ createRequire: () => ({ resolve: () => '/fake/appium-flutter-driver/package.json' }) }));
+vi.mock('node:module', () => ({
+  createRequire: () => ({ resolve: () => '/fake/appium-flutter-driver/package.json' }),
+}));
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
@@ -40,16 +42,22 @@ describe('checkAppiumFlutterDriverFork', () => {
     expect(r.details).toMatch(/goosewobbler/);
   });
 
-  it('should warn when the driver cannot be inspected', async () => {
+  it('should warn (with the fork hint) when the driver cannot be inspected', async () => {
     readMock.mockImplementationOnce(() => {
       throw new Error('ENOENT');
     });
-    expect(await checkAppiumFlutterDriverFork()()).toMatchObject({ status: 'warn' });
+    const r = await checkAppiumFlutterDriverFork()();
+    expect(r.status).toBe('warn');
+    expect(r.details).toMatch(/goosewobbler/);
   });
 });
 
 describe('flutterDoctorChecks', () => {
-  it('should bundle the flutter + fork checks', () => {
-    expect(flutterDoctorChecks()).toHaveLength(2);
+  it('should bundle the flutter + fork checks for an Android run', () => {
+    expect(flutterDoctorChecks(new Set(['android']))).toHaveLength(2);
+  });
+
+  it('should omit the Android-only fork check for an iOS-only run', () => {
+    expect(flutterDoctorChecks(new Set(['ios']))).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes #405. **Stacked on #424 (#378)** — review/merge that first; this PR's diff is only the Flutter-specific delta.

Builds on the shared mechanism. The #378 port seam now auto-allocates `appium:dartVmServicePort` per worker (Flutter's `portCapKey`), so `execute`/`mock` are **zero-config** — no hand-pinned port, no up-to-60s log scrape. This PR adds the Flutter-specific preflight.

- **`diagnostics.ts`**: `flutter`-on-PATH check + a fork-presence check that greps the installed `appium-flutter-driver` for `flutter:getVMServiceUrl`, **warning (not erroring)** when absent. We validate the fork — we don't mutate `node_modules` (pnpm-store-unsafe); CI keeps delivering it until the upstream PR lands.
- **launcher**: compose `flutterDoctorChecks` over the shared base checks.
- **README**: document the now-automatic port + the `autoInstallDriver`/`doctor` options.

### Fork delivery — the real exit
The goosewobbler `appium-flutter-driver` fork carries the Android `vm-service-port` intent extra + `getVMServiceUrl`. The iOS half is **already upstreamed** (appium/appium-flutter-driver#870, which invited the Android follow-up). A follow-up upstream PR for the Android half will retire the fork, the CI override, and this doctor check entirely.

### Tests
106 flutter-service tests (+6 diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)