### PR TITLE
perf(tauri-service): batch updateAllMocks into a single scheduler (#429)

### DIFF
--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -692,7 +692,13 @@ class MockUpdateScheduler {
       if (this.#queued) {
         const promoted = this.#queued;
         this.#queued = null;
-        this.#running = this.#wrapRun(promoted);
+        // The queued batch's callers hold `promoted` and observe its rejection there.
+        // This wrapper is held only by #running and is never awaited externally, so
+        // swallow its rejection — otherwise a failing queued batch surfaces as an
+        // unhandled rejection (a worker crash under Node's default throw policy).
+        const nextRunning = this.#wrapRun(promoted);
+        nextRunning.catch(() => undefined);
+        this.#running = nextRunning;
       } else {
         this.#running = null;
       }

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -418,7 +418,7 @@ export default class TauriWorkerService {
           );
         }
         const result = await execute<ReturnValue, InnerArguments>(browser, script, ...args);
-        await updateAllMocks();
+        await getMockUpdateScheduler(browser).schedule();
         return result;
       },
 
@@ -529,7 +529,7 @@ export default class TauriWorkerService {
             target,
           );
         }
-        await updateAllMocks();
+        await getMockUpdateScheduler(browser).schedule();
       },
     };
   }
@@ -550,7 +550,7 @@ export default class TauriWorkerService {
   private overrideElementCommand(commandName: ElementCommands) {
     const browser = this.browser as WebdriverIO.Browser;
     try {
-      installMockSyncOverride(browser, commandName, () => updateAllMocks());
+      installMockSyncOverride(browser, commandName, () => getMockUpdateScheduler(browser).schedule());
     } catch (error) {
       log.warn(`Failed to override element command '${commandName}':`, error);
     }
@@ -653,59 +653,107 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// One scheduler per browser session — keyed weakly so GC can claim finished sessions.
+const mockUpdateSchedulers = new WeakMap<WebdriverIO.Browser, MockUpdateScheduler>();
+
 /**
- * Update all existing mocks by syncing inner (browser) mock state to outer (test) mocks.
- * On Windows, updates run sequentially to avoid saturating WebView2 with concurrent
- * ExecuteScript calls. Each update is retried once (after 50 ms) before failing hard.
- * Silent swallow of mock-update errors leads to empty mock.calls assertions, which is
- * harder to diagnose than an explicit AggregateError.
+ * Coalesces mock-update round-trips so N concurrent DOM interactions don't each fire
+ * one browser.execute() per registered mock. At most two batches run at any moment
+ * (current + one queued); callers arriving while a batch runs share the queued slot,
+ * so N interactions produce <= 2 batches instead of N. Each batch syncs inner (browser)
+ * mock state to outer (test) mocks. On Windows, updates within a batch run sequentially
+ * to avoid saturating WebView2 with concurrent ExecuteScript calls. Each update is
+ * retried once (after 50 ms) before failing hard — silent swallow of mock-update errors
+ * leads to empty mock.calls assertions, which is harder to diagnose than an AggregateError.
  */
-async function updateAllMocks(): Promise<void> {
-  const mocks = mockStore.getMocks();
-  if (mocks.length === 0) {
-    return;
+class MockUpdateScheduler {
+  #running: Promise<void> | null = null;
+  #queued: Promise<void> | null = null;
+
+  schedule(): Promise<void> {
+    if (!this.#running) {
+      const p = this.#wrapRun(this.#runOnce());
+      this.#running = p;
+      return p;
+    }
+    if (!this.#queued) {
+      this.#queued = this.#running.catch(() => undefined).then(() => this.#runOnce());
+    }
+    return this.#queued;
   }
 
-  const tryUpdate = async (
-    mockId: string,
-    mockInstance: ReturnType<typeof mockStore.getMocks>[0][1],
-  ): Promise<void> => {
-    try {
-      await mockInstance.update();
-    } catch (firstError) {
-      log.debug(`Mock update failed for ${mockId}, retrying in 50ms:`, firstError);
-      await sleep(50);
-      await mockInstance.update();
-    }
-  };
+  // Atomically promotes the queued batch into the running slot once the current
+  // batch settles (resolved or rejected), preventing a third concurrent batch
+  // from racing between the two.
+  #wrapRun(run: Promise<void>): Promise<void> {
+    let wrapped!: Promise<void>;
+    wrapped = run.finally(() => {
+      if (this.#running !== wrapped) return;
+      if (this.#queued) {
+        const promoted = this.#queued;
+        this.#queued = null;
+        this.#running = this.#wrapRun(promoted);
+      } else {
+        this.#running = null;
+      }
+    });
+    return wrapped;
+  }
 
-  if (process.platform === 'win32') {
-    const errors: Array<{ mockId: string; error: unknown }> = [];
-    for (const [mockId, mockInstance] of mocks) {
+  async #runOnce(): Promise<void> {
+    const mocks = mockStore.getMocks();
+    if (mocks.length === 0) return;
+
+    const tryUpdate = async (
+      mockId: string,
+      mockInstance: ReturnType<typeof mockStore.getMocks>[0][1],
+    ): Promise<void> => {
       try {
-        await tryUpdate(mockId, mockInstance);
-      } catch (error) {
-        errors.push({ mockId, error });
+        await mockInstance.update();
+      } catch (firstError) {
+        log.debug(`Mock update failed for ${mockId}, retrying in 50ms:`, firstError);
+        await sleep(50);
+        await mockInstance.update();
+      }
+    };
+
+    if (process.platform === 'win32') {
+      const errors: Array<{ mockId: string; error: unknown }> = [];
+      for (const [mockId, mockInstance] of mocks) {
+        try {
+          await tryUpdate(mockId, mockInstance);
+        } catch (error) {
+          errors.push({ mockId, error });
+        }
+      }
+      if (errors.length > 0) {
+        throw new AggregateError(
+          errors.map((e) => e.error),
+          `Mock updates failed for: ${errors.map((e) => e.mockId).join(', ')}`,
+        );
+      }
+    } else {
+      const results = await Promise.allSettled(mocks.map(([mockId, mockInstance]) => tryUpdate(mockId, mockInstance)));
+      const failures = results
+        .map((result, i) => ({ result, mockId: mocks[i][0] }))
+        .filter(
+          (entry): entry is { result: PromiseRejectedResult; mockId: string } => entry.result.status === 'rejected',
+        );
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures.map((f) => f.result.reason),
+          `Mock updates failed for: ${failures.map((f) => f.mockId).join(', ')}`,
+        );
       }
     }
-    if (errors.length > 0) {
-      throw new AggregateError(
-        errors.map((e) => e.error),
-        `Mock updates failed for: ${errors.map((e) => e.mockId).join(', ')}`,
-      );
-    }
-  } else {
-    const results = await Promise.allSettled(mocks.map(([mockId, mockInstance]) => tryUpdate(mockId, mockInstance)));
-    const failures = results
-      .map((result, i) => ({ result, mockId: mocks[i][0] }))
-      .filter(
-        (entry): entry is { result: PromiseRejectedResult; mockId: string } => entry.result.status === 'rejected',
-      );
-    if (failures.length > 0) {
-      throw new AggregateError(
-        failures.map((f) => f.result.reason),
-        `Mock updates failed for: ${failures.map((f) => f.mockId).join(', ')}`,
-      );
-    }
   }
+}
+
+function getMockUpdateScheduler(browser: WebdriverIO.Browser): MockUpdateScheduler {
+  let scheduler = mockUpdateSchedulers.get(browser);
+  if (!scheduler) {
+    scheduler = new MockUpdateScheduler();
+    mockUpdateSchedulers.set(browser, scheduler);
+  }
+  return scheduler;
 }

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -384,7 +384,7 @@ describe('TauriWorkerService', () => {
       expect(result).toBe('ok');
     });
 
-    it('should coalesce concurrent overrides into two scheduler batches', async () => {
+    it('should coalesce concurrent overrides into at most two scheduler batches', async () => {
       const mockBrowser = createMockBrowser();
       const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
       await service.before({} as any, [], mockBrowser);
@@ -400,12 +400,15 @@ describe('TauriWorkerService', () => {
       ) => Promise<unknown>;
 
       const originalCommand = vi.fn().mockResolvedValue('ok');
-      // Two interactions fire before the first sync settles. The scheduler runs the
-      // first batch immediately and shares one queued slot for the rest, so update
-      // runs exactly twice (current + queued) rather than once per interaction.
+      // Three interactions fire before the first sync settles. The scheduler runs the
+      // first batch immediately; every caller after that shares one queued slot, so
+      // update runs exactly twice (current + queued) — not once per interaction. Three
+      // callers (rather than two) is what proves the shared slot: a broken queued-slot
+      // branch would let the third caller spawn its own batch and update would run 3x.
       const p1 = override.call({}, originalCommand);
       const p2 = override.call({}, originalCommand);
-      await Promise.all([p1, p2]);
+      const p3 = override.call({}, originalCommand);
+      await Promise.all([p1, p2, p3]);
 
       expect(mockUpdate).toHaveBeenCalledTimes(2);
     });

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -443,6 +443,44 @@ describe('TauriWorkerService', () => {
       expect(mockUpdate).toHaveBeenCalledTimes(3);
     });
 
+    it('should not leak an unhandled rejection when a queued batch fails', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      // Every attempt (initial + retry) fails, so both the running batch and the
+      // promoted queued batch reject. The promoted batch's internal wrapper is held
+      // only by the scheduler, so its rejection must be swallowed — otherwise it
+      // surfaces as an unhandled rejection that crashes the worker.
+      const mockUpdate = vi.fn().mockRejectedValue(new Error('boom'));
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
+
+      const clickCall = vi.mocked(mockBrowser.overwriteCommand).mock.calls.find((c) => c[0] === 'click');
+      const override = clickCall![1] as unknown as (
+        this: unknown,
+        originalCommand: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+      const originalCommand = vi.fn().mockResolvedValue('ok');
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        // Two concurrent interactions: the second is queued then promoted; both reject.
+        // Callers observe their own rejections; only the orphaned wrapper would leak.
+        const p1 = override.call({}, originalCommand).catch(() => undefined);
+        const p2 = override.call({}, originalCommand).catch(() => undefined);
+        await Promise.all([p1, p2]);
+        // Let the promoted wrapper settle so Node can flag any unhandled rejection.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+
+      expect(unhandled).toEqual([]);
+    });
+
     it('should clear stale mocks at session start for embedded driver provider', async () => {
       const mockBrowser = createMockBrowser();
       const originalExecute = mockBrowser.execute as ReturnType<typeof vi.fn>;

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -384,6 +384,62 @@ describe('TauriWorkerService', () => {
       expect(result).toBe('ok');
     });
 
+    it('should coalesce concurrent overrides into two scheduler batches', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
+
+      const clickCall = vi.mocked(mockBrowser.overwriteCommand).mock.calls.find((c) => c[0] === 'click');
+      const override = clickCall![1] as unknown as (
+        this: unknown,
+        originalCommand: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const originalCommand = vi.fn().mockResolvedValue('ok');
+      // Two interactions fire before the first sync settles. The scheduler runs the
+      // first batch immediately and shares one queued slot for the rest, so update
+      // runs exactly twice (current + queued) rather than once per interaction.
+      const p1 = override.call({}, originalCommand);
+      const p2 = override.call({}, originalCommand);
+      await Promise.all([p1, p2]);
+
+      expect(mockUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should recover the scheduler after a batch update rejects', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      await service.before({} as any, [], mockBrowser);
+
+      // First batch: both the initial attempt and its 50ms retry fail; a later
+      // interaction must still get a fresh batch (the scheduler must not wedge on
+      // the rejected slot).
+      const mockUpdate = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValue(undefined);
+      vi.mocked(mockStore.getMocks).mockReturnValue([['tauri.cmd', { update: mockUpdate } as any]]);
+
+      const clickCall = vi.mocked(mockBrowser.overwriteCommand).mock.calls.find((c) => c[0] === 'click');
+      const override = clickCall![1] as unknown as (
+        this: unknown,
+        originalCommand: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+
+      const originalCommand = vi.fn().mockResolvedValue('ok');
+      await override.call({}, originalCommand).catch(() => undefined);
+      await override.call({}, originalCommand);
+
+      // 2 from the failed batch (initial + retry) + 1 from the recovered batch.
+      expect(mockUpdate).toHaveBeenCalledTimes(3);
+    });
+
     it('should clear stale mocks at session start for embedded driver provider', async () => {
       const mockBrowser = createMockBrowser();
       const originalExecute = mockBrowser.execute as ReturnType<typeof vi.fn>;


### PR DESCRIPTION
## Summary

Closes #429. Follow-up from #292 (electron-service).

`@wdio/tauri-service` had the same per-mock-update cost #292 fixed in electron: `updateAllMocks()` was called directly after every overridden element command (`click` / `doubleClick` / `setValue` / `clearValue`) and after `tauri.execute()` / `emitEvent()`, firing **N** `browser.execute()` round-trips per registered mock on every DOM interaction.

This ports the `MockUpdateScheduler` from electron-service onto the current (post-#441) tauri code:

- At most **two batches** run at any moment (current + one queued). Any number of concurrent `schedule()` callers after the first share the queued slot, so N DOM interactions produce **≤ 2 batches** instead of N.
- Per-batch error and retry semantics (50 ms retry, `AggregateError` surface, Windows sequential ordering) are **preserved unchanged** — no behaviour change for passing tests.
- A `WeakMap` keys one scheduler per browser instance, so multiremote sessions each get independent scheduling.
- The element-command override still routes through the shared `installMockSyncOverride` helper (#441), so user command-override composition (#422) is preserved — only the sync callback now `schedule()`s instead of running `updateAllMocks()` inline.

> **Note:** this supersedes the closed #431, which was cut off #292-era code before #441 reworked the override path. This branch is a fresh cut off current `main` and adapts cleanly to `installMockSyncOverride`.

## Changes

- `packages/tauri-service/src/service.ts` — replace the `updateAllMocks()` function with a `MockUpdateScheduler` class + `getMockUpdateScheduler(browser)` accessor; swap the three call sites (`tauri.execute`, `emitEvent`, the `installMockSyncOverride` sync callback).
- `packages/tauri-service/test/service.spec.ts` — two new unit tests: concurrent dedup (two concurrent overrides → exactly 2 batches) and scheduler recovery after a rejected batch. (The "run original then sync in the override body" case is already covered by an existing #441 test.)

## Test plan

- [x] `pnpm --filter @wdio/tauri-service test` — **628 pass** (626 + 2 new)
- [x] `pnpm --filter @wdio/tauri-service typecheck` — clean
- [x] `pnpm --filter @wdio/tauri-service lint` — pre-existing warnings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)