### PR TITLE
chore(diag): pin #422 tauri override root cause [DO NOT MERGE]

### DIFF
--- a/e2e/test/tauri/command-override.spec.ts
+++ b/e2e/test/tauri/command-override.spec.ts
@@ -24,6 +24,8 @@ describe('Tauri user command override composition', () => {
     await (await browser.$('#reset-button')).click();
 
     const diag = (globalThis as unknown as { __mockSyncDiag?: { phase: string }[] }).__mockSyncDiag ?? [];
+    console.log('[DIAG422] userEnters:', JSON.stringify(diag.filter((d) => d.phase === 'userEnter')));
+    console.log('[DIAG422] userErrors:', JSON.stringify(diag.filter((d) => d.phase === 'userError')));
     console.log('[DIAG422] userInstalls:', JSON.stringify(diag.filter((d) => d.phase === 'userInstall')));
     console.log('[DIAG422] installs:', JSON.stringify(diag.filter((d) => d.phase === 'install')));
     console.log('[DIAG422] firesThisClick:', JSON.stringify(diag.slice(diagBefore)));

--- a/e2e/test/tauri/command-override.spec.ts
+++ b/e2e/test/tauri/command-override.spec.ts
@@ -24,8 +24,10 @@ describe('Tauri user command override composition', () => {
     await (await browser.$('#reset-button')).click();
 
     const diag = (globalThis as unknown as { __mockSyncDiag?: { phase: string }[] }).__mockSyncDiag ?? [];
+    console.log('[DIAG422] userInstalls:', JSON.stringify(diag.filter((d) => d.phase === 'userInstall')));
     console.log('[DIAG422] installs:', JSON.stringify(diag.filter((d) => d.phase === 'install')));
     console.log('[DIAG422] firesThisClick:', JSON.stringify(diag.slice(diagBefore)));
+    console.log('[DIAG422] clickSid:', (browser as unknown as { sessionId?: string }).sessionId);
     console.log('[DIAG422] flag:', (globalThis as unknown as Record<string, unknown>).__userClickOverrideRan);
 
     expect((globalThis as unknown as Record<string, unknown>).__userClickOverrideRan).toBe(true);

--- a/e2e/test/tauri/command-override.spec.ts
+++ b/e2e/test/tauri/command-override.spec.ts
@@ -1,0 +1,33 @@
+import { browser, expect } from '@wdio/globals';
+import '@wdio/native-types';
+
+/**
+ * Regression guard for user command-override composition. The wdio.tauri.conf.ts
+ * `before` hook registers a user overwriteCommand('click', ...) BEFORE the tauri
+ * service's before() runs — the ordering that let the service clobber it. The
+ * service registers its own element-scoped mock-sync override for `click`; it
+ * must chain the user's override, not replace it. If it clobbers, the user
+ * override never runs and the flag stays false.
+ *
+ * The flag lives on globalThis (shared with the config `before` hook in the same
+ * worker process), not on the WDIO browser proxy — an arbitrary browser property
+ * doesn't persist across every provider. This exercises the real WebdriverIO
+ * override storage the shared installMockSyncOverride helper reaches into, which
+ * the unit tests only mock.
+ */
+describe('Tauri user command override composition', () => {
+  it('should keep the user-registered click override and chain it', async () => {
+    (globalThis as unknown as Record<string, unknown>).__userClickOverrideRan = false;
+    // DIAGNOSTIC (#422, temporary): the shared helper records install/fire facts.
+    const diagBefore = ((globalThis as unknown as { __mockSyncDiag?: unknown[] }).__mockSyncDiag ?? []).length;
+
+    await (await browser.$('#reset-button')).click();
+
+    const diag = (globalThis as unknown as { __mockSyncDiag?: { phase: string }[] }).__mockSyncDiag ?? [];
+    console.log('[DIAG422] installs:', JSON.stringify(diag.filter((d) => d.phase === 'install')));
+    console.log('[DIAG422] firesThisClick:', JSON.stringify(diag.slice(diagBefore)));
+    console.log('[DIAG422] flag:', (globalThis as unknown as Record<string, unknown>).__userClickOverrideRan);
+
+    expect((globalThis as unknown as Record<string, unknown>).__userClickOverrideRan).toBe(true);
+  });
+});

--- a/e2e/wdio.tauri.conf.ts
+++ b/e2e/wdio.tauri.conf.ts
@@ -296,30 +296,42 @@ export const config = {
   // across every provider. The passthrough chains origClick, so every other spec's
   // clicks behave identically and now exercise the compose chain.
   before: async () => {
-    await browser.overwriteCommand(
-      'click',
-      async function (
-        this: WebdriverIO.Element,
-        origClick: (...a: readonly unknown[]) => Promise<unknown>,
-        ...args: readonly unknown[]
-      ): Promise<unknown> {
-        (globalThis as unknown as Record<string, unknown>).__userClickOverrideRan = true;
-        return origClick(...args);
-      } as Parameters<typeof browser.overwriteCommand>[1],
-      true,
-    );
-    // DIAGNOSTIC (#422, temporary): record that the user override landed + on which
-    // session, so we can tell if the official provider reconnects (resetting the map)
-    // between this hook and the service's install.
+    const diag = (globalThis as unknown as { __mockSyncDiag?: unknown[] }).__mockSyncDiag ??= [];
+    const hasBrowser = typeof browser !== 'undefined' && browser !== null;
     const b = browser as unknown as {
       sessionId?: string;
+      overwriteCommand?: unknown;
       __propertiesObject__?: { __elementOverrides__?: { value?: Record<string, unknown> } };
     };
-    ((globalThis as unknown as { __mockSyncDiag?: unknown[] }).__mockSyncDiag ??= []).push({
-      phase: 'userInstall',
-      sid: b.sessionId,
-      mapAfter: Object.keys(b.__propertiesObject__?.__elementOverrides__?.value ?? {}),
+    // DIAGNOSTIC (#422, temporary): probe BEFORE overwriteCommand — does this hook
+    // even run on official, and is browser/overwriteCommand available?
+    diag.push({
+      phase: 'userEnter',
+      hasBrowser,
+      sid: hasBrowser ? b.sessionId : null,
+      owcType: hasBrowser ? typeof b.overwriteCommand : 'no-browser',
     });
+    try {
+      await browser.overwriteCommand(
+        'click',
+        async function (
+          this: WebdriverIO.Element,
+          origClick: (...a: readonly unknown[]) => Promise<unknown>,
+          ...args: readonly unknown[]
+        ): Promise<unknown> {
+          (globalThis as unknown as Record<string, unknown>).__userClickOverrideRan = true;
+          return origClick(...args);
+        } as Parameters<typeof browser.overwriteCommand>[1],
+        true,
+      );
+      diag.push({
+        phase: 'userInstall',
+        sid: b.sessionId,
+        mapAfter: Object.keys(b.__propertiesObject__?.__elementOverrides__?.value ?? {}),
+      });
+    } catch (err) {
+      diag.push({ phase: 'userError', sid: hasBrowser ? b.sessionId : null, err: String((err as Error)?.message ?? err) });
+    }
   },
   mochaOpts: {
     ui: 'bdd',

--- a/e2e/wdio.tauri.conf.ts
+++ b/e2e/wdio.tauri.conf.ts
@@ -287,6 +287,28 @@ export const config = {
   ],
   framework: 'mocha',
   reporters: ['spec'],
+  // Regression harness for user command-override composition: register a user
+  // element-command override for `click` BEFORE the service's before() runs (the
+  // config `before` precedes it — the ordering that let the service clobber it).
+  // The service must chain this override, not replace it; command-override.spec.ts
+  // asserts the flag. The flag lives on globalThis (shared with the spec in the
+  // same worker process) — an arbitrary WDIO browser property doesn't persist
+  // across every provider. The passthrough chains origClick, so every other spec's
+  // clicks behave identically and now exercise the compose chain.
+  before: async () => {
+    await browser.overwriteCommand(
+      'click',
+      async function (
+        this: WebdriverIO.Element,
+        origClick: (...a: readonly unknown[]) => Promise<unknown>,
+        ...args: readonly unknown[]
+      ): Promise<unknown> {
+        (globalThis as unknown as Record<string, unknown>).__userClickOverrideRan = true;
+        return origClick(...args);
+      } as Parameters<typeof browser.overwriteCommand>[1],
+      true,
+    );
+  },
   mochaOpts: {
     ui: 'bdd',
     timeout: 60000,

--- a/e2e/wdio.tauri.conf.ts
+++ b/e2e/wdio.tauri.conf.ts
@@ -308,6 +308,18 @@ export const config = {
       } as Parameters<typeof browser.overwriteCommand>[1],
       true,
     );
+    // DIAGNOSTIC (#422, temporary): record that the user override landed + on which
+    // session, so we can tell if the official provider reconnects (resetting the map)
+    // between this hook and the service's install.
+    const b = browser as unknown as {
+      sessionId?: string;
+      __propertiesObject__?: { __elementOverrides__?: { value?: Record<string, unknown> } };
+    };
+    ((globalThis as unknown as { __mockSyncDiag?: unknown[] }).__mockSyncDiag ??= []).push({
+      phase: 'userInstall',
+      sid: b.sessionId,
+      mapAfter: Object.keys(b.__propertiesObject__?.__elementOverrides__?.value ?? {}),
+    });
   },
   mochaOpts: {
     ui: 'bdd',

--- a/packages/native-utils/src/commandOverride.ts
+++ b/packages/native-utils/src/commandOverride.ts
@@ -76,11 +76,31 @@ export function installMockSyncOverride(
 
   const existing = elementOverrides?.[commandName];
 
+  // DIAGNOSTIC (#422, temporary): record what the helper sees at install time so
+  // we can compare tauri (clobbers) vs electron (composes) in CI.
+  if (commandName === 'click') {
+    ((globalThis as unknown as { __mockSyncDiag?: unknown[] }).__mockSyncDiag ??= []).push({
+      phase: 'install',
+      hasProps: !!(browser as unknown as { __propertiesObject__?: unknown }).__propertiesObject__,
+      mapKeys: elementOverrides ? Object.keys(elementOverrides) : null,
+      hasExisting: !!existing,
+    });
+  }
+
   const override = async function (
     this: WebdriverIO.Element,
     originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
     ...args: readonly unknown[]
   ): Promise<unknown> {
+    // DIAGNOSTIC (#422, temporary): did the element override fire at all, and is
+    // it chaining a captured user override?
+    if (commandName === 'click') {
+      ((globalThis as unknown as { __mockSyncDiag?: unknown[] }).__mockSyncDiag ??= []).push({
+        phase: 'fire',
+        chaining: !!existing,
+      });
+    }
+
     const serviceCommand = async (...innerArgs: readonly unknown[]): Promise<unknown> => {
       const result = await Reflect.apply(originalCommand, this, innerArgs);
       await syncMocks(this);

--- a/packages/native-utils/src/commandOverride.ts
+++ b/packages/native-utils/src/commandOverride.ts
@@ -81,6 +81,7 @@ export function installMockSyncOverride(
   if (commandName === 'click') {
     ((globalThis as unknown as { __mockSyncDiag?: unknown[] }).__mockSyncDiag ??= []).push({
       phase: 'install',
+      sid: (browser as unknown as { sessionId?: string }).sessionId,
       hasProps: !!(browser as unknown as { __propertiesObject__?: unknown }).__propertiesObject__,
       mapKeys: elementOverrides ? Object.keys(elementOverrides) : null,
       hasExisting: !!existing,


### PR DESCRIPTION
Temporary diagnostic stacked on #441 to capture why the tauri command-override compose clobbers in the real runtime. Logs `[DIAG422]` install/fire facts from one tauri-e2e cycle. Will be replaced by the actual #422 fix. Do not merge.