### PR TITLE
chore(release): switch the tauri version group to linked

### DIFF
--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -14,7 +14,7 @@
           "@wdio/tauri-plugin",
           "tauri-plugin-wdio-webdriver"
         ],
-        "sync": "independent"
+        "sync": "linked"
       }
     },
     "versionPrefix": "v",


### PR DESCRIPTION
Split out from #466 (which wires `wdio_flutter` pub.dev publishing). That PR
quietly flipped this group's sync mode and its description still called the
tauri group `independent`, so the intent was ambiguous. Isolating the change
here lets the release-behaviour decision be reviewed on its own.

## Change

`releasekit.config.json` — the `tauri` group `sync`: `"independent"` → `"linked"`.

Members: `@wdio/tauri-service`, `@wdio/tauri-plugin`, `tauri-plugin-wdio-webdriver`.

## What `linked` actually does

Both modes **release only changed members** (releasekit `computeGroup`:
`releasing = sync === 'fixed' ? plans : changedPlans`). The difference is the
version each member lands on:

- **`independent`** (current) — each member versions on its own commit-driven
  line, so the three *can hold different version numbers* over time.
- **`linked`** (this PR) — all members share one computed group version (from the
  highest member baseline). Only changed members publish, but when a member
  publishes it **adopts the shared group version** — so a member that's been
  dormant *skips* to the current group version rather than continuing its own
  line.

> Note: `linked` does **not** force-publish unchanged members on every release —
> an npm-only change still publishes only the npm package; the Rust crate is not
> re-published. That republish-everything behaviour is `fixed`, not `linked`.

## Why this is the right default for tauri

The three are already kept at one version in practice — all currently at
**`1.1.0`** (npm `@wdio/tauri-service` `1.1.0`, `@wdio/tauri-plugin` `1.1.0`,
crate `tauri-plugin-wdio-webdriver` `1.1.0`). `linked` codifies that de-facto
single-version reality and prevents future drift between the JS packages and the
Rust crate. Because all members already sit at the group version, **there is no
version jump on the next release.**

The trade-off being accepted: a member that goes several releases without a
change will, when it next changes, jump straight to the prevailing group version
(skipping the intermediate numbers it would have had under `independent`). For
the tauri family — where the plugin and crate move together and the service
tracks them — that's the desired coupling, not a surprise.

## Scope

One-line config change; no code, no version bump on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)