### PR TITLE
ci: stop the CI Summary job leaving a red check on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1134,9 +1134,16 @@ jobs:
   # protection (stable as jobs are added/removed). A commit status also lets the label-
   # dispatched Dependabot run (a workflow_dispatch, not PR-associated) land its result on the
   # PR merge box; see dependabot-ci.yml.
+  #
+  # Skipped on Dependabot `pull_request` runs: detect-changes (and so every other job) is
+  # already gated off for Dependabot, leaving nothing to summarise. Running it would post a
+  # misleading result — the old `exit 1` left a red check that the later `ci:run` manual run
+  # (a separate, non-PR-associated workflow_dispatch) can never clear. The PR is gated instead
+  # by `CI / Required` staying ABSENT until that dispatched run publishes it. A manual run has
+  # no pull_request context, so this condition lets it through.
   ci-status:
     name: CI Summary
-    if: always()
+    if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
       statuses: write
@@ -1213,15 +1220,6 @@ jobs:
       - package-electron-mac-universal
     runs-on: ubuntu-latest
     steps:
-      # CI is gated off for Dependabot (see detect-changes), which leaves every job skipped
-      # and would otherwise report this required check green. Fail instead so branch
-      # protection blocks the merge until CI is run manually. A manual run arrives as a
-      # workflow_dispatch (no pull_request context), so this step steps aside there.
-      - name: Require a manual run for Dependabot PRs
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        run: |
-          echo "::error::CI is skipped for Dependabot PRs by default. Add the 'ci:run' label, or run Actions → CI → Run workflow on this branch, before merging."
-          exit 1
       - name: Check CI results
         run: |
           results="${{ join(needs.*.result, ' ') }}"
@@ -1234,10 +1232,10 @@ jobs:
           done
           echo "All CI jobs passed or were skipped"
       - name: Publish CI / Required commit status
-        # Skip Dependabot's own pull_request run: its token is read-only and we want
-        # CI / Required to stay unreported there so the PR blocks until the label-dispatched
-        # workflow_dispatch run (no pull_request context) publishes it.
-        if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
+        # The job already skips Dependabot pull_request runs (see the job-level `if`), so this
+        # only ever runs where publishing is wanted: normal PRs, pushes, and the ci:run-
+        # dispatched workflow_dispatch run. `always()` so a failure still posts a red status.
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem

On a Dependabot PR that we manually kick CI off for (the `ci:run` label), the **`CI Summary`** check stays **red even after CI passes**:

- The normal `pull_request`-triggered pipeline has *every* job skipped (detect-changes is Dependabot-gated), so `ci-status` ran only to hit `Require a manual run for Dependabot PRs` → `exit 1` → a **red** check-run.
- The real gate is the **`CI / Required`** commit status the job publishes; that red `CI Summary` check-run was **never a required check** and never blocked.
- The `ci:run`-dispatched run (which posts `CI / Required` green) is a separate `workflow_dispatch`, **not PR-associated**, so its result can't overwrite the red `CI Summary` from the `pull_request` run. → the PR shows green `CI / Required` **and** red `CI Summary`.

## Fix

Skip `ci-status` entirely on Dependabot `pull_request` runs (`if: always() && github.event.pull_request.user.login != 'dependabot[bot]'`) and drop the now-dead `exit 1` step. The PR is gated by `CI / Required` staying **absent** until the dispatched run posts it — same gating, no misleading red. The publish step's redundant `!= dependabot` clause is simplified to `always()`.

Result on a Dependabot PR: jobs show *skipped* (grey), and once `ci:run` dispatches CI, only the green `CI / Required` status remains — no stale red.

## Notes / validation

- Behaviour is unchanged for normal PRs, pushes, and manual `workflow_dispatch` runs (the job still runs and publishes `CI / Required`).
- The `ci-required` ruleset is still in **`evaluate`** mode, so pre-dispatch blocking only takes effect once it's flipped to `active` (then a Dependabot PR shows `CI / Required` — *Expected* until dispatched).
- Needs a real Dependabot PR to confirm end-to-end (can't be reproduced from a fork/local).
- Open Dependabot PRs created before the rename (e.g. #469) still post the old `ci/required`; rebase them onto `main` and re-dispatch so they post `CI / Required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)