### PR TITLE
fix(electron-service): MockUpdateScheduler unhandled rejection on failed queued batch (#467)

### DIFF
--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -150,22 +150,15 @@ class MockUpdateScheduler {
       }
     }
 
-    // Each lane is retried once (after 50 ms) before failing hard. Silently
-    // swallowing a mock-update failure leaves mock.calls empty downstream, which
-    // is harder to diagnose than an AggregateError surfaced at the call site.
-    const tryUpdate = async (label: string, run: () => Promise<void>): Promise<void> => {
-      try {
-        await run();
-      } catch (firstError) {
-        log.debug(`Mock update lane "${label}" failed, retrying in 50ms:`, firstError);
-        await sleep(50);
-        await run();
-      }
-    };
-
+    // Each lane is retried once (after 50 ms) before failing hard (see tryUpdate). Silently
+    // swallowing a mock-update failure leaves mock.calls empty downstream, which is harder to
+    // diagnose than an AggregateError surfaced at the call site. Empty native/browser lanes are
+    // omitted — their batch helpers early-return, so including them only adds no-op scaffold.
     const lanes: Array<{ label: string; run: () => Promise<void> }> = [
-      { label: 'native', run: () => batchUpdateNativeMocks(this.#browser, native) },
-      { label: 'browser', run: () => batchUpdateBrowserModeMocks(this.#browser, browserMode) },
+      ...(native.length > 0 ? [{ label: 'native', run: () => batchUpdateNativeMocks(this.#browser, native) }] : []),
+      ...(browserMode.length > 0
+        ? [{ label: 'browser', run: () => batchUpdateBrowserModeMocks(this.#browser, browserMode) }]
+        : []),
       ...legacy.map(([mockId, m]) => ({
         label: `legacy:${mockId}`,
         run: async () => {
@@ -191,6 +184,19 @@ class MockUpdateScheduler {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Run a single mock-update lane, retrying once after 50 ms before letting the failure
+// propagate. Module-level so it isn't reallocated per batch — it closes over nothing but the
+// module-level log/sleep.
+async function tryUpdate(label: string, run: () => Promise<void>): Promise<void> {
+  try {
+    await run();
+  } catch (firstError) {
+    log.debug(`Mock update lane "${label}" failed, retrying in 50ms:`, firstError);
+    await sleep(50);
+    await run();
+  }
 }
 
 /**

--- a/packages/electron-service/src/service.ts
+++ b/packages/electron-service/src/service.ts
@@ -59,6 +59,16 @@ export function browserModeStoreKey(browser: WebdriverIO.Browser, channel: strin
 const mockUpdateSchedulers = new WeakMap<WebdriverIO.Browser, MockUpdateScheduler>();
 const pendingRegistrations = new WeakMap<WebdriverIO.Browser, Map<string, Promise<void>>>();
 
+/**
+ * Coalesces mock-update round-trips so N concurrent DOM interactions don't each fire
+ * one update per registered mock. At most two batches run at any moment (current +
+ * one queued); callers arriving while a batch runs share the queued slot, so N
+ * interactions produce <= 2 batches instead of N. Each batch syncs inner (app) mock
+ * state to outer (test) mocks over a single CDP round-trip per transport lane. Each
+ * lane is retried once (after 50 ms) before failing hard — silent swallow of
+ * mock-update errors leaves mock.calls empty, which is harder to diagnose than an
+ * AggregateError.
+ */
 class MockUpdateScheduler {
   #running: Promise<void> | null = null;
   #queued: Promise<void> | null = null;
@@ -94,7 +104,13 @@ class MockUpdateScheduler {
       if (this.#queued) {
         const promoted = this.#queued;
         this.#queued = null;
-        this.#running = this.#wrapRun(promoted);
+        // The queued batch's callers hold `promoted` and observe its rejection there.
+        // This wrapper is held only by #running and is never awaited externally, so
+        // swallow its rejection — otherwise a failing queued batch surfaces as an
+        // unhandled rejection (a worker crash under Node's default throw policy).
+        const nextRunning = this.#wrapRun(promoted);
+        nextRunning.catch(() => undefined);
+        this.#running = nextRunning;
       } else {
         this.#running = null;
       }
@@ -134,20 +150,47 @@ class MockUpdateScheduler {
       }
     }
 
-    try {
-      await Promise.all([
-        batchUpdateNativeMocks(this.#browser, native),
-        batchUpdateBrowserModeMocks(this.#browser, browserMode),
-        ...legacy.map(async ([mockId, m]) => {
+    // Each lane is retried once (after 50 ms) before failing hard. Silently
+    // swallowing a mock-update failure leaves mock.calls empty downstream, which
+    // is harder to diagnose than an AggregateError surfaced at the call site.
+    const tryUpdate = async (label: string, run: () => Promise<void>): Promise<void> => {
+      try {
+        await run();
+      } catch (firstError) {
+        log.debug(`Mock update lane "${label}" failed, retrying in 50ms:`, firstError);
+        await sleep(50);
+        await run();
+      }
+    };
+
+    const lanes: Array<{ label: string; run: () => Promise<void> }> = [
+      { label: 'native', run: () => batchUpdateNativeMocks(this.#browser, native) },
+      { label: 'browser', run: () => batchUpdateBrowserModeMocks(this.#browser, browserMode) },
+      ...legacy.map(([mockId, m]) => ({
+        label: `legacy:${mockId}`,
+        run: async () => {
           log.debug(`Updating legacy mock (no accessor): ${mockId}`);
           await m.update?.();
-        }),
-      ]);
-      log.debug('All mock updates completed successfully');
-    } catch (error) {
-      log.warn('Mock update batch failed:', error);
+        },
+      })),
+    ];
+
+    const results = await Promise.allSettled(lanes.map(({ label, run }) => tryUpdate(label, run)));
+    const failures = results
+      .map((result, i) => ({ result, label: lanes[i].label }))
+      .filter((entry): entry is { result: PromiseRejectedResult; label: string } => entry.result.status === 'rejected');
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((f) => f.result.reason),
+        `Mock updates failed for: ${failures.map((f) => f.label).join(', ')}`,
+      );
     }
+    log.debug('All mock updates completed successfully');
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**

--- a/packages/electron-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/electron-service/test/integration/browser-mode.integration.spec.ts
@@ -68,13 +68,16 @@ describe('browser mode — MockUpdateScheduler', () => {
 
   it('should not poison the next batch when a previous batch rejects', async () => {
     const fake = seedMock('appInfo:get');
-    fake.update.mockRejectedValueOnce(new Error('boom'));
+    // Fail both the initial attempt and its one retry so the lane genuinely rejects
+    // (a single rejection would be recovered by tryUpdate's retry and never surface).
+    fake.update.mockRejectedValueOnce(new Error('boom')).mockRejectedValueOnce(new Error('boom-retry'));
 
-    await browser.triggerCommand('click');
-    expect(fake.update).toHaveBeenCalledTimes(1);
-
-    await browser.triggerCommand('click');
+    await expect(browser.triggerCommand('click')).rejects.toThrow();
     expect(fake.update).toHaveBeenCalledTimes(2);
+
+    // A failed batch must not poison the scheduler — the next click recovers.
+    await browser.triggerCommand('click');
+    expect(fake.update).toHaveBeenCalledTimes(3);
   });
 
   it('should run two browser instances independently without cross-blocking', async () => {

--- a/packages/electron-service/test/service.spec.ts
+++ b/packages/electron-service/test/service.spec.ts
@@ -101,6 +101,11 @@ beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
 
+  // clearAllMocks() resets call records but not return values, so a test that
+  // points getMocks at a failing mock would leak into the next; re-establish the
+  // empty default each test (the scheduler now throws on a failed update).
+  vi.mocked(mockStore.getMocks).mockReturnValue([]);
+
   vi.mocked(waitUntilWindowAvailable).mockImplementation(async () => Promise.resolve());
 });
 
@@ -594,10 +599,50 @@ describe('Electron Worker Service', () => {
       ) => Promise<unknown>;
 
       const original = vi.fn().mockResolvedValue('ok');
+      // First batch's only update rejects once, then the retry succeeds (2 calls);
+      // the second batch succeeds on the first try (1 call).
       await overrideFn.call({} as unknown as WebdriverIO.Element, original);
       await overrideFn.call({} as unknown as WebdriverIO.Element, original);
 
-      expect(mockObj.update).toHaveBeenCalledTimes(2);
+      expect(mockObj.update).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not leak an unhandled rejection when a queued batch fails', async () => {
+      instance = new ElectronWorkerService({}, {});
+      await instance.before({}, [], browser);
+
+      // Every attempt (initial + retry) fails, so both the running batch and the
+      // promoted queued batch reject. The promoted batch's internal wrapper is held
+      // only by the scheduler, so its rejection must be swallowed — otherwise it
+      // surfaces as an unhandled rejection that crashes the worker.
+      const storeModule = (await import('../src/mockStore.js')) as any;
+      const mockObj = { update: vi.fn().mockRejectedValue(new Error('boom')) };
+      storeModule.default.getMocks.mockReturnValue([['id', mockObj]]);
+
+      const oc = vi.mocked((browser as any).overwriteCommand);
+      const overrideFn = oc.mock.calls.find((c: unknown[]) => c[0] === 'click')?.[1] as unknown as (
+        this: WebdriverIO.Element,
+        original: (...args: unknown[]) => Promise<unknown>,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+      const original = vi.fn().mockResolvedValue('ok');
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        // Two concurrent interactions: the second is queued then promoted; both reject.
+        // Callers observe their own rejections; only the orphaned wrapper would leak.
+        const p1 = overrideFn.call({} as unknown as WebdriverIO.Element, original).catch(() => undefined);
+        const p2 = overrideFn.call({} as unknown as WebdriverIO.Element, original).catch(() => undefined);
+        await Promise.all([p1, p2]);
+        // Let the promoted wrapper settle so Node can flag any unhandled rejection.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+
+      expect(unhandled).toEqual([]);
     });
 
     it('should copy original api', async () => {


### PR DESCRIPTION
## Description

`@wdio/electron-service`'s `MockUpdateScheduler` (introduced in #292) could leak an **unhandled promise rejection** that crashes the WDIO worker under Node's default `--unhandled-rejections=throw`, mirroring the tauri issue fixed in #465.

This PR ports the tauri fix and brings electron's scheduler to parity. Two coupled changes:

1. **The guard (`#wrapRun`).** When a running batch settles and a queued batch is promoted, `#wrapRun(promoted)` creates a new wrapper held **only** in `#running`. Concurrent callers hold `#queued` (`= promoted`) directly — not this wrapper. If the promoted batch's `#runOnce()` rejects, the orphaned wrapper rejects with no handler → unhandled rejection → worker crash. The fix attaches a no-op `.catch()` to the internally-held wrapper; callers still observe the failure via their own `promoted` reference.

2. **Surfacing failures (`#runOnce`).** Electron's `#runOnce` previously wrapped everything in `try/catch` + `log.warn`, so it **never rejected** — meaning the leak above couldn't actually fire, and a regression test couldn't "fail without the fix". Tauri's `#runOnce` (from #465) instead **retries once then throws** an `AggregateError`. This PR adopts that behavior per transport lane (native / browser / legacy), so a persistent mock-update failure surfaces at the call site instead of leaving `mock.calls` silently empty — and the guard above becomes load-bearing.

> The issue described electron as sharing the bug "verbatim", but only `#wrapRun` was verbatim-shared; `#runOnce` differed (electron swallowed, tauri throws). Full parity was chosen so the fix is real and the regression test is genuine.

## Related Issues

Closes #467
Relates to #465, #292

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope

- [x] `scope:electron` - Electron service and CDP bridge

## Checklist

- [x] My code follows the code style of this project (passes `pnpm lint`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`pnpm test` — 518 passed)
- [x] My changes generate no new TypeScript errors (`pnpm typecheck`)

## Testing

- [x] Unit tests added/updated

Added `should not leak an unhandled rejection when a queued batch fails` — fires two concurrent overrides whose batches both reject and asserts nothing reaches a `process` `unhandledRejection` listener. **Verified it fails without the guard** (catches the leaked `AggregateError`) and passes with it. Updated `should recover the scheduler after a batch update rejects` to expect 3 update calls (retry). Also re-established the empty `getMocks` default in the shared `beforeEach` so a failing-mock return value can't leak across tests now that the scheduler throws.

## Additional Context

**Behavioral change:** with `#runOnce` now throwing, a mock-update failure that persists past its retry will **reject** the triggering command (`click`/`setValue`/…) or `emitEvent`, rather than being silently swallowed. This matches tauri and the mock-architecture convergence goal; an empty `mock.calls` assertion is harder to debug than a surfaced `AggregateError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)