### PR TITLE
test(tauri): browser-mode test parity — integration + E2E (#415)

### DIFF
--- a/.github/workflows/_ci-browser-mode.reusable.yml
+++ b/.github/workflows/_ci-browser-mode.reusable.yml
@@ -85,12 +85,18 @@ jobs:
       # The wdio configs force browserName=chrome and set autoXvfb, so WDIO drives the real
       # Chrome preinstalled on ubuntu-latest under a Xvfb display it starts itself. Each step
       # runs even if an earlier one failed (!cancelled) so one red tier never masks the others;
-      # any failure still fails the job. The electron-browser E2E conf self-hosts its dev
-      # server (:5174); test-package.ts self-hosts the package fixtures' dev server (:5173).
+      # any failure still fails the job. The browser-mode E2E confs self-host their dev servers
+      # (electron-browser :5174, tauri-browser :1421); test-package.ts self-hosts the package
+      # fixtures' dev server (:5173).
       - name: 🧪 Electron browser-mode E2E
         if: ${{ !cancelled() }}
         shell: bash
         run: pnpm e2e:electron-browser
+
+      - name: 🧪 Tauri browser-mode E2E
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: pnpm e2e:tauri-browser
 
       - name: 🧪 Electron browser-mode package test (ESM + CJS)
         if: ${{ !cancelled() }}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,6 +18,7 @@
     "test:e2e:electron-script": "cross-env DEBUG=wdio-electron-service:launcher WDIO_VERBOSE=true FRAMEWORK=electron APP=script BINARY=false tsx scripts/run-matrix.ts",
     "test:e2e:electron-script:window": "cross-env DEBUG=wdio-electron-service:launcher WDIO_VERBOSE=true FRAMEWORK=electron APP=script BINARY=false TEST_TYPE=window ENABLE_SPLASH_WINDOW=true tsx scripts/run-matrix.ts",
     "test:e2e:electron-browser": "wdio run wdio.electron-browser.conf.ts",
+    "test:e2e:tauri-browser": "wdio run wdio.tauri-browser.conf.ts",
     "test:e2e-mac-universal:electron-builder": "cross-env DEBUG=wdio-electron-service:launcher WDIO_VERBOSE=true FRAMEWORK=electron APP=builder BINARY=true MAC_UNIVERSAL=true tsx scripts/run-matrix.ts",
     "test:e2e-mac-universal:electron-forge": "cross-env DEBUG=wdio-electron-service:launcher WDIO_VERBOSE=true FRAMEWORK=electron APP=forge BINARY=true MAC_UNIVERSAL=true tsx scripts/run-matrix.ts",
     "test:e2e:standard": "cross-env TEST_TYPE=standard tsx scripts/run-matrix.ts",

--- a/e2e/test/tauri-browser/mock.spec.ts
+++ b/e2e/test/tauri-browser/mock.spec.ts
@@ -1,0 +1,35 @@
+import { $ } from '@wdio/globals';
+import { browser } from '@wdio/tauri-service';
+
+describe('Tauri browser-mode E2E', () => {
+  it('should intercept a value-returning invoke via browser.tauri.mock', async () => {
+    const mock = await browser.tauri.mock('get_app_version');
+    await mock.mockResolvedValue('99.0.0-browser');
+
+    await $('[data-testid="fetch-version"]').click();
+
+    await browser.waitUntil(async () => (await $('[data-testid="version-output"]').getText()) === '99.0.0-browser', {
+      timeout: 5000,
+      timeoutMsg: 'expected mocked version to render',
+    });
+
+    await mock.update();
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should intercept an invoke with arguments via browser.tauri.mock', async () => {
+    const mock = await browser.tauri.mock('greet');
+    await mock.mockResolvedValue('Hello, WDIO');
+
+    await $('[data-testid="send-greeting"]').click();
+
+    await browser.waitUntil(
+      async () => (await $('[data-testid="greeting-output"]').getText()).includes('Hello, WDIO'),
+      { timeout: 5000, timeoutMsg: 'expected mocked greeting to render' },
+    );
+
+    await mock.update();
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock.mock.calls[0][0]).toEqual({ name: 'WDIO' });
+  });
+});

--- a/e2e/wdio.tauri-browser.conf.ts
+++ b/e2e/wdio.tauri-browser.conf.ts
@@ -1,0 +1,132 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { dirname, extname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Options } from '@wdio/types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const fixtureRoot = resolvePath(__dirname, '..', 'fixtures', 'e2e-apps', 'tauri-browser');
+const port = 1421;
+const devServerUrl = `http://localhost:${port}`;
+
+let staticServer: Server | undefined;
+
+function startStaticServer(rootPath: string): Promise<Server> {
+  const mimeTypes: Record<string, string> = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.mjs': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+  };
+  // Enumerate files up front and look them up by request URL into the map.
+  // Keeps user-controlled input out of `readFileSync` and satisfies CodeQL.
+  const allowed = new Map<string, string>();
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const abs = join(dir, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(abs, rel);
+      } else if (entry.isFile()) {
+        allowed.set(`/${rel}`, abs);
+        if (rel === 'index.html') allowed.set('/', abs);
+      }
+    }
+  };
+  walk(rootPath, '');
+
+  const server = createServer((req, res) => {
+    const key = (req.url ?? '/').split('?')[0];
+    const absolute = allowed.get(key);
+    if (!absolute) {
+      res.statusCode = 404;
+      res.end('Not Found');
+      return;
+    }
+    res.setHeader('Content-Type', mimeTypes[extname(absolute)] ?? 'application/octet-stream');
+    res.end(readFileSync(absolute));
+  });
+  return new Promise((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(port, '127.0.0.1', () => resolveListen(server));
+  });
+}
+
+/**
+ * On Linux/macOS, list running processes to confirm browser mode is not
+ * spawning the Tauri driver stack — `tauri-driver`, the platform webview driver
+ * (`msedgedriver` on Windows / `WebKitWebDriver` on Linux), or a Tauri app
+ * binary. Browser mode drives real Chrome via chromedriver instead, so none of
+ * these should appear. Skip on Windows where `ps` doesn't exist; CI on Windows
+ * relies on the launcher integration test (no driver constructed in browser mode).
+ */
+function assertNoTauriDriverProcesses(): void {
+  if (process.platform === 'win32') return;
+  try {
+    const psOutput = execSync('ps -A -o command=', { encoding: 'utf-8' });
+    const offenders = psOutput
+      .split('\n')
+      .filter((line) => /tauri-driver|msedgedriver|WebKitWebDriver/i.test(line))
+      .filter((line) => !line.includes('wdio.tauri-browser.conf.ts'));
+    if (offenders.length > 0) {
+      throw new Error(`Browser-mode run should not spawn Tauri driver processes, but found:\n${offenders.join('\n')}`);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Browser-mode run should')) {
+      throw error;
+    }
+    // ps failed for some other reason — log but don't fail the run.
+    console.warn(`Could not run ps for process-presence check: ${error}`);
+  }
+}
+
+export const config: Options.Testrunner = {
+  runner: 'local',
+  specs: ['./test/tauri-browser/*.spec.ts'],
+  exclude: [],
+  maxInstances: 1,
+  capabilities: [
+    {
+      browserName: 'tauri',
+      'wdio:tauriServiceOptions': {
+        mode: 'browser',
+        devServerUrl,
+      },
+    },
+  ] as unknown as Options.Testrunner['capabilities'],
+  logLevel: 'info',
+  outputDir: join(__dirname, 'logs', 'tauri-browser'),
+  bail: 0,
+  baseUrl: '',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 3,
+  autoXvfb: true,
+  services: ['tauri'],
+  framework: 'mocha',
+  reporters: ['spec'],
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+  },
+  async onPrepare() {
+    if (!existsSync(fixtureRoot)) {
+      throw new Error(`Fixture not found: ${fixtureRoot}`);
+    }
+    staticServer = await startStaticServer(fixtureRoot);
+    console.log(`Browser-mode static server listening on ${devServerUrl}`);
+  },
+  async beforeSession() {
+    assertNoTauriDriverProcesses();
+  },
+  async onComplete() {
+    if (staticServer) {
+      await new Promise<void>((resolveClose) => staticServer?.close(() => resolveClose()));
+      console.log('Browser-mode static server stopped');
+    }
+  },
+};

--- a/fixtures/e2e-apps/tauri-browser/index.html
+++ b/fixtures/e2e-apps/tauri-browser/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Tauri Browser-Mode E2E Fixture</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 20px;
+        background: linear-gradient(135deg, #24c8db 0%, #1a1a2e 100%);
+        color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
+        text-align: center;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
+      }
+      h1 {
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+      }
+      button {
+        background: rgba(255, 255, 255, 0.25);
+        border: 2px solid rgba(255, 255, 255, 0.4);
+        color: white;
+        padding: 15px 20px;
+        border-radius: 12px;
+        cursor: pointer;
+        font-size: 1em;
+        font-weight: 500;
+        transition: all 0.3s ease;
+        backdrop-filter: blur(5px);
+        margin: 8px;
+      }
+      button:hover {
+        background: rgba(255, 255, 255, 0.35);
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+      }
+      section {
+        margin: 20px 0;
+      }
+      pre {
+        margin-top: 12px;
+        padding: 12px 16px;
+        background: rgba(0, 0, 0, 0.25);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 10px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        min-height: 1.2em;
+        text-align: left;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 data-testid="title">Tauri Browser-Mode E2E</h1>
+
+      <section>
+        <button type="button" data-testid="fetch-version">Fetch version</button>
+        <pre data-testid="version-output"></pre>
+      </section>
+
+      <section>
+        <button type="button" data-testid="send-greeting">Send greeting</button>
+        <pre data-testid="greeting-output"></pre>
+      </section>
+    </div>
+
+    <script>
+      // In a real Tauri app window.__TAURI_INTERNALS__.invoke is provided by the
+      // webview runtime. In browser mode the service's injection script defines
+      // the same shape (and patches invoke to consult registered mocks), so
+      // frontend code is portable as-is. This fallback only matters if a button
+      // is clicked before injection ran.
+      if (!window.__TAURI_INTERNALS__) {
+        window.__TAURI_INTERNALS__ = { invoke: () => Promise.reject(new Error('Tauri IPC not injected')) };
+      }
+
+      document.querySelector('[data-testid="fetch-version"]').addEventListener('click', async () => {
+        try {
+          const version = await window.__TAURI_INTERNALS__.invoke('get_app_version');
+          document.querySelector('[data-testid="version-output"]').textContent = version;
+        } catch (err) {
+          document.querySelector('[data-testid="version-output"]').textContent = `error: ${err.message}`;
+        }
+      });
+
+      document.querySelector('[data-testid="send-greeting"]').addEventListener('click', async () => {
+        try {
+          const reply = await window.__TAURI_INTERNALS__.invoke('greet', { name: 'WDIO' });
+          document.querySelector('[data-testid="greeting-output"]').textContent = String(reply);
+        } catch (err) {
+          document.querySelector('[data-testid="greeting-output"]').textContent = `error: ${err.message}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/fixtures/e2e-apps/tauri-browser/package.json
+++ b/fixtures/e2e-apps/tauri-browser/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "tauri-browser-e2e-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static HTML fixture served as a dev server for Tauri browser-mode E2E tests"
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "e2e:electron-forge": "pnpm protocol-install:electron-forge && pnpm --filter @repo/e2e run test:e2e:electron-forge",
     "e2e:electron-script": "pnpm --filter @repo/e2e run test:e2e:electron-script",
     "e2e:electron-browser": "pnpm --filter @repo/e2e run test:e2e:electron-browser",
+    "e2e:tauri-browser": "pnpm --filter @repo/e2e run test:e2e:tauri-browser",
     "e2e:multiremote": "pnpm --filter @repo/e2e run test:e2e:multiremote",
     "e2e:standalone": "pnpm --filter @repo/e2e run test:e2e:standalone",
     "e2e:tauri": "pnpm protocol-install:tauri && pnpm --filter @repo/e2e run test:e2e:tauri",

--- a/packages/tauri-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/tauri-service/test/integration/browser-mode.integration.spec.ts
@@ -32,6 +32,14 @@ function isInjectionScript(arg: unknown): boolean {
   return typeof arg === 'string' && arg.includes('__TAURI_INTERNALS__') && arg.includes('__wdio_emit_tauri_event__');
 }
 
+// Tauri keys mocks globally (`tauri.<command>`), not per-browser like Electron, so
+// there's no store key to thread through — the scheduler reads the whole store.
+function seedMock(channel: string): FakeMock {
+  const fake = createFakeMock(`tauri.${channel}`);
+  mockStore.setMock(fake.mock);
+  return fake;
+}
+
 describe('browser mode — MockUpdateScheduler', () => {
   let service: TauriWorkerService;
   let browser: FakeBrowser;
@@ -46,14 +54,6 @@ describe('browser mode — MockUpdateScheduler', () => {
   afterEach(() => {
     mockStore.clear();
   });
-
-  // Tauri keys mocks globally (`tauri.<command>`), not per-browser like Electron, so
-  // there's no store key to thread through — the scheduler reads the whole store.
-  function seedMock(channel: string): FakeMock {
-    const fake = createFakeMock(`tauri.${channel}`);
-    mockStore.setMock(fake.mock);
-    return fake;
-  }
 
   it('should trigger two update batches when two concurrent clicks fire', async () => {
     const fake = seedMock('greet');
@@ -127,12 +127,6 @@ describe('browser mode — scheduler error handling', () => {
     mockStore.clear();
   });
 
-  function seedMock(channel: string): FakeMock {
-    const fake = createFakeMock(`tauri.${channel}`);
-    mockStore.setMock(fake.mock);
-    return fake;
-  }
-
   it('should retry a transient mock-update failure once and still settle the batch', async () => {
     const fake = seedMock('greet');
     // One rejection is recoverable: the scheduler retries update() once after 50ms.
@@ -172,12 +166,6 @@ describe('browser mode — navigation lifecycle', () => {
   afterEach(() => {
     mockStore.clear();
   });
-
-  function seedMock(channel: string): FakeMock {
-    const fake = createFakeMock(`tauri.${channel}`);
-    mockStore.setMock(fake.mock);
-    return fake;
-  }
 
   it('should re-inject the IPC script after a navigation', async () => {
     browser.execute.mockClear();

--- a/packages/tauri-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/tauri-service/test/integration/browser-mode.integration.spec.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import mockStore from '../../src/mockStore.js';
+import TauriWorkerService from '../../src/service.js';
+import {
+  createFakeBrowser,
+  createFakeMock,
+  defer,
+  type FakeBrowser,
+  type FakeMock,
+  flushMicrotasks,
+} from './helpers.js';
+
+// Keep `installMockSyncOverride` / `hasSemicolonOutsideQuotes` real (they drive the
+// click override + scheduler under test); only silence the logger.
+vi.mock('@wdio/native-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@wdio/native-utils')>()),
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+}));
+
+const DEV_SERVER = 'http://localhost:1420';
+
+// The Tauri browser-mode IPC injection script is the only one that installs the
+// __TAURI_INTERNALS__ shim plus the event bus — registration scripts touch
+// __wdio_mocks__/__wdio_spy__ but never these markers.
+function isInjectionScript(arg: unknown): boolean {
+  return typeof arg === 'string' && arg.includes('__TAURI_INTERNALS__') && arg.includes('__wdio_emit_tauri_event__');
+}
+
+describe('browser mode — MockUpdateScheduler', () => {
+  let service: TauriWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new TauriWorkerService({ mode: 'browser', devServerUrl: DEV_SERVER }, {} as never);
+    browser = createFakeBrowser();
+    await service.before({} as never, [], browser as unknown as WebdriverIO.Browser);
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  // Tauri keys mocks globally (`tauri.<command>`), not per-browser like Electron, so
+  // there's no store key to thread through — the scheduler reads the whole store.
+  function seedMock(channel: string): FakeMock {
+    const fake = createFakeMock(`tauri.${channel}`);
+    mockStore.setMock(fake.mock);
+    return fake;
+  }
+
+  it('should trigger two update batches when two concurrent clicks fire', async () => {
+    const fake = seedMock('greet');
+
+    const c1 = browser.triggerCommand('click');
+    const c2 = browser.triggerCommand('click');
+    await Promise.all([c1, c2]);
+
+    expect(fake.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('should coalesce three rapid clicks into exactly two batches', async () => {
+    const fake = seedMock('greet');
+
+    const c1 = browser.triggerCommand('click');
+    const c2 = browser.triggerCommand('click');
+    const c3 = browser.triggerCommand('click');
+    await Promise.all([c1, c2, c3]);
+
+    expect(fake.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('should be a no-op when the mock store is empty', async () => {
+    await expect(browser.triggerCommand('click')).resolves.not.toThrow();
+  });
+
+  it('should not run a parallel batch when a click arrives between running and queued', async () => {
+    const fake = seedMock('greet');
+
+    // Block the first batch's update so the queued batch is set up.
+    const firstHeld = defer<void>();
+    fake.update.mockImplementationOnce(() => firstHeld.promise);
+    // Block the second (queued) batch as well, so a third click can race in
+    // between the first batch settling and the queued's #runOnce starting.
+    const secondHeld = defer<void>();
+    fake.update.mockImplementationOnce(() => secondHeld.promise);
+
+    const c1 = browser.triggerCommand('click');
+    const c2 = browser.triggerCommand('click');
+
+    // Settle the first batch — between this and the queued batch's #runOnce,
+    // a third schedule() must NOT spawn a parallel #runOnce.
+    firstHeld.resolve();
+    await flushMicrotasks();
+    const c3 = browser.triggerCommand('click');
+    await flushMicrotasks();
+
+    // Only the queued batch should have started (update call count = 2),
+    // not a third concurrent batch.
+    expect(fake.update).toHaveBeenCalledTimes(2);
+
+    secondHeld.resolve();
+    await Promise.all([c1, c2, c3]);
+    // After all settle, click 3's batch ran exactly once.
+    expect(fake.update).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('browser mode — scheduler error handling', () => {
+  let service: TauriWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new TauriWorkerService({ mode: 'browser', devServerUrl: DEV_SERVER }, {} as never);
+    browser = createFakeBrowser();
+    await service.before({} as never, [], browser as unknown as WebdriverIO.Browser);
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  function seedMock(channel: string): FakeMock {
+    const fake = createFakeMock(`tauri.${channel}`);
+    mockStore.setMock(fake.mock);
+    return fake;
+  }
+
+  it('should retry a transient mock-update failure once and still settle the batch', async () => {
+    const fake = seedMock('greet');
+    // One rejection is recoverable: the scheduler retries update() once after 50ms.
+    fake.update.mockRejectedValueOnce(new Error('transient'));
+
+    await expect(browser.triggerCommand('click')).resolves.not.toThrow();
+
+    // Initial attempt + one retry.
+    expect(fake.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('should surface a persistently failing batch and recover on the next click', async () => {
+    const fake = seedMock('greet');
+    // Both the initial attempt and its retry fail, so the batch rejects.
+    fake.update.mockRejectedValueOnce(new Error('boom')).mockRejectedValueOnce(new Error('boom-retry'));
+
+    await expect(browser.triggerCommand('click')).rejects.toThrow();
+    expect(fake.update).toHaveBeenCalledTimes(2);
+
+    // A failed batch must not poison the scheduler — the next click recovers.
+    await browser.triggerCommand('click');
+    expect(fake.update).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('browser mode — navigation lifecycle', () => {
+  let service: TauriWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new TauriWorkerService({ mode: 'browser', devServerUrl: DEV_SERVER }, {} as never);
+    browser = createFakeBrowser();
+    await service.before({} as never, [], browser as unknown as WebdriverIO.Browser);
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  function seedMock(channel: string): FakeMock {
+    const fake = createFakeMock(`tauri.${channel}`);
+    mockStore.setMock(fake.mock);
+    return fake;
+  }
+
+  it('should re-inject the IPC script after a navigation', async () => {
+    browser.execute.mockClear();
+    await browser.url(`${DEV_SERVER}/page2`);
+
+    const injectionCalls = browser.execute.mock.calls.filter((c) => isInjectionScript(c[0]));
+    expect(injectionCalls.length).toBeGreaterThan(0);
+  });
+
+  it('should not re-inject when the session is not flagged for browser mode', async () => {
+    (browser as unknown as Record<string, boolean>).__wdioBrowserMode__ = false;
+    browser.execute.mockClear();
+    await browser.url(`${DEV_SERVER}/page2`);
+
+    expect(browser.execute.mock.calls.filter((c) => isInjectionScript(c[0]))).toHaveLength(0);
+  });
+
+  it('should not re-inject when url() is called without an href', async () => {
+    browser.execute.mockClear();
+    await browser.url();
+
+    expect(browser.execute.mock.calls.filter((c) => isInjectionScript(c[0]))).toHaveLength(0);
+  });
+
+  it('should rethrow when re-injection fails after a navigation', async () => {
+    browser.execute.mockClear();
+    browser.execute.mockRejectedValueOnce(new Error('inject failed'));
+
+    await expect(browser.url(`${DEV_SERVER}/page2`)).rejects.toThrow('inject failed');
+  });
+
+  it('should keep mock updates working after a navigation cycle', async () => {
+    const fake = seedMock('greet');
+
+    await browser.triggerCommand('click');
+    expect(fake.update).toHaveBeenCalledTimes(1);
+
+    await browser.url(`${DEV_SERVER}/page2`);
+
+    await browser.triggerCommand('click');
+    expect(fake.update).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tauri-service/test/integration/helpers.ts
+++ b/packages/tauri-service/test/integration/helpers.ts
@@ -1,0 +1,97 @@
+import type { TauriMock } from '@wdio/native-types';
+import { vi } from 'vitest';
+
+export type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+export function defer<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export type OverrideFn = (
+  this: unknown,
+  originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
+  ...args: readonly unknown[]
+) => Promise<unknown>;
+
+export interface FakeBrowser {
+  url: ReturnType<typeof vi.fn>;
+  execute: ReturnType<typeof vi.fn>;
+  overwriteCommand: ReturnType<typeof vi.fn>;
+  tauri: Record<string, unknown>;
+  overrides: Map<string, OverrideFn>;
+  /**
+   * Invoke a registered command override. The optional `ownerBrowser` is set as
+   * `this.browser` inside the override — kept for parity with the Electron
+   * harness, though Tauri's mock-sync override closes over the install-time
+   * browser and ignores `this.browser`.
+   */
+  triggerCommand: (name: string, ownerBrowser?: WebdriverIO.Browser) => Promise<unknown>;
+}
+
+export function createFakeBrowser(): FakeBrowser {
+  const overrides = new Map<string, OverrideFn>();
+  const browser = {
+    url: vi.fn().mockResolvedValue(undefined),
+    execute: vi.fn().mockResolvedValue(undefined),
+    overwriteCommand: vi.fn((name: string, fn: OverrideFn, _isElement?: boolean) => {
+      overrides.set(name, fn);
+      // Mirror webdriverio: overwriting a browser command (e.g. url — read-only in wdio >=9.27,
+      // hence overwriteCommand) replaces it, calling through to the original. Element commands
+      // like click are exercised via triggerCommand instead, so only url needs live wiring here.
+      if (name === 'url') {
+        const original = browser.url as unknown as (...args: readonly unknown[]) => Promise<unknown>;
+        browser.url = vi.fn((...args: readonly unknown[]) => fn.call(browser, original, ...args));
+      }
+    }),
+    tauri: {} as Record<string, unknown>,
+    overrides,
+    triggerCommand: (name: string, ownerBrowser?: WebdriverIO.Browser) => {
+      const fn = overrides.get(name);
+      if (!fn) {
+        throw new Error(`No override registered for command "${name}"`);
+      }
+      const originalCommand = vi.fn().mockResolvedValue(undefined);
+      const ctx = ownerBrowser ? { browser: ownerBrowser } : {};
+      return fn.call(ctx, originalCommand);
+    },
+  };
+  return browser;
+}
+
+export interface FakeMock {
+  mock: TauriMock;
+  update: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Create a fake mock whose `update()` resolves immediately by default. Tests
+ * that need controllable timing can override via `.mockImplementationOnce`,
+ * `.mockResolvedValueOnce`, or `.mockRejectedValueOnce`. The shape is the
+ * minimum the scheduler touches: `getMockName()` (the store key) + `update()`.
+ */
+export function createFakeMock(name: string): FakeMock {
+  const update = vi.fn(async () => undefined);
+  const mock = {
+    getMockName: () => name,
+    update,
+  } as unknown as TauriMock;
+  return { mock, update };
+}
+
+/**
+ * Flush the microtask queue. Two `setImmediate` flushes cover .then().then() chains.
+ */
+export async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/packages/tauri-service/test/integration/launcher.browser.integration.spec.ts
+++ b/packages/tauri-service/test/integration/launcher.browser.integration.spec.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFakeBrowser } from './helpers.js';
+
+// Native-mode setup modules — none should be touched when mode is 'browser'.
+vi.mock('../../src/embeddedProvider.js', () => ({
+  checkEmbeddedServerAlive: vi.fn(),
+  startEmbeddedDriver: vi.fn(),
+  stopEmbeddedDriver: vi.fn(),
+  getEmbeddedPort: vi.fn().mockReturnValue(4445),
+  isEmbeddedProvider: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../src/diagnostics.js', () => ({
+  diagnoseTauriEnvironment: vi.fn().mockResolvedValue([]),
+}));
+
+// Keep @wdio/native-utils real — the worker's before() drives the real
+// installMockSyncOverride; only silence the logger.
+vi.mock('@wdio/native-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@wdio/native-utils')>()),
+  createLogger: vi.fn(() => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), trace: vi.fn() })),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../src/driverPool.js', () => ({
+  DriverPool: class MockDriverPool {
+    startDriver = vi.fn();
+    stopDriver = vi.fn().mockResolvedValue(undefined);
+    stopAll = vi.fn().mockResolvedValue(undefined);
+    getStatus = vi.fn().mockReturnValue({ count: 0, running: false });
+    getRunningPids = vi.fn().mockReturnValue([]);
+  },
+}));
+
+vi.mock('../../src/portManager.js', () => ({
+  PortManager: class MockPortManager {
+    allocatePortPair = vi.fn().mockResolvedValue({ port: 4444, nativePort: 4445 });
+    allocatePorts = vi.fn().mockResolvedValue([{ port: 4444, nativePort: 4445 }]);
+    allocatePort = vi.fn().mockResolvedValue(4444);
+    clear = vi.fn();
+  },
+}));
+
+vi.mock('../../src/pathResolver.js', () => ({
+  getWebKitWebDriverPath: vi.fn().mockReturnValue('/usr/bin/WebKitWebDriver'),
+}));
+
+vi.mock('../../src/driverManager.js', () => ({
+  ensureTauriDriver: vi.fn().mockResolvedValue({ ok: true, value: { path: '/tauri-driver', method: 'found' } }),
+  findTestRunnerBackend: vi.fn(),
+}));
+
+vi.mock('../../src/edgeDriverManager.js', () => ({
+  ensureMsEdgeDriver: vi.fn().mockResolvedValue({ ok: true, value: { method: 'found', driverVersion: '120' } }),
+}));
+
+vi.mock('../../src/commands/triggerDeeplink.js', () => ({
+  setEmbeddedModeInfo: vi.fn(),
+  setCrabnebulaModeInfo: vi.fn(),
+  triggerDeeplink: vi.fn(),
+}));
+
+vi.mock('../../src/crabnebulaBackend.js', () => ({
+  startTestRunnerBackend: vi.fn(),
+  stopTestRunnerBackend: vi.fn().mockResolvedValue(undefined),
+  waitTestRunnerBackendReady: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ensureTauriDriver } from '../../src/driverManager.js';
+import { ensureMsEdgeDriver } from '../../src/edgeDriverManager.js';
+import TauriLaunchService from '../../src/launcher.js';
+import mockStore from '../../src/mockStore.js';
+import TauriWorkerService from '../../src/service.js';
+
+const DEV_SERVER = 'http://localhost:1420';
+
+function createLauncher(globalOpts: Record<string, unknown> = {}): TauriLaunchService {
+  return new TauriLaunchService(globalOpts as never, {} as never, { maxInstances: 1 } as never);
+}
+
+describe('launcher → worker handshake (browser mode)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore.clear();
+  });
+
+  it('should transform the Tauri capability into a Chrome capability and remove tauri:options', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      {
+        browserName: 'tauri',
+        'tauri:options': { application: '/app/my-app' },
+        'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+      },
+    ];
+
+    await launcher.onPrepare({} as never, caps as never);
+
+    expect(caps[0].browserName).toBe('chrome');
+    expect(caps[0]['tauri:options']).toBeUndefined();
+  });
+
+  it('should not spawn tauri-driver or msedgedriver in onPrepare', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      { 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+    ];
+
+    await launcher.onPrepare({} as never, caps as never);
+
+    expect(ensureTauriDriver).not.toHaveBeenCalled();
+    expect(ensureMsEdgeDriver).not.toHaveBeenCalled();
+  });
+
+  it('should propagate the launcher devServerUrl into the worker initial navigation', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      {
+        browserName: 'tauri',
+        'tauri:options': { application: '/app/my-app' },
+        'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+      },
+    ];
+    await launcher.onPrepare({} as never, caps as never);
+
+    // The worker is built from the transformed capability; the surviving
+    // wdio:tauriServiceOptions still carries mode + devServerUrl.
+    const worker = new TauriWorkerService({} as never, caps[0] as never);
+    const browser = createFakeBrowser();
+    // initBrowserMode calls browser.url(devServerUrl) before patchBrowserUrl
+    // replaces browser.url — capture the spy before the patch.
+    const urlSpy = browser.url;
+    await worker.before({} as never, [], browser as unknown as WebdriverIO.Browser);
+
+    expect(urlSpy).toHaveBeenCalledWith(DEV_SERVER);
+    expect((browser as unknown as Record<string, boolean>).__wdioBrowserMode__).toBe(true);
+  });
+
+  it('should enter browser mode in the worker without any driver involvement', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      { browserName: 'tauri', 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+    ];
+    await launcher.onPrepare({} as never, caps as never);
+
+    const worker = new TauriWorkerService({} as never, caps[0] as never);
+    const browser = createFakeBrowser();
+    await worker.before({} as never, [], browser as unknown as WebdriverIO.Browser);
+
+    expect((browser as unknown as { tauri?: unknown }).tauri).toBeDefined();
+    expect(browser.overrides.has('url')).toBe(true);
+    expect(ensureTauriDriver).not.toHaveBeenCalled();
+    expect(ensureMsEdgeDriver).not.toHaveBeenCalled();
+  });
+
+  it('should accept devServerUrl via service-level global options', async () => {
+    const launcher = createLauncher({ mode: 'browser', devServerUrl: DEV_SERVER });
+    const caps: Array<Record<string, unknown>> = [{}];
+    await launcher.onPrepare({} as never, caps as never);
+
+    expect(caps[0].browserName).toBe('chrome');
+
+    const worker = new TauriWorkerService({ mode: 'browser', devServerUrl: DEV_SERVER } as never, caps[0] as never);
+    const browser = createFakeBrowser();
+    const urlSpy = browser.url;
+    await worker.before({} as never, [], browser as unknown as WebdriverIO.Browser);
+
+    expect(urlSpy).toHaveBeenCalledWith(DEV_SERVER);
+  });
+});


### PR DESCRIPTION
Closes #415.

Brings the Tauri service's browser-mode coverage up to the Electron template — the integration and E2E tiers that were missing per the parity table in #415. (#415 was split: the Dioxus half is tracked separately in #472.)

## What's added

### Integration (`packages/tauri-service/test/integration/`)
- **`helpers.ts`** — fake browser/mock harness, adapted from `electron-service`'s.
- **`browser-mode.integration.spec.ts`** — `MockUpdateScheduler` coalescing (2 concurrent / 3 rapid clicks → ≤2 batches, queued-slot race), retry-then-aggregate error handling, and navigation re-injection lifecycle.
- **`launcher.browser.integration.spec.ts`** — launcher→worker handshake: capability→`chrome` transform + `tauri:options` removal, no `tauri-driver`/`msedgedriver`, and `devServerUrl` propagated into the worker's initial navigation (incl. service-level global options).

### E2E
- **`fixtures/e2e-apps/tauri-browser/`** — hand-written static fixture driving `window.__TAURI_INTERNALS__.invoke` (mirrors `electron-browser/`).
- **`e2e/wdio.tauri-browser.conf.ts`** — self-hosted static server (:1421), `browserName: 'tauri'` + `mode: 'browser'`, and a `beforeSession` `ps` check asserting no `tauri-driver`/`msedgedriver`/`WebKitWebDriver` spawned.
- **`e2e/test/tauri-browser/mock.spec.ts`** — `browser.tauri.mock()` interception (value-returning invoke + invoke-with-args).

### CI / scripts
- `test:e2e:tauri-browser` (`e2e/package.json` + root `package.json`) and a **Tauri browser-mode E2E** step in `_ci-browser-mode.reusable.yml`, right after the Electron one.

## Two intentional divergences from the Electron template
Tauri's architecture differs in two ways, so a blind 1:1 port would encode behavior Tauri doesn't have:
- **Global mock store** (`tauri.<cmd>`), not per-browser — so Electron's per-browser-key tests (multi-instance independence, instance routing) are dropped rather than faked.
- **Scheduler retries once, then aggregate-throws** (Electron swallows update errors) — so Electron's single "reject doesn't poison" test becomes two Tauri-faithful tests: transient-retry-recovers and persistent-fail-then-recover.

## Verification
- `packages/tauri-service` integration suite: **16/16 pass**; package `typecheck` clean; biome format/lint clean.
- Tauri browser-mode E2E run locally against real Chrome: **2/2 pass** (server self-hosted, process-absence check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
