### PR TITLE
ci(release): use releasekit refresh-after-release for the post-release reconcile

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -295,3 +295,15 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
           OLLAMA_API_KEY: ${{ secrets.ollama_api_key }}
+
+      # Reconcile the standing PR against the just-released HEAD (closes it if nothing's left, else
+      # rebuilds the release branch) and refresh feeder-PR previews — replaces the former
+      # reconcile-after-* jobs. The push reuses the checkout's SSH deploy key so the standing PR's CI
+      # re-runs; a GITHUB_TOKEN push wouldn't trigger it. Only the scoped-release path leaves a stale
+      # standing PR (the standing-pr-publish path is the PR being merged), and never on a dry run.
+      - name: Refresh standing PR after release
+        if: ${{ inputs.standing_pr_number == '' && !inputs.dry_run }}
+        run: pnpm exec releasekit refresh-after-release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OLLAMA_API_KEY: ${{ secrets.ollama_api_key }}

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -1,19 +1,15 @@
 name: Standing PR Update (Reusable)
 
 # Wraps releasekit standing-pr-update for the routine push-triggered update
-# (standing-pr.yml) and the post-release reconcile jobs (release.yml). Pushes the
-# release branch over SSH (DEPLOY_KEY) so CI runs on the standing PR — pushes made
-# with GITHUB_TOKEN don't trigger workflows, which would leave the PR unmergeable
-# under required status checks.
+# (standing-pr.yml). Pushes the release branch over SSH (DEPLOY_KEY) so CI runs on
+# the standing PR — pushes made with GITHUB_TOKEN don't trigger workflows, which would
+# leave the PR unmergeable under required status checks.
+#
+# The post-release reconcile is no longer a job here — `releasekit refresh-after-release`
+# runs in the release job (_release.reusable.yml) after a release completes.
 
 on:
   workflow_call:
-    inputs:
-      reconcile:
-        description: 'Bypass the skip-pattern guard — required for post-release reconcile runs, where HEAD is a release commit'
-        required: false
-        type: boolean
-        default: false
     secrets:
       ssh_key:
         description: 'SSH deploy key for pushing the release branch'
@@ -48,7 +44,6 @@ jobs:
           mode: standing-pr-update
           node-version: '24'
           project-dir: .
-          reconcile: ${{ inputs.reconcile && 'true' || 'false' }}
           verbose: 'true'
           summary: 'true'
           skip-checkout: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,6 @@ on:
         required: false
         type: string
         default: ''
-      reconcile_after:
-        description: "Rebuild the standing release PR after this release completes. Manual callers may enable it so the standing PR drops the just-released changes."
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: release
@@ -139,25 +134,6 @@ jobs:
       crates_io_token: ${{ secrets.CRATES_IO_TOKEN }}
       ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
 
-  # An immediate release leaves the standing PR holding changes that overlap with what
-  # was just published. Re-running standing-pr update reconciles: closes the standing PR
-  # if nothing's left, otherwise rebuilds the release branch against the new HEAD.
-  # reconcile=true bypasses the skip-pattern guard, which would otherwise noop on the
-  # release commit at HEAD.
-  reconcile-after-auto:
-    name: Reconcile standing PR
-    needs: [release-auto]
-    if: needs.release-auto.result == 'success'
-    uses: ./.github/workflows/_standing-pr-update.reusable.yml
-    permissions:
-      contents: write
-      pull-requests: write
-    with:
-      reconcile: true
-    secrets:
-      ssh_key: ${{ secrets.DEPLOY_KEY }}
-      ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
-
   release-manual:
     name: Release (Manual)
     if: github.event_name == 'workflow_dispatch' && inputs.standing_pr_number == ''
@@ -175,20 +151,6 @@ jobs:
     secrets:
       ssh_key: ${{ secrets.DEPLOY_KEY }}
       crates_io_token: ${{ secrets.CRATES_IO_TOKEN }}
-      ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
-
-  reconcile-after-manual:
-    name: Reconcile standing PR
-    needs: [release-manual]
-    if: github.event_name == 'workflow_dispatch' && inputs.reconcile_after && !inputs.dry_run && needs.release-manual.result == 'success'
-    uses: ./.github/workflows/_standing-pr-update.reusable.yml
-    permissions:
-      contents: write
-      pull-requests: write
-    with:
-      reconcile: true
-    secrets:
-      ssh_key: ${{ secrets.DEPLOY_KEY }}
       ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
 
   # Standing-PR publish path. Dispatched by standing-pr.yml via `gh workflow run` so the


### PR DESCRIPTION
Replaces our custom "rebuild the standing PR after release" jobs with releasekit's native **`refresh-after-release`** command (shipped in **0.34.0**, goosewobbler/releasekit#438) — now that #485 put us on 0.34.0.

## Why
`refresh-after-release` is the purpose-built post-release command. It does two things:
1. **Reconcile the standing PR** — `runStandingPRUpdate({ reconcile: true })`: closes it if nothing's left, else rebuilds the release branch against the new HEAD. This is **exactly** what our `reconcile-after-*` jobs did (via `standing-pr-update --reconcile`).
2. **Refresh feeder-PR previews** — replays the "what would release" preview comment on still-open PRs (cosmetic, opt-in).

## Changes
- **`_release.reusable.yml`** — add a `Refresh standing PR after release` step at the end of the release job. Runs after a **scoped, non-dry** release; pushes over the checkout's **SSH deploy key** so the standing PR's CI re-runs (a `GITHUB_TOKEN` push wouldn't trigger it — the load-bearing reason the old reconcile lived in `_standing-pr-update.reusable.yml`).
- **`release.yml`** — remove `reconcile-after-auto`, `reconcile-after-manual`, and the `reconcile_after` dispatch input (−38 lines).
- **`_standing-pr-update.reusable.yml`** — remove the now-orphaned `reconcile` input + action param (only the routine push-triggered update uses this workflow now, without reconcile).

## Behaviour notes
- **Manual releases now always reconcile** — the `reconcile_after` opt-in is gone. The native command is the post-release default; the opt-in was a footgun (forgetting it left the standing PR stale).
- **Standing-pr-publish path unchanged** — the step is gated to the scoped-release path (`standing_pr_number == ''`), so the merged-PR publish flow is untouched (it had no reconcile job before).
- **Dry runs skip it** (`!inputs.dry_run`).
- **Half 2 (feeder-PR preview refresh) is a no-op** until `ci.prPreview.refreshAfterRelease` is enabled — left as a follow-up to avoid introducing new preview config here.

All three workflows validated (YAML parse clean); no dangling references to the removed jobs/input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)