### PR TITLE
chore(flutter): retire the appium-flutter-driver fork now that upstream landed (#461)

### DIFF
--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -118,7 +118,7 @@ jobs:
       # disabling the syslog the Flutter driver reads the (random, auth-coded) VM-service URL from →
       # the first session fails with "mandatory syslog service must be running" while warmed-up later
       # sessions pass. Running one stream now (with a generous window) absorbs that cold start; the
-      # fork's startLogCapture retry is the backstop for any residual transient.
+      # driver's startLogCapture retry (appium-flutter-driver ≥ 3.8.0) is the backstop for any residual transient.
       - name: 🔥 Warm up simulator logd
         shell: bash
         run: |
@@ -130,32 +130,16 @@ jobs:
             sleep 1
           done
           kill "$(cat /tmp/logwarm.pid)" 2>/dev/null || true
-          [ -s /tmp/logwarm.out ] || echo "::warning::logd did not emit within 30s during warm-up (continuing; fork retry is the backstop)"
+          [ -s /tmp/logwarm.out ] || echo "::warning::logd did not emit within 30s during warm-up (continuing; the driver's log-capture retry is the backstop)"
 
-      - name: 🔌 Install XCUITest + use the appium-flutter-driver fork (getVMServiceUrl)
+      - name: 🔌 Install XCUITest driver
         shell: bash
-        # XCUITest installs normally. For Flutter: @repo/e2e depends on appium-flutter-driver
-        # (node_modules), which appium loads by default — so `appium driver install --source=local/git`
-        # can't replace it (and the fork's driver/ subdir has no root package.json for a git dep).
-        # Build the fork and overwrite the node_modules driver's build/ in place so appium loads the
-        # fork's code (getVMServiceUrl). Interim until that's upstreamed/published.
+        # @repo/e2e pins appium-flutter-driver in node_modules (appium loads it by default).
+        # XCUITest is installed here only if the APPIUM_HOME cache doesn't already carry it.
         run: |
           set -euo pipefail
           installed=$(pnpm --filter @repo/e2e exec appium driver list --installed 2>&1 || true)
           echo "$installed" | grep -qi xcuitest || pnpm --filter @repo/e2e exec appium driver install xcuitest
-          git clone --depth 1 -b feat/android-vm-service-port \
-            https://github.com/goosewobbler/appium-flutter-driver "$RUNNER_TEMP/afd"
-          ( cd "$RUNNER_TEMP/afd/driver" && npm install --no-audit --no-fund && npm run build )
-          AFD=$( cd "$GITHUB_WORKSPACE/e2e" && node -e 'process.stdout.write(require("path").dirname(require.resolve("appium-flutter-driver/package.json")))' )
-          echo "Overwriting node_modules appium-flutter-driver at: $AFD"
-          rm -rf "$AFD/build"
-          cp -R "$RUNNER_TEMP/afd/driver/build" "$AFD/build"
-          if grep -q getVMServiceUrl "$AFD/build/lib/commands/execute.js"; then
-            echo "✓ fork getVMServiceUrl present in the loaded driver"
-          else
-            echo "✗ fork overwrite failed — getVMServiceUrl not found"
-            exit 1
-          fi
 
       # WDA DerivedData cache keyed on e2e/package.json (driver pins) + the runner image version.
       - name: 💾 Restore WDA DerivedData cache
@@ -197,12 +181,9 @@ jobs:
           # (occasionally flaky) e2e failure. It stays second so it runs on a sim the suite warmed.
           e2e_rc=0; pnpm --filter @repo/e2e run test:e2e:flutter:ios || e2e_rc=$?
           # Packed @wdio/flutter-service against THIS booted sim, reusing the prebuilt WDA
-          # (FLUTTER_WDA_DD, read by the fixture config). test-package.ts overwrites the isolated
-          # fixture's appium-flutter-driver with the getVMServiceUrl fork (AFD_FORK_BUILD_DIR, built
-          # above) — the published driver can't reach the Dart VM.
+          # (FLUTTER_WDA_DD, read by the fixture config).
           smoke_rc=0
-          FLUTTER_PLATFORM=ios FLUTTER_DEVICE_NAME="$FLUTTER_IOS_DEVICE" \
-            AFD_FORK_BUILD_DIR="$RUNNER_TEMP/afd/driver/build" pnpm test:package:flutter || smoke_rc=$?
+          FLUTTER_PLATFORM=ios FLUTTER_DEVICE_NAME="$FLUTTER_IOS_DEVICE" pnpm test:package:flutter || smoke_rc=$?
           if [ "$e2e_rc" != 0 ] || [ "$smoke_rc" != 0 ]; then exit 1; fi
 
       - name: 📦 Upload Test Logs

--- a/.github/workflows/_ci-e2e-flutter.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter.reusable.yml
@@ -139,30 +139,6 @@ jobs:
           flutter build apk --debug --target-platform android-x64
           echo "FLUTTER_APP_PATH=$FIXTURE_DIR/build/app/outputs/flutter-apk/app-debug.apk" >> "$GITHUB_ENV"
 
-      - name: 🔌 Use the goosewobbler appium-flutter-driver fork (getVMServiceUrl)
-        shell: bash
-        # @repo/e2e depends on appium-flutter-driver (node_modules), and `appium driver list
-        # --installed` detects node_modules drivers — so appium loads THAT, not an APPIUM_HOME
-        # install. `appium driver install --source=local/git` therefore can't replace it (and the
-        # fork's driver/ subdir has no root package.json for a git dep). So build the fork and
-        # overwrite the node_modules driver's build/ in place — appium then loads the fork's code
-        # (the getVMServiceUrl command). Interim until getVMServiceUrl is upstreamed/published.
-        run: |
-          set -euo pipefail
-          git clone --depth 1 -b feat/android-vm-service-port \
-            https://github.com/goosewobbler/appium-flutter-driver "$RUNNER_TEMP/afd"
-          ( cd "$RUNNER_TEMP/afd/driver" && npm install --no-audit --no-fund && npm run build )
-          AFD=$( cd "$GITHUB_WORKSPACE/e2e" && node -e 'process.stdout.write(require("path").dirname(require.resolve("appium-flutter-driver/package.json")))' )
-          echo "Overwriting node_modules appium-flutter-driver at: $AFD"
-          rm -rf "$AFD/build"
-          cp -R "$RUNNER_TEMP/afd/driver/build" "$AFD/build"
-          if grep -q getVMServiceUrl "$AFD/build/lib/commands/execute.js"; then
-            echo "✓ fork getVMServiceUrl present in the loaded driver"
-          else
-            echo "✗ fork overwrite failed — getVMServiceUrl not found"
-            exit 1
-          fi
-
       - name: 🤖 Run E2E on Android emulator
         # Third-party action (non-GitHub-owned) → pin to a full commit SHA, not a floating
         # tag, since secrets: inherit gives this job secret access. Bump deliberately.
@@ -182,14 +158,11 @@ jobs:
             # Run the e2e suite and the package smoke DECOUPLED so a flaky e2e can't mask the smoke's
             # signal (does the PACKED tarball install + compose?): `|| rc=$?` captures each exit code,
             # then we fail at the end only if either failed. The smoke validates the PACKED
-            # @wdio/flutter-service against THIS already-booted emulator; AFD_FORK_BUILD_DIR lets
-            # test-package.ts overwrite the isolated fixture's appium-flutter-driver with the
-            # getVMServiceUrl fork built above (the published driver can't reach the Dart VM); no arch
-            # split → runs once.
+            # @wdio/flutter-service against THIS already-booted emulator; no arch split → runs once.
             # The WHOLE pipeline MUST be one line: android-emulator-runner runs the script line-by-line,
             # each in its own `sh -c`, so a var set on one line is gone on the next — split across lines
             # the final check sees empty e2e_rc/smoke_rc and `[ "" != 0 ]` always exits 1.
-            e2e_rc=0; pnpm --filter @repo/e2e run test:e2e:flutter || e2e_rc=$?; smoke_rc=0; FLUTTER_PLATFORM=android AFD_FORK_BUILD_DIR="$RUNNER_TEMP/afd/driver/build" pnpm test:package:flutter || smoke_rc=$?; if [ "$e2e_rc" != 0 ] || [ "$smoke_rc" != 0 ]; then exit 1; fi
+            e2e_rc=0; pnpm --filter @repo/e2e run test:e2e:flutter || e2e_rc=$?; smoke_rc=0; FLUTTER_PLATFORM=android pnpm test:package:flutter || smoke_rc=$?; if [ "$e2e_rc" != 0 ] || [ "$smoke_rc" != 0 ]; then exit 1; fi
 
       - name: 📦 Upload Test Logs
         if: always()

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -89,7 +89,7 @@
     "@wdio/native-types": "workspace:*",
     "@wdio/types": "catalog:default",
     "appium": "^3.5.0",
-    "appium-flutter-driver": "^3.7.0",
+    "appium-flutter-driver": "^3.8.0",
     "appium-uiautomator2-driver": "^7.6.0",
     "appium-xcuitest-driver": "^11.9.0",
     "cross-env": "^10.1.0",

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -74,8 +74,8 @@ const flutterServiceOptions: FlutterServiceOptions = {
   platform: isIos ? 'iOS' : 'Android',
   // Forward the device (logcat/syslog) logs into the WDIO log on each test.
   captureBackendLogs: true,
-  // Exercise the preflight doctor end-to-end (appium-service present, flutter on PATH, the
-  // fork's getVMServiceUrl present on Android, iOS toolchain warm). strict mode makes a
+  // Exercise the preflight doctor end-to-end (appium-service present, flutter on PATH,
+  // appium-flutter-driver ≥ 3.8.0 on Android, iOS toolchain warm). strict mode makes a
   // regression that breaks the preflight fail CI.
   doctor: { strict: true },
 };

--- a/fixtures/package-tests/flutter-app/package.json
+++ b/fixtures/package-tests/flutter-app/package.json
@@ -18,7 +18,7 @@
     "@wdio/flutter-service": "workspace:*",
     "@wdio/spec-reporter": "9.27.1",
     "appium": "^3.5.0",
-    "appium-flutter-driver": "^3.7.0",
+    "appium-flutter-driver": "^3.8.0",
     "typescript": "5.9.3"
   }
 }

--- a/packages/flutter-service/README.md
+++ b/packages/flutter-service/README.md
@@ -42,14 +42,12 @@ appium driver install --source=npm appium-flutter-driver
 > worker**, so you no longer need to set it by hand — pin it yourself only to override. Without it,
 > find/tap/deeplink/contexts still work; only `execute`/`mock` use it.
 >
-> On **iOS** the published `appium-flutter-driver` (≥ 3.7.1) honours the port via `processArguments`.
-> On **Android** the equivalent (a `vm-service-port` launch-intent extra + the `flutter:getVMServiceUrl`
-> command) lives in a [fork](https://github.com/goosewobbler/appium-flutter-driver) pending an upstream
-> PR to `appium/appium-flutter-driver` (the iOS half merged as
-> [#870](https://github.com/appium/appium-flutter-driver/pull/870)) — until it lands, Android
-> `execute`/`mock` need that fork. The preflight doctor warns if the installed driver lacks
-> `getVMServiceUrl`. Set `autoInstallDriver: true` to let the launcher install the `flutter` driver
-> for you, and `doctor: { strict: true }` to fail fast on a missing toolchain.
+> The port pin is honoured by the published `appium-flutter-driver` on both platforms: **iOS** from
+> ≥ 3.7.1 ([#870](https://github.com/appium/appium-flutter-driver/pull/870), via `processArguments`)
+> and **Android** from ≥ 3.8.0 ([#880](https://github.com/appium/appium-flutter-driver/pull/880), via
+> a `vm-service-port` launch-intent extra + the `flutter:getVMServiceUrl` command). The preflight
+> doctor warns if the installed driver is older. Set `autoInstallDriver: true` to let the launcher
+> install the `flutter` driver for you, and `doctor: { strict: true }` to fail fast on a missing toolchain.
 
 ## Quick start
 
@@ -185,9 +183,8 @@ no log scrape. Pin `vmServicePort` only to override.
 `autoInstallDriver: true` installs the `flutter` Appium driver (appium-flutter-driver) if
 it isn't already present, at a version known-good for your Appium **server major** (from a
 maintained matrix). It's **idempotent** and **off by default** (CI usually manages drivers
-explicitly). Note it installs the **stock** driver — on Android, `execute`/`mock` still need
-the goosewobbler fork until it's upstreamed (see [Installation](#installation)); the doctor
-warns when the fork is absent.
+explicitly). It installs `appium-flutter-driver` ≥ 3.8.0 — the version Android `execute`/`mock`
+need (see [Installation](#installation)); the doctor warns when an older driver is present.
 
 ### `doctor` — preflight checks
 
@@ -201,8 +198,7 @@ as a clear message instead of a cryptic Appium timeout:
 | `{ strict: true }` | Run the checks; abort the run (`SevereServiceError`) on any error-level check. |
 
 For Flutter it checks: `@wdio/appium-service` is in `services`, `flutter` is on PATH, the
-installed `appium-flutter-driver` carries `getVMServiceUrl` (Android only), and (iOS) the
-Xcode toolchain is warm.
+installed `appium-flutter-driver` is ≥ 3.8.0 (Android only), and (iOS) the Xcode toolchain is warm.
 
 ### iOS launch caps — auto-applied
 

--- a/packages/flutter-service/src/constants.ts
+++ b/packages/flutter-service/src/constants.ts
@@ -17,11 +17,12 @@ export const VM_SERVICE_CONNECT_INTERVAL_MS = 1000;
 
 /**
  * Discovery budget for the best-effort pre-warm in `before()`. The pre-warm only wants the URL
- * if it's *already* discoverable at session start (the fork's driver command, a pinned port, or a
- * "listening on …" line still in the log buffer); a single quick scrape suffices. It must NOT run
- * the full {@link VM_SERVICE_CONNECT_RETRIES} loop — that would block worker setup for ~60s on a
- * release build (no VM service) or any run without the fork/pin, including find/tap-only tests that
- * never touch the VM service. A miss falls through to the lazy path, which keeps the full budget.
+ * if it's *already* discoverable at session start (the driver's `flutter:getVMServiceUrl` command, a
+ * pinned port, or a "listening on …" line still in the log buffer); a single quick scrape suffices.
+ * It must NOT run the full {@link VM_SERVICE_CONNECT_RETRIES} loop — that would block worker setup
+ * for ~60s on a release build (no VM service) or any run without that command or a pin, including
+ * find/tap-only tests that never touch the VM service. A miss falls through to the lazy path, which
+ * keeps the full budget.
  */
 export const VM_SERVICE_PREWARM_RETRIES = 1;
 

--- a/packages/flutter-service/src/diagnostics.ts
+++ b/packages/flutter-service/src/diagnostics.ts
@@ -1,12 +1,18 @@
 // Flutter-service preflight checks, composed from @wdio/native-mobile-core's doctor builders
-// and run from the launcher's onPrepare. Validates the toolchain + the one fork-specific
-// requirement that makes Android execute/mock work until it's upstreamed.
+// and run from the launcher's onPrepare. Validates the toolchain + the minimum
+// `appium-flutter-driver` that makes Android execute/mock work.
 
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { checkCommandOnPath, type DoctorCheck } from '@wdio/native-mobile-core';
 import type { DiagnosticResult } from '@wdio/native-utils';
+
+// First published appium-flutter-driver carrying the Android `appium:dartVmServicePort` cap +
+// `flutter:getVMServiceUrl` command (upstream appium/appium-flutter-driver#880). Below this the
+// engine ignores the port pin, so Android execute/mock can't reach the Dart VM. Keep in lockstep
+// with the `flutter` row in @wdio/native-mobile-core's APPIUM_MATRIX (and e2e/package.json).
+const MIN_FLUTTER_DRIVER_VERSION = '3.8.0';
 
 /** `flutter` on PATH — needed for app builds and SDK-adjacent tooling. */
 export function checkFlutterOnPath(): DoctorCheck {
@@ -16,56 +22,60 @@ export function checkFlutterOnPath(): DoctorCheck {
   });
 }
 
+/** True when `version` (major.minor.patch) is ≥ `floor`. Prerelease suffixes are ignored. */
+function meetsMinimum(version: string, floor: string): boolean {
+  const parts = (v: string) => v.split('.', 3).map((p) => Number.parseInt(p, 10) || 0);
+  const [vMaj, vMin, vPatch] = parts(version);
+  const [fMaj, fMin, fPatch] = parts(floor);
+  if (vMaj !== fMaj) return vMaj > fMaj;
+  if (vMin !== fMin) return vMin > fMin;
+  return vPatch >= fPatch;
+}
+
 /**
- * Verify the installed `appium-flutter-driver` carries the `flutter:getVMServiceUrl` command.
- * Android `execute`/`mock` need the goosewobbler fork (vm-service-port intent extra +
- * getVMServiceUrl) until it is upstreamed/published; on the stock driver this surfaces as a
- * clear warning rather than a silent execute/mock failure. (Delivery stays in CI — we
- * validate, we don't mutate node_modules; see ROADMAP / the upstream PR.)
+ * Verify the installed `appium-flutter-driver` is recent enough for Android execute/mock — it
+ * needs the `appium:dartVmServicePort` cap + `flutter:getVMServiceUrl` command that landed in
+ * {@link MIN_FLUTTER_DRIVER_VERSION}. An older driver surfaces as a clear warning rather than a
+ * silent execute/mock failure. iOS is unaffected (its port pin works from ≥ 3.7.1).
  */
-export function checkAppiumFlutterDriverFork(): DoctorCheck {
+export function checkAppiumFlutterDriverVersion(): DoctorCheck {
   return (): DiagnosticResult => {
-    const forkHint =
-      'Android execute/mock need the goosewobbler appium-flutter-driver fork (vm-service-port + ' +
-      'getVMServiceUrl) until it is upstreamed. iOS is unaffected (uses appium:dartVmServicePort directly).';
+    const hint =
+      `Android execute/mock need appium-flutter-driver ≥ ${MIN_FLUTTER_DRIVER_VERSION} ` +
+      '(adds appium:dartVmServicePort + flutter:getVMServiceUrl). Reinstall the flutter Appium driver to upgrade.';
     try {
       const req = createRequire(join(process.cwd(), 'noop.js'));
-      const pkg = req.resolve('appium-flutter-driver/package.json');
-      // The driver's compiled command lives at build/lib/commands/execute.js. This layout is
-      // stable across the versions we target; the check is temporary and retired once the fork
-      // lands upstream, so a future layout change just needs this path (and the catch keeps the
-      // fork hint so a drift still points the right way).
-      const execJs = join(dirname(pkg), 'build', 'lib', 'commands', 'execute.js');
-      const src = readFileSync(execJs, 'utf8');
-      if (src.includes('getVMServiceUrl')) {
-        return { category: 'appium-flutter-driver', status: 'ok', message: 'getVMServiceUrl present' };
+      const pkgPath = req.resolve('appium-flutter-driver/package.json');
+      const version = (JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string }).version;
+      if (meetsMinimum(version, MIN_FLUTTER_DRIVER_VERSION)) {
+        return { category: 'appium-flutter-driver', status: 'ok', message: `v${version}` };
       }
       return {
         category: 'appium-flutter-driver',
         status: 'warn',
-        message: 'getVMServiceUrl not found in the installed driver',
-        details: forkHint,
+        message: `v${version} is below ${MIN_FLUTTER_DRIVER_VERSION}`,
+        details: hint,
       };
     } catch (error) {
       return {
         category: 'appium-flutter-driver',
         status: 'warn',
         message: `could not inspect appium-flutter-driver (${(error as Error).message})`,
-        details: forkHint,
+        details: hint,
       };
     }
   };
 }
 
 /**
- * The Flutter-specific preflight checks. The fork check is Android-only — the vm-service-port
- * intent extra + getVMServiceUrl are an Android concern, so it's omitted for an iOS-only run
- * (iOS pins the port via processArguments and isn't affected by the fork).
+ * The Flutter-specific preflight checks. The driver-version check is Android-only — the
+ * `dartVmServicePort` cap + `getVMServiceUrl` are an Android concern, so it's omitted for an
+ * iOS-only run (iOS pins the port via processArguments from ≥ 3.7.1).
  */
 export function flutterDoctorChecks(platforms: Set<'android' | 'ios'>): DoctorCheck[] {
   const checks: DoctorCheck[] = [checkFlutterOnPath()];
   if (platforms.has('android')) {
-    checks.push(checkAppiumFlutterDriverFork());
+    checks.push(checkAppiumFlutterDriverVersion());
   }
   return checks;
 }

--- a/packages/flutter-service/src/service.ts
+++ b/packages/flutter-service/src/service.ts
@@ -71,8 +71,8 @@ export default class FlutterWorkerService {
     const store = this.store;
 
     // `retries` is parameterised so the best-effort pre-warm can use a short budget (a 60-retry
-    // scrape there would block worker setup for ~60s on a release build / any unpinned non-fork run);
-    // the lazy on-demand path keeps the full budget.
+    // scrape there would block worker setup for ~60s on a release build / any unpinned run on a
+    // pre-getVMServiceUrl driver); the lazy on-demand path keeps the full budget.
     const discover = (retries = VM_SERVICE_CONNECT_RETRIES) =>
       discoverVmServiceUrl(browser, {
         platform,
@@ -205,8 +205,8 @@ export default class FlutterWorkerService {
     // getLogs scrape finds nothing (appium-flutter-driver catches it only because it streams the
     // log from session start). Discovering here, right after launch, captures it; a later relaunch
     // re-scrapes its fresh line via the reconnect path. Best-effort with a SHORT budget so it never
-    // blocks worker setup: a release build (no VM service) or any unpinned non-fork run misses fast
-    // and falls through to the lazy retry, which keeps the full budget for genuine on-demand use.
+    // blocks worker setup: a release build (no VM service) or any unpinned pre-getVMServiceUrl run
+    // misses fast and falls through to the lazy retry, which keeps the full budget for on-demand use.
     if (platform) {
       this.vmServiceUrl = (await discover(VM_SERVICE_PREWARM_RETRIES).catch(() => undefined)) ?? this.vmServiceUrl;
     }

--- a/packages/flutter-service/src/vmServiceDiscovery.ts
+++ b/packages/flutter-service/src/vmServiceDiscovery.ts
@@ -105,8 +105,8 @@ export async function discoverVmServiceUrl(
   // Primary: ask appium-flutter-driver for the observatory URL it already discovered, forwarded, and
   // connected to (ws://host:port/[auth-code]/ws). The driver does the heavy lifting — log scrape +
   // adb forward — so we just attach our own client to the same VM Service. This sidesteps both the
-  // unsupported getLogs scrape and the port-pin (which the engine ignores). Needs the fork's
-  // flutter:getVMServiceUrl command; on an older driver that lacks it, fall through to pin/scrape.
+  // unsupported getLogs scrape and the port-pin (which the engine ignores). Needs the driver's
+  // flutter:getVMServiceUrl command (≥ 3.8.0); on an older driver that lacks it, fall through to pin/scrape.
   try {
     const driverUrl = (await browser.execute('flutter:getVMServiceUrl')) as unknown;
     if (typeof driverUrl === 'string' && /^wss?:\/\//.test(driverUrl)) {

--- a/packages/flutter-service/test/diagnostics.spec.ts
+++ b/packages/flutter-service/test/diagnostics.spec.ts
@@ -8,7 +8,7 @@ vi.mock('node:module', () => ({
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { checkAppiumFlutterDriverFork, checkFlutterOnPath, flutterDoctorChecks } from '../src/diagnostics.js';
+import { checkAppiumFlutterDriverVersion, checkFlutterOnPath, flutterDoctorChecks } from '../src/diagnostics.js';
 
 const execMock = vi.mocked(execFileSync);
 const readMock = vi.mocked(readFileSync);
@@ -29,35 +29,40 @@ describe('checkFlutterOnPath', () => {
   });
 });
 
-describe('checkAppiumFlutterDriverFork', () => {
-  it('should report ok when getVMServiceUrl is present in the installed driver', async () => {
-    readMock.mockReturnValueOnce('exports.getVMServiceUrl = ...');
-    expect(await checkAppiumFlutterDriverFork()()).toMatchObject({ status: 'ok' });
+describe('checkAppiumFlutterDriverVersion', () => {
+  it('should report ok when the installed driver meets the minimum', async () => {
+    readMock.mockReturnValueOnce(JSON.stringify({ version: '3.8.0' }));
+    expect(await checkAppiumFlutterDriverVersion()()).toMatchObject({ status: 'ok', message: 'v3.8.0' });
   });
 
-  it('should warn with the fork hint when getVMServiceUrl is absent', async () => {
-    readMock.mockReturnValueOnce('exports.execute = ...');
-    const r = await checkAppiumFlutterDriverFork()();
+  it('should report ok for a higher minor/major (numeric, not lexical, compare)', async () => {
+    readMock.mockReturnValueOnce(JSON.stringify({ version: '3.10.0' }));
+    expect(await checkAppiumFlutterDriverVersion()()).toMatchObject({ status: 'ok' });
+  });
+
+  it('should warn with the upgrade hint when the driver is below the minimum', async () => {
+    readMock.mockReturnValueOnce(JSON.stringify({ version: '3.7.1' }));
+    const r = await checkAppiumFlutterDriverVersion()();
     expect(r.status).toBe('warn');
-    expect(r.details).toMatch(/goosewobbler/);
+    expect(r.details).toMatch(/3\.8\.0/);
   });
 
-  it('should warn (with the fork hint) when the driver cannot be inspected', async () => {
+  it('should warn (with the upgrade hint) when the driver cannot be inspected', async () => {
     readMock.mockImplementationOnce(() => {
       throw new Error('ENOENT');
     });
-    const r = await checkAppiumFlutterDriverFork()();
+    const r = await checkAppiumFlutterDriverVersion()();
     expect(r.status).toBe('warn');
-    expect(r.details).toMatch(/goosewobbler/);
+    expect(r.details).toMatch(/3\.8\.0/);
   });
 });
 
 describe('flutterDoctorChecks', () => {
-  it('should bundle the flutter + fork checks for an Android run', () => {
+  it('should bundle the flutter + driver-version checks for an Android run', () => {
     expect(flutterDoctorChecks(new Set(['android']))).toHaveLength(2);
   });
 
-  it('should omit the Android-only fork check for an iOS-only run', () => {
+  it('should omit the Android-only driver-version check for an iOS-only run', () => {
     expect(flutterDoctorChecks(new Set(['ios']))).toHaveLength(1);
   });
 });

--- a/packages/flutter-service/test/service.spec.ts
+++ b/packages/flutter-service/test/service.spec.ts
@@ -241,7 +241,7 @@ describe('FlutterWorkerService', () => {
     const browser = {} as WebdriverIO.Browser;
     const service = new FlutterWorkerService({}, cap);
     await service.before(cap, [], browser);
-    // A release build / unpinned non-fork run would otherwise burn the full ~60s scrape here.
+    // A release build / unpinned pre-getVMServiceUrl run would otherwise burn the full ~60s scrape here.
     expect(discoverVmServiceUrl).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ retries: VM_SERVICE_PREWARM_RETRIES }),

--- a/packages/native-mobile-core/src/versionMatrix.ts
+++ b/packages/native-mobile-core/src/versionMatrix.ts
@@ -28,7 +28,7 @@ export const APPIUM_MATRIX: AppiumCompat[] = [
     drivers: {
       uiautomator2: { name: 'uiautomator2', source: 'appium-uiautomator2-driver', version: '^7.6.0' },
       xcuitest: { name: 'xcuitest', source: 'appium-xcuitest-driver', version: '^11.9.0' },
-      flutter: { name: 'flutter', source: 'appium-flutter-driver', version: '^3.7.0' },
+      flutter: { name: 'flutter', source: 'appium-flutter-driver', version: '^3.8.0' },
     },
   },
 ];

--- a/packages/native-mobile-core/test/appiumDriverManager.spec.ts
+++ b/packages/native-mobile-core/test/appiumDriverManager.spec.ts
@@ -109,7 +109,7 @@ describe('ensureAppiumDriver', () => {
     expect(r).toMatchObject({ ok: true, value: { method: 'installed' } });
     expect(spawnMock).toHaveBeenCalledWith(
       expect.any(String),
-      ['driver', 'install', '--source=npm', 'appium-flutter-driver@^3.7.0'],
+      ['driver', 'install', '--source=npm', 'appium-flutter-driver@^3.8.0'],
       // a timeout caps the install so a slow registry can't hang onPrepare
       expect.objectContaining({ timeout: 300000 }),
     );
@@ -134,10 +134,10 @@ describe('ensureAppiumDriver', () => {
   it('should honour a source override for the install spec', async () => {
     mockAppium('3.5.0', []);
     spawnMock.mockReturnValueOnce(fakeProc(0));
-    await ensureAppiumDriver('flutter', { autoInstallDriver: true, source: '@goosewobbler/appium-flutter-driver' });
+    await ensureAppiumDriver('flutter', { autoInstallDriver: true, source: '@example/appium-flutter-driver' });
     expect(spawnMock).toHaveBeenCalledWith(
       expect.any(String),
-      ['driver', 'install', '--source=npm', '@goosewobbler/appium-flutter-driver@^3.7.0'],
+      ['driver', 'install', '--source=npm', '@example/appium-flutter-driver@^3.8.0'],
       expect.any(Object),
     );
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       appium-flutter-driver:
-        specifier: ^3.7.0
-        version: 3.7.1(appium@3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: ^3.8.0
+        version: 3.8.0(appium@3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       appium-uiautomator2-driver:
         specifier: ^7.6.0
         version: 7.6.0(appium@3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -4368,8 +4368,8 @@ packages:
     resolution: {integrity: sha512-wSt8iBNMvyB5tz7bsxNjcp74RMmsNN3/o6qOafda7PcuFzhby88It1NwRyvXaSlLJFFi2Hnu25MwhD+Lmwj96g==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
 
-  appium-flutter-driver@3.7.1:
-    resolution: {integrity: sha512-9y2WrDPu1j3gM4JWKyqdaR8ihiQqPC6q5opTi7+fcT5xEe5Hy4UAD3YMwjhYLfEVKNsKfjG85JuGLKwSNVOqOQ==}
+  appium-flutter-driver@3.8.0:
+    resolution: {integrity: sha512-8ZzQXA3iZZjsrtYc04e2MUhhXMb1TA2PcSrArRRI89USullyTkzS88g9UpmEoRzi/UgtEgK1S2ohoMI1tbcQPA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
     peerDependencies:
       appium: ^3.0.0
@@ -12198,7 +12198,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  appium-flutter-driver@3.7.1(appium@3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  appium-flutter-driver@3.8.0(appium@3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       appium: 3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       appium-android-driver: 13.2.3(appium@3.5.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -12438,7 +12438,7 @@ snapshots:
       node-devicectl: 1.4.0
       node-simctl: 8.2.3
       portscanner: 2.2.0
-      semver: 7.8.4
+      semver: 7.8.5
       teen_process: 4.1.3
       winston: 3.19.0
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -635,22 +635,6 @@ async function testExample(
     const addCommand = `pnpm add ${packagesToInstall.join(' ')}`;
     execCommand(addCommand, packageDir, `Installing local packages for ${packageName}`);
 
-    // Flutter drives the Dart VM via appium-flutter-driver's getVMServiceUrl, which only exists
-    // in the goosewobbler fork (not the published driver). CI builds that fork and points
-    // AFD_FORK_BUILD_DIR at its build/ output; overwrite the isolated fixture's driver build/ with
-    // it so the smoke can reach the VM — mirrors what the flutter e2e does to e2e/node_modules.
-    // No-op without the env (a local run must install the fork itself). Drop once it's published.
-    if (service === 'flutter' && process.env.AFD_FORK_BUILD_DIR && existsSync(process.env.AFD_FORK_BUILD_DIR)) {
-      const afdDir = execSync(
-        `node -e "process.stdout.write(require('path').dirname(require.resolve('appium-flutter-driver/package.json')))"`,
-        { cwd: packageDir, encoding: 'utf-8' },
-      ).trim();
-      const afdBuild = join(afdDir, 'build');
-      log(`Overwriting appium-flutter-driver build/ with the getVMServiceUrl fork at ${afdBuild}`);
-      rmSync(afdBuild, { recursive: true, force: true });
-      cpSync(process.env.AFD_FORK_BUILD_DIR, afdBuild, { recursive: true });
-    }
-
     // Ensure logs directory exists for WebdriverIO output
     mkdirSync(logsDir, { recursive: true });
     log(`✅ Created logs directory: ${logsDir}`);


### PR DESCRIPTION
## What

`appium-flutter-driver@3.8.0` (published to npm today) ships everything the `@goosewobbler` fork carried, so the fork machinery can go:

- **Android** `appium:dartVmServicePort` cap + `flutter:getVMServiceUrl` command — [appium/appium-flutter-driver#880](https://github.com/appium/appium-flutter-driver/pull/880) (merged)
- **iOS** log-capture retry — [appium/appium-flutter-driver#881](https://github.com/appium/appium-flutter-driver/pull/881) (merged)

Verified the published `3.8.0` tarball ships both `getVMServiceUrl` and Android `dartVmServicePort`.

## Changes (the #461 checklist)

- [x] **Matrix → `^3.8.0`** — `APPIUM_MATRIX.flutter` in `@wdio/native-mobile-core` (source was already the published driver; the fork was only ever CI-delivered). `e2e/package.json` + the isolated `flutter-app` fixture pinned to `^3.8.0`; `pnpm-lock.yaml` regenerated (clean 3.7.1→3.8.0 bump).
- [x] **CI fork-delivery deleted** — removed the clone→build→overwrite step from both flutter e2e workflows + the `AFD_FORK_BUILD_DIR` plumbing in `test-package.ts` and the run scripts. The iOS step keeps its XCUITest install (renamed "Install XCUITest driver").
- [x] **Doctor → min-version check** — `checkAppiumFlutterDriverFork` → `checkAppiumFlutterDriverVersion`: warns when the installed driver is `< 3.8.0` (still Android-only gated; iOS works from ≥ 3.7.1).
- [x] **Stopgap** — no actual `@goosewobbler/appium-flutter-driver` publish workflow existed; the only reference was a test fixture, now de-forked.

Plus de-forking the README and the source/CI comments.

## Verification

- `@wdio/native-mobile-core` (112) + `@wdio/flutter-service` (108) unit tests pass; both typecheck.
- Full `turbo run test --filter=./packages/*` green (pre-push).
- `biome format` clean on all edited files; both workflows parse as valid YAML.
- Zero residual fork references in the tree.

Closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)