### PR TITLE
chore(flutter): reconcile manifests to the published 1.0.0-next.0

### DIFF
--- a/packages/flutter-service/package.json
+++ b/packages/flutter-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdio/flutter-service",
-  "version": "0.0.1",
+  "version": "1.0.0-next.0",
   "description": "WebdriverIO service for testing Flutter mobile applications",
   "author": "WebdriverIO Community",
   "homepage": "https://github.com/webdriverio/desktop-mobile/tree/main/packages/flutter-service",

--- a/packages/flutter-service/wdio_flutter/pubspec.yaml
+++ b/packages/flutter-service/wdio_flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   WebdriverIO Flutter service contract — opt-in Dart VM service extensions (ext.wdio.*)
   and a mock registry your app's DI seams route through, driven by @wdio/flutter-service
   over the Dart VM Service. The app-side half of browser.flutter.mock.*.
-version: 0.0.1
+version: 1.0.0-next.0
 homepage: https://github.com/webdriverio/desktop-mobile/tree/main/packages/flutter-service/wdio_flutter
 repository: https://github.com/webdriverio/desktop-mobile
 issue_tracker: https://github.com/webdriverio/desktop-mobile/issues


### PR DESCRIPTION
Fixes the flutter prerelease dry run [graduating to a stable `1.0.0`](https://github.com/webdriverio/desktop-mobile/actions/runs/28270078269) instead of incrementing to `1.0.0-next.1`.

## Root cause
`1.0.0-next.0` published to npm + was tagged, but its **version commit never landed on main** (the push was declined by branch-protection rulesets at the time — since fixed). So:

| | version |
|---|---|
| npm `next` dist-tag | `1.0.0-next.0` |
| git tag `wdio-flutter-service@v1.0.0-next.0` | `1.0.0-next.0` (orphaned — not an ancestor of main) |
| **main manifests** | **`0.0.1`** ← stale |

On the next dispatch the per-package calc reads the stale `0.0.1` manifest (the tag isn't reachable, so it falls back to it) while the linked-group baseline reads `1.0.0-next.0` from the tag. The diff between them resolves to a **major** bump → `semver.inc('1.0.0-next.0','major')` = `1.0.0` → releasekit graduates (`"Graduated 1.0.0-next.0 → 1.0.0 (bump ignored)"`).

## Fix
Set both manifests to the published `1.0.0-next.0`:
- `packages/flutter-service/package.json`
- `packages/flutter-service/wdio_flutter/pubspec.yaml`

With the baseline consistent, a `bump=prerelease` dispatch computes `1.0.0-next.1`.

## After this merges
1. **Re-point the orphaned tag** `wdio-flutter-service@v1.0.0-next.0` onto a main commit so the next release's changelog bounds cleanly (cosmetic but worth doing) — I can do this once merged.
2. Dispatch `release_type=prerelease`, `bump=prerelease`, `scope=flutter` → `1.0.0-next.1`.

> Note: there's arguably a releasekit hardening here too — a `stable=false` (prerelease) dispatch shouldn't graduate to a stable version even when the manifest lags the tag. But that only surfaces in this inconsistent state; reconciling the manifest is the direct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)