### PR TITLE
ci: rename merge gate to "CI / Required" + aggregator job to "CI Summary"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1129,13 +1129,13 @@ jobs:
 
           echo "✅ Universal binary verified: $ARCHS"
 
-  # Aggregates every required job and publishes the `ci/required` commit status to the PR
+  # Aggregates every required job and publishes the `CI / Required` commit status to the PR
   # head. That status — not this job's auto check-run — is the sole required check in branch
   # protection (stable as jobs are added/removed). A commit status also lets the label-
   # dispatched Dependabot run (a workflow_dispatch, not PR-associated) land its result on the
   # PR merge box; see dependabot-ci.yml.
   ci-status:
-    name: CI Status
+    name: CI Summary
     if: always()
     permissions:
       contents: read
@@ -1233,9 +1233,9 @@ jobs:
             fi
           done
           echo "All CI jobs passed or were skipped"
-      - name: Publish ci/required commit status
+      - name: Publish CI / Required commit status
         # Skip Dependabot's own pull_request run: its token is read-only and we want
-        # ci/required to stay unreported there so the PR blocks until the label-dispatched
+        # CI / Required to stay unreported there so the PR blocks until the label-dispatched
         # workflow_dispatch run (no pull_request context) publishes it.
         if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
         env:
@@ -1257,9 +1257,9 @@ jobs:
               break
             fi
           done
-          echo "Publishing ci/required=$state to $SHA"
+          echo "Publishing CI / Required=$state to $SHA"
           gh api "repos/$REPO/statuses/$SHA" \
             -f state="$state" \
-            -f context='ci/required' \
+            -f context='CI / Required' \
             -f description="$description" \
             -f target_url="$RUN_URL"

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -7,7 +7,7 @@ name: Dependabot CI
 # token (not Dependabot's restricted one) and can dispatch + edit the PR.
 #
 # The dispatched run is a `workflow_dispatch`, so GitHub never associates it with the PR —
-# it won't appear in the PR's checks list. To give immediate feedback we post a `ci/required`
+# it won't appear in the PR's checks list. To give immediate feedback we post a `CI / Required`
 # pending status (the dispatched ci.yml run overwrites it with the final result via ci-status)
 # and comment a direct link to the run.
 on:
@@ -40,7 +40,7 @@ jobs:
           gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH" -f force_all=true
           echo "prev=$prev" >> "$GITHUB_OUTPUT"
           echo "runs_url=$GITHUB_SERVER_URL/$REPO/actions/workflows/ci.yml?query=branch%3A$BRANCH+event%3Aworkflow_dispatch" >> "$GITHUB_OUTPUT"
-      - name: Mark ci/required pending on the PR
+      - name: Mark CI / Required pending on the PR
         # Posted right after dispatch — before locating the exact run — so feedback is instant.
         # target_url is the branch-filtered Actions page; the comment below links the exact run.
         # Best-effort: a transient status-API failure must not fail the dispatch.
@@ -53,7 +53,7 @@ jobs:
         run: |
           gh api "repos/$REPO/statuses/$SHA" \
             -f state=pending \
-            -f context='ci/required' \
+            -f context='CI / Required' \
             -f description='CI dispatched via ci:run, running' \
             -f target_url="$RUNS_URL"
       - name: Locate the dispatched run
@@ -93,7 +93,7 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ steps.locate.outputs.run_url }}
         run: |
-          gh pr comment "$PR" --repo "$REPO" --body "CI dispatched via \`ci:run\` → [view run]($RUN_URL). The result posts back as the \`ci/required\` status on this PR; the run itself won't appear in the PR checks list (\`workflow_dispatch\` runs aren't PR-associated)."
+          gh pr comment "$PR" --repo "$REPO" --body "CI dispatched via \`ci:run\` → [view run]($RUN_URL). The result posts back as the \`CI / Required\` status on this PR; the run itself won't appear in the PR checks list (\`workflow_dispatch\` runs aren't PR-associated)."
       - name: Remove the ci:run label
         # Always remove so re-adding the label re-runs CI, even if a feedback step hiccupped.
         if: always()


### PR DESCRIPTION
## What

The aggregator job published its required commit status as **`ci/required`** — a slug that read like neither a job nor an obvious "this is the merge gate", and clashed with the Title-Case job names in the PR checks list. This renames the pair so they read coherently:

- **CI Summary** (the aggregator job) *runs* and publishes →
- **CI / Required** (the commit status that is the sole required check in branch protection)

## Changes

- `ci.yml` — job display name `CI Status` → `CI Summary`; published status context `ci/required` → `CI / Required` (+ comment/step-name/echo).
- `dependabot-ci.yml` — the pending status it posts → `CI / Required` (+ comment + PR-comment text).
- The **`ci-required` ruleset** required-check context updated to `CI / Required` via API (still in `evaluate` mode).

The job **key** `ci-status` is intentionally unchanged (only the display name moved), to avoid churning the `ci-status.needs` comment references throughout the file.

## Reviewer note / migration

The ruleset is in `evaluate` mode, so this can't block anything during the transition. PRs opened before this merges still carry the old `ci/required` status — **re-run their CI** before flipping the `ci-required` ruleset to `active`, so they pick up `CI / Required`. This PR's own run posts `CI / Required`, exercising the new name end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)