### PR TITLE
chore: skip Greptile review on the automated release PR

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,8 @@
+{
+  "disabledLabels": [
+    "release"
+  ],
+  "excludeAuthors": [
+    "github-actions[bot]"
+  ]
+}


### PR DESCRIPTION
## What

Adds a `greptile.json` (this repo had none) so Greptile skips the releasekit **standing release PR** (`release/next`):

```json
{
  "disabledLabels": ["release"],
  "excludeAuthors": ["github-actions[bot]"]
}
```

## Why

The standing PR is machine-generated — authored by `github-actions[bot]` and carrying the `release` label (currently #400). It only ever contains version bumps and generated changelogs, so Greptile reviews of it are pure noise, and it surfaces false positives (e.g. the `tauri-plugin-wdio-webdriver` "no-op" finding on #449).

This mirrors the config already in use in the [releasekit](https://github.com/goosewobbler/releasekit) repo. Both triggers match this repo's standing PR; either one suppresses it on its own. `excludeAuthors` additionally covers any other bot-authored automation PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)