### PR TITLE
chore(release): standardise scope label naming

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       scope:
-        description: 'Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, utils, types, spy, core, cdp-bridge, shared) — controls build and toolchain steps'
+        description: 'Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, native-utils, native-types, native-spy, native-core, native-cdp-bridge, shared) — controls build and toolchain steps'
         required: true
         type: string
       standing_pr_number:
@@ -127,19 +127,19 @@ jobs:
             react-native)
               echo "packages=@wdio/react-native-service" >> "$GITHUB_OUTPUT"
               ;;
-            utils)
+            native-utils)
               echo "packages=@wdio/native-utils" >> "$GITHUB_OUTPUT"
               ;;
-            types)
+            native-types)
               echo "packages=@wdio/native-types" >> "$GITHUB_OUTPUT"
               ;;
-            spy)
+            native-spy)
               echo "packages=@wdio/native-spy" >> "$GITHUB_OUTPUT"
               ;;
-            core)
+            native-core)
               echo "packages=@wdio/native-core" >> "$GITHUB_OUTPUT"
               ;;
-            cdp-bridge)
+            native-cdp-bridge)
               echo "packages=@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
               ;;
             native-mobile-core)
@@ -234,19 +234,19 @@ jobs:
                 --filter='@wdio/react-native-service...' \
                 --filter='@wdio/bundler...'
               ;;
-            utils)
+            native-utils)
               pnpm turbo run build --filter='@wdio/native-utils...'
               ;;
-            types)
+            native-types)
               pnpm turbo run build --filter='@wdio/native-types...'
               ;;
-            spy)
+            native-spy)
               pnpm turbo run build --filter='@wdio/native-spy...'
               ;;
-            core)
+            native-core)
               pnpm turbo run build --filter='@wdio/native-core...'
               ;;
-            cdp-bridge)
+            native-cdp-bridge)
               pnpm turbo run build --filter='@wdio/native-cdp-bridge...'
               ;;
             native-mobile-core)
@@ -279,7 +279,7 @@ jobs:
           scope="${{ inputs.scope }}"
           scope="${scope#scope:}"
           case "$scope" in
-            spy)
+            native-spy)
               echo "Verifying @wdio/native-spy package contents..."
               cd packages/native-spy
               ls -la dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,16 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: "Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, utils, types, spy, core, cdp-bridge, shared)"
+        description: "Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, native-utils, native-types, native-spy, native-core, native-cdp-bridge, shared)"
         required: true
         type: choice
         options:
           - shared
-          - utils
-          - types
-          - spy
-          - core
-          - cdp-bridge
+          - native-utils
+          - native-types
+          - native-spy
+          - native-core
+          - native-cdp-bridge
           - native-mobile-core
           - electron
           - tauri

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,7 +381,7 @@ See ReleaseKit's [versioning docs](https://github.com/goosewobbler/releasekit/bl
 
 | Label | Effect |
 |-------|--------|
-| `scope:electron` / `scope:tauri` / `scope:dioxus` / `scope:electrobun` / `scope:shared` | Package set (immediate release, or scope override on the standing PR) |
+| Scope labels — `scope:<framework>` (`electron`, `tauri`, `dioxus`, `electrobun`, `react-native`, `flutter`) for a framework's whole package family; `scope:native-<pkg>` (`native-utils`, `native-types`, `native-spy`, `native-core`, `native-cdp-bridge`, `native-mobile-core`) for a single shared package; `scope:shared` for all `@wdio/native-*` | Package set (immediate release, or scope override on the standing PR) |
 | `bump:patch` / `bump:minor` / `bump:major` | Version bump (immediate release, or bump override on the standing PR) |
 | `release:immediate` | Bypass the standing PR — direct release on merge (requires scope + bump labels) |
 | `release:prerelease` | Prerelease modifier (use with bump labels) |

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -61,16 +61,18 @@
     },
     "scopeLabels": {
       "scope:shared": "@wdio/native-*",
-      "scope:utils": "@wdio/native-utils",
-      "scope:types": "@wdio/native-types",
-      "scope:spy": "@wdio/native-spy",
-      "scope:core": "@wdio/native-core",
-      "scope:cdp-bridge": "@wdio/native-cdp-bridge",
+      "scope:native-utils": "@wdio/native-utils",
+      "scope:native-types": "@wdio/native-types",
+      "scope:native-spy": "@wdio/native-spy",
+      "scope:native-core": "@wdio/native-core",
+      "scope:native-cdp-bridge": "@wdio/native-cdp-bridge",
+      "scope:native-mobile-core": "@wdio/native-mobile-core",
       "scope:tauri": "@wdio/tauri-*,tauri-plugin-wdio*",
       "scope:dioxus": "@wdio/dioxus-*,wdio-dioxus-*",
       "scope:electron": "@wdio/electron-*",
       "scope:electrobun": "@wdio/electrobun-*",
-      "scope:react-native": "@wdio/react-native-*"
+      "scope:react-native": "@wdio/react-native-*",
+      "scope:flutter": "@wdio/flutter-*"
     }
   },
   "notes": {


### PR DESCRIPTION
## What

Standardises the release **scope label** naming, which had drifted across the four places it's defined (`releasekit.config.json`, the manual workflow's three `case` blocks, the `release.yml` dropdown, and the GitHub labels).

**The rule:** a scope label is the package glob with `@wdio/` and any trailing `-*` stripped.

- **Wildcard family glob → stem** (covers a whole package family): `tauri`, `electron`, `dioxus`, `electrobun`, `react-native`, `flutter`, and `shared` (umbrella for `@wdio/native-*`). The `-service`/suffix is correctly dropped because the scope spans more than one package. _Unchanged._
- **Exact single-package glob → full name**: `native-utils`, `native-types`, `native-spy`, `native-core`, `native-cdp-bridge`, `native-mobile-core`.

This fixes the actual inconsistency — the shared singletons were shedding the `native-` prefix (`scope:utils`) while `native-mobile-core` kept it — so the scope namespace now mirrors the package namespace 1:1 (`scope:native-utils` ↔ `@wdio/native-utils`).

## Changes

| Now | → |
|---|---|
| `scope:utils` | `scope:native-utils` |
| `scope:types` | `scope:native-types` |
| `scope:spy` | `scope:native-spy` |
| `scope:core` | `scope:native-core` |
| `scope:cdp-bridge` | `scope:native-cdp-bridge` |

Plus **two gaps closed** — these existed in the workflow/dropdown but were missing from `scopeLabels`, so label-driven releases couldn't resolve them:
- Added `scope:flutter` → `@wdio/flutter-*` (the `scope:flutter` GH label already existed but config had no mapping).
- Added `scope:native-mobile-core` → `@wdio/native-mobile-core`.

Files touched: `releasekit.config.json`, `.github/workflows/_release.reusable.yml` (all three `case` blocks + the scope input description), `.github/workflows/release.yml` (dropdown + description), `CONTRIBUTING.md` (documents the convention).

## ⚠️ Merge checklist — rename the GitHub labels

The labels must be renamed to match config **at merge** (renaming earlier would break label-driven releases against `main`'s old config). Run:

```bash
R=webdriverio/desktop-mobile
gh label edit scope:utils      --name scope:native-utils      --repo $R
gh label edit scope:types      --name scope:native-types      --repo $R
gh label edit scope:spy        --name scope:native-spy        --repo $R
gh label edit scope:core       --name scope:native-core       --repo $R
gh label edit scope:cdp-bridge --name scope:native-cdp-bridge --repo $R
gh label create scope:native-mobile-core --description "Native mobile core package" --color 1d76db --repo $R
```

(`gh label edit … --name` renames in place, preserving existing assignments and history.)

## Follow-up (not in this PR)

The scope→package map is still **duplicated** between `releasekit.config.json` `scopeLabels` and the workflow's hardcoded `case` block — which is *why* it drifted in the first place. A follow-up should drive the manual workflow via releasekit's `--scope` (resolving targets from config) and delete the duplicated `case`, leaving config as the single source of truth. Kept separate from this rename so the behaviour change can be reviewed and tested on its own.
