### PR TITLE
fix(tauri-service): sync mocks via afterCommand so user command overrides survive

### DIFF
--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -23,11 +23,12 @@ const log = createLogger('tauri-service', 'service');
 const EXECUTE_PATCHED = Symbol('wdio-tauri-execute-patched');
 const browserInterceptor = createIpcInterceptor('tauri');
 
+/** Element commands whose completion should re-sync mocks from the app context. */
+const MOCK_UPDATE_COMMANDS = new Set<string>(['click', 'doubleClick', 'setValue', 'clearValue']);
+
 /**
  * Tauri worker service
  */
-type ElementCommands = 'click' | 'doubleClick' | 'setValue' | 'clearValue';
-
 export default class TauriWorkerService {
   private browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser;
   private clearMocks: boolean;
@@ -194,9 +195,6 @@ export default class TauriWorkerService {
         }
       }
 
-      // Install command overrides to trigger mock updates after DOM interactions
-      stage = 'installCommandOverrides';
-      this.installCommandOverrides();
       log.info('before() complete');
     } catch (error) {
       log.error(
@@ -233,6 +231,20 @@ export default class TauriWorkerService {
     } catch (error) {
       log.warn('Failed to ensure window focus before command:', error);
     }
+  }
+
+  /**
+   * Re-sync mocks after element commands that mutate the DOM. Implemented as an
+   * afterCommand hook rather than browser.overwriteCommand: element-scoped
+   * overrides are keyed by command name and do not chain, so re-registering
+   * click/setValue/etc. silently clobbered any user-defined override of the same
+   * command. afterCommand leaves the user's command chain untouched.
+   */
+  async afterCommand(commandName: string, _args: unknown[], _result: unknown, error?: Error): Promise<void> {
+    if (error || !MOCK_UPDATE_COMMANDS.has(commandName)) {
+      return;
+    }
+    await updateAllMocks();
   }
 
   async afterTest(_test: unknown, _context: unknown, _results: unknown): Promise<void> {
@@ -349,7 +361,6 @@ export default class TauriWorkerService {
     }
     this.addTauriApi(browser, true);
     this.patchBrowserUrl(browser, injectionScript);
-    this.installCommandOverrides();
     log.debug('Browser-only mode initialized');
   }
 
@@ -527,38 +538,6 @@ export default class TauriWorkerService {
         await updateAllMocks();
       },
     };
-  }
-
-  /**
-   * Install command overrides to trigger mock updates after DOM interactions
-   */
-  private installCommandOverrides() {
-    const commandsToOverride: ElementCommands[] = ['click', 'doubleClick', 'setValue', 'clearValue'];
-    commandsToOverride.forEach((commandName) => {
-      this.overrideElementCommand(commandName);
-    });
-  }
-
-  /**
-   * Override an element-level command to add mock update after execution
-   */
-  private overrideElementCommand(commandName: ElementCommands) {
-    const browser = this.browser as WebdriverIO.Browser;
-    try {
-      const testOverride = async function (
-        this: WebdriverIO.Element,
-        originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
-        ...args: readonly unknown[]
-      ): Promise<unknown> {
-        const result = await Reflect.apply(originalCommand, this, args as unknown[]);
-        await updateAllMocks();
-        return result;
-      } as Parameters<typeof browser.overwriteCommand>[1];
-
-      browser.overwriteCommand(commandName, testOverride, true);
-    } catch (error) {
-      log.warn(`Failed to override element command '${commandName}':`, error);
-    }
   }
 
   /**

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -302,16 +302,48 @@ describe('TauriWorkerService', () => {
       await expect(service.before({} as any, [], mockBrowser)).resolves.not.toThrow();
     });
 
-    it('should install command overrides after initialization', async () => {
+    it('should not register element command overrides (preserves user overrides)', async () => {
       const mockBrowser = createMockBrowser();
       const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
 
       await service.before({} as any, [], mockBrowser);
 
-      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('click', expect.any(Function), true);
-      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('doubleClick', expect.any(Function), true);
-      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('setValue', expect.any(Function), true);
-      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('clearValue', expect.any(Function), true);
+      // Element-scoped overrides are keyed by command name and do not chain, so
+      // registering these would clobber a user's overwriteCommand('click', ...).
+      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('click', expect.any(Function), true);
+      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('doubleClick', expect.any(Function), true);
+      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('setValue', expect.any(Function), true);
+      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('clearValue', expect.any(Function), true);
+    });
+
+    it('should update mocks via afterCommand for DOM-mutating commands', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
+
+      for (const command of ['click', 'doubleClick', 'setValue', 'clearValue']) {
+        mockUpdate.mockClear();
+        await service.afterCommand(command, [], undefined, undefined);
+        expect(mockUpdate).toHaveBeenCalledOnce();
+      }
+    });
+
+    it('should not update mocks via afterCommand for unrelated commands or on error', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
+
+      await service.afterCommand('getText', [], 'text', undefined);
+      expect(mockUpdate).not.toHaveBeenCalled();
+
+      await service.afterCommand('click', [], undefined, new Error('click failed'));
+      expect(mockUpdate).not.toHaveBeenCalled();
     });
 
     it('should clear stale mocks at session start for embedded driver provider', async () => {


### PR DESCRIPTION
## Problem

To re-sync mocks after DOM mutations, the worker service registered element-scoped `overwriteCommand` wrappers for `click`/`doubleClick`/`setValue`/`clearValue` in `before()`. WDIO stores element-scoped overrides (`overwriteCommand(name, fn, /* attachToElement */ true)`) in a map **keyed by command name** — they do **not** chain (only browser-scoped overrides capture and chain `origCommand`). So the service's registration silently clobbered any user-defined `overwriteCommand('click', …)` (and, symmetrically, a user override registered last would clobber the service's mock-sync). Reported in #422.

## Fix

Move the mock re-sync to the **`afterCommand`** worker hook and stop registering element overrides entirely. The old wrappers only ran the original command and then `updateAllMocks()` — they never modified args or the return value — so `afterCommand` is a behaviour-preserving drop-in that leaves the user's command chain untouched.

- Removed `installCommandOverrides` / `overrideElementCommand` and both call sites.
- Added `afterCommand`, which runs `updateAllMocks()` for the four DOM-mutating commands (skipped when the command itself errored).
- The separate, legitimate `browser.url` override (browser mode) is unchanged.

## Behaviour note

Previously a mock-update failure rejected the triggering command. Via `afterCommand` the same failure is logged by WDIO's hook runner instead of failing the command (the `updateAllMocks` AggregateError still surfaces in logs). This is the one intentional behaviour change.

## Tests

- Replaced the "installs command overrides" unit test with a #422 regression guard (the service must **not** register element overrides), plus `afterCommand` coverage (updates mocks for the four commands; no-op for unrelated commands and when the command errored).
- `pnpm --filter @wdio/tauri-service typecheck` clean; full suite **626/626** green.

## Scope

`@wdio/electron-service` has the identical bug. Per maintainer decision it's handled separately (its fix interacts with the #292 batched `MockUpdateScheduler` + multiremote per-instance routing and ~44 test refs) — tracked in #432.

Fixes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
