### PR TITLE
revert: tauri afterCommand mock-sync (#434)

### DIFF
--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -545,7 +545,7 @@ export default class TauriWorkerService {
   private overrideElementCommand(commandName: ElementCommands) {
     const browser = this.browser as WebdriverIO.Browser;
     try {
-      const testOverride = async function (
+      const mockSyncOverride = async function (
         this: WebdriverIO.Element,
         originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
         ...args: readonly unknown[]
@@ -555,7 +555,7 @@ export default class TauriWorkerService {
         return result;
       } as Parameters<typeof browser.overwriteCommand>[1];
 
-      browser.overwriteCommand(commandName, testOverride, true);
+      browser.overwriteCommand(commandName, mockSyncOverride, true);
     } catch (error) {
       log.warn(`Failed to override element command '${commandName}':`, error);
     }

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -23,12 +23,11 @@ const log = createLogger('tauri-service', 'service');
 const EXECUTE_PATCHED = Symbol('wdio-tauri-execute-patched');
 const browserInterceptor = createIpcInterceptor('tauri');
 
-/** Element commands whose completion should re-sync mocks from the app context. */
-const MOCK_UPDATE_COMMANDS = new Set<string>(['click', 'doubleClick', 'setValue', 'clearValue']);
-
 /**
  * Tauri worker service
  */
+type ElementCommands = 'click' | 'doubleClick' | 'setValue' | 'clearValue';
+
 export default class TauriWorkerService {
   private browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser;
   private clearMocks: boolean;
@@ -195,6 +194,9 @@ export default class TauriWorkerService {
         }
       }
 
+      // Install command overrides to trigger mock updates after DOM interactions
+      stage = 'installCommandOverrides';
+      this.installCommandOverrides();
       log.info('before() complete');
     } catch (error) {
       log.error(
@@ -231,20 +233,6 @@ export default class TauriWorkerService {
     } catch (error) {
       log.warn('Failed to ensure window focus before command:', error);
     }
-  }
-
-  /**
-   * Re-sync mocks after element commands that mutate the DOM. Implemented as an
-   * afterCommand hook rather than browser.overwriteCommand: element-scoped
-   * overrides are keyed by command name and do not chain, so re-registering
-   * click/setValue/etc. silently clobbered any user-defined override of the same
-   * command. afterCommand leaves the user's command chain untouched.
-   */
-  async afterCommand(commandName: string, _args: unknown[], _result: unknown, error?: Error): Promise<void> {
-    if (error || !MOCK_UPDATE_COMMANDS.has(commandName)) {
-      return;
-    }
-    await updateAllMocks();
   }
 
   async afterTest(_test: unknown, _context: unknown, _results: unknown): Promise<void> {
@@ -361,6 +349,7 @@ export default class TauriWorkerService {
     }
     this.addTauriApi(browser, true);
     this.patchBrowserUrl(browser, injectionScript);
+    this.installCommandOverrides();
     log.debug('Browser-only mode initialized');
   }
 
@@ -538,6 +527,38 @@ export default class TauriWorkerService {
         await updateAllMocks();
       },
     };
+  }
+
+  /**
+   * Install command overrides to trigger mock updates after DOM interactions
+   */
+  private installCommandOverrides() {
+    const commandsToOverride: ElementCommands[] = ['click', 'doubleClick', 'setValue', 'clearValue'];
+    commandsToOverride.forEach((commandName) => {
+      this.overrideElementCommand(commandName);
+    });
+  }
+
+  /**
+   * Override an element-level command to add mock update after execution
+   */
+  private overrideElementCommand(commandName: ElementCommands) {
+    const browser = this.browser as WebdriverIO.Browser;
+    try {
+      const testOverride = async function (
+        this: WebdriverIO.Element,
+        originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
+        ...args: readonly unknown[]
+      ): Promise<unknown> {
+        const result = await Reflect.apply(originalCommand, this, args as unknown[]);
+        await updateAllMocks();
+        return result;
+      } as Parameters<typeof browser.overwriteCommand>[1];
+
+      browser.overwriteCommand(commandName, testOverride, true);
+    } catch (error) {
+      log.warn(`Failed to override element command '${commandName}':`, error);
+    }
   }
 
   /**

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -314,6 +314,34 @@ describe('TauriWorkerService', () => {
       expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('clearValue', expect.any(Function), true);
     });
 
+    it('should run the original command then sync mocks in the override body', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
+
+      // Capture the override WDIO registered for 'click' and invoke it the way
+      // WDIO would (override(originalCommand, ...args)). This guards the override
+      // *body* — not just that it was registered — so dropping updateAllMocks()
+      // would fail here.
+      const clickCall = vi.mocked(mockBrowser.overwriteCommand).mock.calls.find((c) => c[0] === 'click');
+      expect(clickCall).toBeDefined();
+      const override = clickCall![1] as unknown as (
+        this: unknown,
+        originalCommand: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const originalCommand = vi.fn().mockResolvedValue('ok');
+      const result = await override.call({}, originalCommand);
+
+      expect(originalCommand).toHaveBeenCalledOnce();
+      expect(mockUpdate).toHaveBeenCalledOnce();
+      expect(result).toBe('ok');
+    });
+
     it('should clear stale mocks at session start for embedded driver provider', async () => {
       const mockBrowser = createMockBrowser();
       const originalExecute = mockBrowser.execute as ReturnType<typeof vi.fn>;

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -302,48 +302,16 @@ describe('TauriWorkerService', () => {
       await expect(service.before({} as any, [], mockBrowser)).resolves.not.toThrow();
     });
 
-    it('should not register element command overrides (preserves user overrides)', async () => {
+    it('should install command overrides after initialization', async () => {
       const mockBrowser = createMockBrowser();
       const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
 
       await service.before({} as any, [], mockBrowser);
 
-      // Element-scoped overrides are keyed by command name and do not chain, so
-      // registering these would clobber a user's overwriteCommand('click', ...).
-      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('click', expect.any(Function), true);
-      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('doubleClick', expect.any(Function), true);
-      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('setValue', expect.any(Function), true);
-      expect(mockBrowser.overwriteCommand).not.toHaveBeenCalledWith('clearValue', expect.any(Function), true);
-    });
-
-    it('should update mocks via afterCommand for DOM-mutating commands', async () => {
-      const mockBrowser = createMockBrowser();
-      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
-      await service.before({} as any, [], mockBrowser);
-
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
-
-      for (const command of ['click', 'doubleClick', 'setValue', 'clearValue']) {
-        mockUpdate.mockClear();
-        await service.afterCommand(command, [], undefined, undefined);
-        expect(mockUpdate).toHaveBeenCalledOnce();
-      }
-    });
-
-    it('should not update mocks via afterCommand for unrelated commands or on error', async () => {
-      const mockBrowser = createMockBrowser();
-      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
-      await service.before({} as any, [], mockBrowser);
-
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
-
-      await service.afterCommand('getText', [], 'text', undefined);
-      expect(mockUpdate).not.toHaveBeenCalled();
-
-      await service.afterCommand('click', [], undefined, new Error('click failed'));
-      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('click', expect.any(Function), true);
+      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('doubleClick', expect.any(Function), true);
+      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('setValue', expect.any(Function), true);
+      expect(mockBrowser.overwriteCommand).toHaveBeenCalledWith('clearValue', expect.any(Function), true);
     });
 
     it('should clear stale mocks at session start for embedded driver provider', async () => {


### PR DESCRIPTION
Reverts #434 (commit `d3b0dd1f7`).

## Why

#434 replaced tauri's element-scoped `overwriteCommand` mock-sync with the `afterCommand` worker hook. The sibling electron PR (#435) used the identical approach, and its Electron e2e — `mocking.spec.ts › Integration Tests › Command Overrides › should trigger mock updates when DOM interactions occur` — **failed**: `afterCommand` does not drive the mock re-sync after a real `element.click()`. The element-scoped override is required for that, which is why it was used in the first place.

Tauri's e2e has **no** DOM-interaction mock test, so the same regression merged here silently (green CI). The unit tests don't catch it either — they call `afterCommand` directly rather than verifying WDIO drives it after a real click.

This restores tauri's proven element-override mock-sync.

## Follow-up

#422 (the service clobbering a user's own `overwriteCommand('click', …)`) goes back to unfixed for tauri. It will be re-approached separately — with a mechanism that **preserves** the working mock-sync (likely keeping the element override and chaining any user override), plus a tauri DOM-interaction mock e2e test so this class of regression can't merge silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
