### PR TITLE
docs(tauri): ADR for driver-provider naming + migrate docs to 'external'

### DIFF
--- a/docs/adr/0001-driver-provider-naming.md
+++ b/docs/adr/0001-driver-provider-naming.md
@@ -1,0 +1,39 @@
+# 1. Driver-provider names describe the mechanism, not the vendor
+
+Date: 2026-06-24
+
+## Status
+
+Accepted — retroactively documenting the decision made in [#275](https://github.com/webdriverio/desktop-mobile/pull/275) (2026-05-18).
+
+## Context
+
+The native-app testing services (`@wdio/electron-service`, `@wdio/tauri-service`, `@wdio/dioxus-service`, and the mobile services that follow) are converging on a near-identical API and feature surface, with shared plumbing extracted into `@wdio/native-core`. A consistent vocabulary across that family is a goal in its own right: an option a user learns for one service should mean the same thing in the next.
+
+Every service that drives a WebView through WebDriver has to choose _how_ the WebDriver server is provided. Two mechanisms recur across the family:
+
+- **In-app server** — WebDriver is served from inside the application under test. Tauri does this with `tauri-plugin-wdio-webdriver`; Dioxus with its embedded driver.
+- **Separate driver process** — an external WebDriver binary is spawned alongside the app. Tauri uses `tauri-driver`; Dioxus uses `wdio-dioxus-driver` (which proxies to `msedgedriver` on Windows).
+
+Tauri originally named these two `'embedded'` and `'official'`. `'official'` was _vendor_-framed: it meant the "official" upstream `tauri-driver`, as opposed to [CrabNebula](https://crabnebula.dev)'s fork. That framing does not generalise — Dioxus has no "official" driver — so it could not become the shared name for "use a separate driver process". CrabNebula's fork is a genuinely distinct third option, selected with `'crabnebula'`.
+
+## Decision
+
+Driver-provider values name the **mechanism**, not the vendor:
+
+- **`'embedded'`** — the WebDriver server runs inside the app under test.
+- **`'external'`** — a separate, external WebDriver process is used.
+
+Consequences of that principle:
+
+- **`'embedded'` is the default** for every service when `driverProvider` is unset.
+- A vendor-specific driver that is not the generic external path keeps an explicit name. For Tauri that is **`'crabnebula'`**.
+- Tauri's `'official'` becomes a deprecated alias for `'external'`. It is normalised to `'external'` with a one-time warning and is scheduled for removal in `@wdio/tauri-service` v2.
+
+## Consequences
+
+- One vocabulary across the service family: `embedded` vs `external` carries over from Tauri to Dioxus to future services, instead of each service inventing its own provider names.
+- `'crabnebula'` remains a named exception. That is acceptable: it is a distinct commercial product, not "the generic external driver".
+- Service docs and configs that still teach `'official'` are now stale and must migrate to `'external'`, citing this ADR. (`'official'` keeps working until v2, so the migration is non-breaking.)
+- We accept a small loss of local clarity — `'official'` arguably read more naturally as "the canonical `tauri-driver`" — in exchange for family-wide consistency.
+- The upstream project is still called "the official `tauri-driver`" in prose where that is the accurate description; only the configuration _value_ changes.

--- a/packages/tauri-service/README.md
+++ b/packages/tauri-service/README.md
@@ -88,16 +88,18 @@ See [Configuration Reference](./docs/configuration.md) for all options.
 
 | Platform | Supported | Driver Providers | Notes |
 |----------|-----------|------------------|-------|
-| **Windows** | ✅ Yes | `official`, `crabnebula`, `embedded` | Edge WebDriver auto-managed |
-| **Linux** | ✅ Yes | `official`, `crabnebula`, `embedded` | Requires `webkit2gtk-driver` |
+| **Windows** | ✅ Yes | `embedded`, `external`, `crabnebula` | `external` auto-manages the Edge WebDriver |
+| **Linux** | ✅ Yes | `embedded`, `external`, `crabnebula` | `external` requires `webkit2gtk-driver` |
 | **macOS** | ✅ Yes | `embedded`, `crabnebula` | Native via embedded, or CrabNebula |
 
 See [Platform Support](./docs/platform-support.md) for detailed information including distribution support and troubleshooting.
 
-> **Choosing a driver provider:**
-> - **`embedded`** (recommended) — Native support on all platforms, no external driver needed
-> - **`official`** — Community driver, Windows/Linux only
-> - **`crabnebula`** — All platforms, requires subscription (CN_API_KEY for macOS)
+> **Choosing a driver provider** (see [ADR 0001](https://github.com/webdriverio/desktop-mobile/blob/main/docs/adr/0001-driver-provider-naming.md) for the naming):
+> - **`embedded`** (default, all platforms) — WebDriver runs inside your app; no external driver needed
+> - **`external`** — a separate `tauri-driver` process; Windows/Linux only
+> - **`crabnebula`** — CrabNebula's cross-platform driver; requires a subscription (CN_API_KEY for macOS)
+>
+> `driverProvider: 'official'` is a deprecated alias for `'external'` and will be removed in v2.
 
 ## Example Projects
 

--- a/packages/tauri-service/docs/api-reference.md
+++ b/packages/tauri-service/docs/api-reference.md
@@ -564,7 +564,7 @@ interface TauriServiceOptions {
   captureFrontendLogs?: boolean;
   backendLogLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
   frontendLogLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
-  driverProvider?: 'official' | 'crabnebula' | 'embedded';
+  driverProvider?: 'embedded' | 'external' | 'crabnebula'; // 'official' is a deprecated alias for 'external'
   embeddedPort?: number;
   statusPollTimeout?: number;
   crabnebulaDriverPath?: string;

--- a/packages/tauri-service/docs/configuration.md
+++ b/packages/tauri-service/docs/configuration.md
@@ -176,7 +176,7 @@ Timeout in milliseconds for the Tauri app to start and become ready.
 startTimeout: 60000  // 60 seconds
 ```
 
-**Default:** `30000` for the `'official'` and `'crabnebula'` providers, `60000` for the `'embedded'` provider (the embedded WebDriver server takes longer to come up, especially on Windows CI).
+**Default:** `30000` for the `'external'` and `'crabnebula'` providers, `60000` for the `'embedded'` provider (the embedded WebDriver server takes longer to come up, especially on Windows CI).
 
 ---
 
@@ -372,35 +372,29 @@ If set, only mocks whose command name starts with this prefix are restored. Only
 
 ---
 
-### `driverProvider` ('official' | 'crabnebula' | 'embedded', optional)
+### `driverProvider` ('embedded' | 'external' | 'crabnebula', optional)
 
 Select which driver provider to use for WebDriver communication.
 
-- `'embedded'`: Use embedded WebDriver server via tauri-plugin-wdio-webdriver (no external driver needed, works on all platforms)
-- `'official'`: Use the cargo-installed tauri-driver (supports Windows/Linux)
+- `'embedded'`: Use the embedded WebDriver server via tauri-plugin-wdio-webdriver (no external driver needed, works on all platforms)
+- `'external'`: Use the cargo-installed tauri-driver (supports Windows/Linux)
 - `'crabnebula'`: Use @crabnebula/tauri-driver from npm (supports Windows/Linux/macOS; CN_API_KEY required for macOS only)
 
-**Auto-detection (no explicit config needed):**
+**Default:** `'embedded'` on every platform when `driverProvider` is unset. The embedded provider requires `tauri-plugin-wdio-webdriver` in your app — if the plugin is missing, the embedded server never comes up and the session times out, so add the plugin or select another provider explicitly.
 
-The service automatically selects `'embedded'` when either of the following signals is present:
-- `TAURI_WEBDRIVER_PORT` environment variable is set (you've configured the plugin's port)
-- Running on macOS (WKWebView requires the embedded approach)
-
-If neither signal is present on Windows or Linux, the service throws an immediate error with instructions.
+> `driverProvider: 'official'` is a deprecated alias for `'external'`. It still works but logs a warning and will be removed in v2. See [ADR 0001](https://github.com/webdriverio/desktop-mobile/blob/main/docs/adr/0001-driver-provider-naming.md) for the naming.
 
 **Example:**
 ```typescript
-// Auto-detected on macOS, or when TAURI_WEBDRIVER_PORT is set — no config needed
-// driverProvider: 'embedded'  (set this explicitly to be unambiguous)
+// Default — the embedded WebDriver server (requires tauri-plugin-wdio-webdriver)
+// driverProvider: 'embedded'
 
 // Use CrabNebula — all platforms; CN_API_KEY required for macOS
 driverProvider: 'crabnebula'
 
-// Use official tauri-driver — opt out of embedded provider
-driverProvider: 'official'
+// Drive the external tauri-driver instead of the embedded server
+driverProvider: 'external'
 ```
-
-**Default:** Auto-detected (see above). Set explicitly to override.
 
 **Note:** Install `tauri-plugin-wdio-webdriver` in your Tauri app to use the embedded provider. See [Plugin Setup](./plugin-setup.md) for details.
 
@@ -410,15 +404,15 @@ driverProvider: 'official'
 
 | Provider | Platform Support | External driver required | Notes |
 |----------|-----------------|--------------------------|-------|
-| `'embedded'` | Windows, Linux, macOS | No | No external deps; auto-detected on macOS or via `TAURI_WEBDRIVER_PORT` |
-| `'official'` | Windows, Linux | Yes (tauri-driver + platform driver) | Explicit opt-in; cargo-installed |
-| `'crabnebula'` | Windows, Linux, macOS | Yes (platform driver; CN_API_KEY for macOS) | Fork of official driver; good fit if already on CrabNebula platform |
+| `'embedded'` | Windows, Linux, macOS | No | Default; no external deps; requires `tauri-plugin-wdio-webdriver` |
+| `'external'` | Windows, Linux | Yes (tauri-driver + platform driver) | Explicit opt-in; cargo-installed |
+| `'crabnebula'` | Windows, Linux, macOS | Yes (platform driver; CN_API_KEY for macOS) | Fork of the upstream tauri-driver; good fit if already on CrabNebula platform |
 
 **Recommendation:**
 
-- **`'embedded'`** — simplest setup: no external driver installation, works on all three platforms
+- **`'embedded'`** — the default and simplest setup: no external driver installation, works on all three platforms
 - **`'crabnebula'`** — best if you are already using CrabNebula Cloud or want a single driver config across all platforms; macOS testing requires a CrabNebula subscription
-- **`'official'`** — explicit opt-in for Windows/Linux if you have `tauri-driver` already installed
+- **`'external'`** — explicit opt-in for Windows/Linux if you have `tauri-driver` already installed
 
 ---
 

--- a/packages/tauri-service/docs/configuration.md
+++ b/packages/tauri-service/docs/configuration.md
@@ -422,7 +422,7 @@ Port for the embedded WebDriver server. Only used when `driverProvider: 'embedde
 
 - The service spawns your Tauri app with this port
 - Each worker instance gets a unique port (basePort + workerIndex)
-- Can also be set via the `TAURI_WEBDRIVER_PORT` or `WDIO_EMBEDDED_PORT` environment variable. Setting either env var also serves as the auto-detection signal that opts you into the embedded provider on Windows/Linux.
+- Can also be set via the `TAURI_WEBDRIVER_PORT` or `WDIO_EMBEDDED_PORT` environment variable.
 
 **Example:**
 ```typescript

--- a/packages/tauri-service/docs/crabnebula-setup.md
+++ b/packages/tauri-service/docs/crabnebula-setup.md
@@ -436,11 +436,13 @@ export const config = {
 };
 ```
 
-Or conditionally use different providers:
+Or conditionally use different external drivers — CrabNebula on macOS, the standard
+`external` tauri-driver where you already have it. (If you'd rather not run an external
+driver at all, `embedded` works on every platform and is the simplest default.)
 
 ```typescript
-const driverProvider = process.env.DRIVER_PROVIDER || 
-  (process.platform === 'darwin' ? 'embedded' : 'external');
+const driverProvider = process.env.DRIVER_PROVIDER ||
+  (process.platform === 'darwin' ? 'crabnebula' : 'external');
 
 export const config = {
   services: [['@wdio/tauri-service', {

--- a/packages/tauri-service/docs/crabnebula-setup.md
+++ b/packages/tauri-service/docs/crabnebula-setup.md
@@ -440,7 +440,7 @@ Or conditionally use different providers:
 
 ```typescript
 const driverProvider = process.env.DRIVER_PROVIDER || 
-  (process.platform === 'darwin' ? 'embedded' : 'official');
+  (process.platform === 'darwin' ? 'embedded' : 'external');
 
 export const config = {
   services: [['@wdio/tauri-service', {
@@ -451,7 +451,7 @@ export const config = {
 
 ## Comparison: Driver Providers
 
-| Feature | `official` | `crabnebula` | `embedded` |
+| Feature | `external` | `crabnebula` | `embedded` |
 |---------|-----------|--------------|------------|
 | Windows | ✅ | ✅ | ✅ |
 | Linux | ✅ | ✅ | ✅ |

--- a/packages/tauri-service/docs/platform-support.md
+++ b/packages/tauri-service/docs/platform-support.md
@@ -6,9 +6,11 @@ Complete guide to platform-specific requirements, limitations, and WebDriver set
 
 | Platform | Supported | WebDriver | Driver Provider | Setup |
 |----------|-----------|-----------|----------------|-------|
-| **Windows** | ✅ Yes | Microsoft Edge WebDriver | All (official, crabnebula, embedded) | Auto-managed |
-| **Linux** | ✅ Yes | WebKitWebDriver | All (official, crabnebula, embedded) | Manual install |
+| **Windows** | ✅ Yes | Microsoft Edge WebDriver | All (`'embedded'`, `'external'`, `'crabnebula'`) | `'external'` auto-manages the Edge WebDriver |
+| **Linux** | ✅ Yes | WebKitWebDriver | All (`'embedded'`, `'external'`, `'crabnebula'`) | `'external'` needs `webkit2gtk-driver` |
 | **macOS** | ✅ Yes | Built-in | `'embedded'`, `'crabnebula'` | No external driver needed |
+
+> `'embedded'` is the default on every platform when `driverProvider` is unset. `driverProvider: 'official'` is a deprecated alias for `'external'`. See [ADR 0001](https://github.com/webdriverio/desktop-mobile/blob/main/docs/adr/0001-driver-provider-naming.md).
 
 ## Windows
 
@@ -80,17 +82,17 @@ Version mismatch between driver and WebView2. Solutions:
 
 3. Add to PATH or disable auto-download and specify manually
 
-### Alternative Driver Providers on Windows
+### Driver Providers on Windows
 
-The default Windows setup uses `tauri-driver` + MSEdgeDriver (the `'official'` provider), but both other providers also work on Windows:
+`'embedded'` is the default. All three providers work on Windows:
 
 | Provider | Notes |
 |----------|-------|
-| `'official'` | Default — uses tauri-driver + MSEdgeDriver, auto-managed |
-| `'embedded'` | Requires `tauri-plugin-wdio-webdriver` in your app; no external driver |
+| `'embedded'` | Default — requires `tauri-plugin-wdio-webdriver` in your app; no external driver |
+| `'external'` | Uses `tauri-driver` + MSEdgeDriver; the Edge WebDriver is auto-managed |
 | `'crabnebula'` | Requires a paid CrabNebula API key; cross-platform alternative |
 
-Use `'embedded'` if you want a consistent setup across Windows, Linux, and macOS without managing external drivers. Use `'crabnebula'` if you already have a CrabNebula subscription.
+Use `'embedded'` for a consistent setup across Windows, Linux, and macOS without managing external drivers, `'external'` to drive `tauri-driver` directly, or `'crabnebula'` if you already have a CrabNebula subscription.
 
 ### Windows-Specific Features
 
@@ -270,17 +272,17 @@ Use `sudo` for package installation:
 sudo apt-get install webkit2gtk-driver
 ```
 
-### Alternative Driver Providers on Linux
+### Driver Providers on Linux
 
-The default Linux setup uses `tauri-driver` + WebKitWebDriver (the `'official'` provider), but both other providers also work on Linux:
+`'embedded'` is the default. All three providers work on Linux:
 
 | Provider | Notes |
 |----------|-------|
-| `'official'` | Default — uses tauri-driver + WebKitWebDriver, requires manual install |
-| `'embedded'` | Requires `tauri-plugin-wdio-webdriver` in your app; no external driver |
+| `'embedded'` | Default — requires `tauri-plugin-wdio-webdriver` in your app; no external driver |
+| `'external'` | Uses `tauri-driver` + WebKitWebDriver; requires `webkit2gtk-driver` (see above) |
 | `'crabnebula'` | Requires a paid CrabNebula API key; cross-platform alternative |
 
-Use `'embedded'` if you want a consistent setup across Windows, Linux, and macOS without managing external drivers. Use `'crabnebula'` if you already have a CrabNebula subscription.
+Use `'embedded'` for a consistent setup across Windows, Linux, and macOS without managing external drivers, `'external'` to drive `tauri-driver` directly, or `'crabnebula'` if you already have a CrabNebula subscription.
 
 ### Linux-Specific Features
 
@@ -295,7 +297,7 @@ Use `'embedded'` if you want a consistent setup across Windows, Linux, and macOS
 
 ### Requirements
 
-- **WebKitGTK development libraries** (webkit2gtk-driver) — only needed for `'official'` provider
+- **WebKitGTK development libraries** (webkit2gtk-driver) — only needed for the `'external'` provider
 - **Xvfb** (optional, for headless testing)
 - **Rust toolchain** (for building Tauri apps)
 - **Node.js 18+**

--- a/packages/tauri-service/docs/plugin-setup.md
+++ b/packages/tauri-service/docs/plugin-setup.md
@@ -29,7 +29,7 @@ There are two Tauri plugins for WebdriverIO testing:
   - Provides built-in WebDriver HTTP server
   - Eliminates need for external tauri-driver
   - Enables native macOS testing without CrabNebula
-  - Auto-detected on macOS; signal via `TAURI_WEBDRIVER_PORT` on Windows/Linux
+  - Used whenever the `embedded` provider is active — the default on every platform when `driverProvider` is unset
 
 ## Why Is It Required?
 
@@ -424,7 +424,7 @@ This plugin embeds a W3C WebDriver HTTP server directly in your Tauri applicatio
 ### Requirements
 
 - Tauri v2.0+
-- Embedded provider selected (auto-detected on macOS, or set `driverProvider: 'embedded'` / `TAURI_WEBDRIVER_PORT`)
+- The `embedded` provider in use (the default; or set `driverProvider: 'embedded'` explicitly)
 
 ### Installation
 
@@ -478,7 +478,7 @@ services: [['@wdio/tauri-service', {
 }]]
 ```
 
-Or via environment variable (also triggers auto-detection on Windows/Linux):
+Or set the port via environment variable:
 ```bash
 TAURI_WEBDRIVER_PORT=4445 npx wdio run wdio.conf.ts
 ```

--- a/packages/tauri-service/docs/plugin-setup.md
+++ b/packages/tauri-service/docs/plugin-setup.md
@@ -492,7 +492,7 @@ TAURI_WEBDRIVER_PORT=4445 npx wdio run wdio.conf.ts
 
 ### Differences from External Driver
 
-| Aspect | External Driver (official/crabnebula) | Embedded Server |
+| Aspect | External Driver (external/crabnebula) | Embedded Server |
 |--------|--------------------------------------|-----------------|
 | Architecture | Separate driver process | HTTP server in-app |
 | macOS support | Requires CrabNebula | Native |

--- a/packages/tauri-service/docs/quick-start.md
+++ b/packages/tauri-service/docs/quick-start.md
@@ -357,7 +357,7 @@ The service couldn't determine which driver to use, or couldn't find tauri-drive
    ```typescript
    driverProvider: 'embedded'
    ```
-   Requires `tauri-plugin-wdio-webdriver` in your Tauri app. On macOS this is auto-detected.
+   Requires `tauri-plugin-wdio-webdriver` in your Tauri app. It is the default on every platform when `driverProvider` is unset.
 
 2. **Install tauri-driver manually** (if using `driverProvider: 'external'`):
    ```bash

--- a/packages/tauri-service/docs/quick-start.md
+++ b/packages/tauri-service/docs/quick-start.md
@@ -241,8 +241,8 @@ export const config = {
   // Tauri service configuration
   services: [['@wdio/tauri-service', {
     appBinaryPath: './src-tauri/target/release/my-app.exe', // Adjust for your OS/app name
-    driverProvider: 'embedded',  // Use embedded WebDriver (recommended, no external drivers needed)
-    // driverProvider: 'official',  // Use external tauri-driver (explicit opt-in)
+    driverProvider: 'embedded',  // Default — embedded WebDriver, no external drivers needed
+    // driverProvider: 'external',  // Use external tauri-driver (explicit opt-in)
     // driverProvider: 'crabnebula',  // Use CrabNebula (requires paid API key)
   }]],
 
@@ -359,14 +359,14 @@ The service couldn't determine which driver to use, or couldn't find tauri-drive
    ```
    Requires `tauri-plugin-wdio-webdriver` in your Tauri app. On macOS this is auto-detected.
 
-2. **Install tauri-driver manually** (if using `driverProvider: 'official'`):
+2. **Install tauri-driver manually** (if using `driverProvider: 'external'`):
    ```bash
    cargo install tauri-driver
    ```
 
 3. **Or enable auto-install** in `wdio.conf.ts`:
    ```typescript
-   driverProvider: 'official',
+   driverProvider: 'external',
    autoInstallTauriDriver: true
    ```
 

--- a/packages/tauri-service/docs/troubleshooting.md
+++ b/packages/tauri-service/docs/troubleshooting.md
@@ -407,7 +407,7 @@ See [Platform Support](./platform-support.md) for per-platform details.
 
 ### macOS: Embedded WebDriver Not Ready
 
-On macOS the embedded provider is auto-detected, but if the plugin is not installed the service will time out waiting for the WebDriver server.
+macOS has no external WebDriver driver, so the `embedded` provider (the default) or `crabnebula` is your only option there. If `tauri-plugin-wdio-webdriver` isn't installed, the embedded server never starts and the service times out waiting for it.
 
 **Solution:** Ensure `tauri-plugin-wdio-webdriver` is installed and registered:
 

--- a/packages/tauri-service/docs/troubleshooting.md
+++ b/packages/tauri-service/docs/troubleshooting.md
@@ -376,36 +376,29 @@ Get-Process -Id (Get-NetTCPConnection -LocalPort 4444).OwningProcess | Stop-Proc
 
 ## Platform Issues
 
-### "No driverProvider configured and no embedded WebDriver server detected"
+### Embedded WebDriver server never becomes ready
 
-The service cannot determine which driver provider to use.
+`'embedded'` is the default provider on every platform, and it requires `tauri-plugin-wdio-webdriver` in your app. If the plugin is missing or not registered, the embedded server never starts and the session times out waiting for it.
 
-**Why this happens:** On Windows and Linux, the service does not default to any driver provider automatically. It auto-detects the embedded provider only when either:
-- `TAURI_WEBDRIVER_PORT` environment variable is set, or
-- You are on macOS
-
-**Solution 1: Use embedded provider (recommended)**
+**Solution 1: Add the embedded plugin (recommended)**
 
 1. Install `tauri-plugin-wdio-webdriver` in your Tauri app:
    ```bash
    cd src-tauri && cargo add tauri-plugin-wdio-webdriver
    ```
-2. Register it in your Rust code and set `TAURI_WEBDRIVER_PORT` or configure `driverProvider: 'embedded'`:
+2. Register it in your Rust code (debug builds) and keep the default embedded provider:
    ```typescript
    services: [['@wdio/tauri-service', {
      driverProvider: 'embedded',
    }]]
    ```
-   Or signal via environment variable:
-   ```bash
-   TAURI_WEBDRIVER_PORT=4445 npx wdio run wdio.conf.ts
-   ```
+   The embedded server listens on port 4445 by default; override it with the `embeddedPort` option or the `TAURI_WEBDRIVER_PORT` env var if needed.
 
-**Solution 2: Use official tauri-driver**
+**Solution 2: Use the external tauri-driver instead**
 
 ```typescript
 services: [['@wdio/tauri-service', {
-  driverProvider: 'official',
+  driverProvider: 'external',
   autoInstallTauriDriver: true,
 }]]
 ```


### PR DESCRIPTION
## What

Adds the repo's first ADR — `docs/adr/0001-driver-provider-naming.md` — recording **why `driverProvider` values name the mechanism (`embedded`/`external`), not the vendor**, and reconciles the `@wdio/tauri-service` docs with the code, which they had drifted from on two points.

## Why

`@wdio/tauri-service` makes `'external'` the canonical provider value and treats `'official'` as a deprecated alias (`launcher.ts` normalises it with a warning, removed in v2). The decision came in #275 (the Dioxus service + `@wdio/native-core`): the native-service family shares one vocabulary, and `embedded`/`external` describes the mechanism (WebDriver in-app vs a separate driver process) in a way that generalises across services, whereas Tauri's vendor-framed `'official'` does not. That decision was only encoded in code — hence the ADR.

While documenting it, two doc/code drifts surfaced and are fixed here:

1. **Deprecated value taught as canonical.** README / configuration / quick-start / api-reference / troubleshooting / crabnebula-setup / plugin-setup all used `driverProvider: 'official'`. Migrated to `'external'`, with a note that `'official'` is a deprecated alias.
2. **Wrong default.** `platform-support.md` claimed Windows/Linux default to `'official'`; `configuration.md` and `troubleshooting.md` claimed embedded is auto-detected only on macOS / when `TAURI_WEBDRIVER_PORT` is set. **Neither is true:** `isEmbeddedProvider()` has returned `true`-when-unset since #166, with no platform or env gating — `'embedded'` is the default on every platform. Those sections are rewritten to the real behaviour (embedded is the default and needs `tauri-plugin-wdio-webdriver`, else the session times out).

## Scope notes

- Prose "official `tauri-driver`" (the upstream project CrabNebula forks) is left as-is — only the config *value* changes.
- The historical `release-notes/v1.0.0.md` is untouched (it records what shipped).
- No code change; `'official'` keeps working until v2, so this is non-breaking.
- The webdriver.io website mirrors these docs in a separate repo and would need a follow-up sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
