### PR TITLE
refactor(native-mobile-core): make iOS toolchain probes async (no event-loop block)

### DIFF
--- a/packages/native-mobile-core/src/iosSetup.ts
+++ b/packages/native-mobile-core/src/iosSetup.ts
@@ -6,7 +6,7 @@
 // All macOS-only; every helper is a no-op / empty result off darwin so it's safe to call
 // unconditionally from the shared launcher.
 
-import { execFileSync, spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
@@ -61,17 +61,30 @@ export function pickIosUdid(simctlJson: string, deviceName: string, platformVers
   return undefined;
 }
 
+/**
+ * Promise wrapper around `execFile('xcrun', …)` — async (not `execFileSync`) so a cold or
+ * stalled toolchain probe can't block the event loop for up to the 30s timeout while the
+ * launcher is preparing other capabilities. Mirrors `prebuildWda`'s spawn-based style.
+ */
+function runXcrun(args: string[], timeoutMs = 30000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('xcrun', args, { encoding: 'utf8', timeout: timeoutMs }, (error, stdout) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
 /** Resolve the exact simulator UDID for a device name (macOS only). */
-export function resolveIosUdid(deviceName: string, platformVersion?: string): string | undefined {
+export async function resolveIosUdid(deviceName: string, platformVersion?: string): Promise<string | undefined> {
   if (!isMac()) {
     return undefined;
   }
   try {
-    const json = execFileSync('xcrun', ['simctl', 'list', 'devices', 'available', '--json'], {
-      encoding: 'utf8',
-      stdio: 'pipe',
-      timeout: 30000,
-    });
+    const json = await runXcrun(['simctl', 'list', 'devices', 'available', '--json']);
     return pickIosUdid(json, deviceName, platformVersion);
   } catch (error) {
     log.debug(`resolveIosUdid failed: ${(error as Error).message}`);
@@ -83,17 +96,13 @@ export function resolveIosUdid(deviceName: string, platformVersion?: string): st
  * Pre-resolve the Xcode SDK and simulator list before the session, surfacing a broken/cold
  * toolchain as a clear diagnostic instead of appium-xcuitest's internal SDK-probe timeout.
  */
-export function warmUpXcodeToolchain(): DiagnosticResult[] {
+export async function warmUpXcodeToolchain(): Promise<DiagnosticResult[]> {
   if (!isMac()) {
     return [];
   }
   const results: DiagnosticResult[] = [];
   try {
-    const sdk = execFileSync('xcrun', ['--sdk', 'iphonesimulator', '--show-sdk-version'], {
-      encoding: 'utf8',
-      stdio: 'pipe',
-      timeout: 30000,
-    }).trim();
+    const sdk = (await runXcrun(['--sdk', 'iphonesimulator', '--show-sdk-version'])).trim();
     results.push({ category: 'iOS SDK', status: 'ok', message: `iphonesimulator ${sdk}` });
   } catch (error) {
     results.push({
@@ -104,7 +113,7 @@ export function warmUpXcodeToolchain(): DiagnosticResult[] {
     });
   }
   try {
-    execFileSync('xcrun', ['simctl', 'list', 'devices'], { stdio: 'ignore', timeout: 30000 });
+    await runXcrun(['simctl', 'list', 'devices']);
     results.push({ category: 'iOS Simulators', status: 'ok', message: 'simctl reachable' });
   } catch (error) {
     results.push({

--- a/packages/native-mobile-core/src/launcher.ts
+++ b/packages/native-mobile-core/src/launcher.ts
@@ -195,7 +195,7 @@ export abstract class MobileBaseLauncher<
         // iOS: resolve the exact simulator UDID from deviceName when not already pinned, so a
         // duplicate device name across runtimes can't boot a different instance than intended.
         if (platform === 'ios' && c['appium:udid'] === undefined && typeof c['appium:deviceName'] === 'string') {
-          const udid = resolveIosUdid(
+          const udid = await resolveIosUdid(
             c['appium:deviceName'] as string,
             c['appium:platformVersion'] as string | undefined,
           );

--- a/packages/native-mobile-core/test/iosSetup.spec.ts
+++ b/packages/native-mobile-core/test/iosSetup.spec.ts
@@ -91,6 +91,26 @@ describe('warmUpXcodeToolchain', () => {
     const results = await warmUpXcodeToolchain();
     expect(results.find((r) => r.category === 'iOS SDK')).toMatchObject({ status: 'error' });
   });
+
+  it('should report both probes ok on a healthy toolchain', async () => {
+    setPlatform('darwin');
+    xcrunResolves('17.5\n'); // --show-sdk-version (trimmed into the message)
+    xcrunResolves(''); // simctl list devices
+    const results = await warmUpXcodeToolchain();
+    expect(results.find((r) => r.category === 'iOS SDK')).toMatchObject({
+      status: 'ok',
+      message: 'iphonesimulator 17.5',
+    });
+    expect(results.find((r) => r.category === 'iOS Simulators')).toMatchObject({ status: 'ok' });
+  });
+
+  it('should warn (not error) when the simctl probe fails', async () => {
+    setPlatform('darwin');
+    xcrunResolves('17.5'); // SDK ok
+    xcrunRejects('simctl boom'); // simctl list devices fails
+    const results = await warmUpXcodeToolchain();
+    expect(results.find((r) => r.category === 'iOS Simulators')).toMatchObject({ status: 'warn' });
+  });
 });
 
 describe('prebuildWda', () => {

--- a/packages/native-mobile-core/test/iosSetup.spec.ts
+++ b/packages/native-mobile-core/test/iosSetup.spec.ts
@@ -1,16 +1,24 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+vi.mock('node:child_process', () => ({ execFile: vi.fn(), spawn: vi.fn() }));
 vi.mock('node:fs', () => ({ existsSync: vi.fn() }));
 vi.mock('@wdio/native-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@wdio/native-utils')>();
   return { ...actual, createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) };
 });
 
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { pickIosUdid, prebuildWda, resolveIosUdid, warmUpXcodeToolchain } from '../src/iosSetup.js';
 
-const execMock = vi.mocked(execFileSync);
+const execMock = vi.mocked(execFile);
+
+// The code wraps execFile in a promise; the helper resolves/rejects the (file, args, opts, cb)
+// callback so a test can stand in for one `xcrun` invocation.
+type ExecCb = (error: Error | null, stdout: string, stderr: string) => void;
+const xcrunOnce = (impl: (cb: ExecCb) => void) =>
+  execMock.mockImplementationOnce(((_file: string, _args: string[], _opts: unknown, cb: ExecCb) => impl(cb)) as never);
+const xcrunResolves = (stdout: string) => xcrunOnce((cb) => cb(null, stdout, ''));
+const xcrunRejects = (message: string) => xcrunOnce((cb) => cb(new Error(message), '', ''));
 const origPlatform = process.platform;
 const setPlatform = (p: NodeJS.Platform) =>
   Object.defineProperty(process, 'platform', { value: p, configurable: true });
@@ -51,41 +59,36 @@ describe('pickIosUdid', () => {
 });
 
 describe('resolveIosUdid', () => {
-  it('should return undefined off macOS without shelling out', () => {
+  it('should return undefined off macOS without shelling out', async () => {
     setPlatform('linux');
-    expect(resolveIosUdid('iPhone 16')).toBeUndefined();
+    expect(await resolveIosUdid('iPhone 16')).toBeUndefined();
     expect(execMock).not.toHaveBeenCalled();
   });
 
-  it('should resolve via simctl on macOS', () => {
+  it('should resolve via simctl on macOS', async () => {
     setPlatform('darwin');
-    execMock.mockReturnValueOnce(simctl);
-    expect(resolveIosUdid('iPhone 16')).toBe('NEW');
+    xcrunResolves(simctl);
+    expect(await resolveIosUdid('iPhone 16')).toBe('NEW');
   });
 
-  it('should return undefined when simctl throws', () => {
+  it('should return undefined when simctl throws', async () => {
     setPlatform('darwin');
-    execMock.mockImplementationOnce(() => {
-      throw new Error('xcrun missing');
-    });
-    expect(resolveIosUdid('iPhone 16')).toBeUndefined();
+    xcrunRejects('xcrun missing');
+    expect(await resolveIosUdid('iPhone 16')).toBeUndefined();
   });
 });
 
 describe('warmUpXcodeToolchain', () => {
-  it('should be empty off macOS', () => {
+  it('should be empty off macOS', async () => {
     setPlatform('linux');
-    expect(warmUpXcodeToolchain()).toEqual([]);
+    expect(await warmUpXcodeToolchain()).toEqual([]);
   });
 
-  it('should report an error result when the SDK probe fails', () => {
+  it('should report an error result when the SDK probe fails', async () => {
     setPlatform('darwin');
-    execMock
-      .mockImplementationOnce(() => {
-        throw new Error('no sdk');
-      })
-      .mockReturnValueOnce('' as never);
-    const results = warmUpXcodeToolchain();
+    xcrunRejects('no sdk'); // --show-sdk-version
+    xcrunResolves(''); // simctl list devices
+    const results = await warmUpXcodeToolchain();
     expect(results.find((r) => r.category === 'iOS SDK')).toMatchObject({ status: 'error' });
   });
 });

--- a/packages/native-mobile-core/test/launcher.spec.ts
+++ b/packages/native-mobile-core/test/launcher.spec.ts
@@ -17,8 +17,8 @@ vi.mock('@wdio/native-core', () => ({
 const ensureSpy = vi.hoisted(() => vi.fn(async () => ({ ok: true, value: { name: 'x', method: 'skipped' as const } })));
 vi.mock('../src/appiumDriverManager.js', () => ({ ensureAppiumDriver: ensureSpy }));
 vi.mock('../src/iosSetup.js', () => ({
-  resolveIosUdid: vi.fn(() => undefined),
-  warmUpXcodeToolchain: vi.fn(() => []),
+  resolveIosUdid: vi.fn(async () => undefined),
+  warmUpXcodeToolchain: vi.fn(async () => []),
 }));
 vi.mock('@wdio/native-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@wdio/native-utils')>();


### PR DESCRIPTION
Follow-up to #378 (merged via #424) — addresses the one remaining Greptile consistency note on that PR.

## Problem

`resolveIosUdid` and `warmUpXcodeToolchain` (in `packages/native-mobile-core/src/iosSetup.ts`) shell out via **synchronous `execFileSync`** with 30s timeouts. That blocks the Node event loop for the duration of each `xcrun` probe while the launcher is preparing other capabilities. It's a consistency gap with `prebuildWda` in the same file, which already uses async `spawn` *precisely* to avoid blocking the loop (and keep logging/SIGINT live).

Cosmetic — it doesn't affect correctness — but worth fixing before more checks get added to the doctor framework on top of these helpers.

## Change

- Add a small `runXcrun` promise wrapper around `execFile` (mirrors `prebuildWda`'s hand-rolled-Promise style) and make both `resolveIosUdid` and `warmUpXcodeToolchain` `async`.
- `doctorChecks` needs **no change** — `DoctorCheck` already permits a `Promise` return, and `runDoctor` awaits checks.
- `onWorkerStart` `await`s `resolveIosUdid` (already an async hook).
- Tests switch the `node:child_process` mock from `execFileSync` to callback-style `execFile` via a small `xcrunOnce`/`xcrunResolves`/`xcrunRejects` helper.

## Verification

- 108 `@wdio/native-mobile-core` unit tests pass
- `typecheck`, biome `lint`, and `format:check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)