### PR TITLE
ci(release): resolve scope→packages via releasekit + remove vestigial scope:shared

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,6 @@
 
 - [ ] `scope:electron` - Electron service and CDP bridge
 - [ ] `scope:tauri` - Tauri service and plugin
-- [ ] `scope:shared` - Shared utilities and infrastructure
 
 ## Checklist
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,7 +33,6 @@ Automated releases trigger when CI completes on `main` with release labels on me
 - **Scope labels** (prefix `scope:`):
   - `scope:electron` - Release Electron packages
   - `scope:tauri` - Release Tauri packages
-  - `scope:shared` - Release shared packages
 
 - **Bump labels** (prefix `bump:`):
   - `bump:patch`, `bump:minor`, `bump:major`
@@ -45,10 +44,8 @@ Automated releases trigger when CI completes on `main` with release labels on me
 **Examples:**
 - `scope:electron` + `bump:major` → Electron packages at major bump
 - `scope:tauri` + `bump:minor` → Tauri packages at minor bump
-- `scope:shared` only → Shared packages at minor bump (default)
-- `bump:major` only → Shared packages at major bump
 
-**Default behavior:** If only scope is specified, uses `minor` bump. If only version is specified, uses `shared` scope.
+**Default behavior:** If only scope is specified, uses `minor` bump.
 
 **Preview workflow:** When a PR has release labels, the `release-preview.yml` workflow shows what packages would be released and their new versions.
 

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       scope:
-        description: 'Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, native-utils, native-types, native-spy, native-core, native-cdp-bridge, shared) — controls build and toolchain steps'
+        description: 'Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, native-utils, native-types, native-spy, native-core, native-cdp-bridge) — controls build and toolchain steps'
         required: true
         type: string
       standing_pr_number:
@@ -105,65 +105,6 @@ jobs:
           sudo apt-get install -y libappindicator3-dev || true
           sudo apt-get install -y libayatana-appindicator3-dev || true
           sudo apt-get install -y libsoup3-dev || true
-
-      - name: Compute target packages from scope
-        id: targets
-        run: |
-          scope="${{ inputs.scope }}"
-          scope="${scope#scope:}"
-          case "$scope" in
-            electron)
-              echo "packages=@wdio/electron-service,@wdio/electron-cdp-bridge" >> "$GITHUB_OUTPUT"
-              ;;
-            tauri)
-              echo "packages=@wdio/tauri-service,@wdio/tauri-plugin,tauri-plugin-wdio-webdriver" >> "$GITHUB_OUTPUT"
-              ;;
-            dioxus)
-              echo "packages=@wdio/dioxus-service,@wdio/dioxus-bridge,wdio-dioxus-bridge,wdio-dioxus-embedded-driver,wdio-dioxus-driver" >> "$GITHUB_OUTPUT"
-              ;;
-            electrobun)
-              echo "packages=@wdio/electrobun-service" >> "$GITHUB_OUTPUT"
-              ;;
-            react-native)
-              echo "packages=@wdio/react-native-service" >> "$GITHUB_OUTPUT"
-              ;;
-            native-utils)
-              echo "packages=@wdio/native-utils" >> "$GITHUB_OUTPUT"
-              ;;
-            native-types)
-              echo "packages=@wdio/native-types" >> "$GITHUB_OUTPUT"
-              ;;
-            native-spy)
-              echo "packages=@wdio/native-spy" >> "$GITHUB_OUTPUT"
-              ;;
-            native-core)
-              echo "packages=@wdio/native-core" >> "$GITHUB_OUTPUT"
-              ;;
-            native-cdp-bridge)
-              echo "packages=@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
-              ;;
-            native-mobile-core)
-              echo "packages=@wdio/native-mobile-core" >> "$GITHUB_OUTPUT"
-              ;;
-            flutter)
-              echo "packages=@wdio/flutter-service" >> "$GITHUB_OUTPUT"
-              ;;
-            shared)
-              echo "packages=@wdio/native-utils,@wdio/native-types,@wdio/native-spy,@wdio/native-core,@wdio/native-cdp-bridge" >> "$GITHUB_OUTPUT"
-              ;;
-            all)
-              if [[ -z "${{ inputs.standing_pr_number }}" ]]; then
-                echo "::error::scope=all requires standing_pr_number; use a specific scope for a direct release"
-                exit 1
-              fi
-              # standing-pr publish resolves its package set from the merged PR's manifest
-              echo "packages=" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::error::Unknown scope: $scope"
-              exit 1
-              ;;
-          esac
 
       - name: Compute releasekit parameters
         id: params
@@ -255,14 +196,6 @@ jobs:
             flutter)
               pnpm turbo run build --filter='@wdio/flutter-service...'
               ;;
-            shared)
-              pnpm turbo run build \
-                --filter='@wdio/native-types...' \
-                --filter='@wdio/native-utils...' \
-                --filter='@wdio/native-spy...' \
-                --filter='@wdio/native-core...' \
-                --filter='@wdio/native-cdp-bridge...'
-              ;;
             all)
               # standing-pr publish path — the manifest can span every scope
               pnpm build
@@ -310,7 +243,11 @@ jobs:
         with:
           mode: release
           node-version: '24'
-          target: ${{ inputs.target_packages || steps.targets.outputs.packages }}
+          # Resolve packages from ci.scopeLabels in releasekit (single source of truth).
+          # target_packages is an optional manual override; pass scope only when it's absent,
+          # because releasekit's --scope overwrites --target.
+          target: ${{ inputs.target_packages }}
+          scope: ${{ inputs.target_packages == '' && inputs.scope || '' }}
           branch: ${{ inputs.target_branch }}
           bump: ${{ steps.params.outputs.bump }}
           stable: ${{ steps.params.outputs.stable }}

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -23,7 +23,6 @@ jobs:
             const scopeLabels = [
               { patterns: ['Electron Service', '@wdio/electron-service'], label: 'scope:electron' },
               { patterns: ['Tauri Service', '@wdio/tauri-service'], label: 'scope:tauri' },
-              { patterns: ['Shared Utilities', '@wdio/native-utils', '@wdio/native-types'], label: 'scope:shared' },
               { patterns: ['Electron CDP Bridge', '@wdio/electron-cdp-bridge'], label: 'scope:electron' },
               { patterns: ['Tauri Plugin', '@wdio/tauri-plugin'], label: 'scope:tauri' },
               { patterns: ['Documentation'], label: 'area:documentation' }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,10 @@ on:
   workflow_dispatch:
     inputs:
       scope:
-        description: "Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, native-utils, native-types, native-spy, native-core, native-cdp-bridge, shared)"
+        description: "Release scope (electron, tauri, dioxus, electrobun, react-native, flutter, native-mobile-core, native-utils, native-types, native-spy, native-core, native-cdp-bridge)"
         required: true
         type: choice
         options:
-          - shared
           - native-utils
           - native-types
           - native-spy
@@ -33,7 +32,7 @@ on:
           - electrobun
           - react-native
           - flutter
-        default: shared
+        default: native-utils
       bump:
         description: "Version increment"
         required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,13 +348,12 @@ Releases are automated via GitHub Actions using a **standing release PR** (Relea
 
 For changes that must publish on merge without waiting for the standing PR:
 
-1. Add `release:immediate` to your PR, plus a scope label (`scope:tauri`, `scope:shared`, …) and a bump label (`bump:patch`, `bump:minor`, `bump:major`)
+1. Add `release:immediate` to your PR, plus a scope label (`scope:tauri`, `scope:electron`, …) and a bump label (`bump:patch`, `bump:minor`, `bump:major`)
 2. After CI passes on the merge, the gate dispatches a direct scoped release
 3. The standing PR is reconciled afterwards so it no longer contains the just-released changes
 
 **Examples:**
 - `release:immediate` + `scope:electron` + `bump:major` → Electron packages at major bump
-- `release:immediate` + `scope:shared` + `bump:patch` → Shared packages at patch bump
 - Add `release:prerelease` to publish the immediate release as a prerelease (e.g., 11.0.0-next.0)
 
 ### Manual Release
@@ -381,7 +380,7 @@ See ReleaseKit's [versioning docs](https://github.com/goosewobbler/releasekit/bl
 
 | Label | Effect |
 |-------|--------|
-| Scope labels — `scope:<framework>` (`electron`, `tauri`, `dioxus`, `electrobun`, `react-native`, `flutter`) for a framework's whole package family; `scope:native-<pkg>` (`native-utils`, `native-types`, `native-spy`, `native-core`, `native-cdp-bridge`, `native-mobile-core`) for a single shared package; `scope:shared` for all `@wdio/native-*` | Package set (immediate release, or scope override on the standing PR) |
+| Scope labels — `scope:<framework>` (`electron`, `tauri`, `dioxus`, `electrobun`, `react-native`, `flutter`) for a framework's whole package family; `scope:native-<pkg>` (`native-utils`, `native-types`, `native-spy`, `native-core`, `native-cdp-bridge`, `native-mobile-core`) for a single shared package | Package set (immediate release, or scope override on the standing PR) |
 | `bump:patch` / `bump:minor` / `bump:major` | Version bump (immediate release, or bump override on the standing PR) |
 | `release:immediate` | Bypass the standing PR — direct release on merge (requires scope + bump labels) |
 | `release:prerelease` | Prerelease modifier (use with bump labels) |

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -60,7 +60,6 @@
       "mergeMethod": "squash"
     },
     "scopeLabels": {
-      "scope:shared": "@wdio/native-*",
       "scope:native-utils": "@wdio/native-utils",
       "scope:native-types": "@wdio/native-types",
       "scope:native-spy": "@wdio/native-spy",


### PR DESCRIPTION
## What

Two related cleanups to the release scope plumbing:

1. **Single source of truth.** The manual release workflow's scope→packages `case` block in `_release.reusable.yml` duplicated `releasekit.config.json` `ci.scopeLabels` — the drift this causes is *why* #452 had to fix the same map in four places. Pass `scope` straight to the releasekit action (it resolves targets from `ci.scopeLabels` via `resolveScopeToTarget`) and **delete the case block**.

2. **Remove the `scope:shared` scope.** It released the `@wdio/native-*` libs as a batch but has never been used — per-package scopes plus multiple scope labels on one PR cover the same need. The hand-maintained batch set was also a drift liability (see Greptile note below). Removed from config, the workflow build arm + scope input, the `release.yml` dropdown, the PR template, the issue auto-labeler, and docs.

Net: −82 lines.

## Details

- **`target`/`scope` precedence:** releasekit's `--scope` overwrites `--target`, so `scope` is passed only when `target_packages` is empty. The optional manual `target_packages` override still wins when provided.
- **Removed the `scope=all` guard:** `scope=all` only runs the standing-pr-publish step (regular release is `if: standing_pr_number == ''`); a misuse now errors clearly from releasekit.
- All remaining scopes resolve **identically** to the old case block — verified by expanding every `scopeLabels` glob against the actual package set. (`scope:tauri` additionally names the co-located `tauri-plugin-wdio` crate, which already shipped with `@wdio/tauri-plugin` — no net change.)

## Addresses Greptile review

- **"Scope format mismatch" (manual dispatch passes bare `electron`):** false positive — `resolveScopeToTarget` tries the `scope:`-prefixed key first, then the bare key, so both forms resolve. Verified against the live config for all scopes × both forms ([thread](https://github.com/webdriverio/desktop-mobile/pull/454#discussion_r3459402953)).
- **"`shared` build is stale — `@wdio/native-mobile-core` published unbuilt":** real, and the trigger for removing `scope:shared` entirely. With the scope gone there's no stale batch build set to maintain.

## ⚠️ Merge step

Delete the now-unused GitHub label at merge: `gh label delete scope:shared --repo webdriverio/desktop-mobile`.

`actionlint` clean + config JSON valid; zero `scope:shared` references remain repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)