### PR TITLE
docs(mobile): correct the multiremote claim (it's parallel workers) for RN + Flutter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 - **Tauri** - `@wdio/tauri-service` (v1.x)
 - **Dioxus** - `@wdio/dioxus-service` (v1.x)
 - **Electrobun** - `@wdio/electrobun-service` (v0.1.x — **macOS** via CEF + **Windows** via the native WebView2 renderer (CDP), incl. multi-window/multiremote; **Linux** upstream-blocked, and deeplink/multiremote blocked on the macOS CEF path — see the package README)
-- **React Native** - `@wdio/react-native-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via Appium (UiAutomator2/XCUITest); `execute` + `mock` via Hermes CDP (debug/Metro build); full mock, deeplink, context switching, logs, multiremote)
-- **Flutter** - `@wdio/flutter-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (Dart expression) + `mock` (Tier-2 cooperative `wdio_flutter` Dart contract) via the Dart VM Service (debug/profile build); full mock, deeplink, context switching, logs, multiremote). Built on `@wdio/native-mobile-core`.
+- **React Native** - `@wdio/react-native-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via Appium (UiAutomator2/XCUITest); `execute` + `mock` via Hermes CDP (debug/Metro build); full mock, deeplink, context switching, logs, parallel workers (multiremote not yet — see #446))
+- **Flutter** - `@wdio/flutter-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (Dart expression) + `mock` (Tier-2 cooperative `wdio_flutter` Dart contract) via the Dart VM Service (debug/profile build); full mock, deeplink, context switching, logs, parallel workers (multiremote not yet — see #446)). Built on `@wdio/native-mobile-core`.
 
 **Planned:** the generic `@wdio/mobile-service` base (ships ahead of Capacitor; React Native & Flutter converge onto it), then Capacitor and Neutralino. See [ROADMAP.md](./ROADMAP.md) for details.
 

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -149,7 +149,7 @@ export const config = {
   runner: 'local',
   specs,
   exclude,
-  // One emulator/sim per CI job; multiremote is exercised by unit tests, not here.
+  // One emulator/sim per CI job; multiremote is unimplemented (see #446) — unit tests cover only capability-shape parsing.
   maxInstances: 1,
   capabilities,
   logLevel: 'info',

--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -183,7 +183,7 @@ export const config = {
   runner: 'local',
   specs,
   exclude,
-  // One emulator per CI job; multiremote/multi-device is exercised by unit tests, not here.
+  // One emulator per CI job; multiremote is unimplemented (see #446) — unit tests cover only capability-shape parsing.
   maxInstances: 1,
   capabilities,
   logLevel: 'info',

--- a/packages/flutter-service/README.md
+++ b/packages/flutter-service/README.md
@@ -321,7 +321,7 @@ available via `browser.$(<json-finder>)` once in the `FLUTTER` context.
 The service collects **logcat** (Android) / **syslog** (iOS) and forwards them to the WDIO test
 output. Enable via `captureBackendLogs`.
 
-## Multiremote / parallel workers
+## Parallel workers
 
 Set `devices` in the service options to pool descriptors across workers:
 
@@ -339,6 +339,11 @@ const config = {
 
 Each worker claims a device round-robin (and its own `adb forward` tunnel). Omit `devices` for a
 single-device run.
+
+> **Multiremote** — one session driving several devices at once (a capabilities object plus
+> `multiremotebrowser.getInstance(...)`) — is **not yet supported**: the `devices` pool gives each
+> *worker* one device, not each *instance*. Tracked in
+> [webdriverio/desktop-mobile#446](https://github.com/webdriverio/desktop-mobile/issues/446).
 
 ## Standalone / session mode
 
@@ -368,7 +373,8 @@ try {
 | Android | ✅ full support |
 | iOS | ✅ full support |
 | find/tap (`byValueKey` / `byText`) | ✅ via appium-flutter-driver |
-| multiremote | ✅ via the `devices` pool |
+| parallel workers | ✅ N workers → N devices via the `devices` pool |
+| multiremote (one session, N devices) | ❌ not yet — [#446](https://github.com/webdriverio/desktop-mobile/issues/446) |
 | context switching (`NATIVE_APP` ↔ `FLUTTER`) | ✅ |
 | deeplink | ✅ via `mobile: deepLink` |
 | log capture | ✅ logcat / syslog |

--- a/packages/react-native-service/README.md
+++ b/packages/react-native-service/README.md
@@ -314,7 +314,7 @@ and off by default:
 `*LogLevel` is the minimum level captured — e.g. `frontendLogLevel: 'warn'` drops
 `console.log`/`console.info`. (`console.log` is treated as `info`.)
 
-## Multiremote / parallel workers
+## Parallel workers
 
 Set `devices` in the service options to pool descriptors across workers:
 
@@ -336,6 +336,11 @@ const config = {
 
 Each worker claims a device round-robin. Omit `devices` for a single-device run —
 Appium picks whatever is connected.
+
+> **Multiremote** — one session driving several devices at once (a capabilities object plus
+> `multiremotebrowser.getInstance(...)`) — is **not yet supported**: the `devices` pool gives each
+> *worker* one device, not each *instance*. Tracked in
+> [webdriverio/desktop-mobile#446](https://github.com/webdriverio/desktop-mobile/issues/446).
 
 ## Standalone / session mode
 
@@ -367,7 +372,8 @@ try {
 | `execute` / `mock` | ✅ supported — **debug / Metro build only** (Hermes inspector present only when `HERMES_ENABLE_DEBUGGER` is set) |
 | Android | ✅ full support |
 | iOS | ✅ full support |
-| multiremote | ✅ via the `devices` pool |
+| parallel workers | ✅ N workers → N devices via the `devices` pool |
+| multiremote (one session, N devices) | ❌ not yet — [#446](https://github.com/webdriverio/desktop-mobile/issues/446) |
 | context switching (`NATIVE_APP` ↔ `WEBVIEW_*`) | ✅ |
 | deeplink | ✅ via `mobile: deepLink` |
 | log capture | ✅ logcat / syslog + Metro console |


### PR DESCRIPTION
## What

The RN and Flutter docs/config comments advertised **multiremote** support, but only capability-shape parsing exists. This corrects the overclaim. No code behaviour changes — docs + comments only.

## Why

The claim conflated two different features:

- **Parallel workers** ✅ — N worker processes, one device each (N:N), via the `devices` pool. Works.
- **Multiremote** ❌ — *one* worker driving N devices in a single session (`multiremotebrowser.getInstance(...)`). The device pool stamps the same device on every instance of a multiremote worker, and neither worker (`react-native-service`/`flutter-service` `service.ts`) has an `isMultiremote` path — each builds a single JS-realm channel (one `MetroBridge` / one `VmServiceClient`) and attaches the API to the aggregate browser. So commands can't be routed per device.

The `| multiremote | ✅ via the devices pool |` table row was true for parallel workers and false for multiremote.

## Changes

- **`AGENTS.md`**: `multiremote` → `parallel workers (multiremote not yet — see #446)` for both mobile services.
- **RN + Flutter READMEs**: retitle the section `Multiremote / parallel workers` → `Parallel workers`, add a note that multiremote is unsupported, and split the limitations-table row into `parallel workers ✅` / `multiremote ❌`.
- **`e2e/wdio.react-native.conf.ts` + `wdio.flutter.conf.ts`**: the comment now says multiremote is unimplemented (unit tests cover only capability-shape parsing), instead of "exercised by unit tests".

## Tracking

Part of #446 (Task 1). Real multi-device multiremote implementation + E2E remains open there. Standalone coverage is #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)