### PR TITLE
test(tauri): self-flipping #179 tripwire for CrabNebula logging + isolate it in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
           - '@wdio/*'
           - 'webdriver'
           - 'webdriverio'
+      # Keep CrabNebula bumps in their own PR: a new @crabnebula/test-runner-backend release is the
+      # trigger to re-check #179 (Tauri logging via CrabNebula on macOS). logging.crabnebula-tripwire
+      # flips that PR's tauri e2e leg red if the new version forwards app stdout/stderr.
+      crabnebula:
+        patterns:
+          - '@crabnebula/*'
       production-dependencies:
         dependency-type: 'production'
         patterns:
@@ -22,6 +28,7 @@ updates:
           - '@wdio/*'
           - 'webdriver'
           - 'webdriverio'
+          - '@crabnebula/*'
       development-dependencies:
         dependency-type: 'development'
         patterns:
@@ -30,6 +37,7 @@ updates:
           - '@wdio/*'
           - 'webdriver'
           - 'webdriverio'
+          - '@crabnebula/*'
     ignore:
       # For all packages, ignore major updates
       - dependency-name: '*'

--- a/e2e/test/tauri/logging.crabnebula-tripwire.spec.ts
+++ b/e2e/test/tauri/logging.crabnebula-tripwire.spec.ts
@@ -1,0 +1,79 @@
+// Tripwire for #179 — Tauri logging under the CrabNebula provider on macOS.
+//
+// CrabNebula's closed-source `test-runner-backend` doesn't forward the macOS app's stdout/stderr, so
+// the real logging specs (logging.spec.ts etc.) are excluded for the crabnebula provider in
+// wdio.tauri.conf.ts and main stays green. That exclusion silently hides the day CrabNebula ships a
+// fix. This spec is the inverse: it runs ONLY on macOS + crabnebula and asserts the app's backend
+// logs are STILL not forwarded. While #179 is open it passes; the moment the forwarded line appears
+// it fails — the signal to remove this spec, drop the crabnebula logging exclusions, and close #179.
+//
+// Two scoping details earlier revisions got wrong:
+//   - macOS only — CrabNebula forwards logs fine on Linux/Windows, so the inverse assertion would
+//     false-fire there. (Config also excludes this spec off macOS+crabnebula; the guard below is
+//     defence in depth.)
+//   - Specific forwarded content (`[Tauri:Backend] ... INFO level log`) rather than the bare
+//     `[Tauri:Backend` prefix — the service emits that prefix for its own backend-process capture
+//     even when the app's output is not forwarded, so a prefix check also false-fires.
+//
+// New CrabNebula releases arrive as their own Dependabot PR (.github/dependabot.yml); that PR's
+// macOS tauri e2e run is what trips this wire.
+import { browser } from '@wdio/globals';
+import '@wdio/native-types';
+import path from 'node:path';
+import process from 'node:process';
+import url from 'node:url';
+import { getLogDirName, readWdioLogs } from '../../lib/utils.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const isMacOsCrabNebula = process.platform === 'darwin' && process.env.DRIVER_PROVIDER === 'crabnebula';
+
+// The exact forwarded line logging.spec.ts asserts — present only if the app's backend output
+// actually reaches the test process.
+const FORWARDED_BACKEND_LOG = /\[Tauri:Backend[^\]]*\].*INFO level log/s;
+
+// waitUntil's timeout message — also matched in the catch below so that ONLY a genuine timeout
+// counts as "still not forwarded". Any other error (readWdioLogs I/O, session crash, …) is
+// re-thrown and surfaces as a real failure instead of false-greening the tripwire.
+const NOT_FORWARDED_TIMEOUT_MSG = 'app backend logs still not forwarded under CrabNebula';
+
+function getLogDir() {
+  return path.join(__dirname, '..', '..', 'logs', getLogDirName('standard', 'tauri', 'crabnebula'));
+}
+
+describe('CrabNebula logging tripwire (#179)', () => {
+  it('should still NOT forward app backend logs under CrabNebula (fails when #179 is fixed)', async function () {
+    if (!isMacOsCrabNebula) {
+      this.skip();
+    }
+
+    await browser.tauri.execute(({ core }) => core.invoke('generate_test_logs'));
+
+    // Give the forwarded output an ample window, then confirm it never arrived. waitUntil throwing
+    // on timeout is the expected, healthy path while #179 is open; it resolving means the app's
+    // backend logs now reach us — i.e. forwarding works.
+    let forwarded = false;
+    try {
+      await browser.waitUntil(async () => FORWARDED_BACKEND_LOG.test(await readWdioLogs(getLogDir())), {
+        timeout: 8000,
+        timeoutMsg: NOT_FORWARDED_TIMEOUT_MSG,
+      });
+      forwarded = true;
+    } catch (err) {
+      // Only a waitUntil timeout means "still not forwarded" (the healthy state while #179 is open).
+      // Anything else is a real failure — re-throw so it can't masquerade as a green tripwire.
+      if (!(err instanceof Error) || !err.message.includes(NOT_FORWARDED_TIMEOUT_MSG)) {
+        throw err;
+      }
+      forwarded = false;
+    }
+
+    if (forwarded) {
+      throw new Error(
+        'CrabNebula test-runner-backend now forwards app stdout/stderr on macOS — #179 looks fixed. ' +
+          'Remove this tripwire spec, drop the crabnebula exclusion of logging.spec.ts / ' +
+          'logging.tauri-driver.spec.ts / multiremote/logging.spec.ts in wdio.tauri.conf.ts (and the ' +
+          'isCrabNebula skips inside logging.spec.ts), and close #179.',
+      );
+    }
+  });
+});

--- a/e2e/wdio.tauri.conf.ts
+++ b/e2e/wdio.tauri.conf.ts
@@ -122,13 +122,20 @@ switch (envContext.testType) {
     break;
 }
 
-// CrabNebula: exclude logging specs (test-runner-backend doesn't forward app stderr)
+// CrabNebula: the standard logging specs can't pass (test-runner-backend doesn't forward the app's
+// stdout/stderr — #179), so they stay excluded. logging.crabnebula-tripwire.spec.ts runs in their
+// place and flips red if that ever changes.
 if (envContext.driverProvider === 'crabnebula') {
   exclude.push(
     './test/tauri/logging.spec.ts',
     './test/tauri/logging.tauri-driver.spec.ts',
     './test/tauri/multiremote/logging.spec.ts',
   );
+}
+// #179 is macOS-specific — CrabNebula forwards logs fine on Linux/Windows and under every other
+// provider, where the tripwire's inverse assertion would false-fire. Run it only on macOS+crabnebula.
+if (process.platform !== 'darwin' || envContext.driverProvider !== 'crabnebula') {
+  exclude.push('./test/tauri/logging.crabnebula-tripwire.spec.ts');
 }
 
 // Configure capabilities


### PR DESCRIPTION
## Why

**#179** (Tauri logging broken on macOS under CrabNebula — `test-runner-backend` doesn't forward the app's stdout/stderr) is gated at the **config level**: `wdio.tauri.conf.ts` excludes `logging.spec.ts` (and the tauri-driver / multiremote logging specs) for the crabnebula provider. That keeps `main` green but silently hides the day CrabNebula ships a fix.

> Note: an earlier revision tried to convert the in-test `isCrabNebula` skips to an xfail — but those guards are **dead code** (the spec never loads under crabnebula), so it did nothing. Reworked.

## What

**1. Dedicated tripwire spec** — `e2e/test/tauri/logging.crabnebula-tripwire.spec.ts`. Runs **only** under crabnebula and asserts the app's backend logs are **still not** forwarded. Green while #179 is open; **red the moment** `test-runner-backend` starts forwarding output — the signal to remove it, drop the crabnebula logging exclusions, and close #179.

**2. Config wiring** — `wdio.tauri.conf.ts` keeps excluding the real logging specs for crabnebula (still broken) and excludes the tripwire for every *other* provider (where logs work and the inverted assertion would false-positive).

**3. Dependabot isolation** — `@crabnebula/*` gets its own group, so a new `test-runner-backend` release lands as a standalone PR whose tauri e2e run trips the wire, instead of being buried in the weekly devDependencies batch.

Leaves `logging.spec.ts` and its existing exclusion untouched.

## Relationship to the probe (#463)
- #463 (do-not-merge) is the positive-polarity read of the **current** 0.2.8: crabnebula green = fixed.
- This PR is the durable, inverse-polarity detector meant to **merge** and watch future releases.
- If #463 is red (still broken — expected), merge this. If #463 is green (already fixed), skip the tripwire — just drop the exclusions and close #179.

Refs #179.