### PR TITLE
fix(native-mobile-core): honour capability-level launcher options

### DIFF
--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -213,12 +213,9 @@ export const config = {
   // sim-boot/WDA/FrontBoard trace, which is the only place the #359 session-create flake is
   // diagnosable (the failing session has no app/page-source to capture).
   //
-  // Pass reactNativeServiceOptions to the SERVICE registration (not only the capability):
-  // launcher-level options — manageMetro/metroProjectRoot/prebundle/doctor — are read from
-  // the service's own options in onPrepare, NOT from wdio:reactNativeServiceOptions (which is
-  // the worker channel). Registering bare 'react-native' left this.options empty, so managed
-  // Metro silently never started and the doctor never ran. The capability copy below still
-  // feeds the worker.
+  // reactNativeServiceOptions is set on both the service registration and the capability: the
+  // launcher merges the two (resolveLauncherOptions) for run-level options like manageMetro and
+  // doctor, and the worker reads its own copy from wdio:reactNativeServiceOptions.
   services: [
     ['appium', { logPath: logDir, args: { logLevel: 'debug' } }],
     ['react-native', reactNativeServiceOptions],

--- a/packages/native-mobile-core/src/launcher.ts
+++ b/packages/native-mobile-core/src/launcher.ts
@@ -115,10 +115,30 @@ export abstract class MobileBaseLauncher<
     return checks;
   }
 
+  /**
+   * Effective launcher options: the global service options merged with the per-capability
+   * `wdio:<framework>ServiceOptions` (capability wins, matching the shared precedence). Run-level
+   * decisions — `autoInstallDriver`, `doctor`, and a subclass's Metro options — MUST read this,
+   * not `this.options` alone: configuring the service only on the capability (the idiomatic WDIO
+   * pattern) would otherwise silently no-op those features. For multiremote, later instances'
+   * options win on conflict; run-level options are realistically set in one place.
+   */
+  protected resolveLauncherOptions(capabilities: TCap | TCap[] | Record<string, unknown>): TOptions {
+    return flattenCaps<TCap>(capabilities).reduce<TOptions>(
+      (acc, cap) =>
+        mergeServiceOptions(
+          acc,
+          getServiceOptionsFromCapability<TOptions>(cap as Record<string, unknown>, this.capKey),
+        ),
+      this.options,
+    );
+  }
+
   async onPrepare(
     config: Options.Testrunner,
     capabilities: TCap[] | Record<string, { capabilities: TCap }>,
   ): Promise<void> {
+    const effectiveOptions = this.resolveLauncherOptions(capabilities);
     const platforms = new Set<'android' | 'ios'>();
     for (const cap of flattenCaps<TCap>(capabilities)) {
       const options = mergeServiceOptions(
@@ -135,7 +155,7 @@ export abstract class MobileBaseLauncher<
     }
 
     // Driver auto-install — opt-in, idempotent, once per launcher (not per worker).
-    if (this.options.autoInstallDriver) {
+    if (effectiveOptions.autoInstallDriver) {
       const names = new Set<string>();
       for (const platform of platforms) {
         for (const name of this.requiredDrivers(platform)) {
@@ -154,7 +174,7 @@ export abstract class MobileBaseLauncher<
     }
 
     // Preflight doctor — fail-fast only under doctor: { strict: true }.
-    const { run: runTheDoctor, failFast } = resolveDoctor(this.options.doctor);
+    const { run: runTheDoctor, failFast } = resolveDoctor(effectiveOptions.doctor);
     if (runTheDoctor) {
       await runDoctor(this.doctorChecks(config, platforms), {
         serviceName: this.logNamespace,

--- a/packages/native-mobile-core/test/launcher.spec.ts
+++ b/packages/native-mobile-core/test/launcher.spec.ts
@@ -128,6 +128,14 @@ describe('MobileBaseLauncher.onPrepare', () => {
   it('should not throw under the default warn doctor mode', async () => {
     await expect(new TestLauncher().onPrepare(config, [cap()])).resolves.toBeUndefined();
   });
+
+  it('should honour autoInstallDriver set on the capability, not only the service', async () => {
+    // The idiomatic WDIO pattern puts service options on the capability; run-level decisions
+    // must read the merged options, not this.options alone (else they silently no-op).
+    const c = { ...cap(), 'wdio:testServiceOptions': { autoInstallDriver: true } } as TestCap;
+    await new TestLauncher().onPrepare(config, [c]);
+    expect(ensureSpy).toHaveBeenCalledWith('uiautomator2', { autoInstallDriver: true });
+  });
 });
 
 describe('MobileBaseLauncher doctor fail-fast', () => {
@@ -139,6 +147,11 @@ describe('MobileBaseLauncher doctor fail-fast', () => {
 
   it('should throw under { strict: true } when a check errors', async () => {
     await expect(new StrictLauncher({ doctor: { strict: true } }).onPrepare(config, [cap()])).rejects.toThrow(/bad/);
+  });
+
+  it('should fail-fast when { strict: true } is set on the capability, not the service', async () => {
+    const c = { ...cap(), 'wdio:testServiceOptions': { doctor: { strict: true } } } as TestCap;
+    await expect(new StrictLauncher().onPrepare(config, [c])).rejects.toThrow(/bad/);
   });
 
   it('should only log when run without strict (doctor: true)', async () => {

--- a/packages/react-native-service/src/launcher.ts
+++ b/packages/react-native-service/src/launcher.ts
@@ -24,6 +24,10 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
   // Metro would bind-conflict on 8081. The Android device→host `adb reverse` is set up
   // per-worker in onWorkerStart (pre-launch); workers then connect via MetroBridge.
   #metro: MetroProcess | undefined;
+  // The capability-merged options, captured in onPrepare so doctorChecks — invoked inside
+  // super.onPrepare — probes the configured metroHost/metroPort even when set only on the
+  // capability (otherwise it falls back to this.options and would probe the default 8081).
+  #resolvedOptions: ReactNativeServiceGlobalOptions | undefined;
 
   constructor(
     options: ReactNativeServiceGlobalOptions,
@@ -51,9 +55,10 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
   }
 
   protected doctorChecks(config: Options.Testrunner, platforms: Set<'android' | 'ios'>): DoctorCheck[] {
+    const options = this.#resolvedOptions ?? this.options;
     return [
       ...super.doctorChecks(config, platforms),
-      ...reactNativeDoctorChecks(this.options.metroHost ?? '127.0.0.1', this.options.metroPort ?? DEFAULT_METRO_PORT),
+      ...reactNativeDoctorChecks(options.metroHost ?? '127.0.0.1', options.metroPort ?? DEFAULT_METRO_PORT),
     ];
   }
 
@@ -61,19 +66,24 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
     config: Options.Testrunner,
     capabilities: ReactNativeCapabilities[] | Record<string, { capabilities: ReactNativeCapabilities }>,
   ): Promise<void> {
+    // Read launcher options from the global service options merged with the capability —
+    // manageMetro/metroProjectRoot/prebundle work whether configured on the service registration
+    // or on wdio:reactNativeServiceOptions (the common WDIO pattern).
+    const options = this.resolveLauncherOptions(capabilities);
+    this.#resolvedOptions = options; // so doctorChecks (inside super.onPrepare) sees the merged values
     // Start Metro before super.onPrepare so the Metro-reachable doctor check sees it up.
-    if (this.options.manageMetro) {
+    if (options.manageMetro) {
       this.#metro = new MetroProcess();
       try {
         // Resolve platform the same way onWorkerStart does — options.platform wins over the
         // capability, so an options-level iOS run pre-warms the iOS bundle, not Android.
         const firstCap = flattenCaps<ReactNativeCapabilities>(capabilities)[0];
-        const firstPlatform = (this.options.platform ?? firstCap?.platformName)?.toLowerCase();
+        const firstPlatform = (options.platform ?? firstCap?.platformName)?.toLowerCase();
         await this.#metro.start({
-          projectRoot: this.options.metroProjectRoot,
-          port: this.options.metroPort,
+          projectRoot: options.metroProjectRoot,
+          port: options.metroPort,
           platform: firstPlatform === 'ios' ? 'ios' : 'android',
-          prebundle: this.options.prebundle,
+          prebundle: options.prebundle,
         });
       } catch (error) {
         // start() can throw *after* Metro spawned (e.g. readiness timeout) — the child is
@@ -105,10 +115,11 @@ export default class ReactNativeLaunchService extends MobileBaseLauncher<
     // i.e. before the app launches — the correct point to set up `adb reverse` so the Android
     // app's first JS-bundle load reaches host Metro. super.onWorkerStart has just stamped the
     // device udid, so target the exact emulator when several are attached.
-    const port = this.options.metroPort ?? DEFAULT_METRO_PORT;
+    const options = this.resolveLauncherOptions(capabilities);
+    const port = options.metroPort ?? DEFAULT_METRO_PORT;
     for (const cap of flattenCaps<ReactNativeCapabilities>(capabilities)) {
       const c = cap as unknown as Record<string, unknown>;
-      const platform = (this.options.platform ?? (c.platformName as string | undefined))?.toLowerCase();
+      const platform = (options.platform ?? (c.platformName as string | undefined))?.toLowerCase();
       if (platform === 'android') {
         await adbReverse(port, c['appium:udid'] as string | undefined);
       }

--- a/packages/react-native-service/test/launcher.spec.ts
+++ b/packages/react-native-service/test/launcher.spec.ts
@@ -20,6 +20,11 @@ vi.mock('../src/metroProcess.js', () => ({
 const adbReverseMock = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock('../src/adb.js', () => ({ adbReverse: adbReverseMock }));
 
+// Capture the host/port the doctor would probe (and avoid the real probe, since the metroProcess
+// mock above doesn't export probeMetroStatus).
+const rnDoctorChecks = vi.hoisted(() => vi.fn(() => []));
+vi.mock('../src/diagnostics.js', () => ({ reactNativeDoctorChecks: rnDoctorChecks }));
+
 import ReactNativeLaunchService from '../src/launcher.js';
 import type { ReactNativeCapabilities, ReactNativeServiceGlobalOptions } from '../src/types.js';
 
@@ -80,6 +85,14 @@ describe('ReactNativeLaunchService Metro lifecycle', () => {
 
   it('should start Metro before onPrepare when manageMetro is set', async () => {
     await make({ manageMetro: true }).onPrepare(config, [cap({ platformName: 'Android' })]);
+    expect(metroStart).toHaveBeenCalledOnce();
+  });
+
+  it('should start Metro when manageMetro is set on the capability, not the service', async () => {
+    // Regression for the dogfooding-conf footgun: launcher options set only on
+    // wdio:reactNativeServiceOptions must still start managed Metro.
+    const c = cap({ platformName: 'Android', 'wdio:reactNativeServiceOptions': { manageMetro: true } });
+    await make().onPrepare(config, [c]);
     expect(metroStart).toHaveBeenCalledOnce();
   });
 
@@ -163,5 +176,17 @@ describe('ReactNativeLaunchService.onWorkerStart', () => {
   it('should not adb-reverse for an iOS worker', async () => {
     await make().onWorkerStart('0-0', cap({ platformName: 'iOS' }));
     expect(adbReverseMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReactNativeLaunchService doctor', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('should probe the capability-level metroPort in the Metro doctor check', async () => {
+    // doctor runs (default) with metroPort set only on the capability — the resolved value must
+    // reach the Metro doctor check, not the default 8081.
+    const c = cap({ 'wdio:reactNativeServiceOptions': { metroPort: 9999 } });
+    await new ReactNativeLaunchService({}, {} as ReactNativeCapabilities, config).onPrepare(config, [c]);
+    expect(rnDoctorChecks).toHaveBeenCalledWith('127.0.0.1', 9999);
   });
 });


### PR DESCRIPTION
**Stacked on #426** (feat/406-rn-metro-lifecycle) — review/merge that first; this PR's diff is the launcher-options delta.

## The footgun

The mobile launchers read **run-level** options (`autoInstallDriver`, `doctor`, and RN's `manageMetro`/`metroProjectRoot`/`prebundle`/`metroPort`) from `this.options` — the **service-registration** options (`['react-native', {…}]`). If a user instead configures the service on the **capability** (`wdio:reactNativeServiceOptions` — the idiomatic WDIO pattern, and what the e2e dogfooding conf did), those options are silently ignored.

This is exactly what broke #426's RN Android E2E: `manageMetro` was set only on the capability, so managed Metro never started → the app couldn't load its bundle → "Hermes inspector is not connected" on every `execute`/`mock` spec. Worse, `doctor: { strict: true }` — the check meant to catch "Metro not reachable" — was disabled by the *same* gap, so nothing flagged it. (The conf itself is fixed on #426 by passing options at the service level; this PR fixes the underlying footgun so capability-only config also works.)

## Fix

`MobileBaseLauncher.resolveLauncherOptions(capabilities)` returns the global options merged with the per-capability `wdio:<framework>ServiceOptions` (capability wins, matching the precedence `mergeServiceOptions` already uses for `mutateCapability`). Run-level decisions now read it:

- **base** (`onPrepare`): `autoInstallDriver`, `doctor` → so **Flutter inherits the fix** automatically (its doctor was also silently off when configured on the capability).
- **RN** (`onPrepare`): `manageMetro`/`metroProjectRoot`/`prebundle`/`platform`; (`onWorkerStart`): `metroPort`/`platform` for the pre-launch `adb reverse`.

The per-capability `mutateCapability` merge is unchanged (it correctly uses each cap's own options).

## Tests

- `native-mobile-core` +2: `autoInstallDriver` and `doctor: { strict: true }` set on the **capability** drive the launcher.
- `react-native-service` +1: `manageMetro` on the capability starts managed Metro.
- All green: native-mobile-core 110, react-native-service 141; typecheck + biome clean.

> Note: when #426 squash-merges to main, this branch's base should retarget to `main` (the stacked-PR merge-target trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)