### PR TITLE
fix(electron-service): sync mocks via afterCommand so user command overrides survive

### DIFF
--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -497,9 +497,11 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
    * command. afterCommand leaves the user's command chain untouched.
    *
    * afterCommand exposes only the root browser, not the multiremote instance a
-   * command ran on, so for multiremote we schedule every instance's batch. Each
-   * scheduler filters to native mocks (shared) plus its own browser-mode mocks,
-   * so all affected mocks update without needing to know which instance fired.
+   * command ran on, so for multiremote we schedule each Electron instance's batch.
+   * Non-Electron instances are skipped — they have no mock surface and no
+   * browser.electron to drive a native update, so scheduling them would just warn.
+   * Each scheduler filters to native mocks (shared) plus its own browser-mode
+   * mocks, so all affected mocks update without knowing which instance fired.
    */
   async afterCommand(commandName: string, _args: unknown[], _result: unknown, error?: Error): Promise<void> {
     const browser = this.browser;
@@ -508,9 +510,10 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
     }
     if (isMultiremote(browser)) {
       await Promise.all(
-        browser.instances.map((instanceName) =>
-          getMockUpdateScheduler(browser.getInstance(instanceName) as WebdriverIO.Browser).schedule(),
-        ),
+        browser.instances
+          .map((instanceName) => browser.getInstance(instanceName) as WebdriverIO.Browser)
+          .filter(isElectronInstance)
+          .map((instance) => getMockUpdateScheduler(instance).schedule()),
       );
       return;
     }
@@ -812,6 +815,18 @@ function isMultiremote(
   browser: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser,
 ): browser is WebdriverIO.MultiRemoteBrowser {
   return browser.isMultiremote;
+}
+
+/**
+ * A multiremote instance is an Electron session when it carries the service's
+ * custom capability; other instances (Firefox, Chrome, …) have no mock surface.
+ */
+function isElectronInstance(browser: WebdriverIO.Browser): boolean {
+  const caps =
+    (browser.requestedCapabilities as Capabilities.W3CCapabilities)?.alwaysMatch ||
+    (browser.requestedCapabilities as WebdriverIO.Capabilities) ||
+    {};
+  return Boolean(caps[CUSTOM_CAPABILITY_NAME]);
 }
 
 async function initCdpBridge(

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -313,7 +313,8 @@ function getMockUpdateScheduler(browser: WebdriverIO.Browser): MockUpdateSchedul
 
 const log = createLogger('electron-service', 'service');
 
-type ElementCommands = 'click' | 'doubleClick' | 'setValue' | 'clearValue';
+/** Element commands whose completion should re-sync mocks from the app context. */
+const MOCK_UPDATE_COMMANDS = new Set<string>(['click', 'doubleClick', 'setValue', 'clearValue']);
 
 export default class ElectronWorkerService extends ServiceConfig implements Services.ServiceInstance {
   private logCaptureManager?: LogCaptureManager;
@@ -369,12 +370,6 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         browser?.electron && typeof browser.electron.execute === 'function' && cdpBridge !== undefined;
 
       const hasElectronApi = isElectronApiAvailable(this.browser, cdpBridge);
-
-      // Install command overrides if the electron API is available
-      if (hasElectronApi) {
-        stage = 'installCommandOverrides';
-        this.installCommandOverrides();
-      }
 
       if (isMultiremote(instance)) {
         const mrBrowser = instance;
@@ -494,6 +489,34 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
     await ensureActiveWindowFocus(this.browser, commandName);
   }
 
+  /**
+   * Re-sync mocks after element commands that mutate the DOM. Implemented as an
+   * afterCommand hook rather than browser.overwriteCommand: element-scoped
+   * overrides are keyed by command name and do not chain, so re-registering
+   * click/setValue/etc. silently clobbered any user-defined override of the same
+   * command. afterCommand leaves the user's command chain untouched.
+   *
+   * afterCommand exposes only the root browser, not the multiremote instance a
+   * command ran on, so for multiremote we schedule every instance's batch. Each
+   * scheduler filters to native mocks (shared) plus its own browser-mode mocks,
+   * so all affected mocks update without needing to know which instance fired.
+   */
+  async afterCommand(commandName: string, _args: unknown[], _result: unknown, error?: Error): Promise<void> {
+    const browser = this.browser;
+    if (error || !browser || !MOCK_UPDATE_COMMANDS.has(commandName)) {
+      return;
+    }
+    if (isMultiremote(browser)) {
+      await Promise.all(
+        browser.instances.map((instanceName) =>
+          getMockUpdateScheduler(browser.getInstance(instanceName) as WebdriverIO.Browser).schedule(),
+        ),
+      );
+      return;
+    }
+    await getMockUpdateScheduler(browser).schedule();
+  }
+
   after() {
     this.logCaptureManager?.stopCapture();
     clearPuppeteerSessions();
@@ -565,14 +588,8 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         instance.electron = this.getElectronBrowserModeAPI(instance);
       }
 
-      // WDIO's multiremote overwriteCommand wrapper forwards the call to origOverwriteCommand
-      // with all per-instance browsers as the `instances` argument. The underlying implementation
-      // then registers the override on every instance's __elementOverrides__ directly, so both
-      // mrBrowser.$('btn').click() and mrBrowser.getInstance('a').$('btn').click() go through
-      // the override. Calling it on each instance separately would double-wrap element commands.
       browser.electron = this.getElectronBrowserModeAPI(browser);
       this.patchBrowserUrl(browser, injectionScript);
-      this.installCommandOverrides(browser as unknown as WebdriverIO.Browser);
     } else {
       const devServerUrl = this.globalOptions.devServerUrl;
       if (!devServerUrl) {
@@ -583,7 +600,6 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
       (browser as unknown as Record<string, boolean>).__wdioElectronBrowserMode__ = true;
       browser.electron = this.getElectronBrowserModeAPI(browser);
       this.patchBrowserUrl(browser, injectionScript);
-      this.installCommandOverrides();
     }
     log.debug('Electron browser mode initialised');
   }
@@ -732,45 +748,6 @@ export default class ElectronWorkerService extends ServiceConfig implements Serv
         await getMockUpdateScheduler(browser).schedule();
       },
     } as unknown as BrowserExtension['electron'];
-  }
-
-  /**
-   * Install command overrides to trigger mock updates after DOM interactions
-   */
-  private installCommandOverrides(targetBrowser?: WebdriverIO.Browser) {
-    const commandsToOverride = ['click', 'doubleClick', 'setValue', 'clearValue'];
-    commandsToOverride.forEach((commandName) => {
-      this.overrideElementCommand(commandName as ElementCommands, targetBrowser);
-    });
-  }
-
-  /**
-   * Override an element-level command to add mock update after execution
-   */
-  private overrideElementCommand(commandName: ElementCommands, targetBrowser?: WebdriverIO.Browser) {
-    const browser = (targetBrowser ?? this.browser) as WebdriverIO.Browser;
-    try {
-      const testOverride = async function (
-        this: WebdriverIO.Element,
-        originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
-        ...args: readonly unknown[]
-      ): Promise<unknown> {
-        // Use Reflect.apply to safely call the original command with the correct 'this' context
-        // This avoids TypeScript's strict function signature checking while maintaining runtime safety
-        const result = await Reflect.apply(originalCommand, this, args as unknown[]);
-        // In multiremote, the override is registered on the root but fires per
-        // instance — this.browser is the per-instance owning session. Route
-        // through that browser's scheduler so per-instance mock keys match;
-        // otherwise the root scheduler filters everything out.
-        const ownerBrowser = (this as { browser?: WebdriverIO.Browser }).browser ?? browser;
-        await getMockUpdateScheduler(ownerBrowser).schedule();
-        return result;
-      } as Parameters<typeof browser.overwriteCommand>[1];
-
-      browser.overwriteCommand(commandName, testOverride, true);
-    } catch (error) {
-      log.warn(`Failed to override element command '${commandName}':`, error);
-    }
   }
 
   /**

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -1392,6 +1392,48 @@ describe('Electron Worker Service', () => {
         await instance.afterCommand('click', [], undefined, undefined);
         expect(mockObj.update).toHaveBeenCalled();
       });
+
+      it('should only schedule Electron instances, skipping non-Electron ones', async () => {
+        instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
+
+        const electronBrowser = {
+          url: vi.fn().mockResolvedValue(undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          requestedCapabilities: {
+            alwaysMatch: { browserName: 'electron', 'wdio:electronServiceOptions': {} },
+          },
+          electron: {},
+        } as unknown as WebdriverIO.Browser;
+
+        const firefoxBrowser = {
+          url: vi.fn().mockResolvedValue(undefined),
+          execute: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          requestedCapabilities: { alwaysMatch: { browserName: 'firefox' } },
+        } as unknown as WebdriverIO.Browser;
+
+        const rootBrowser = {
+          instances: ['app1', 'ff1'],
+          getInstance: (name: string) => (name === 'app1' ? electronBrowser : firefoxBrowser),
+          execute: vi.fn().mockResolvedValue(undefined),
+          url: vi.fn().mockResolvedValue(undefined),
+          overwriteCommand: vi.fn(),
+          isMultiremote: true,
+          electron: {},
+        } as unknown as WebdriverIO.MultiRemoteBrowser;
+
+        await instance.before({}, [], rootBrowser);
+
+        const storeModule = (await import('../src/mockStore.js')) as any;
+        const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+        storeModule.default.getMocks.mockReturnValue([['id', mockObj]]);
+        await instance.afterCommand('click', [], undefined, undefined);
+
+        // Only the Electron instance is scheduled, so the shared native mock is
+        // updated once — not once per instance — and Firefox is left untouched.
+        expect(mockObj.update).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('root multiremote browser.electron.mock()', () => {

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -240,25 +240,22 @@ describe('Electron Worker Service', () => {
       await expect(instance.before({}, [], browser)).rejects.toThrow('Window not found');
     });
 
-    it('should install element command overrides with overwriteCommand', async () => {
+    it('should not register element command overrides (preserves user overrides)', async () => {
       instance = new ElectronWorkerService({}, {});
 
       await instance.before({}, [], browser);
 
+      // Element-scoped overrides are keyed by command name and do not chain, so
+      // registering these would clobber a user's overwriteCommand('click', ...).
       const oc = vi.mocked((browser as any).overwriteCommand);
-      const calls = oc.mock.calls;
-      const overridden = calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
-      expect(overridden).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'click', isElement: true }),
-          expect.objectContaining({ name: 'doubleClick', isElement: true }),
-          expect.objectContaining({ name: 'setValue', isElement: true }),
-          expect.objectContaining({ name: 'clearValue', isElement: true }),
-        ]),
-      );
+      const overridden = oc.mock.calls.map((c: unknown[]) => c[0]);
+      expect(overridden).not.toContain('click');
+      expect(overridden).not.toContain('doubleClick');
+      expect(overridden).not.toContain('setValue');
+      expect(overridden).not.toContain('clearValue');
     });
 
-    it('should update mocks after overridden element command executes', async () => {
+    it('should update mocks after a DOM-mutating command via afterCommand', async () => {
       instance = new ElectronWorkerService({}, {});
       await instance.before({}, [], browser);
 
@@ -269,23 +266,30 @@ describe('Electron Worker Service', () => {
       };
       storeModule.default.getMocks.mockReturnValueOnce([['electron.app.getName', mockObj]]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const clickCall = oc.mock.calls.find((c: unknown[]) => c[0] === 'click');
-      expect(clickCall).toBeDefined();
-      const overrideFn = clickCall?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      await overrideFn?.call({} as unknown as WebdriverIO.Element, original);
+      await instance.afterCommand('click', [], undefined, undefined);
 
       // Batched scheduler hands the read-back call data to __applyCalls; this
-      // proves the override still drives mock sync after the per-mock update()
-      // path was retired.
+      // proves afterCommand drives mock sync after the per-mock update() path
+      // was retired.
       expect(mockObj.__applyCalls).toHaveBeenCalledTimes(1);
-      expect(original).toHaveBeenCalled();
+    });
+
+    it('should not update mocks via afterCommand for unrelated commands or on error', async () => {
+      instance = new ElectronWorkerService({}, {});
+      await instance.before({}, [], browser);
+
+      const storeModule = (await import('../src/mockStore.js')) as any;
+      const mockObj = {
+        __accessor: { kind: 'api', apiName: 'app', funcName: 'getName' },
+        __applyCalls: vi.fn(),
+      };
+      storeModule.default.getMocks.mockReturnValue([['electron.app.getName', mockObj]]);
+
+      await instance.afterCommand('getText', [], 'text', undefined);
+      expect(mockObj.__applyCalls).not.toHaveBeenCalled();
+
+      await instance.afterCommand('click', [], undefined, new Error('click failed'));
+      expect(mockObj.__applyCalls).not.toHaveBeenCalled();
     });
 
     it('should batch updates for ≥2 mocks into a single browser.electron.execute call', async () => {
@@ -315,15 +319,7 @@ describe('Electron Worker Service', () => {
         ['electron.Tray.__constructor', mockC],
       ]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      await instance.afterCommand('click', [], undefined, undefined);
 
       // Acceptance criteria: one CDP round-trip regardless of mock count.
       expect(executeMock).toHaveBeenCalledTimes(1);
@@ -365,13 +361,7 @@ describe('Electron Worker Service', () => {
         [keyB, mockB],
       ]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-      await overrideFn.call({} as unknown as WebdriverIO.Element, vi.fn().mockResolvedValue('ok'));
+      await instance.afterCommand('click', [], undefined, undefined);
 
       // Healthy mock still receives its data — one bad reader doesn't tank the batch.
       expect(mockA.__applyCalls).toHaveBeenCalledTimes(1);
@@ -403,13 +393,7 @@ describe('Electron Worker Service', () => {
       };
       storeModule.default.getMocks.mockReturnValueOnce([['electron.app.getName', mockObj]]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-      await overrideFn.call({} as unknown as WebdriverIO.Element, vi.fn().mockResolvedValue('ok'));
+      await instance.afterCommand('click', [], undefined, undefined);
 
       expect(mockObj.__applyCalls).toHaveBeenCalledTimes(1);
       expect(mockObj.__applyCalls).toHaveBeenCalledWith(
@@ -448,15 +432,7 @@ describe('Electron Worker Service', () => {
         [keyB, mockB],
       ]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      await instance.afterCommand('click', [], undefined, undefined);
 
       expect(browserExecute).toHaveBeenCalledTimes(1);
       expect(mockA.__applyCalls).toHaveBeenCalledTimes(1);
@@ -492,15 +468,7 @@ describe('Electron Worker Service', () => {
         [browserModeStoreKey(browser, 'ipc-x'), browserMock],
       ]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      await instance.afterCommand('click', [], undefined, undefined);
 
       // Mixed registration: one CDP call for native, one renderer call for browser-mode.
       expect(executeMock).toHaveBeenCalledTimes(1);
@@ -517,16 +485,8 @@ describe('Electron Worker Service', () => {
       const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
       storeModule.default.getMocks.mockReturnValue([['id', mockObj]]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      const p1 = overrideFn.call({} as unknown as WebdriverIO.Element, original);
-      const p2 = overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      const p1 = instance.afterCommand('click', [], undefined, undefined);
+      const p2 = instance.afterCommand('click', [], undefined, undefined);
       await Promise.all([p1, p2]);
 
       expect(mockObj.update).toHaveBeenCalledTimes(2);
@@ -541,16 +501,8 @@ describe('Electron Worker Service', () => {
       (mockObj.update as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'));
       storeModule.default.getMocks.mockReturnValue([['id', mockObj]]);
 
-      const oc = vi.mocked((browser as any).overwriteCommand);
-      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
-        this: WebdriverIO.Element,
-        original: (...args: unknown[]) => Promise<unknown>,
-        ...args: unknown[]
-      ) => Promise<unknown>;
-
-      const original = vi.fn().mockResolvedValue('ok');
-      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
-      await overrideFn.call({} as unknown as WebdriverIO.Element, original);
+      await instance.afterCommand('click', [], undefined, undefined);
+      await instance.afterCommand('click', [], undefined, undefined);
 
       expect(mockObj.update).toHaveBeenCalledTimes(2);
     });
@@ -1231,20 +1183,16 @@ describe('Electron Worker Service', () => {
         await expect(browserModeBrowser.url('http://localhost:5173/settings')).resolves.toBeUndefined();
       });
 
-      it('should install element command overrides in browser mode', async () => {
+      it('should not register element command overrides in browser mode', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
         await instance.before({}, [], browserModeBrowser);
 
         const oc = vi.mocked((browserModeBrowser as any).overwriteCommand);
-        const overridden = oc.mock.calls.map((c: unknown[]) => ({ name: c[0], isElement: c[2] }));
-        expect(overridden).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ name: 'click', isElement: true }),
-            expect.objectContaining({ name: 'doubleClick', isElement: true }),
-            expect.objectContaining({ name: 'setValue', isElement: true }),
-            expect.objectContaining({ name: 'clearValue', isElement: true }),
-          ]),
-        );
+        const overridden = oc.mock.calls.map((c: unknown[]) => c[0]);
+        expect(overridden).not.toContain('click');
+        expect(overridden).not.toContain('doubleClick');
+        expect(overridden).not.toContain('setValue');
+        expect(overridden).not.toContain('clearValue');
       });
 
       it('should route emitEvent through browser.execute in browser mode', async () => {
@@ -1405,7 +1353,7 @@ describe('Electron Worker Service', () => {
         expect((firefoxBrowser.execute as ReturnType<typeof vi.fn>).mock.calls.length).toBe(firefoxExecuteBefore);
       });
 
-      it('should install command overrides only on the root browser, not on individual Electron instances', async () => {
+      it('should not register element overrides and drives per-instance mock updates via afterCommand', async () => {
         instance = new ElectronWorkerService({ mode: 'browser', devServerUrl: 'http://localhost:5173' }, {});
 
         const electronBrowser = {
@@ -1430,12 +1378,19 @@ describe('Electron Worker Service', () => {
 
         await instance.before({}, [], rootBrowser);
 
-        // Root browser gets overwriteCommand calls (for click, doubleClick, setValue, clearValue)
-        expect((rootBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
-        // Per-instance browser gets no direct overwriteCommand call: WDIO's multiremote
-        // overwriteCommand wrapper propagates to all instances' __elementOverrides__ internally,
-        // so a separate call on each instance would double-wrap element commands.
+        // No element command overrides on root or instances (would clobber user overrides).
+        // The url override (browser mode) may still be registered on the root.
+        const elementCmds = ['click', 'doubleClick', 'setValue', 'clearValue'];
+        const rootOverridden = (rootBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+        expect(rootOverridden.filter((n) => elementCmds.includes(n as string))).toHaveLength(0);
         expect((electronBrowser.overwriteCommand as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+
+        // afterCommand fans out the mock-update batch to each instance's scheduler.
+        const storeModule = (await import('../src/mockStore.js')) as any;
+        const mockObj = { update: vi.fn().mockResolvedValue(undefined) };
+        storeModule.default.getMocks.mockReturnValue([['id', mockObj]]);
+        await instance.afterCommand('click', [], undefined, undefined);
+        expect(mockObj.update).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Problem

`@wdio/electron-service` registered element-scoped `overwriteCommand` wrappers for `click`/`doubleClick`/`setValue`/`clearValue` (in `before()` and browser-mode init) to re-sync mocks after DOM mutations. WDIO stores element-scoped overrides in a map **keyed by command name** — they do **not** chain — so the service's registration silently clobbered any user-defined `overwriteCommand('click', …)` (and vice-versa). Reported in #432; same root cause as #422 (Tauri, fixed in #434).

## Fix

Mirror the Tauri fix (#434): move the mock re-sync to the **`afterCommand`** worker hook and stop registering element overrides. The old wrappers only ran the original command and then scheduled a mock update — they never modified args or the return value — so `afterCommand` is behaviour-preserving and leaves the user's command chain untouched.

- Removed `installCommandOverrides` / `overrideElementCommand` and all three call sites (native `before()` + both browser-mode paths).
- Added `afterCommand`, which schedules a mock-update batch for the four DOM-mutating commands (skipped when the command itself errored).
- The separate, legitimate `browser.url` override (browser mode) is unchanged.

### Multiremote

The old element override got the firing instance from the element's `this.browser`, so it scheduled that instance's `MockUpdateScheduler` (which filters mocks per-instance — see #292). `afterCommand` only exposes the root browser, so for multiremote it **fans out** `getMockUpdateScheduler(instance).schedule()` across all instances. Each scheduler still filters to native mocks (shared) plus its own browser-mode mocks, so every affected mock updates correctly. Trade-off: in multiremote, idle instances get an extra (idempotent) scheduler pass per command; single-session is unchanged.

### Behaviour note

As in #434, a mock-update failure is now logged by WDIO's hook runner instead of rejecting the triggering command.

## Tests

- Reworked the override-mechanism tests in `service.spec.ts` to drive the (unchanged) batched scheduler through `afterCommand` instead of an extracted override fn — the batching/error-isolation/native-vs-browser-split/concurrency assertions are preserved.
- Flipped the "installs element overrides" assertions (native + browser mode) into regression guards that the service does **not** register element overrides.
- Reworked the multiremote test to assert no element overrides + `afterCommand` drives the per-instance scheduler.
- Added an `afterCommand` no-op case (unrelated command / command error).

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
