### PR TITLE
ci(dependabot): post pending ci/required status + run-link comment on dispatch

### DIFF
--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -5,6 +5,11 @@ name: Dependabot CI
 # `ci:run` label dispatches the full pipeline for the PR's branch; the label is removed
 # afterwards so re-adding it re-runs CI. A human adds the label, so this run gets a normal
 # token (not Dependabot's restricted one) and can dispatch + edit the PR.
+#
+# The dispatched run is a `workflow_dispatch`, so GitHub never associates it with the PR —
+# it won't appear in the PR's checks list. To give immediate feedback we post a `ci/required`
+# pending status (the dispatched ci.yml run overwrites it with the final result via ci-status)
+# and comment a direct link to the run.
 on:
   pull_request:
     types: [labeled]
@@ -13,6 +18,7 @@ permissions:
   actions: write
   pull-requests: write
   contents: read
+  statuses: write
 
 jobs:
   dispatch:
@@ -22,12 +28,75 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch CI for the PR branch
+        id: dispatch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH" -f force_all=true
+        run: |
+          # Note the current latest dispatch run (if any) so the locate step can detect the new one.
+          prev=$(gh run list --repo "$REPO" --workflow=ci.yml --branch="$BRANCH" \
+            --event=workflow_dispatch --limit=1 --json databaseId --jq '.[0].databaseId // empty')
+          gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH" -f force_all=true
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
+          echo "runs_url=$GITHUB_SERVER_URL/$REPO/actions/workflows/ci.yml?query=branch%3A$BRANCH+event%3Aworkflow_dispatch" >> "$GITHUB_OUTPUT"
+      - name: Mark ci/required pending on the PR
+        # Posted right after dispatch — before locating the exact run — so feedback is instant.
+        # target_url is the branch-filtered Actions page; the comment below links the exact run.
+        # Best-effort: a transient status-API failure must not fail the dispatch.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          RUNS_URL: ${{ steps.dispatch.outputs.runs_url }}
+        run: |
+          gh api "repos/$REPO/statuses/$SHA" \
+            -f state=pending \
+            -f context='ci/required' \
+            -f description='CI dispatched via ci:run, running' \
+            -f target_url="$RUNS_URL"
+      - name: Locate the dispatched run
+        id: locate
+        # `gh workflow run` doesn't return the run id, so poll until a run newer than `prev`
+        # registers (one list call per iteration, reused). Fall back to the Actions page.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PREV: ${{ steps.dispatch.outputs.prev }}
+          FALLBACK_URL: ${{ steps.dispatch.outputs.runs_url }}
+        run: |
+          url="$FALLBACK_URL"
+          for _ in $(seq 1 20); do
+            sleep 3
+            # Tolerate transient gh/jq failures (default shell is `bash -eo pipefail`): on any
+            # hiccup, skip to the next attempt rather than aborting the step. `url` only ever
+            # moves from the fallback to a non-empty run URL, so run_url is always valid — the
+            # comment link is never empty/broken.
+            result=$(gh run list --repo "$REPO" --workflow=ci.yml --branch="$BRANCH" \
+              --event=workflow_dispatch --limit=1 --json databaseId,url 2>/dev/null) || continue
+            id=$(echo "$result" | jq -r '.[0].databaseId // empty' 2>/dev/null) || continue
+            if [ -n "$id" ] && [ "$id" != "$PREV" ]; then
+              found=$(echo "$result" | jq -r '.[0].url // empty' 2>/dev/null)
+              [ -n "$found" ] && url="$found"
+              break
+            fi
+          done
+          echo "run_url=$url" >> "$GITHUB_OUTPUT"
+      - name: Comment the dispatched run link
+        # Best-effort: a transient comment-API failure must not fail the dispatch.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ steps.locate.outputs.run_url }}
+        run: |
+          gh pr comment "$PR" --repo "$REPO" --body "CI dispatched via \`ci:run\` → [view run]($RUN_URL). The result posts back as the \`ci/required\` status on this PR; the run itself won't appear in the PR checks list (\`workflow_dispatch\` runs aren't PR-associated)."
       - name: Remove the ci:run label
+        # Always remove so re-adding the label re-runs CI, even if a feedback step hiccupped.
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem

When `ci:run` dispatches CI for a Dependabot PR, the resulting **`workflow_dispatch` run isn't PR-associated** (inherent GitHub behavior — it won't appear in the PR's checks list). #453 made the *final* result post back as a `ci/required` commit status, but that only lands when the run's `ci-status` job finishes (~40 min). In the meantime the PR shows nothing new — just the failed `pull_request` gate run — so it reads as "broken" even though CI is running. (Recurring confusion, e.g. on #402.)

## Change

`dependabot-ci.yml` now gives **immediate** feedback the moment the label is processed:

1. **Pending status** — posts `ci/required = pending` to the PR head SHA right after dispatch. The dispatched `ci.yml` run overwrites it with success/failure via its `ci-status` job (#453).
2. **Run-link comment** — comments a direct link to the dispatched run. `gh workflow run` doesn't return the run id, so it polls `gh run list` for a run newer than the prior dispatch, falling back to the branch-filtered Actions page if it never registers.

Adds `statuses: write` to the workflow permissions. The comment also restates that the run won't appear in the checks list, to defuse the recurring confusion.

## Notes

- Re-labelling (to re-run) posts a fresh pending status + comment each time — one per dispatched run. (Could be made a sticky/updated comment later if the trail gets noisy.)
- Doesn't retroactively help #402's in-flight run (dispatched before this lands); that one still posts `ci/required` when it finishes.

`actionlint` clean (incl. shellcheck on the run scripts) + YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)