### PR TITLE
ci(detect-changes): narrow shared-package changes to affected services

### DIFF
--- a/scripts/detect-changes.ts
+++ b/scripts/detect-changes.ts
@@ -44,6 +44,7 @@ interface Classification {
   lintOnly: boolean;
   triggersAll: string[];
   unknownFiles: string[];
+  sharedDetail: Array<{ file: string; pkg: string; services: string[]; typesOnly: boolean }>;
   perFile: Array<{ file: string; verdict: Verdict }>;
 }
 
@@ -86,6 +87,12 @@ const LINT_ONLY_FILES = new Set(['biome.jsonc', 'eslint.config.js']);
 const SHARED_PACKAGE_PREFIXES = ['native-'];
 const SHARED_PACKAGES = new Set(['bundler']);
 
+// Types-only packages ship nothing but type declarations (erased at compile time), so a change
+// to one can only break COMPILATION — caught by the always-on build + unit jobs — never a
+// service's runtime. They therefore need no per-service E2E. Guarded by
+// test/scripts/native-types-types-only.spec.ts, which fails if real runtime code ever lands here.
+const TYPES_ONLY_PACKAGES = new Set(['native-types']);
+
 export function discoverServices(repoRoot: string): string[] {
   const packagesDir = path.join(repoRoot, 'packages');
   return fs
@@ -93,6 +100,52 @@ export function discoverServices(repoRoot: string): string[] {
     .filter((name) => name.endsWith('-service'))
     .map((name) => name.slice(0, -'-service'.length))
     .sort();
+}
+
+/**
+ * Map each shared package dir → the service names that transitively depend on it, derived from
+ * the `@wdio/*` deps in every package's `package.json`. A shared code change can then run only
+ * the services it can actually affect at runtime (e.g. native-mobile-core → react-native +
+ * flutter) instead of all of them. Reads package.json only — no install — so it still runs on the
+ * bare-node detect job. Convention-driven: derived from real deps, never a hand-maintained map.
+ */
+export function buildServiceDependents(repoRoot: string, services: string[]): Record<string, string[]> {
+  const packagesDir = path.join(repoRoot, 'packages');
+  const dirByName: Record<string, string> = {};
+  const wdioDepsByDir: Record<string, string[]> = {};
+  for (const dir of fs.readdirSync(packagesDir)) {
+    const pkgPath = path.join(packagesDir, dir, 'package.json');
+    if (!fs.existsSync(pkgPath)) continue;
+    let pkg: { name?: string; dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+    try {
+      pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (pkg.name) dirByName[pkg.name] = dir;
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    wdioDepsByDir[dir] = Object.keys(deps).filter((d) => d.startsWith('@wdio/'));
+  }
+  // Transitive set of workspace package dirs a given dir depends on.
+  const closure = (dir: string, seen: Set<string>): Set<string> => {
+    for (const depName of wdioDepsByDir[dir] ?? []) {
+      const depDir = dirByName[depName];
+      if (depDir && !seen.has(depDir)) {
+        seen.add(depDir);
+        closure(depDir, seen);
+      }
+    }
+    return seen;
+  };
+  const dependents: Record<string, string[]> = {};
+  for (const svc of services) {
+    for (const sharedDir of closure(`${svc}-service`, new Set<string>())) {
+      if (!dependents[sharedDir]) dependents[sharedDir] = [];
+      dependents[sharedDir].push(svc);
+    }
+  }
+  for (const dir of Object.keys(dependents)) dependents[dir].sort();
+  return dependents;
 }
 
 function serviceForDir(dir: string, services: string[]): string | undefined {
@@ -159,7 +212,11 @@ export function classifyFile(file: string, services: string[]): Verdict {
   return 'none';
 }
 
-export function classifyChanges(files: string[], services: string[], { forceAll = false } = {}): Classification {
+export function classifyChanges(
+  files: string[],
+  services: string[],
+  { forceAll = false, dependents = {} as Record<string, string[]> } = {},
+): Classification {
   const runs: Record<string, boolean> = Object.fromEntries(services.map((svc) => [svc, false]));
   let sharedChanges = false;
   // Deliberate run-everything verdicts (core infra, cross-service scripts, shared e2e)
@@ -167,10 +224,11 @@ export function classifyChanges(files: string[], services: string[], { forceAll 
   // latter signal naming-convention drift.
   const triggersAll: string[] = [];
   const unknownFiles: string[] = [];
+  const sharedDetail: Array<{ file: string; pkg: string; services: string[]; typesOnly: boolean }> = [];
 
   if (forceAll) {
     for (const svc of services) runs[svc] = true;
-    return { runs, sharedChanges: true, lintOnly: false, triggersAll, unknownFiles, perFile: [] };
+    return { runs, sharedChanges: true, lintOnly: false, triggersAll, unknownFiles, sharedDetail, perFile: [] };
   }
 
   const perFile: Array<{ file: string; verdict: Verdict }> = [];
@@ -178,9 +236,27 @@ export function classifyChanges(files: string[], services: string[], { forceAll 
     const verdict = classifyFile(file, services);
     perFile.push({ file, verdict });
     if (verdict === 'none') continue;
-    if (verdict === 'shared' || verdict === 'all' || verdict === 'unknown') {
-      if (verdict === 'shared') sharedChanges = true;
-      else if (verdict === 'all') triggersAll.push(file);
+    if (verdict === 'shared') {
+      // A shared-package change always needs build/unit (sharedChanges keeps it off the lint-only
+      // path below), but only the services it can affect at RUNTIME need E2E: none for a
+      // types-only package (compile-time-only — build/unit already cover it), otherwise the
+      // transitive dependents from the dep graph. Fall back to every service when a shared
+      // package has no known dependents — an infra/build-tool package like `bundler`, or a new
+      // shared package — so we over-run rather than ever silently under-run.
+      sharedChanges = true;
+      const dir = (file.match(/^packages\/([^/]+)\//) as RegExpMatchArray)[1];
+      const typesOnly = TYPES_ONLY_PACKAGES.has(dir);
+      const affected = typesOnly
+        ? [] // erased at compile time — build/unit already cover it
+        : SHARED_PACKAGES.has(dir)
+          ? services // build tool (bundler) — changes every package's build output → all E2E
+          : dependents[dir]?.length
+            ? dependents[dir] // shared code → only the services that transitively depend on it
+            : services; // new/unknown shared package with no known dependents → defensive all
+      for (const svc of affected) runs[svc] = true;
+      sharedDetail.push({ file, pkg: dir, services: affected, typesOnly });
+    } else if (verdict === 'all' || verdict === 'unknown') {
+      if (verdict === 'all') triggersAll.push(file);
       else unknownFiles.push(file);
       for (const svc of services) runs[svc] = true;
     } else {
@@ -188,8 +264,11 @@ export function classifyChanges(files: string[], services: string[], { forceAll 
     }
   }
 
-  const lintOnly = services.every((svc) => !runs[svc]);
-  return { runs, sharedChanges, lintOnly, triggersAll, unknownFiles, perFile };
+  // Lint-only = nothing needs build: no service runs AND no shared (compile-affecting) change.
+  // A types-only shared change runs no service yet must still build/typecheck, so the
+  // sharedChanges term keeps it off this path (build + unit gate on `run_lint_only != true`).
+  const lintOnly = services.every((svc) => !runs[svc]) && !sharedChanges;
+  return { runs, sharedChanges, lintOnly, triggersAll, unknownFiles, sharedDetail, perFile };
 }
 
 function appendFile(envVar: string, content: string): void {
@@ -201,10 +280,13 @@ function main(): void {
   const files: string[] = JSON.parse(process.env.CHANGED_FILES || '[]');
   const forceAll = process.env.FORCE_ALL === 'true';
   const services = discoverServices(process.cwd());
+  const dependents = buildServiceDependents(process.cwd(), services);
 
-  const { runs, sharedChanges, lintOnly, triggersAll, unknownFiles, perFile } = classifyChanges(files, services, {
-    forceAll,
-  });
+  const { runs, sharedChanges, lintOnly, triggersAll, unknownFiles, sharedDetail, perFile } = classifyChanges(
+    files,
+    services,
+    { forceAll, dependents },
+  );
 
   let output = '';
   for (const [svc, run] of Object.entries(runs)) output += `run_${svc}=${run}\n`;
@@ -218,6 +300,14 @@ function main(): void {
   summary += '| Service | Run |\n|---------|-----|\n';
   for (const [svc, run] of Object.entries(runs)) summary += `| ${svc} | ${run} |\n`;
   summary += `\n- Shared package changes: ${sharedChanges}\n- Lint only: ${lintOnly}\n`;
+  if (sharedDetail.length > 0) {
+    summary += '\n### Shared package changes (narrowed to runtime dependents)\n\n';
+    summary += 'build + unit run regardless; E2E runs only for the services a shared change can affect:\n\n';
+    for (const { file, pkg, services: svcs, typesOnly } of sharedDetail) {
+      const target = typesOnly ? 'types-only → typecheck/build only, no E2E' : svcs.join(', ') || 'all';
+      summary += `- \`${file}\` (${pkg}) → ${target}\n`;
+    }
+  }
   if (triggersAll.length > 0) {
     summary += '\n### Core infra / cross-service changes (run all pipelines)\n\n';
     for (const file of triggersAll) summary += `- \`${file}\`\n`;

--- a/scripts/detect-changes.ts
+++ b/scripts/detect-changes.ts
@@ -212,6 +212,19 @@ export function classifyFile(file: string, services: string[]): Verdict {
   return 'none';
 }
 
+/**
+ * Services whose E2E a shared-package change must run. A types-only package needs none — its
+ * change is erased at compile time, so build/unit already cover it. The `bundler` build tool
+ * changes every package's build output, so all. Otherwise: the transitive dependents from the dep
+ * graph, falling back to every service for a new/unknown shared package with no known dependents
+ * (over-run, never silently under-run).
+ */
+function affectedServices(dir: string, services: string[], dependents: Record<string, string[]>): string[] {
+  if (TYPES_ONLY_PACKAGES.has(dir)) return [];
+  if (SHARED_PACKAGES.has(dir)) return services;
+  return dependents[dir]?.length ? dependents[dir] : services;
+}
+
 export function classifyChanges(
   files: string[],
   services: string[],
@@ -238,23 +251,12 @@ export function classifyChanges(
     if (verdict === 'none') continue;
     if (verdict === 'shared') {
       // A shared-package change always needs build/unit (sharedChanges keeps it off the lint-only
-      // path below), but only the services it can affect at RUNTIME need E2E: none for a
-      // types-only package (compile-time-only — build/unit already cover it), otherwise the
-      // transitive dependents from the dep graph. Fall back to every service when a shared
-      // package has no known dependents — an infra/build-tool package like `bundler`, or a new
-      // shared package — so we over-run rather than ever silently under-run.
+      // path below); affectedServices decides which services' E2E it can actually affect at runtime.
       sharedChanges = true;
       const dir = (file.match(/^packages\/([^/]+)\//) as RegExpMatchArray)[1];
-      const typesOnly = TYPES_ONLY_PACKAGES.has(dir);
-      const affected = typesOnly
-        ? [] // erased at compile time — build/unit already cover it
-        : SHARED_PACKAGES.has(dir)
-          ? services // build tool (bundler) — changes every package's build output → all E2E
-          : dependents[dir]?.length
-            ? dependents[dir] // shared code → only the services that transitively depend on it
-            : services; // new/unknown shared package with no known dependents → defensive all
+      const affected = affectedServices(dir, services, dependents);
       for (const svc of affected) runs[svc] = true;
-      sharedDetail.push({ file, pkg: dir, services: affected, typesOnly });
+      sharedDetail.push({ file, pkg: dir, services: affected, typesOnly: TYPES_ONLY_PACKAGES.has(dir) });
     } else if (verdict === 'all' || verdict === 'unknown') {
       if (verdict === 'all') triggersAll.push(file);
       else unknownFiles.push(file);

--- a/test/scripts/detect-changes.spec.ts
+++ b/test/scripts/detect-changes.spec.ts
@@ -1,15 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { classifyChanges, classifyFile, discoverServices } from '../../scripts/detect-changes.ts';
+import {
+  buildServiceDependents,
+  classifyChanges,
+  classifyFile,
+  discoverServices,
+} from '../../scripts/detect-changes.ts';
 
 const SERVICES = ['dioxus', 'electrobun', 'electron', 'flutter', 'react-native', 'tauri'];
+const REPO_ROOT = new URL('../..', import.meta.url).pathname;
+// Use the REAL workspace dependency graph so the narrowing tests reflect production exactly (and
+// double as a guard: if a service's native-* deps change, the asserted closures below shift).
+const DEPENDENTS = buildServiceDependents(REPO_ROOT, SERVICES);
 
 function decide(files: string[], forceAll = false) {
-  return classifyChanges(files, SERVICES, { forceAll });
+  return classifyChanges(files, SERVICES, { forceAll, dependents: DEPENDENTS });
 }
 
 describe('discoverServices', () => {
   it('should derive the service list from packages/*-service', () => {
     expect(discoverServices(new URL('../..', import.meta.url).pathname)).toEqual(SERVICES);
+  });
+});
+
+describe('buildServiceDependents', () => {
+  it('should map each shared package to the services that transitively depend on it', () => {
+    // The narrowing wins: mobile-core is mobile-only; the CDP bridge is electrobun + RN.
+    expect(DEPENDENTS['native-mobile-core']).toEqual(['flutter', 'react-native']);
+    expect(DEPENDENTS['native-cdp-bridge']).toEqual(['electrobun', 'react-native']);
+    // Universally-depended-on packages still map to every service.
+    expect(DEPENDENTS['native-utils']).toEqual([...SERVICES].sort());
+    expect(DEPENDENTS['native-core']).toEqual([...SERVICES].sort());
   });
 });
 
@@ -31,7 +51,12 @@ describe('classifyFile', () => {
     ['packages/dioxus-embedded-driver/src/lib.rs', 'dioxus'],
     ['packages/native-utils/src/teardown.ts', 'shared'],
     ['packages/native-core/src/index.ts', 'shared'],
+    ['packages/native-mobile-core/src/launcher.ts', 'shared'],
     ['packages/bundler/src/index.ts', 'shared'],
+    // native-types is 'shared' at the file level too — the runtime-dependent narrowing
+    // (incl. types-only → no E2E) is applied in classifyChanges, not classifyFile.
+    ['packages/native-types/src/react-native.ts', 'shared'],
+    ['packages/native-types/src/shared.ts', 'shared'],
     ['packages/some-new-thing/src/index.ts', 'unknown'],
     // e2e
     ['e2e/test/electron/api.spec.ts', 'electron'],
@@ -178,11 +203,68 @@ describe('classifyChanges decisions', () => {
     expect(d.triggersAll).toEqual(['scripts/test-package.ts']);
   });
 
-  it('should run everything and flag shared for a shared package change', () => {
+  it('should run everything and flag shared for a universal shared package change', () => {
     const d = decide(['packages/native-utils/src/teardown.ts']);
     expect(Object.values(d.runs).every(Boolean)).toBe(true);
     expect(d.sharedChanges).toBe(true);
     expect(d.triggersAll).toEqual([]);
+  });
+
+  it('should narrow a native-mobile-core change to the mobile services only (no desktop E2E)', () => {
+    const d = decide(['packages/native-mobile-core/src/launcher.ts']);
+    expect(d.runs).toEqual({
+      dioxus: false,
+      electrobun: false,
+      electron: false,
+      flutter: true,
+      'react-native': true,
+      tauri: false,
+    });
+    expect(d.sharedChanges).toBe(true);
+    expect(d.lintOnly).toBe(false);
+  });
+
+  it('should narrow a native-cdp-bridge change to electrobun + react-native', () => {
+    const d = decide(['packages/native-cdp-bridge/src/connection.ts']);
+    expect(d.runs).toEqual({
+      dioxus: false,
+      electrobun: true,
+      electron: false,
+      flutter: false,
+      'react-native': true,
+      tauri: false,
+    });
+    expect(d.sharedChanges).toBe(true);
+  });
+
+  it('should run typecheck/build but NO per-service E2E for a types-only native-types change', () => {
+    const d = decide(['packages/native-types/src/react-native.ts']);
+    // No service E2E — a type change is erased at compile time, build + unit cover it.
+    expect(Object.values(d.runs).every((v) => v === false)).toBe(true);
+    // …but it is NOT lint-only: sharedChanges keeps build + unit running.
+    expect(d.sharedChanges).toBe(true);
+    expect(d.lintOnly).toBe(false);
+    expect(d.sharedDetail[0]).toMatchObject({ pkg: 'native-types', typesOnly: true, services: [] });
+  });
+
+  it('should treat native-types/src/shared.ts as types-only too (runtime axis, not "shared" name)', () => {
+    const d = decide(['packages/native-types/src/shared.ts']);
+    expect(Object.values(d.runs).every((v) => v === false)).toBe(true);
+    expect(d.lintOnly).toBe(false);
+  });
+
+  it('should run every service for a bundler (build-tool) change', () => {
+    const d = decide(['packages/bundler/src/index.ts']);
+    expect(Object.values(d.runs).every(Boolean)).toBe(true);
+    expect(d.sharedChanges).toBe(true);
+  });
+
+  it('should union narrowed shared + a service change (mobile-core + electron src)', () => {
+    const d = decide(['packages/native-mobile-core/src/launcher.ts', 'packages/electron-service/src/x.ts']);
+    expect(d.runs.flutter).toBe(true);
+    expect(d.runs['react-native']).toBe(true);
+    expect(d.runs.electron).toBe(true); // its own file triggers it independently
+    expect(d.runs.tauri).toBe(false);
   });
 
   it('should run only electron for mixed md + electron src, not lint-only', () => {

--- a/test/scripts/native-types-types-only.spec.ts
+++ b/test/scripts/native-types-types-only.spec.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 // Soundness guard for scripts/detect-changes.ts: it classifies `native-types` as a TYPES_ONLY
@@ -12,27 +13,42 @@ import { describe, expect, it } from 'vitest';
 const SRC = new URL('../../packages/native-types/src', import.meta.url).pathname;
 const ALLOWED_RUNTIME_EXPORTS = new Set(['__nativeTypesVersion']);
 
-/** Lines that introduce a runtime (non-erased) binding — everything `export type`/`interface` is erased. */
-function runtimeExportLines(source: string): string[] {
-  const offenders: string[] = [];
-  for (const raw of source.split('\n')) {
-    const line = raw.trim();
-    if (!line.startsWith('export ') && line !== 'export{') continue;
-    if (/^export\s+(type|interface)\b/.test(line)) continue; // `export type …`, `export type { … }`, `export interface …`
-    const named = line.match(/^export\s+(?:default\s+)?(?:async\s+)?(?:const|let|var|function|class|enum)\s+([\w$]+)/);
-    if (named && ALLOWED_RUNTIME_EXPORTS.has(named[1])) continue; // allowlisted inert constant
-    offenders.push(line);
+/**
+ * Transpile a TS source to JS and report the names it still runtime-exports. Using the real
+ * compiler erases every type-only construct exactly — `export type { … }`, the inline
+ * `export { type X }` form, `interface`, `declare global`, type aliases — so only genuine runtime
+ * bindings survive. Far more robust than scanning TS source with regexes.
+ */
+function runtimeExports(source: string): string[] {
+  const js = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ESNext, isolatedModules: true },
+  }).outputText;
+  const names: string[] = [];
+  for (const m of js.matchAll(/\bexport\s+(?:default\s+)?(?:async\s+)?(?:const|let|var|function|class)\s+([\w$]+)/g)) {
+    names.push(m[1]);
   }
-  return offenders;
+  for (const m of js.matchAll(/\bexport\s*\{([^}]*)\}/g)) {
+    for (const spec of m[1].split(',')) {
+      // exported identifier is the part after `as` (or the bare name when there's no alias)
+      const name = spec
+        .trim()
+        .split(/\s+as\s+/)
+        .pop()
+        ?.trim();
+      if (name) names.push(name);
+    }
+  }
+  if (/\bexport\s+default\b/.test(js)) names.push('default');
+  return names;
 }
 
 describe('native-types stays types-only (detect-changes soundness guard)', () => {
   it('should export no runtime values beyond the allowlisted version constant', () => {
     const offenders: string[] = [];
     for (const file of readdirSync(SRC)) {
-      if (!file.endsWith('.ts')) continue;
-      for (const line of runtimeExportLines(readFileSync(join(SRC, file), 'utf8'))) {
-        offenders.push(`${file}: ${line}`);
+      if (!/\.[cm]?tsx?$/.test(file)) continue; // .ts / .tsx / .mts / .cts
+      for (const name of runtimeExports(readFileSync(join(SRC, file), 'utf8'))) {
+        if (!ALLOWED_RUNTIME_EXPORTS.has(name)) offenders.push(`${file}: ${name}`);
       }
     }
     expect(offenders).toEqual([]);
@@ -40,6 +56,6 @@ describe('native-types stays types-only (detect-changes soundness guard)', () =>
 
   it('should still export the version constant the allowlist expects (keeps the guard honest)', () => {
     const index = readFileSync(join(SRC, 'index.ts'), 'utf8');
-    expect(index).toMatch(/export\s+const\s+__nativeTypesVersion\b/);
+    expect(runtimeExports(index)).toContain('__nativeTypesVersion');
   });
 });

--- a/test/scripts/native-types-types-only.spec.ts
+++ b/test/scripts/native-types-types-only.spec.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Soundness guard for scripts/detect-changes.ts: it classifies `native-types` as a TYPES_ONLY
+// package, so a change to it skips every per-service E2E (a type change is erased at compile time
+// and can only break compilation, which the always-on build + unit jobs catch). That holds only
+// while native-types ships no runtime code beyond an inert version constant. This test fails the
+// moment a real runtime export lands — at which point either restore types-only, or remove
+// native-types from TYPES_ONLY_PACKAGES so its changes run the full matrix again.
+
+const SRC = new URL('../../packages/native-types/src', import.meta.url).pathname;
+const ALLOWED_RUNTIME_EXPORTS = new Set(['__nativeTypesVersion']);
+
+/** Lines that introduce a runtime (non-erased) binding — everything `export type`/`interface` is erased. */
+function runtimeExportLines(source: string): string[] {
+  const offenders: string[] = [];
+  for (const raw of source.split('\n')) {
+    const line = raw.trim();
+    if (!line.startsWith('export ') && line !== 'export{') continue;
+    if (/^export\s+(type|interface)\b/.test(line)) continue; // `export type …`, `export type { … }`, `export interface …`
+    const named = line.match(/^export\s+(?:default\s+)?(?:async\s+)?(?:const|let|var|function|class|enum)\s+([\w$]+)/);
+    if (named && ALLOWED_RUNTIME_EXPORTS.has(named[1])) continue; // allowlisted inert constant
+    offenders.push(line);
+  }
+  return offenders;
+}
+
+describe('native-types stays types-only (detect-changes soundness guard)', () => {
+  it('should export no runtime values beyond the allowlisted version constant', () => {
+    const offenders: string[] = [];
+    for (const file of readdirSync(SRC)) {
+      if (!file.endsWith('.ts')) continue;
+      for (const line of runtimeExportLines(readFileSync(join(SRC, file), 'utf8'))) {
+        offenders.push(`${file}: ${line}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('should still export the version constant the allowlist expects (keeps the guard honest)', () => {
+    const index = readFileSync(join(SRC, 'index.ts'), 'utf8');
+    expect(index).toMatch(/export\s+const\s+__nativeTypesVersion\b/);
+  });
+});


### PR DESCRIPTION
Today a change to any `packages/native-*` (or `bundler`) classifies as `shared` and runs **every** service's full E2E/package matrix. This narrows that two ways. Both rest on one fact: `build` + `unit-matrix` run on *any* non-lint-only change (gated only by `run_lint_only`), so cross-package compile/type breakage is **always** caught regardless of which services' E2E run. Only the expensive per-service E2E/package matrices get narrowed.

## 1. Types-only packages → no E2E (`native-types`)

`native-types` ships only type declarations (sole runtime export is the inert `__nativeTypesVersion` constant). Types are **erased at compile time**, so a change to it produces byte-identical runtime for every service — it can only break *compilation*, which `build` already catches. So a `native-types/src/**` change runs **build + unit only**, **no per-service E2E**. (`run_lint_only` stays `false` via `has_shared_changes`, so build/unit still run.)

This also subsumes the "per-service type file" idea — `native-types/src/react-native.ts` is type-only, so it needs neither RN's E2E nor anyone's. If the same PR changes RN *runtime* code, that file independently triggers RN's pipeline (classification ORs across files).

## 2. Shared **code** packages → transitive dependents only

A shared code change only affects a service's *runtime* (the only thing E2E exercises) if that service transitively depends on it. Computed from the `@wdio/*` deps in each `package.json` (no install → still bare-node safe in the detect job; convention-driven, no hand-maintained map):

| Changed package | Runs |
|---|---|
| `native-mobile-core` | react-native, flutter (**skips electron/tauri/dioxus/electrobun**) |
| `native-cdp-bridge` | electrobun, react-native |
| `native-core` · `native-utils` · `native-spy` · `native-types`(graph) | all |
| `bundler` (build tool) + any shared pkg with no known dependents | all (defensive — never under-run) |

## No `ci.yml` changes

The existing `run_<svc>` / `run_lint_only` / `has_shared_changes` gates already consume exactly these signals — only what *feeds* them is refined. `has_shared_changes` still fires on any shared touch, so the `setup-automation-smoke` job is unaffected.

## Soundness guard

`test/scripts/native-types-types-only.spec.ts` fails if a real runtime export ever lands in `native-types` — the premise for narrowing #1. If that happens, either restore types-only or drop it from `TYPES_ONLY_PACKAGES`.

## Verification

- 96 script tests pass — including a `buildServiceDependents` block asserting the real graph (`native-mobile-core → [flutter, react-native]`, `native-cdp-bridge → [electrobun, react-native]`) and `classifyChanges` decision tests for every case above.
- Functional smoke of the real script confirms end-to-end: `native-types → all services false`, `native-mobile-core → flutter+react-native`, `bundler → all`.
- `typecheck:scripts`, biome lint + format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)