### PR TITLE
test(tauri): PROBE (do not merge) — re-check #179 by running CrabNebula log assertions on 0.2.8

### DIFF
--- a/e2e/test/tauri/logging.spec.ts
+++ b/e2e/test/tauri/logging.spec.ts
@@ -7,9 +7,9 @@ import { getLogDirName, readWdioLogs } from '../../lib/utils.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
-// Detect driver provider - backend logs from app stderr are not captured by CrabNebula
+// PROBE (#179): the isCrabNebula skips are removed so the crabnebula provider runs the log
+// assertions. A green crabnebula leg means test-runner-backend now forwards app stdout/stderr.
 const driverProvider = process.env.DRIVER_PROVIDER as 'official' | 'crabnebula' | 'embedded' | undefined;
-const isCrabNebula = driverProvider === 'crabnebula';
 
 function getLogDir() {
   const logDirName = getLogDirName('standard', 'tauri', driverProvider);
@@ -19,9 +19,6 @@ function getLogDir() {
 describe('Tauri Log Integration', () => {
   describe('Command Execution', () => {
     it('should capture backend logs via generate_test_logs command', async function () {
-      if (isCrabNebula) {
-        this.skip(); // Backend log capture not supported for CrabNebula (test-runner-backend doesn't forward app stderr)
-      }
       await browser.tauri.execute(({ core }) => core.invoke('generate_test_logs'));
 
       await browser.waitUntil(
@@ -61,9 +58,6 @@ describe('Tauri Log Integration', () => {
 
   describe('Console Log Capture', () => {
     it('should capture frontend console.log from browser.execute', async function () {
-      if (isCrabNebula) {
-        this.skip(); // Frontend logs don't work for CrabNebula - app stderr not forwarded by test-runner-backend
-      }
       await browser.execute(() => {
         console.info('Frontend INFO from execute');
         console.warn('Frontend WARN from execute');
@@ -85,9 +79,6 @@ describe('Tauri Log Integration', () => {
     });
 
     it('should capture info, warn, error log levels from browser.execute', async function () {
-      if (isCrabNebula) {
-        this.skip(); // Frontend logs don't work for CrabNebula - app stderr not forwarded by test-runner-backend
-      }
       await browser.execute(() => {
         console.info('INFO from execute');
         console.warn('WARN from execute');
@@ -109,9 +100,6 @@ describe('Tauri Log Integration', () => {
     });
 
     it('should capture console.log with various message types', async function () {
-      if (isCrabNebula) {
-        this.skip(); // Frontend logs don't work for CrabNebula - app stderr not forwarded by test-runner-backend
-      }
       // Use console.info for reliable capture across all driver providers
       await browser.execute(() => {
         console.info('String message');

--- a/e2e/wdio.tauri.conf.ts
+++ b/e2e/wdio.tauri.conf.ts
@@ -122,13 +122,11 @@ switch (envContext.testType) {
     break;
 }
 
-// CrabNebula: exclude logging specs (test-runner-backend doesn't forward app stderr)
+// CrabNebula: logging.spec.ts is deliberately NOT excluded for this PROBE (#179) — run it under
+// crabnebula to see whether test-runner-backend 0.2.8 now forwards the app's stdout/stderr.
+// (tauri-driver console + multiremote logging stay excluded to isolate the #179 signal.)
 if (envContext.driverProvider === 'crabnebula') {
-  exclude.push(
-    './test/tauri/logging.spec.ts',
-    './test/tauri/logging.tauri-driver.spec.ts',
-    './test/tauri/multiremote/logging.spec.ts',
-  );
+  exclude.push('./test/tauri/logging.tauri-driver.spec.ts', './test/tauri/multiremote/logging.spec.ts');
 }
 
 // Configure capabilities


### PR DESCRIPTION
## ⚠️ Throwaway probe — do not merge

Re-checks **#179** against the currently pinned `@crabnebula/test-runner-backend` 0.2.8.

## Corrected mechanism

The #179 logging specs are gated for CrabNebula at **two** layers, and the first revision of this probe only touched the dead one:
1. **`wdio.tauri.conf.ts` excludes `logging.spec.ts` entirely for the crabnebula provider** — the real gate.
2. In-test `isCrabNebula` `this.skip()` — *dead code*, since the spec never loads under crabnebula.

The first push only removed (2), so the spec still never ran under crabnebula → the macOS leg was a **false green**. This revision also drops `logging.spec.ts` from the crabnebula `exclude` (keeping `logging.tauri-driver` + `multiremote/logging` excluded to isolate the signal), so the assertions actually execute.

## Read the `Tauri [macOS-ARM] - standard` leg
- **crabnebula GREEN** → `test-runner-backend` now forwards app stdout/stderr → **#179 fixed**.
- **crabnebula RED** → still broken (expected).

Refs #179. Durable detector: #464.