### PR TITLE
chore(release): wire wdio_flutter pub.dev publishing (disabled pending wdio publisher)

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -91,6 +91,14 @@ jobs:
         shell: bash
         run: rustup update stable && rustup default stable
 
+      - name: Setup Dart
+        # pub.dev publishing for the wdio_flutter contract — ubuntu-latest ships no Dart CLI, and
+        # releasekit provisions no toolchains itself (Rust is set up above, by the same token).
+        # setup-dart also performs the OIDC token exchange for `dart pub publish` (this job grants
+        # id-token: write), which is how automated pub.dev publishing authenticates.
+        if: ${{ contains(inputs.scope, 'flutter') || inputs.scope == 'all' }}
+        uses: dart-lang/setup-dart@v1
+
       - name: Install GTK development libraries
         if: ${{ contains(inputs.scope, 'tauri') || contains(inputs.scope, 'dioxus') || inputs.scope == 'all' }}
         run: |

--- a/packages/flutter-service/wdio_flutter/CHANGELOG.md
+++ b/packages/flutter-service/wdio_flutter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.0.1
+
+- Baseline of the `wdio_flutter` Dart contract: opt-in Dart VM service extensions
+  (`ext.wdio.*`) and a mock registry your app's DI seams route through, driven by
+  `@wdio/flutter-service` over the Dart VM Service. Aligned to the `@wdio/flutter-service`
+  version line; the first published release is a `1.0.0-next.*` prerelease.

--- a/packages/flutter-service/wdio_flutter/CHANGELOG.md
+++ b/packages/flutter-service/wdio_flutter/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## 0.0.1
-
-- Baseline of the `wdio_flutter` Dart contract: opt-in Dart VM service extensions
-  (`ext.wdio.*`) and a mock registry your app's DI seams route through, driven by
-  `@wdio/flutter-service` over the Dart VM Service. Aligned to the `@wdio/flutter-service`
-  version line; the first published release is a `1.0.0-next.*` prerelease.

--- a/packages/flutter-service/wdio_flutter/LICENSE
+++ b/packages/flutter-service/wdio_flutter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 WebdriverIO Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flutter-service/wdio_flutter/pubspec.yaml
+++ b/packages/flutter-service/wdio_flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   WebdriverIO Flutter service contract — opt-in Dart VM service extensions (ext.wdio.*)
   and a mock registry your app's DI seams route through, driven by @wdio/flutter-service
   over the Dart VM Service. The app-side half of browser.flutter.mock.*.
-version: 1.0.0
+version: 0.0.1
 homepage: https://github.com/webdriverio/desktop-mobile/tree/main/packages/flutter-service/wdio_flutter
 repository: https://github.com/webdriverio/desktop-mobile
 issue_tracker: https://github.com/webdriverio/desktop-mobile/issues

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -15,6 +15,13 @@
           "tauri-plugin-wdio-webdriver"
         ],
         "sync": "linked"
+      },
+      "flutter": {
+        "packages": [
+          "@wdio/flutter-service",
+          "wdio_flutter"
+        ],
+        "sync": "linked"
       }
     },
     "versionPrefix": "v",
@@ -25,6 +32,12 @@
     "mismatchStrategy": "prefer-package",
     "cargo": {
       "enabled": true
+    },
+    "pub": {
+      "enabled": true,
+      "paths": [
+        "packages/flutter-service/wdio_flutter"
+      ]
     },
     "skip": [
       "@repo/e2e",
@@ -71,7 +84,7 @@
       "scope:electron": "@wdio/electron-*",
       "scope:electrobun": "@wdio/electrobun-*",
       "scope:react-native": "@wdio/react-native-*",
-      "scope:flutter": "@wdio/flutter-*"
+      "scope:flutter": "@wdio/flutter-*,wdio_flutter"
     }
   },
   "notes": {
@@ -148,6 +161,9 @@
     "cargo": {
       "enabled": true,
       "noVerify": true
+    },
+    "pub": {
+      "enabled": true
     },
     "git": {
       "push": true,

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -163,7 +163,7 @@
       "noVerify": true
     },
     "pub": {
-      "enabled": true
+      "enabled": false
     },
     "git": {
       "push": true,


### PR DESCRIPTION
Wires the **pub.dev** half of the Flutter release so releasekit can version-bump and (eventually) publish the `wdio_flutter` Dart contract alongside `@wdio/flutter-service`. **Publishing is wired but disabled** (`publish.pub.enabled: false`) until the official **webdriverio** pub.dev verified publisher is set up — so this does **not** gate `@wdio/flutter-service` prereleases.

## Why disabled

pub.dev publishing rights are stricter than crates.io (no personal-token "just create the package" path; first publish must be manual, then automated publishing is configured on an existing package). Standing up the official publisher takes time, and we don't want it blocking flutter-service prereleases. So the publish step is off; everything else is staged and ready to flip on.

## What this enables (`releasekit.config.json`)

- **`version.groups.flutter`** — `@wdio/flutter-service` + `wdio_flutter`, **`sync: "linked"`**: both adopt one shared version. `version.pub` keeps the pubspec bumped in lockstep (a **local file write only — no network, can't fail a release**). The `tauri` group is untouched (`linked`, from #473).
- **`version.pub`** — `{ enabled, paths: [...] }` so releasekit discovers the nested pubspec and bumps it.
- **`publish.pub.enabled: false`** — pub.dev publishing **disabled** for now. Re-enabling is a one-line flip (`true`) once the publisher exists.
- **`scope:flutter`** — extended to `@wdio/flutter-*,wdio_flutter`.

## Pre-staged so re-enabling is trivial

- **`wdio_flutter/LICENSE`** + **`README.md`** (pub.dev expects them and `publish.pub` has no `copyFiles`, so they must live in the package dir). No `CHANGELOG.md` — pub.dev only warns on its absence and releasekit commits no per-package changelog in standing-pr mode, so one here would just go stale.
- pubspec aligned **down to `0.0.1`** (the linked-group baseline; first published version will be the service's current version when publishing is turned on).
- `_release.reusable.yml` gains a scope-gated **`Setup Dart`** step (`dart-lang/setup-dart@v1`) — ready for when publishing is enabled (also does the OIDC token exchange).

## Behaviour while disabled

A `scope:flutter` prerelease publishes `@wdio/flutter-service` to **npm** and bumps the `wdio_flutter` pubspec in the release commit (linked), but **does not** touch pub.dev. flutter-service prereleases are unblocked.

## To turn publishing on later (when the wdio publisher is ready)

1. Flip `publish.pub.enabled` → `true`.
2. Manual first publish (`dart pub publish`) under the webdriverio publisher — pub.dev OIDC only works after the package exists.
3. Enable "Automated publishing from GitHub Actions" on the package → releasekit handles every subsequent version.

npm shared deps are already published (`native-mobile-core@1.0.0` etc.), so the flutter `workspace:*` chain resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
