### PR TITLE
feat(react-native-service): manage Metro lifecycle + zero-config Hermes setup (#406)

### DIFF
--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -244,11 +244,6 @@ jobs:
             RN_PLATFORM=ios pnpm test:package:react-native
           fi
 
-      - name: 🐛 Show Metro log on failure
-        if: failure()
-        shell: bash
-        run: tail -n 200 e2e/metro.log || true
-
       # The failing session-create (#359) leaves no app/page-source, so the appium debug log is the
       # primary evidence. Surface its tail inline (the session error is near the end) for a quick
       # read without downloading the artifact; the full log ships in Upload Test Logs below.
@@ -265,6 +260,5 @@ jobs:
           name: e2e-logs-react-native-ios-${{ inputs.new-arch && 'new' || 'old' }}-arch-${{ inputs.os }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-type }}
           path: |
             e2e/logs/**/*.log
-            e2e/metro.log
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -226,18 +226,12 @@ jobs:
           RN_IOS_DEVICE: ${{ inputs.ios-device }}
         run: |
           set -euo pipefail
-          # Metro serves the JS bundle + Hermes inspector; the simulator reaches it over
-          # the shared host loopback (no adb-reverse equivalent needed on iOS).
-          ( cd "$RN_BUILD_DIR" && npx react-native start --port 8081 > "$GITHUB_WORKSPACE/e2e/metro.log" 2>&1 & )
-          # wait-on is a pinned e2e devDependency — run the workspace-local binary (not an
-          # unpinned `npx --yes`) so a breaking release can't silently break the readiness check.
-          pnpm --filter @repo/e2e exec wait-on tcp:8081 --timeout 120000
-          # Pre-bundle: Metro compiles the JS bundle lazily on first request (~60s cold). Without
-          # this, the first app launch lands on Metro's "Bundling…" overlay with an empty native
-          # tree, and the earliest specs fail finding elements before bundling completes. Force the
-          # compile now (best-effort — the specs surface a real bundling error more clearly).
-          curl -fsS --max-time 300 "http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false" -o /dev/null \
-            && echo "Metro bundle pre-built" || echo "::warning::Metro pre-bundle request failed (continuing)"
+          # Metro is now service-managed (manageMetro + prebundle): the @wdio/react-native-service
+          # launcher starts `react-native start`, waits for /status, force-compiles the JS bundle
+          # (so the first launch doesn't land on the "Bundling…" overlay), and tears it down. The
+          # simulator reaches it over the shared host loopback (no adb-reverse needed on iOS). This
+          # leg is the direct e2e verification of that lifecycle (replaces the manual
+          # start + wait-on + curl-prebundle previously here).
           pnpm --filter @repo/e2e run test:e2e:react-native:ios
           # Package-install smoke (#387): validate the PACKED @wdio/react-native-service tarball
           # against THIS booted simulator + Metro, reusing the prebuilt WDA. test-package.ts installs

--- a/.github/workflows/_ci-e2e-react-native.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native.reusable.yml
@@ -194,11 +194,6 @@ jobs:
             # `sh -c`), so a multi-line if/then/fi splits and the `if` executes without its `fi`.
             if [ "${{ inputs.new-arch }}" = "true" ]; then RN_PLATFORM=android pnpm test:package:react-native; fi
 
-      - name: 🐛 Show Metro log on failure
-        if: failure()
-        shell: bash
-        run: tail -n 200 e2e/metro.log || true
-
       - name: 📦 Upload Test Logs
         if: always()
         continue-on-error: true
@@ -207,6 +202,5 @@ jobs:
           name: e2e-logs-react-native-${{ inputs.new-arch && 'new' || 'old' }}-arch-${{ inputs.os }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-type }}
           path: |
             e2e/logs/**/*.log
-            e2e/metro.log
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/_ci-e2e-react-native.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native.reusable.yml
@@ -176,14 +176,14 @@ jobs:
           # boot. Use POSIX-safe `set -eu`.
           script: |
             set -eu
-            # Map emulator:8081 → host:8081 so both the debug bundle load and the Hermes
-            # inspector attach reach Metro running on the runner host.
+            # Map emulator:8081 → host:8081 so the app's first debug-bundle load reaches Metro
+            # on the runner host (must be in place before the app launches). The Hermes inspector
+            # attach is re-established per-device by MetroBridge.
             adb reverse tcp:8081 tcp:8081
-            # Start Metro from the scaffolded project (serves the JS bundle + Hermes inspector).
-            ( cd "$RN_BUILD_DIR" && npx react-native start --port 8081 > "$GITHUB_WORKSPACE/e2e/metro.log" 2>&1 & )
-            # wait-on is a pinned e2e devDependency — run the workspace-local binary (not an
-            # unpinned `npx --yes`) so a breaking release can't silently break the readiness check.
-            pnpm --filter @repo/e2e exec wait-on tcp:8081 --timeout 120000
+            # Metro itself is now service-managed (manageMetro: true) — the @wdio/react-native-service
+            # launcher starts `react-native start`, waits for /status, pre-bundles, and tears it
+            # down. This leg is the direct e2e verification of that lifecycle (replaces the manual
+            # start + wait-on previously here).
             pnpm --filter @repo/e2e run test:e2e:react-native
             # Package-install smoke (#387): validate the PACKED @wdio/react-native-service tarball
             # installs + composes against THIS already-booted emulator + Metro + APK — the cheap

--- a/.github/workflows/_ci-e2e-react-native.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native.reusable.yml
@@ -176,13 +176,11 @@ jobs:
           # boot. Use POSIX-safe `set -eu`.
           script: |
             set -eu
-            # Map emulator:8081 → host:8081 so the app's first debug-bundle load reaches Metro
-            # on the runner host (must be in place before the app launches). The Hermes inspector
-            # attach is re-established per-device by MetroBridge.
-            adb reverse tcp:8081 tcp:8081
-            # Metro itself is now service-managed (manageMetro: true) — the @wdio/react-native-service
-            # launcher starts `react-native start`, waits for /status, pre-bundles, and tears it
-            # down. This leg is the direct e2e verification of that lifecycle (replaces the manual
+            # Metro AND the device→host `adb reverse` are now service-managed: the
+            # @wdio/react-native-service launcher starts `react-native start`, waits for /status,
+            # pre-bundles, and tears it down (manageMetro), and maps emulator:8081 → host:8081 in
+            # onWorkerStart — pre-launch, so the app's first bundle load reaches Metro. This leg is
+            # the direct e2e verification of that lifecycle (replaces the manual adb-reverse +
             # start + wait-on previously here).
             pnpm --filter @repo/e2e run test:e2e:react-native
             # Package-install smoke (#387): validate the PACKED @wdio/react-native-service tarball

--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -219,7 +219,10 @@ export const config = {
   // the worker channel). Registering bare 'react-native' left this.options empty, so managed
   // Metro silently never started and the doctor never ran. The capability copy below still
   // feeds the worker.
-  services: [['appium', { logPath: logDir, args: { logLevel: 'debug' } }], ['react-native', reactNativeServiceOptions]],
+  services: [
+    ['appium', { logPath: logDir, args: { logLevel: 'debug' } }],
+    ['react-native', reactNativeServiceOptions],
+  ],
   port: 4723,
   framework: 'mocha',
   reporters: ['spec'],

--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -93,6 +93,16 @@ const reactNativeServiceOptions: ReactNativeServiceOptions = {
   // frontend = the app's JS/Metro console. The logging spec asserts frontend capture.
   captureBackendLogs: true,
   captureFrontendLogs: true,
+  // Dogfood the service-managed Metro lifecycle: the service starts `react-native start`,
+  // waits for readiness, pre-bundles, and tears it down — replacing the manual CI start/
+  // wait-on/prebundle. Only in CI, where RN_BUILD_DIR points at the scaffolded app; a local
+  // run keeps starting Metro itself. (Android `adb reverse` stays a pre-launch CI step.)
+  ...(process.env.RN_BUILD_DIR
+    ? { manageMetro: true, metroProjectRoot: process.env.RN_BUILD_DIR, prebundle: true }
+    : {}),
+  // Exercise the preflight doctor end-to-end (appium-service present, Metro reachable, iOS
+  // toolchain warm). 'strict' makes a regression that breaks the preflight fail CI.
+  doctor: 'strict',
 };
 
 type ReactNativeCapability = {

--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -212,7 +212,14 @@ export const config = {
   // artifact via the e2e/logs/**/*.log glob); --log-level debug surfaces the XCUITest driver's
   // sim-boot/WDA/FrontBoard trace, which is the only place the #359 session-create flake is
   // diagnosable (the failing session has no app/page-source to capture).
-  services: [['appium', { logPath: logDir, args: { logLevel: 'debug' } }], 'react-native'],
+  //
+  // Pass reactNativeServiceOptions to the SERVICE registration (not only the capability):
+  // launcher-level options — manageMetro/metroProjectRoot/prebundle/doctor — are read from
+  // the service's own options in onPrepare, NOT from wdio:reactNativeServiceOptions (which is
+  // the worker channel). Registering bare 'react-native' left this.options empty, so managed
+  // Metro silently never started and the doctor never ran. The capability copy below still
+  // feeds the worker.
+  services: [['appium', { logPath: logDir, args: { logLevel: 'debug' } }], ['react-native', reactNativeServiceOptions]],
   port: 4723,
   framework: 'mocha',
   reporters: ['spec'],

--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -101,8 +101,8 @@ const reactNativeServiceOptions: ReactNativeServiceOptions = {
     ? { manageMetro: true, metroProjectRoot: process.env.RN_BUILD_DIR, prebundle: true }
     : {}),
   // Exercise the preflight doctor end-to-end (appium-service present, Metro reachable, iOS
-  // toolchain warm). 'strict' makes a regression that breaks the preflight fail CI.
-  doctor: 'strict',
+  // toolchain warm). strict mode makes a regression that breaks the preflight fail CI.
+  doctor: { strict: true },
 };
 
 type ReactNativeCapability = {

--- a/fixtures/package-tests/react-native-app/wdio.conf.ts
+++ b/fixtures/package-tests/react-native-app/wdio.conf.ts
@@ -27,6 +27,13 @@ const platform = rawPlatform as 'android' | 'ios';
 const rnServiceOptions: ReactNativeServiceOptions = {
   captureBackendLogs: true,
   captureFrontendLogs: true,
+  // Type-level coverage: assert the published package exports/types the setup-automation
+  // options. Values are runtime no-ops so this stays a config-composition smoke test.
+  manageMetro: false,
+  metroProjectRoot: process.cwd(),
+  prebundle: false,
+  autoInstallDriver: false,
+  doctor: 'off',
 };
 
 const capabilities: ReactNativeCapabilities[] = [

--- a/fixtures/package-tests/react-native-app/wdio.conf.ts
+++ b/fixtures/package-tests/react-native-app/wdio.conf.ts
@@ -33,7 +33,7 @@ const rnServiceOptions: ReactNativeServiceOptions = {
   metroProjectRoot: process.cwd(),
   prebundle: false,
   autoInstallDriver: false,
-  doctor: 'off',
+  doctor: false,
 };
 
 const capabilities: ReactNativeCapabilities[] = [

--- a/fixtures/package-tests/react-native-app/wdio.conf.ts
+++ b/fixtures/package-tests/react-native-app/wdio.conf.ts
@@ -27,11 +27,14 @@ const platform = rawPlatform as 'android' | 'ios';
 const rnServiceOptions: ReactNativeServiceOptions = {
   captureBackendLogs: true,
   captureFrontendLogs: true,
-  // Type-level coverage: assert the published package exports/types the setup-automation
-  // options. Values are runtime no-ops so this stays a config-composition smoke test.
-  manageMetro: false,
-  metroProjectRoot: process.cwd(),
-  prebundle: false,
+  // The execute smoke needs Metro. In CI (RN_BUILD_DIR = the scaffolded RN app the APK was built
+  // from) the packed service manages its OWN Metro: the main e2e run owns + tears down its Metro
+  // in onComplete before this separate run starts, so there's no shared Metro left to reuse. This
+  // also dogfoods managed Metro from the packed tarball. Locally (no RN_BUILD_DIR) it stays a
+  // no-op config-composition smoke — run your own Metro.
+  ...(process.env.RN_BUILD_DIR
+    ? { manageMetro: true, metroProjectRoot: process.env.RN_BUILD_DIR, prebundle: true }
+    : { manageMetro: false, metroProjectRoot: process.cwd(), prebundle: false }),
   autoInstallDriver: false,
   doctor: false,
 };

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -286,6 +286,24 @@ export interface ReactNativeServiceOptions extends LogCaptureConfig, MockLifecyc
    */
   metroPort?: number;
   /**
+   * Opt-in: have the launcher own the Metro lifecycle — start `react-native start` as a
+   * long-lived child, wait for readiness, and tear it down on completion. Off by default
+   * since many devs run Metro themselves.
+   * @default false
+   */
+  manageMetro?: boolean;
+  /**
+   * App project root that `react-native start` runs in (only used with `manageMetro`).
+   * @default process.cwd()
+   */
+  metroProjectRoot?: string;
+  /**
+   * With `manageMetro`, pre-bundle (`/index.bundle`) after Metro is ready to warm the
+   * ~60s cold compile so the first spec doesn't land on the "Bundling…" overlay.
+   * @default false
+   */
+  prebundle?: boolean;
+  /**
    * Path to a built app (`.apk` / `.app` / `.ipa`). Convenience that maps onto
    * `appium:app` when the capability doesn't already set a launch target —
    * prefer setting the `appium:*` launch capability directly.

--- a/packages/react-native-service/README.md
+++ b/packages/react-native-service/README.md
@@ -141,6 +141,50 @@ interface ReactNativeServiceOptions {
 }
 ```
 
+## Zero-config setup automation
+
+Like `@wdio/electron-service` (which auto-manages chromedriver), the service can drive as
+much of the Appium setup as is feasible. Everything here is **opt-in and apply-if-unset** —
+an explicit capability or option you set always wins.
+
+### `manageMetro` — own the Metro lifecycle
+
+Covered under [Build requirement](#build-requirement): `manageMetro: true` starts
+`react-native start` for the run, waits for readiness, optionally pre-bundles, and tears it
+down on completion — so you don't script it yourself.
+
+### `autoInstallDriver` — install the Appium driver
+
+`autoInstallDriver: true` installs the platform's Appium driver (`uiautomator2` on Android,
+`xcuitest` on iOS) if it isn't already present, at a version known-good for your Appium
+**server major** (from a maintained matrix). It's **idempotent** — a no-op when the driver
+is already installed — and **off by default**, because CI usually manages drivers explicitly
+and may lack network/permissions. Requires `appium` to be resolvable (it comes with
+`@wdio/appium-service`).
+
+### `doctor` — preflight checks
+
+`doctor` runs fail-fast preflight validation in `onPrepare` so a misconfiguration surfaces
+as a clear message instead of a cryptic Appium timeout:
+
+| Mode | Behaviour |
+|---|---|
+| `'off'` | Skip all checks. |
+| `'warn'` *(default)* | Log actionable warnings; never abort. |
+| `'strict'` | Abort the run (`SevereServiceError`) on any error-level check. |
+
+For React Native it checks: `@wdio/appium-service` is in `services`, Metro is reachable on
+the configured port, and (iOS) the Xcode toolchain is warm. Checks are advisory (`warn`)
+unless you opt into `'strict'`.
+
+### iOS launch caps — auto-applied
+
+On iOS the service fills in launch caps you didn't set (each only if absent): a generous
+`appium:wdaLaunchTimeout` / `appium:simulatorStartupTimeout`, `appium:isHeadless` under CI,
+and — when you give `appium:deviceName` but no `appium:udid` — it resolves the exact
+simulator UDID (preferring the newest runtime) to avoid booting a duplicate-named device.
+On Android it sets `appium:autoGrantPermissions`. Set any of these yourself to override.
+
 ## API (`browser.reactNative.*`)
 
 ### `execute(fn, ...args)`

--- a/packages/react-native-service/README.md
+++ b/packages/react-native-service/README.md
@@ -120,7 +120,7 @@ interface ReactNativeServiceOptions {
 
   // Appium driver auto-install + preflight doctor (shared mobile setup automation)
   autoInstallDriver?: boolean;  // install uiautomator2 / xcuitest if missing (default: false)
-  doctor?: 'off' | 'warn' | 'strict'; // preflight checks (default: 'warn')
+  doctor?: boolean | { strict?: boolean }; // preflight checks (default: true; { strict: true } aborts on error)
 
   // Convenience — maps onto appium:app if not already set in the capability
   appBinaryPath?: string;
@@ -167,11 +167,11 @@ and may lack network/permissions. Requires `appium` to be resolvable (it comes w
 `doctor` runs fail-fast preflight validation in `onPrepare` so a misconfiguration surfaces
 as a clear message instead of a cryptic Appium timeout:
 
-| Mode | Behaviour |
+| `doctor` | Behaviour |
 |---|---|
-| `'off'` | Skip all checks. |
-| `'warn'` *(default)* | Log actionable warnings; never abort. |
-| `'strict'` | Abort the run (`SevereServiceError`) on any error-level check. |
+| `false` | Skip all checks. |
+| `true` *(default)*, or omitted | Run the checks; log actionable warnings; never abort. |
+| `{ strict: true }` | Run the checks; abort the run (`SevereServiceError`) on any error-level check. |
 
 For React Native it checks: `@wdio/appium-service` is in `services`, Metro is reachable on
 the configured port, and (iOS) the Xcode toolchain is warm. Checks are advisory (`warn`)

--- a/packages/react-native-service/README.md
+++ b/packages/react-native-service/README.md
@@ -85,6 +85,11 @@ For **iOS**: `cd ios && xcodebuild -workspace App.xcworkspace -scheme App -confi
 
 Native find/tap via Appium works with any build (debug or release).
 
+`execute` / `mock` also need **Metro running** so Hermes exposes its inspector target. Start
+it yourself (`npx react-native start`), or set **`manageMetro: true`** to have the service
+start it, wait for readiness, and tear it down on completion (optionally `prebundle: true`
+to warm the first cold compile). The preflight doctor warns if Metro is unreachable.
+
 ## Capabilities
 
 All standard [Appium capabilities](https://appium.io/docs/en/latest/guides/caps/) are
@@ -107,6 +112,15 @@ interface ReactNativeServiceOptions {
   // Metro inspector-proxy connection
   metroHost?: string;           // default: 'localhost'
   metroPort?: number;           // default: 8081
+
+  // Metro lifecycle (opt-in) — the service owns `react-native start` so you don't have to
+  manageMetro?: boolean;        // start/stop Metro for the run (default: false)
+  metroProjectRoot?: string;    // app project root for `react-native start` (default: cwd)
+  prebundle?: boolean;          // warm the cold compile via /index.bundle (default: false)
+
+  // Appium driver auto-install + preflight doctor (shared mobile setup automation)
+  autoInstallDriver?: boolean;  // install uiautomator2 / xcuitest if missing (default: false)
+  doctor?: 'off' | 'warn' | 'strict'; // preflight checks (default: 'warn')
 
   // Convenience — maps onto appium:app if not already set in the capability
   appBinaryPath?: string;

--- a/packages/react-native-service/src/adb.ts
+++ b/packages/react-native-service/src/adb.ts
@@ -1,0 +1,26 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from './constants.js';
+
+const log = createLogger(SERVICE_NAME, 'launcher');
+const execFileAsync = promisify(execFile);
+
+/**
+ * Map the device's Metro port to the host (`adb reverse tcp:<port> tcp:<port>`) so the
+ * Android app can load its JS bundle from host Metro over the emulator loopback. Best-effort
+ * (Metro may already be reachable); pass `udid` to target a specific device when several
+ * emulators are attached (parallel / multiremote).
+ */
+export async function adbReverse(port: number, udid?: string): Promise<void> {
+  const args = udid ? ['-s', udid, 'reverse', `tcp:${port}`, `tcp:${port}`] : ['reverse', `tcp:${port}`, `tcp:${port}`];
+  try {
+    await execFileAsync('adb', args);
+    log.debug(`adb ${args.join(' ')} ✓`);
+  } catch (error) {
+    log.warn(
+      `adb reverse tcp:${port} failed (continuing — Metro may already be reachable): ${(error as Error).message}`,
+    );
+  }
+}

--- a/packages/react-native-service/src/diagnostics.ts
+++ b/packages/react-native-service/src/diagnostics.ts
@@ -1,0 +1,31 @@
+// React Native preflight checks, composed from @wdio/native-mobile-core's doctor framework
+// and run from the launcher's onPrepare (after Metro is started when manageMetro is on).
+
+import type { DoctorCheck } from '@wdio/native-mobile-core';
+import type { DiagnosticResult } from '@wdio/native-utils';
+
+import { probeMetroStatus } from './metroProcess.js';
+
+/**
+ * Verify Metro is reachable on the configured port. When the service doesn't manage Metro
+ * (the default), a down server is the most common cause of a cryptic "no Hermes target"
+ * failure — surface it here as an actionable warning instead.
+ */
+export function checkMetroReachable(port: number): DoctorCheck {
+  return async (): Promise<DiagnosticResult> => {
+    const reachable = await probeMetroStatus(port);
+    return reachable
+      ? { category: 'Metro', status: 'ok', message: `reachable on port ${port}` }
+      : {
+          category: 'Metro',
+          status: 'warn',
+          message: `not reachable on port ${port}`,
+          details: 'Start Metro (`react-native start`) or set manageMetro: true to have the service own it.',
+        };
+  };
+}
+
+/** The React Native-specific preflight checks. */
+export function reactNativeDoctorChecks(metroPort: number): DoctorCheck[] {
+  return [checkMetroReachable(metroPort)];
+}

--- a/packages/react-native-service/src/diagnostics.ts
+++ b/packages/react-native-service/src/diagnostics.ts
@@ -7,25 +7,27 @@ import type { DiagnosticResult } from '@wdio/native-utils';
 import { probeMetroStatus } from './metroProcess.js';
 
 /**
- * Verify Metro is reachable on the configured port. When the service doesn't manage Metro
+ * Verify Metro is reachable on the configured host/port. When the service doesn't manage Metro
  * (the default), a down server is the most common cause of a cryptic "no Hermes target"
- * failure — surface it here as an actionable warning instead.
+ * failure — surface it here as an actionable warning instead. Probes `metroHost` (not a hardcoded
+ * localhost) so a remote-Metro setup doesn't get a spurious "not reachable" warning.
  */
-export function checkMetroReachable(port: number): DoctorCheck {
+export function checkMetroReachable(host: string, port: number): DoctorCheck {
   return async (): Promise<DiagnosticResult> => {
-    const reachable = await probeMetroStatus(port);
+    const reachable = await probeMetroStatus(port, host);
+    const where = `${host}:${port}`;
     return reachable
-      ? { category: 'Metro', status: 'ok', message: `reachable on port ${port}` }
+      ? { category: 'Metro', status: 'ok', message: `reachable on ${where}` }
       : {
           category: 'Metro',
           status: 'warn',
-          message: `not reachable on port ${port}`,
+          message: `not reachable on ${where}`,
           details: 'Start Metro (`react-native start`) or set manageMetro: true to have the service own it.',
         };
   };
 }
 
 /** The React Native-specific preflight checks. */
-export function reactNativeDoctorChecks(metroPort: number): DoctorCheck[] {
-  return [checkMetroReachable(metroPort)];
+export function reactNativeDoctorChecks(metroHost: string, metroPort: number): DoctorCheck[] {
+  return [checkMetroReachable(metroHost, metroPort)];
 }

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -6,17 +6,24 @@
 // this subclass supplies the one per-framework seam — RN's automation names — via
 // `mutateCapability`.
 
-import { MobileBaseLauncher } from '@wdio/native-mobile-core';
+import { type DoctorCheck, flattenCaps, MobileBaseLauncher, SevereServiceError } from '@wdio/native-mobile-core';
 import type { Options } from '@wdio/types';
 
 import { prepareReactNativeCapability } from './capabilities.js';
-import { CUSTOM_CAPABILITY_NAME, SERVICE_NAME } from './constants.js';
+import { CUSTOM_CAPABILITY_NAME, DEFAULT_METRO_PORT, SERVICE_NAME } from './constants.js';
+import { reactNativeDoctorChecks } from './diagnostics.js';
+import { MetroProcess } from './metroProcess.js';
 import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from './types.js';
 
 export default class ReactNativeLaunchService extends MobileBaseLauncher<
   ReactNativeServiceGlobalOptions,
   ReactNativeCapabilities
 > {
+  // One shared Metro for the whole run, owned by the launcher (main process). Per-worker
+  // Metro would bind-conflict on 8081; workers connect via MetroBridge, which does the
+  // per-device `adb reverse`.
+  #metro: MetroProcess | undefined;
+
   constructor(
     options: ReactNativeServiceGlobalOptions,
     _capabilities: ReactNativeCapabilities,
@@ -40,5 +47,41 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
   // allocated realm port — so there's no capability for the base launcher to stamp.
   protected portCapKey(): string | undefined {
     return undefined;
+  }
+
+  protected doctorChecks(config: Options.Testrunner, platforms: Set<'android' | 'ios'>): DoctorCheck[] {
+    return [
+      ...super.doctorChecks(config, platforms),
+      ...reactNativeDoctorChecks(this.options.metroPort ?? DEFAULT_METRO_PORT),
+    ];
+  }
+
+  async onPrepare(
+    config: Options.Testrunner,
+    capabilities: ReactNativeCapabilities[] | Record<string, { capabilities: ReactNativeCapabilities }>,
+  ): Promise<void> {
+    // Start Metro before super.onPrepare so the Metro-reachable doctor check sees it up.
+    if (this.options.manageMetro) {
+      this.#metro = new MetroProcess();
+      try {
+        const firstPlatform = flattenCaps<ReactNativeCapabilities>(capabilities)[0]?.platformName?.toLowerCase();
+        await this.#metro.start({
+          projectRoot: this.options.metroProjectRoot,
+          port: this.options.metroPort,
+          platform: firstPlatform === 'ios' ? 'ios' : 'android',
+          prebundle: this.options.prebundle,
+        });
+      } catch (error) {
+        throw new SevereServiceError(`Failed to start Metro: ${(error as Error).message}`);
+      }
+    }
+    await super.onPrepare(config, capabilities);
+  }
+
+  async onComplete(): Promise<void> {
+    if (this.#metro) {
+      await this.#metro.stop();
+      this.#metro = undefined;
+    }
   }
 }

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -9,6 +9,7 @@
 import { type DoctorCheck, flattenCaps, MobileBaseLauncher, SevereServiceError } from '@wdio/native-mobile-core';
 import type { Options } from '@wdio/types';
 
+import { adbReverse } from './adb.js';
 import { prepareReactNativeCapability } from './capabilities.js';
 import { CUSTOM_CAPABILITY_NAME, DEFAULT_METRO_PORT, SERVICE_NAME } from './constants.js';
 import { reactNativeDoctorChecks } from './diagnostics.js';
@@ -20,8 +21,8 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
   ReactNativeCapabilities
 > {
   // One shared Metro for the whole run, owned by the launcher (main process). Per-worker
-  // Metro would bind-conflict on 8081; workers connect via MetroBridge, which does the
-  // per-device `adb reverse`.
+  // Metro would bind-conflict on 8081. The Android device→host `adb reverse` is set up
+  // per-worker in onWorkerStart (pre-launch); workers then connect via MetroBridge.
   #metro: MetroProcess | undefined;
 
   constructor(
@@ -86,6 +87,28 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
       // holding port 8081 and the next run hits EADDRINUSE.
       await this.#stopMetro();
       throw error;
+    }
+  }
+
+  async onWorkerStart(
+    cid: string,
+    capabilities: ReactNativeCapabilities | ReactNativeCapabilities[] | Record<string, unknown> | undefined,
+  ): Promise<void> {
+    await super.onWorkerStart(cid, capabilities);
+    if (!capabilities) {
+      return;
+    }
+    // This launcher hook runs (and is awaited) BEFORE the worker creates the Appium session,
+    // i.e. before the app launches — the correct point to set up `adb reverse` so the Android
+    // app's first JS-bundle load reaches host Metro. super.onWorkerStart has just stamped the
+    // device udid, so target the exact emulator when several are attached.
+    const port = this.options.metroPort ?? DEFAULT_METRO_PORT;
+    for (const cap of flattenCaps<ReactNativeCapabilities>(capabilities)) {
+      const c = cap as unknown as Record<string, unknown>;
+      const platform = (this.options.platform ?? (c.platformName as string | undefined))?.toLowerCase();
+      if (platform === 'android') {
+        await adbReverse(port, c['appium:udid'] as string | undefined);
+      }
     }
   }
 

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -65,7 +65,10 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
     if (this.options.manageMetro) {
       this.#metro = new MetroProcess();
       try {
-        const firstPlatform = flattenCaps<ReactNativeCapabilities>(capabilities)[0]?.platformName?.toLowerCase();
+        // Resolve platform the same way onWorkerStart does — options.platform wins over the
+        // capability, so an options-level iOS run pre-warms the iOS bundle, not Android.
+        const firstCap = flattenCaps<ReactNativeCapabilities>(capabilities)[0];
+        const firstPlatform = (this.options.platform ?? firstCap?.platformName)?.toLowerCase();
         await this.#metro.start({
           projectRoot: this.options.metroProjectRoot,
           port: this.options.metroPort,

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -75,10 +75,22 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
         throw new SevereServiceError(`Failed to start Metro: ${(error as Error).message}`);
       }
     }
-    await super.onPrepare(config, capabilities);
+    try {
+      await super.onPrepare(config, capabilities);
+    } catch (error) {
+      // super.onPrepare can throw (e.g. doctor: 'strict' fails a check). WDIO then aborts
+      // without calling onComplete, so stop the Metro we started — otherwise it's orphaned
+      // holding port 8081 and the next run hits EADDRINUSE.
+      await this.#stopMetro();
+      throw error;
+    }
   }
 
   async onComplete(): Promise<void> {
+    await this.#stopMetro();
+  }
+
+  async #stopMetro(): Promise<void> {
     if (this.#metro) {
       await this.#metro.stop();
       this.#metro = undefined;

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -72,6 +72,9 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
           prebundle: this.options.prebundle,
         });
       } catch (error) {
+        // start() can throw *after* Metro spawned (e.g. readiness timeout) — the child is
+        // live but unready, so stop it before aborting or it orphans port 8081.
+        await this.#stopMetro();
         throw new SevereServiceError(`Failed to start Metro: ${(error as Error).message}`);
       }
     }

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -53,7 +53,7 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
   protected doctorChecks(config: Options.Testrunner, platforms: Set<'android' | 'ios'>): DoctorCheck[] {
     return [
       ...super.doctorChecks(config, platforms),
-      ...reactNativeDoctorChecks(this.options.metroPort ?? DEFAULT_METRO_PORT),
+      ...reactNativeDoctorChecks(this.options.metroHost ?? '127.0.0.1', this.options.metroPort ?? DEFAULT_METRO_PORT),
     ];
   }
 

--- a/packages/react-native-service/src/metroProcess.ts
+++ b/packages/react-native-service/src/metroProcess.ts
@@ -106,6 +106,11 @@ export class MetroProcess {
   }
 
   isRunning(): boolean {
+    // A failed spawn (ENOENT) fires 'error' but leaves exitCode/signalCode/killed in their
+    // initial "never started" state, so guard on #spawnError before those checks.
+    if (this.#spawnError) {
+      return false;
+    }
     const p = this.#proc;
     if (!p) {
       return false;

--- a/packages/react-native-service/src/metroProcess.ts
+++ b/packages/react-native-service/src/metroProcess.ts
@@ -37,7 +37,7 @@ export interface MetroStartOptions {
 }
 
 /** A one-shot readiness probe — resolves true when Metro answers `/status`. */
-export type MetroReadyProbe = (port: number) => Promise<boolean>;
+export type MetroReadyProbe = (port: number, host?: string) => Promise<boolean>;
 /** A best-effort pre-bundle fetch. */
 export type MetroBundleFetch = (port: number, platform: 'android' | 'ios') => Promise<void>;
 
@@ -56,9 +56,9 @@ export function resolveReactNativeBin(projectRoot: string): { cmd: string; prefi
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /** Default readiness probe: Metro answers `GET /status` with 200 once the bundler is up. */
-export const probeMetroStatus: MetroReadyProbe = (port) =>
+export const probeMetroStatus: MetroReadyProbe = (port, host = '127.0.0.1') =>
   new Promise((resolve) => {
-    const req = http.get(`http://127.0.0.1:${port}/status`, (res) => {
+    const req = http.get(`http://${host}:${port}/status`, (res) => {
       res.resume();
       resolve(res.statusCode === 200);
     });
@@ -92,6 +92,10 @@ export class MetroProcess {
   // A spawn 'error' (e.g. ENOENT — the CLI isn't installed) leaves exitCode/signalCode null,
   // so the readiness loop would otherwise spin to the full timeout. Capture it to fail fast.
   #spawnError?: Error;
+  // Last few stderr lines, so a startup failure (EADDRINUSE on 8081, a bad metro.config.js, a
+  // missing peer dep) surfaces its actual cause in the thrown error — Metro's stderr is otherwise
+  // only at `debug` level and invisible in a default `info` WDIO run.
+  #stderrTail: string[] = [];
   readonly #spawn: typeof nodeSpawn;
   readonly #probe: MetroReadyProbe;
   readonly #fetchBundle: MetroBundleFetch;
@@ -127,6 +131,7 @@ export class MetroProcess {
     const port = options.port ?? DEFAULT_METRO_PORT;
     this.#port = port;
     this.#spawnError = undefined;
+    this.#stderrTail = [];
 
     const { cmd, prefixArgs } = resolveReactNativeBin(projectRoot);
     log.info(`Starting Metro on port ${port} (cwd: ${projectRoot})`);
@@ -137,7 +142,16 @@ export class MetroProcess {
     });
     this.#proc = proc;
     proc.stdout?.on('data', (d: Buffer) => log.debug(`[metro] ${d.toString().trim()}`));
-    proc.stderr?.on('data', (d: Buffer) => log.debug(`[metro] ${d.toString().trim()}`));
+    proc.stderr?.on('data', (d: Buffer) => {
+      const line = d.toString().trim();
+      log.debug(`[metro] ${line}`);
+      if (line) {
+        this.#stderrTail.push(line);
+        if (this.#stderrTail.length > 20) {
+          this.#stderrTail.shift();
+        }
+      }
+    });
     proc.on('error', (e) => {
       this.#spawnError = e;
       log.error(`Metro spawn error: ${e.message}`);
@@ -165,7 +179,7 @@ export class MetroProcess {
       }
       const p = this.#proc;
       if (p && (p.exitCode !== null || p.signalCode !== null)) {
-        throw new Error('Metro process exited during startup');
+        throw new Error(this.#withStderr('Metro process exited during startup'));
       }
       if (await this.#probe(port)) {
         // A spawn 'error' may have fired during the probe await; a pre-existing Metro already
@@ -180,7 +194,12 @@ export class MetroProcess {
       }
       await delay(interval);
     }
-    throw new Error(`Metro did not become ready within ${timeout}ms on port ${port}`);
+    throw new Error(this.#withStderr(`Metro did not become ready within ${timeout}ms on port ${port}`));
+  }
+
+  /** Append the buffered Metro stderr tail to a startup-failure message so the cause is visible. */
+  #withStderr(message: string): string {
+    return this.#stderrTail.length > 0 ? `${message}\nMetro stderr:\n${this.#stderrTail.join('\n')}` : message;
   }
 
   async stop(): Promise<void> {

--- a/packages/react-native-service/src/metroProcess.ts
+++ b/packages/react-native-service/src/metroProcess.ts
@@ -86,6 +86,9 @@ const defaultFetchBundle: MetroBundleFetch = (port, platform) =>
 export class MetroProcess {
   #proc?: ChildProcess;
   #port = DEFAULT_METRO_PORT;
+  // A spawn 'error' (e.g. ENOENT — the CLI isn't installed) leaves exitCode/signalCode null,
+  // so the readiness loop would otherwise spin to the full timeout. Capture it to fail fast.
+  #spawnError?: Error;
   readonly #spawn: typeof nodeSpawn;
   readonly #probe: MetroReadyProbe;
   readonly #fetchBundle: MetroBundleFetch;
@@ -115,6 +118,7 @@ export class MetroProcess {
     const projectRoot = options.projectRoot ?? process.cwd();
     const port = options.port ?? DEFAULT_METRO_PORT;
     this.#port = port;
+    this.#spawnError = undefined;
 
     const { cmd, prefixArgs } = resolveReactNativeBin(projectRoot);
     log.info(`Starting Metro on port ${port} (cwd: ${projectRoot})`);
@@ -126,7 +130,10 @@ export class MetroProcess {
     this.#proc = proc;
     proc.stdout?.on('data', (d: Buffer) => log.debug(`[metro] ${d.toString().trim()}`));
     proc.stderr?.on('data', (d: Buffer) => log.debug(`[metro] ${d.toString().trim()}`));
-    proc.on('error', (e) => log.error(`Metro spawn error: ${e.message}`));
+    proc.on('error', (e) => {
+      this.#spawnError = e;
+      log.error(`Metro spawn error: ${e.message}`);
+    });
 
     await this.#waitForReady(port, options);
 
@@ -145,6 +152,9 @@ export class MetroProcess {
     const interval = options.pollIntervalMs ?? 500;
     const start = Date.now();
     while (Date.now() - start < timeout) {
+      if (this.#spawnError) {
+        throw new Error(`Metro failed to start: ${this.#spawnError.message}`);
+      }
       const p = this.#proc;
       if (p && (p.exitCode !== null || p.signalCode !== null)) {
         throw new Error('Metro process exited during startup');

--- a/packages/react-native-service/src/metroProcess.ts
+++ b/packages/react-native-service/src/metroProcess.ts
@@ -77,10 +77,11 @@ const defaultFetchBundle: MetroBundleFetch = (port, platform) =>
       res.statusCode === 200 ? resolve() : reject(new Error(`bundle request returned ${res.statusCode}`));
     });
     // Best-effort warm-up: cap at 60s so a slow/stuck bundle can't hold up onPrepare for
-    // the full 5 minutes a cold compile might otherwise allow.
+    // the full 5 minutes a cold compile might otherwise allow. Pass the reason to destroy()
+    // so the single 'error' settle wins with our message — a bare destroy() can emit a
+    // synthetic "socket hang up" that would otherwise mask the timeout in the warning log.
     req.setTimeout(60000, () => {
-      req.destroy();
-      reject(new Error('bundle request timeout'));
+      req.destroy(new Error('bundle request timeout'));
     });
     req.on('error', reject);
   });

--- a/packages/react-native-service/src/metroProcess.ts
+++ b/packages/react-native-service/src/metroProcess.ts
@@ -173,6 +173,13 @@ export class MetroProcess {
     if (!proc || proc.killed) {
       return;
     }
+    if (this.#spawnError) {
+      // Spawn failed (ENOENT): Node fired 'error' but never will fire 'exit', so
+      // #waitForExit would hang to the SIGKILL grace. There's no live process to kill —
+      // just drop the handle.
+      this.#proc = undefined;
+      return;
+    }
     if (proc.exitCode !== null || proc.signalCode !== null) {
       this.#proc = undefined;
       return;

--- a/packages/react-native-service/src/metroProcess.ts
+++ b/packages/react-native-service/src/metroProcess.ts
@@ -76,7 +76,9 @@ const defaultFetchBundle: MetroBundleFetch = (port, platform) =>
       res.resume();
       res.statusCode === 200 ? resolve() : reject(new Error(`bundle request returned ${res.statusCode}`));
     });
-    req.setTimeout(300000, () => {
+    // Best-effort warm-up: cap at 60s so a slow/stuck bundle can't hold up onPrepare for
+    // the full 5 minutes a cold compile might otherwise allow.
+    req.setTimeout(60000, () => {
       req.destroy();
       reject(new Error('bundle request timeout'));
     });
@@ -160,6 +162,13 @@ export class MetroProcess {
         throw new Error('Metro process exited during startup');
       }
       if (await this.#probe(port)) {
+        // A spawn 'error' may have fired during the probe await; a pre-existing Metro already
+        // on this port would still answer, so re-check before claiming we started it. The
+        // assertion defeats the stale CFA narrowing from the loop-top guard above.
+        const spawnError = this.#spawnError as Error | undefined;
+        if (spawnError) {
+          throw new Error(`Metro failed to start: ${spawnError.message}`);
+        }
         log.info(`Metro ready on port ${port}`);
         return;
       }

--- a/packages/react-native-service/src/metroProcess.ts
+++ b/packages/react-native-service/src/metroProcess.ts
@@ -1,0 +1,194 @@
+// Metro dev-server lifecycle (opt-in) — owns `react-native start` the way
+// @wdio/electron-service owns chromedriver. Starts Metro as a long-lived child, polls its
+// `/status` endpoint for readiness, optionally pre-bundles to warm the cold compile, and
+// tears it down on onComplete. One shared Metro serves all workers (the worker-side
+// MetroBridge connects to it and does the per-device `adb reverse`), so this lives in the
+// launcher's main process — never per worker.
+//
+// Mirrors the SIGTERM→SIGKILL shutdown discipline of native-core's DriverProcess; Metro's
+// arg shape (`start --port`) and `/status` readiness don't fit DriverProcess.start(), so
+// the process handling is local but the lifecycle semantics are the same.
+
+import { type ChildProcess, spawn as nodeSpawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import http from 'node:http';
+import { join } from 'node:path';
+import { createLogger } from '@wdio/native-utils';
+
+import { DEFAULT_METRO_PORT, SERVICE_NAME } from './constants.js';
+
+const log = createLogger(SERVICE_NAME, 'launcher');
+
+const isWindows = process.platform === 'win32';
+
+export interface MetroStartOptions {
+  /** App project root that `react-native start` runs in. Default `process.cwd()`. */
+  projectRoot?: string;
+  /** Metro port. Default 8081. */
+  port?: number;
+  /** Platform for the optional pre-bundle request. */
+  platform?: 'android' | 'ios';
+  /** Pre-bundle (`/index.bundle`) after ready to warm the ~60s cold compile. Default off. */
+  prebundle?: boolean;
+  /** Readiness budget (ms). Default 180s in CI, 120s locally. */
+  readyTimeoutMs?: number;
+  /** Readiness poll interval (ms). Default 500. */
+  pollIntervalMs?: number;
+}
+
+/** A one-shot readiness probe — resolves true when Metro answers `/status`. */
+export type MetroReadyProbe = (port: number) => Promise<boolean>;
+/** A best-effort pre-bundle fetch. */
+export type MetroBundleFetch = (port: number, platform: 'android' | 'ios') => Promise<void>;
+
+/** Resolve the project's `react-native` CLI; fall back to the project-local `npx`. */
+export function resolveReactNativeBin(projectRoot: string): { cmd: string; prefixArgs: string[] } {
+  const localBin = isWindows
+    ? join(projectRoot, 'node_modules', '.bin', 'react-native.cmd')
+    : join(projectRoot, 'node_modules', '.bin', 'react-native');
+  if (existsSync(localBin)) {
+    return { cmd: localBin, prefixArgs: [] };
+  }
+  // --no-install so a missing CLI fails fast instead of fetching from the registry mid-run.
+  return { cmd: isWindows ? 'npx.cmd' : 'npx', prefixArgs: ['--no-install', 'react-native'] };
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Default readiness probe: Metro answers `GET /status` with 200 once the bundler is up. */
+export const probeMetroStatus: MetroReadyProbe = (port) =>
+  new Promise((resolve) => {
+    const req = http.get(`http://127.0.0.1:${port}/status`, (res) => {
+      res.resume();
+      resolve(res.statusCode === 200);
+    });
+    req.setTimeout(1000, () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.on('error', () => resolve(false));
+  });
+
+const defaultFetchBundle: MetroBundleFetch = (port, platform) =>
+  new Promise((resolve, reject) => {
+    const url = `http://127.0.0.1:${port}/index.bundle?platform=${platform}&dev=true&minify=false`;
+    const req = http.get(url, (res) => {
+      res.resume();
+      res.statusCode === 200 ? resolve() : reject(new Error(`bundle request returned ${res.statusCode}`));
+    });
+    req.setTimeout(300000, () => {
+      req.destroy();
+      reject(new Error('bundle request timeout'));
+    });
+    req.on('error', reject);
+  });
+
+export class MetroProcess {
+  #proc?: ChildProcess;
+  #port = DEFAULT_METRO_PORT;
+  readonly #spawn: typeof nodeSpawn;
+  readonly #probe: MetroReadyProbe;
+  readonly #fetchBundle: MetroBundleFetch;
+
+  constructor(deps: { spawn?: typeof nodeSpawn; probe?: MetroReadyProbe; fetchBundle?: MetroBundleFetch } = {}) {
+    this.#spawn = deps.spawn ?? nodeSpawn;
+    this.#probe = deps.probe ?? probeMetroStatus;
+    this.#fetchBundle = deps.fetchBundle ?? defaultFetchBundle;
+  }
+
+  get port(): number {
+    return this.#port;
+  }
+
+  isRunning(): boolean {
+    const p = this.#proc;
+    if (!p) {
+      return false;
+    }
+    if (p.exitCode !== null || p.signalCode !== null) {
+      return false;
+    }
+    return !p.killed;
+  }
+
+  async start(options: MetroStartOptions = {}): Promise<void> {
+    const projectRoot = options.projectRoot ?? process.cwd();
+    const port = options.port ?? DEFAULT_METRO_PORT;
+    this.#port = port;
+
+    const { cmd, prefixArgs } = resolveReactNativeBin(projectRoot);
+    log.info(`Starting Metro on port ${port} (cwd: ${projectRoot})`);
+    const proc = this.#spawn(cmd, [...prefixArgs, 'start', '--port', String(port)], {
+      cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+    this.#proc = proc;
+    proc.stdout?.on('data', (d: Buffer) => log.debug(`[metro] ${d.toString().trim()}`));
+    proc.stderr?.on('data', (d: Buffer) => log.debug(`[metro] ${d.toString().trim()}`));
+    proc.on('error', (e) => log.error(`Metro spawn error: ${e.message}`));
+
+    await this.#waitForReady(port, options);
+
+    if (options.prebundle) {
+      try {
+        await this.#fetchBundle(port, options.platform ?? 'android');
+        log.info('Metro bundle pre-built');
+      } catch (error) {
+        log.warn(`Metro pre-bundle failed (continuing): ${(error as Error).message}`);
+      }
+    }
+  }
+
+  async #waitForReady(port: number, options: MetroStartOptions): Promise<void> {
+    const timeout = options.readyTimeoutMs ?? (process.env.CI ? 180000 : 120000);
+    const interval = options.pollIntervalMs ?? 500;
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      const p = this.#proc;
+      if (p && (p.exitCode !== null || p.signalCode !== null)) {
+        throw new Error('Metro process exited during startup');
+      }
+      if (await this.#probe(port)) {
+        log.info(`Metro ready on port ${port}`);
+        return;
+      }
+      await delay(interval);
+    }
+    throw new Error(`Metro did not become ready within ${timeout}ms on port ${port}`);
+  }
+
+  async stop(): Promise<void> {
+    const proc = this.#proc;
+    if (!proc || proc.killed) {
+      return;
+    }
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      this.#proc = undefined;
+      return;
+    }
+    log.debug('Stopping Metro...');
+    proc.kill('SIGTERM');
+    await this.#waitForExit(proc);
+    this.#proc = undefined;
+  }
+
+  #waitForExit(proc: ChildProcess): Promise<void> {
+    const stopTimeout = process.env.CI ? 10000 : 5000;
+    return new Promise<void>((resolve) => {
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      const graceTimer = setTimeout(() => {
+        log.warn(`Metro did not stop gracefully after ${stopTimeout}ms, forcing kill`);
+        proc.kill('SIGKILL');
+        killTimer = setTimeout(resolve, 5000);
+      }, stopTimeout);
+      proc.once('exit', () => {
+        clearTimeout(graceTimer);
+        if (killTimer) {
+          clearTimeout(killTimer);
+        }
+        resolve();
+      });
+    });
+  }
+}

--- a/packages/react-native-service/test/diagnostics.spec.ts
+++ b/packages/react-native-service/test/diagnostics.spec.ts
@@ -10,19 +10,25 @@ afterEach(() => vi.clearAllMocks());
 describe('checkMetroReachable', () => {
   it('should report ok when Metro answers /status', async () => {
     probe.mockResolvedValueOnce(true);
-    expect(await checkMetroReachable(8081)()).toMatchObject({ status: 'ok', category: 'Metro' });
+    expect(await checkMetroReachable('127.0.0.1', 8081)()).toMatchObject({ status: 'ok', category: 'Metro' });
   });
 
   it('should warn with an actionable hint when Metro is down', async () => {
     probe.mockResolvedValueOnce(false);
-    const r = await checkMetroReachable(8081)();
+    const r = await checkMetroReachable('127.0.0.1', 8081)();
     expect(r.status).toBe('warn');
     expect(r.details).toMatch(/manageMetro/);
+  });
+
+  it('should probe the configured host, not a hardcoded localhost', async () => {
+    probe.mockResolvedValueOnce(true);
+    await checkMetroReachable('my-metro-box.lan', 8081)();
+    expect(probe).toHaveBeenCalledWith(8081, 'my-metro-box.lan');
   });
 });
 
 describe('reactNativeDoctorChecks', () => {
-  it('should bundle the Metro check for the configured port', () => {
-    expect(reactNativeDoctorChecks(8088)).toHaveLength(1);
+  it('should bundle the Metro check for the configured host/port', () => {
+    expect(reactNativeDoctorChecks('127.0.0.1', 8088)).toHaveLength(1);
   });
 });

--- a/packages/react-native-service/test/diagnostics.spec.ts
+++ b/packages/react-native-service/test/diagnostics.spec.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const probe = vi.hoisted(() => vi.fn());
+vi.mock('../src/metroProcess.js', () => ({ probeMetroStatus: probe }));
+
+import { checkMetroReachable, reactNativeDoctorChecks } from '../src/diagnostics.js';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('checkMetroReachable', () => {
+  it('should report ok when Metro answers /status', async () => {
+    probe.mockResolvedValueOnce(true);
+    expect(await checkMetroReachable(8081)()).toMatchObject({ status: 'ok', category: 'Metro' });
+  });
+
+  it('should warn with an actionable hint when Metro is down', async () => {
+    probe.mockResolvedValueOnce(false);
+    const r = await checkMetroReachable(8081)();
+    expect(r.status).toBe('warn');
+    expect(r.details).toMatch(/manageMetro/);
+  });
+});
+
+describe('reactNativeDoctorChecks', () => {
+  it('should bundle the Metro check for the configured port', () => {
+    expect(reactNativeDoctorChecks(8088)).toHaveLength(1);
+  });
+});

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -101,6 +101,15 @@ describe('ReactNativeLaunchService Metro lifecycle', () => {
     await make().onPrepare(config, [cap({ platformName: 'Android' })]);
     expect(metroStart).not.toHaveBeenCalled();
   });
+
+  it('should prebundle for the options.platform when platformName is unset (not default android)', async () => {
+    // Match onWorkerStart's precedence: options.platform wins, so an options-level iOS run
+    // pre-warms the iOS bundle rather than silently warming android.
+    await make({ manageMetro: true, prebundle: true, platform: 'iOS' }).onPrepare(config, [
+      cap({ platformName: undefined }),
+    ]);
+    expect(metroStart).toHaveBeenCalledWith(expect.objectContaining({ platform: 'ios', prebundle: true }));
+  });
 });
 
 describe('ReactNativeLaunchService.onWorkerStart', () => {

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -86,6 +86,13 @@ describe('ReactNativeLaunchService Metro lifecycle', () => {
     expect(metroStop).toHaveBeenCalledOnce();
   });
 
+  it('should stop Metro if start() itself fails (e.g. readiness timeout)', async () => {
+    metroStart.mockRejectedValueOnce(new Error('did not become ready'));
+    const launcher = make({ manageMetro: true });
+    await expect(launcher.onPrepare(config, [cap({ platformName: 'Android' })])).rejects.toThrow(SevereServiceError);
+    expect(metroStop).toHaveBeenCalledOnce();
+  });
+
   it('should not touch Metro when manageMetro is off', async () => {
     await make().onPrepare(config, [cap({ platformName: 'Android' })]);
     expect(metroStart).not.toHaveBeenCalled();

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -16,6 +16,10 @@ vi.mock('../src/metroProcess.js', () => ({
   },
 }));
 
+// Don't shell out to adb in unit tests — assert the pre-launch reverse is requested.
+const adbReverseMock = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock('../src/adb.js', () => ({ adbReverse: adbReverseMock }));
+
 import ReactNativeLaunchService from '../src/launcher.js';
 import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from '../src/types.js';
 
@@ -101,6 +105,7 @@ describe('ReactNativeLaunchService Metro lifecycle', () => {
 
 describe('ReactNativeLaunchService.onWorkerStart', () => {
   const withDevices = () => make({ devices: [{ udid: 'emulator-5554' }, { udid: 'emulator-5556' }] });
+  afterEach(() => vi.clearAllMocks());
 
   it('should stamp appium:udid onto a single bare capability', async () => {
     const c = cap({ platformName: 'Android' });
@@ -134,5 +139,20 @@ describe('ReactNativeLaunchService.onWorkerStart', () => {
 
   it('should not throw on undefined capabilities', async () => {
     await expect(withDevices().onWorkerStart('0-0', undefined)).resolves.toBeUndefined();
+  });
+
+  it('should adb-reverse the Metro port for an Android worker (pre-launch)', async () => {
+    await make({ metroPort: 8099 }).onWorkerStart('0-0', cap({ platformName: 'Android' }));
+    expect(adbReverseMock).toHaveBeenCalledWith(8099, undefined);
+  });
+
+  it('should target the stamped device udid when a pool is configured', async () => {
+    await withDevices().onWorkerStart('0-0', cap({ platformName: 'Android' }));
+    expect(adbReverseMock).toHaveBeenCalledWith(8081, 'emulator-5554');
+  });
+
+  it('should not adb-reverse for an iOS worker', async () => {
+    await make().onWorkerStart('0-0', cap({ platformName: 'iOS' }));
+    expect(adbReverseMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -1,10 +1,20 @@
 import type { Options } from '@wdio/types';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SevereServiceError } from 'webdriverio';
 
 // BaseLauncher carries @wdio/native-core's port/driver infra the launcher doesn't
 // use yet — stub it so onPrepare is exercised in isolation.
 vi.mock('@wdio/native-core', () => ({ BaseLauncher: class {} }));
+
+// Controllable Metro so the manageMetro lifecycle can be exercised without a real process.
+const metroStart = vi.hoisted(() => vi.fn(async () => {}));
+const metroStop = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock('../src/metroProcess.js', () => ({
+  MetroProcess: class {
+    start = metroStart;
+    stop = metroStop;
+  },
+}));
 
 import ReactNativeLaunchService from '../src/launcher.js';
 import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from '../src/types.js';
@@ -58,6 +68,27 @@ describe('ReactNativeLaunchService.onPrepare', () => {
   it('should throw a SevereServiceError for an unsupported platform', async () => {
     const caps = [cap({ platformName: 'Windows' })];
     await expect(make().onPrepare(config, caps)).rejects.toThrow(SevereServiceError);
+  });
+});
+
+describe('ReactNativeLaunchService Metro lifecycle', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('should start Metro before onPrepare when manageMetro is set', async () => {
+    await make({ manageMetro: true }).onPrepare(config, [cap({ platformName: 'Android' })]);
+    expect(metroStart).toHaveBeenCalledOnce();
+  });
+
+  it('should stop Metro if onPrepare fails after Metro started (no orphaned port 8081)', async () => {
+    const launcher = make({ manageMetro: true });
+    await expect(launcher.onPrepare(config, [cap({ platformName: 'Windows' })])).rejects.toThrow();
+    expect(metroStart).toHaveBeenCalledOnce();
+    expect(metroStop).toHaveBeenCalledOnce();
+  });
+
+  it('should not touch Metro when manageMetro is off', async () => {
+    await make().onPrepare(config, [cap({ platformName: 'Android' })]);
+    expect(metroStart).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/react-native-service/test/metroProcess.spec.ts
+++ b/packages/react-native-service/test/metroProcess.spec.ts
@@ -105,6 +105,19 @@ describe('MetroProcess.start', () => {
     await expect(starting).rejects.toThrow(/ENOENT/);
   });
 
+  it('should surface a spawn error even when a pre-existing Metro answers the probe', async () => {
+    existsMock.mockReturnValue(true);
+    const proc = fakeProc();
+    // Our spawn errors, but a Metro already on the port answers /status — must not be
+    // mistaken for the one we started.
+    const probe = vi.fn(async () => {
+      proc.emit('error', new Error('spawn react-native ENOENT'));
+      return true;
+    });
+    const mp = new MetroProcess({ spawn: vi.fn(() => proc) as never, probe });
+    await expect(mp.start({ readyTimeoutMs: 1000, pollIntervalMs: 10 })).rejects.toThrow(/ENOENT/);
+  });
+
   it('should stop() immediately after a spawn error without hanging on a never-fired exit', async () => {
     existsMock.mockReturnValue(true);
     const proc = fakeProc();

--- a/packages/react-native-service/test/metroProcess.spec.ts
+++ b/packages/react-native-service/test/metroProcess.spec.ts
@@ -96,6 +96,19 @@ describe('MetroProcess.start', () => {
     await expect(mp.start({ readyTimeoutMs: 1000, pollIntervalMs: 10 })).rejects.toThrow(/exited during startup/);
   });
 
+  it('should surface captured Metro stderr in a startup-failure error', async () => {
+    existsMock.mockReturnValue(true);
+    const proc = fakeProc();
+    // Emit a stderr line, then mark the process exited — the failure must carry the stderr tail
+    // so the root cause is visible even at the default `info` log level.
+    queueMicrotask(() => {
+      proc.stderr.emit('data', Buffer.from('error: listen EADDRINUSE: address already in use :::8081'));
+      proc.exitCode = 1;
+    });
+    const mp = new MetroProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
+    await expect(mp.start({ readyTimeoutMs: 1000, pollIntervalMs: 10 })).rejects.toThrow(/EADDRINUSE/);
+  });
+
   it('should fail fast with the spawn error instead of timing out (ENOENT)', async () => {
     existsMock.mockReturnValue(true);
     const proc = fakeProc();

--- a/packages/react-native-service/test/metroProcess.spec.ts
+++ b/packages/react-native-service/test/metroProcess.spec.ts
@@ -1,0 +1,118 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs', () => ({ existsSync: vi.fn() }));
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return { ...actual, createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) };
+});
+
+import { existsSync } from 'node:fs';
+import { MetroProcess, resolveReactNativeBin } from '../src/metroProcess.js';
+
+const existsMock = vi.mocked(existsSync);
+
+/** A fake long-lived child process. */
+function fakeProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    exitCode: number | null;
+    signalCode: string | null;
+    killed: boolean;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.exitCode = null;
+  proc.signalCode = null;
+  proc.killed = false;
+  return proc;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('resolveReactNativeBin', () => {
+  it('should use the project-local CLI when present', () => {
+    existsMock.mockReturnValueOnce(true);
+    expect(resolveReactNativeBin('/proj')).toEqual({ cmd: expect.stringContaining('react-native'), prefixArgs: [] });
+  });
+
+  it('should fall back to npx --no-install when the local CLI is absent', () => {
+    existsMock.mockReturnValueOnce(false);
+    const r = resolveReactNativeBin('/proj');
+    expect(r.cmd).toContain('npx');
+    expect(r.prefixArgs).toEqual(['--no-install', 'react-native']);
+  });
+});
+
+describe('MetroProcess.start', () => {
+  it('should spawn react-native start and resolve once Metro is ready', async () => {
+    existsMock.mockReturnValue(true);
+    const proc = fakeProc();
+    const spawn = vi.fn(() => proc) as never;
+    const probe = vi.fn(async () => true);
+    const mp = new MetroProcess({ spawn, probe });
+
+    await mp.start({ projectRoot: '/proj', port: 8090, readyTimeoutMs: 1000, pollIntervalMs: 10 });
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.stringContaining('react-native'),
+      ['start', '--port', '8090'],
+      expect.objectContaining({ cwd: '/proj' }),
+    );
+    expect(mp.port).toBe(8090);
+  });
+
+  it('should pre-bundle when requested', async () => {
+    existsMock.mockReturnValue(true);
+    const fetchBundle = vi.fn(async () => {});
+    const mp = new MetroProcess({ spawn: vi.fn(() => fakeProc()) as never, probe: async () => true, fetchBundle });
+    await mp.start({ port: 8081, platform: 'ios', prebundle: true, readyTimeoutMs: 1000, pollIntervalMs: 10 });
+    expect(fetchBundle).toHaveBeenCalledWith(8081, 'ios');
+  });
+
+  it('should not fail the run when pre-bundle fails', async () => {
+    existsMock.mockReturnValue(true);
+    const fetchBundle = vi.fn(async () => {
+      throw new Error('bundle 500');
+    });
+    const mp = new MetroProcess({ spawn: vi.fn(() => fakeProc()) as never, probe: async () => true, fetchBundle });
+    await expect(mp.start({ prebundle: true, readyTimeoutMs: 1000, pollIntervalMs: 10 })).resolves.toBeUndefined();
+  });
+
+  it('should throw when Metro never becomes ready', async () => {
+    existsMock.mockReturnValue(true);
+    const mp = new MetroProcess({ spawn: vi.fn(() => fakeProc()) as never, probe: async () => false });
+    await expect(mp.start({ readyTimeoutMs: 40, pollIntervalMs: 10 })).rejects.toThrow(/did not become ready/);
+  });
+
+  it('should throw when the Metro process exits during startup', async () => {
+    existsMock.mockReturnValue(true);
+    const proc = fakeProc();
+    proc.exitCode = 1;
+    const mp = new MetroProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
+    await expect(mp.start({ readyTimeoutMs: 1000, pollIntervalMs: 10 })).rejects.toThrow(/exited during startup/);
+  });
+});
+
+describe('MetroProcess.stop', () => {
+  it('should SIGTERM the process and resolve on exit', async () => {
+    existsMock.mockReturnValue(true);
+    const proc = fakeProc();
+    const mp = new MetroProcess({ spawn: vi.fn(() => proc) as never, probe: async () => true });
+    await mp.start({ readyTimeoutMs: 1000, pollIntervalMs: 10 });
+
+    const stopping = mp.stop();
+    proc.emit('exit', 0);
+    await stopping;
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mp.isRunning()).toBe(false);
+  });
+
+  it('should be a no-op when nothing is running', async () => {
+    const mp = new MetroProcess();
+    await expect(mp.stop()).resolves.toBeUndefined();
+  });
+});

--- a/packages/react-native-service/test/metroProcess.spec.ts
+++ b/packages/react-native-service/test/metroProcess.spec.ts
@@ -103,6 +103,8 @@ describe('MetroProcess.start', () => {
     const starting = mp.start({ readyTimeoutMs: 5000, pollIntervalMs: 20 });
     proc.emit('error', new Error('spawn react-native ENOENT'));
     await expect(starting).rejects.toThrow(/ENOENT/);
+    // A failed-spawn process must not report as running (exitCode/signalCode/killed stay unset).
+    expect(mp.isRunning()).toBe(false);
   });
 
   it('should surface a spawn error even when a pre-existing Metro answers the probe', async () => {

--- a/packages/react-native-service/test/metroProcess.spec.ts
+++ b/packages/react-native-service/test/metroProcess.spec.ts
@@ -95,6 +95,15 @@ describe('MetroProcess.start', () => {
     const mp = new MetroProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
     await expect(mp.start({ readyTimeoutMs: 1000, pollIntervalMs: 10 })).rejects.toThrow(/exited during startup/);
   });
+
+  it('should fail fast with the spawn error instead of timing out (ENOENT)', async () => {
+    existsMock.mockReturnValue(true);
+    const proc = fakeProc();
+    const mp = new MetroProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
+    const starting = mp.start({ readyTimeoutMs: 5000, pollIntervalMs: 20 });
+    proc.emit('error', new Error('spawn react-native ENOENT'));
+    await expect(starting).rejects.toThrow(/ENOENT/);
+  });
 });
 
 describe('MetroProcess.stop', () => {

--- a/packages/react-native-service/test/metroProcess.spec.ts
+++ b/packages/react-native-service/test/metroProcess.spec.ts
@@ -104,6 +104,18 @@ describe('MetroProcess.start', () => {
     proc.emit('error', new Error('spawn react-native ENOENT'));
     await expect(starting).rejects.toThrow(/ENOENT/);
   });
+
+  it('should stop() immediately after a spawn error without hanging on a never-fired exit', async () => {
+    existsMock.mockReturnValue(true);
+    const proc = fakeProc();
+    const mp = new MetroProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
+    const starting = mp.start({ readyTimeoutMs: 5000, pollIntervalMs: 20 });
+    proc.emit('error', new Error('spawn react-native ENOENT'));
+    await expect(starting).rejects.toThrow(/ENOENT/);
+    // No 'exit' will fire for a failed spawn — stop() must early-return, not await SIGKILL.
+    await mp.stop();
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
 });
 
 describe('MetroProcess.stop', () => {


### PR DESCRIPTION
Closes #406. **Stacked on #424 (#378)** — review/merge that first; this PR's diff is only the RN-specific delta.

`@wdio/electron-service` owns chromedriver's whole lifecycle; the RN analog is owning Metro's. Opt-in via `manageMetro`, replacing the manual CI `react-native start` → `wait-on` → curl-prebundle dance.

- **`metroProcess.ts`**: starts `react-native start` as a long-lived child (resolves the project-local CLI, falls back to `npx --no-install`), polls `/status` for readiness, and tears down with native-core's SIGTERM→SIGKILL discipline. Optional best-effort pre-bundle warms the ~60s cold compile. Readiness probe + spawn are injectable for tests. **One shared Metro** for the run — `adb reverse` stays per-device in `MetroBridge`.
- **launcher**: `onPrepare` starts Metro (before `super` so the doctor sees it up), `onComplete` stops it; `doctorChecks` adds a Metro-reachable warning.
- **options**: `manageMetro` / `metroProjectRoot` / `prebundle`.
- **README**: document `manageMetro` + `autoInstallDriver`/`doctor`.

### Tests
129 react-native-service tests (+12: MetroProcess start/ready/stop/prebundle, bin resolution, Metro doctor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)