### PR TITLE
perf(tauri-service): batch updateAllMocks into a single scheduler

### DIFF
--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -413,7 +413,7 @@ export default class TauriWorkerService {
           );
         }
         const result = await execute<ReturnValue, InnerArguments>(browser, script, ...args);
-        await updateAllMocks();
+        await getMockUpdateScheduler(browser).schedule();
         return result;
       },
 
@@ -524,7 +524,7 @@ export default class TauriWorkerService {
             target,
           );
         }
-        await updateAllMocks();
+        await getMockUpdateScheduler(browser).schedule();
       },
     };
   }
@@ -551,7 +551,7 @@ export default class TauriWorkerService {
         ...args: readonly unknown[]
       ): Promise<unknown> {
         const result = await Reflect.apply(originalCommand, this, args as unknown[]);
-        await updateAllMocks();
+        await getMockUpdateScheduler(browser).schedule();
         return result;
       } as Parameters<typeof browser.overwriteCommand>[1];
 
@@ -658,59 +658,101 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * Update all existing mocks by syncing inner (browser) mock state to outer (test) mocks.
- * On Windows, updates run sequentially to avoid saturating WebView2 with concurrent
- * ExecuteScript calls. Each update is retried once (after 50 ms) before failing hard.
- * Silent swallow of mock-update errors leads to empty mock.calls assertions, which is
- * harder to diagnose than an explicit AggregateError.
- */
-async function updateAllMocks(): Promise<void> {
-  const mocks = mockStore.getMocks();
-  if (mocks.length === 0) {
-    return;
+// One scheduler per browser session — keyed weakly so GC can claim finished sessions.
+const mockUpdateSchedulers = new WeakMap<WebdriverIO.Browser, MockUpdateScheduler>();
+
+class MockUpdateScheduler {
+  #running: Promise<void> | null = null;
+  #queued: Promise<void> | null = null;
+
+  schedule(): Promise<void> {
+    if (!this.#running) {
+      const p = this.#wrapRun(this.#runOnce());
+      this.#running = p;
+      return p;
+    }
+    if (!this.#queued) {
+      this.#queued = this.#running.catch(() => undefined).then(() => this.#runOnce());
+    }
+    return this.#queued;
   }
 
-  const tryUpdate = async (
-    mockId: string,
-    mockInstance: ReturnType<typeof mockStore.getMocks>[0][1],
-  ): Promise<void> => {
-    try {
-      await mockInstance.update();
-    } catch (firstError) {
-      log.debug(`Mock update failed for ${mockId}, retrying in 50ms:`, firstError);
-      await sleep(50);
-      await mockInstance.update();
-    }
-  };
+  // Atomically promotes the queued batch into the running slot once the current
+  // batch settles (resolved or rejected), preventing a third concurrent batch
+  // from racing between the two.
+  #wrapRun(run: Promise<void>): Promise<void> {
+    let wrapped!: Promise<void>;
+    wrapped = run.finally(() => {
+      if (this.#running !== wrapped) return;
+      if (this.#queued) {
+        const promoted = this.#queued;
+        this.#queued = null;
+        this.#running = this.#wrapRun(promoted);
+      } else {
+        this.#running = null;
+      }
+    });
+    return wrapped;
+  }
 
-  if (process.platform === 'win32') {
-    const errors: Array<{ mockId: string; error: unknown }> = [];
-    for (const [mockId, mockInstance] of mocks) {
+  async #runOnce(): Promise<void> {
+    const mocks = mockStore.getMocks();
+    if (mocks.length === 0) return;
+
+    // Retry once on transient failures (e.g. WebView2 hiccup). Silent swallow of
+    // persistent errors leads to empty mock.calls assertions that are hard to debug,
+    // so we surface them as AggregateError after the retry is exhausted.
+    const tryUpdate = async (
+      mockId: string,
+      mockInstance: ReturnType<typeof mockStore.getMocks>[0][1],
+    ): Promise<void> => {
       try {
-        await tryUpdate(mockId, mockInstance);
-      } catch (error) {
-        errors.push({ mockId, error });
+        await mockInstance.update();
+      } catch (firstError) {
+        log.debug(`Mock update failed for ${mockId}, retrying in 50ms:`, firstError);
+        await sleep(50);
+        await mockInstance.update();
+      }
+    };
+
+    if (process.platform === 'win32') {
+      // Sequential on Windows to avoid saturating WebView2 with concurrent ExecuteScript calls.
+      const errors: Array<{ mockId: string; error: unknown }> = [];
+      for (const [mockId, mockInstance] of mocks) {
+        try {
+          await tryUpdate(mockId, mockInstance);
+        } catch (error) {
+          errors.push({ mockId, error });
+        }
+      }
+      if (errors.length > 0) {
+        throw new AggregateError(
+          errors.map((e) => e.error),
+          `Mock updates failed for: ${errors.map((e) => e.mockId).join(', ')}`,
+        );
+      }
+    } else {
+      const results = await Promise.allSettled(mocks.map(([mockId, mockInstance]) => tryUpdate(mockId, mockInstance)));
+      const failures = results
+        .map((result, i) => ({ result, mockId: mocks[i][0] }))
+        .filter(
+          (entry): entry is { result: PromiseRejectedResult; mockId: string } => entry.result.status === 'rejected',
+        );
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures.map((f) => f.result.reason),
+          `Mock updates failed for: ${failures.map((f) => f.mockId).join(', ')}`,
+        );
       }
     }
-    if (errors.length > 0) {
-      throw new AggregateError(
-        errors.map((e) => e.error),
-        `Mock updates failed for: ${errors.map((e) => e.mockId).join(', ')}`,
-      );
-    }
-  } else {
-    const results = await Promise.allSettled(mocks.map(([mockId, mockInstance]) => tryUpdate(mockId, mockInstance)));
-    const failures = results
-      .map((result, i) => ({ result, mockId: mocks[i][0] }))
-      .filter(
-        (entry): entry is { result: PromiseRejectedResult; mockId: string } => entry.result.status === 'rejected',
-      );
-    if (failures.length > 0) {
-      throw new AggregateError(
-        failures.map((f) => f.result.reason),
-        `Mock updates failed for: ${failures.map((f) => f.mockId).join(', ')}`,
-      );
-    }
   }
+}
+
+function getMockUpdateScheduler(browser: WebdriverIO.Browser): MockUpdateScheduler {
+  let scheduler = mockUpdateSchedulers.get(browser);
+  if (!scheduler) {
+    scheduler = new MockUpdateScheduler();
+    mockUpdateSchedulers.set(browser, scheduler);
+  }
+  return scheduler;
 }

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -314,6 +314,81 @@ describe('TauriWorkerService', () => {
       expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('clearValue', expect.any(Function), true);
     });
 
+    it('should update mocks after overridden element command executes', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+      vi.mocked(mockStore.getMocks).mockReturnValueOnce([['tauri.cmd', mockObj as any]]);
+
+      const oc = vi.mocked(mockBrowser.overwriteCommand);
+      const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
+      expect(clickCall).toBeDefined();
+      const overrideFn = clickCall?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const original = vi.fn().mockResolvedValue('ok');
+      await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
+
+      expect(mockObj.update).toHaveBeenCalledTimes(1);
+      expect(original).toHaveBeenCalled();
+    });
+
+    it('should run two scheduler batches when two overrides fire concurrently', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', mockObj as any]]);
+
+      const oc = vi.mocked(mockBrowser.overwriteCommand);
+      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const original = vi.fn().mockResolvedValue('ok');
+      const p1 = overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      const p2 = overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      await Promise.all([p1, p2]);
+
+      expect(mockObj.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('should recover the scheduler after a batch update rejects', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      const mockObj = { update: vi.fn() };
+      // First batch: both update attempts fail (initial + retry)
+      (mockObj.update as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValue(undefined);
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', mockObj as any]]);
+
+      const oc = vi.mocked(mockBrowser.overwriteCommand);
+      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const original = vi.fn().mockResolvedValue('ok');
+      await overrideFn.call({} as unknown as WebdriverIO.Element, original).catch(() => undefined);
+      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
+
+      // 2 from the failed batch (initial + retry) + 1 from the recovered batch
+      expect(mockObj.update).toHaveBeenCalledTimes(3);
+    });
+
     it('should clear stale mocks at session start for embedded driver provider', async () => {
       const mockBrowser = createMockBrowser();
       const originalExecute = mockBrowser.execute as ReturnType<typeof vi.fn>;


### PR DESCRIPTION
## Summary

Closes #429.

Mirrors the `MockUpdateScheduler` introduced in #292 (electron-service). The old `updateAllMocks()` function was called synchronously after every overridden element command (`click`, `setValue`, `doubleClick`, `clearValue`) and after `tauri.execute()`/`emitEvent()`, firing **N** `browser.execute()` round-trips per registered mock on every DOM interaction.

Under the new scheduler:

- At most **two batches** run at any moment (current + one queued). Any number of concurrent `schedule()` callers after the first share the queued slot, so N DOM interactions produce ≤ 2 × M execute calls (M = mock count) instead of N × M.
- Per-batch error and retry semantics (50 ms retry, `AggregateError` surface, Windows sequential ordering) are **preserved unchanged** — no behaviour change for passing tests.
- A `WeakMap` keys one scheduler per browser instance so multiremote sessions each get independent scheduling.

## Changes

- `packages/tauri-service/src/service.ts` — replace `updateAllMocks()` function with `MockUpdateScheduler` class + `getMockUpdateScheduler(browser)` accessor; update the three call sites in `getTauriAPI` and `overrideElementCommand`.
- `packages/tauri-service/test/service.spec.ts` — three new unit tests: element-command dispatch, concurrent dedup (two concurrent overrides → exactly 2 batches), and scheduler recovery after a rejected batch.

## Test plan

- [x] `pnpm --filter @wdio/tauri-service test` — 627 tests pass (was 624; 3 new)
- [x] `pnpm --filter @wdio/tauri-service typecheck` — clean
- [x] `pnpm --filter @wdio/tauri-service lint` — pre-existing warnings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)