### PR TITLE
chore(release): couple the tauri release units as an independent version group

### DIFF
--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -7,6 +7,16 @@
   "version": {
     "preset": "angular",
     "sync": false,
+    "groups": {
+      "tauri": {
+        "packages": [
+          "@wdio/tauri-service",
+          "@wdio/tauri-plugin",
+          "tauri-plugin-wdio-webdriver"
+        ],
+        "sync": "independent"
+      }
+    },
     "versionPrefix": "v",
     "tagTemplate": "${packageName}@v${version}",
     "commitMessage": "chore: release ${packageName}@${version} [skip ci]",


### PR DESCRIPTION
## What

Adds a `version.groups.tauri` entry to `releasekit.config.json` (release groups, new in releasekit 0.31.0):

```jsonc
"version": {
  "sync": false,
  "groups": {
    "tauri": {
      "packages": ["@wdio/tauri-service", "@wdio/tauri-plugin", "tauri-plugin-wdio-webdriver"],
      "sync": "independent"
    }
  }
}
```

## Why

The Tauri stack is **three** release units that share a WebDriver/mock contract:

- `@wdio/tauri-service` (npm)
- `@wdio/tauri-plugin` (npm) — carries the co-located `tauri-plugin-wdio` crate, which rides along automatically
- `tauri-plugin-wdio-webdriver` (standalone crate, `packages/tauri-plugin-webdriver/`)

They have **no `package.json`/Cargo dependency edge** between them, so neither `--include-prerequisites` nor the dependency graph can couple them — a declared group is the only durable mechanism to guarantee they release together. This matches how the `scope:tauri` label (`@wdio/tauri-*,tauri-plugin-wdio*`) already bundles all three today.

`sync: independent` keeps each on its own version line while making the set **atomic**: selecting any member (via label, `--target`, or standing-PR checkbox) pulls in the others.

Requires `version.sync: false`, which is already set.

## Validation

Verified locally with `releasekit version --dry-run` (releasekit 0.31.x):

- **Atomicity:** targeting only `@wdio/tauri-service` → `expanding to all 3 members so the group releases atomically: @wdio/tauri-plugin, @wdio/tauri-service, tauri-plugin-wdio-webdriver`.
- **Independent versioning:** `Group "tauri" (independent): releasing 3 member(s) on their own version lines`.
- **Crate coupling:** the co-located `tauri-plugin-wdio` Cargo.toml bumps as part of `@wdio/tauri-plugin`.
- **No regression:** targeting a non-grouped package (`@wdio/electron-service`) still prepares exactly 1 package — ungrouped packages version independently as before.

Config formatted with `biome format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)