### PR TITLE
test(dioxus): browser-mode test parity (integration + E2E + fixture)

### DIFF
--- a/.github/workflows/_ci-browser-mode.reusable.yml
+++ b/.github/workflows/_ci-browser-mode.reusable.yml
@@ -1,8 +1,8 @@
 name: Browser Mode
 # Description: Runs browser-mode tests — real Chrome against a user-managed dev server,
 # with native IPC mocked at the JS boundary. No native binary, no platform driver, no app
-# build. Covers the Electron browser-mode E2E suite plus the Tauri/Electron/Dioxus
-# browser-mode package tests. Linux only — fast feedback is the whole point of this mode.
+# build. Covers the Electron/Tauri/Dioxus browser-mode E2E suites plus the
+# Tauri/Electron/Dioxus browser-mode package tests. Linux only — fast feedback is the whole point of this mode.
 
 permissions:
   contents: read
@@ -86,8 +86,8 @@ jobs:
       # Chrome preinstalled on ubuntu-latest under a Xvfb display it starts itself. Each step
       # runs even if an earlier one failed (!cancelled) so one red tier never masks the others;
       # any failure still fails the job. The browser-mode E2E confs self-host their dev servers
-      # (electron-browser :5174, tauri-browser :1421); test-package.ts self-hosts the package
-      # fixtures' dev server (:5173).
+      # (electron-browser :5174, tauri-browser :1421, dioxus-browser :8088); test-package.ts
+      # self-hosts the package fixtures' dev server (:5173).
       - name: 🧪 Electron browser-mode E2E
         if: ${{ !cancelled() }}
         shell: bash
@@ -97,6 +97,11 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: pnpm e2e:tauri-browser
+
+      - name: 🧪 Dioxus browser-mode E2E
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: pnpm e2e:dioxus-browser
 
       - name: 🧪 Electron browser-mode package test (ESM + CJS)
         if: ${{ !cancelled() }}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,6 +19,7 @@
     "test:e2e:electron-script:window": "cross-env DEBUG=wdio-electron-service:launcher WDIO_VERBOSE=true FRAMEWORK=electron APP=script BINARY=false TEST_TYPE=window ENABLE_SPLASH_WINDOW=true tsx scripts/run-matrix.ts",
     "test:e2e:electron-browser": "wdio run wdio.electron-browser.conf.ts",
     "test:e2e:tauri-browser": "wdio run wdio.tauri-browser.conf.ts",
+    "test:e2e:dioxus-browser": "wdio run wdio.dioxus-browser.conf.ts",
     "test:e2e-mac-universal:electron-builder": "cross-env DEBUG=wdio-electron-service:launcher WDIO_VERBOSE=true FRAMEWORK=electron APP=builder BINARY=true MAC_UNIVERSAL=true tsx scripts/run-matrix.ts",
     "test:e2e-mac-universal:electron-forge": "cross-env DEBUG=wdio-electron-service:launcher WDIO_VERBOSE=true FRAMEWORK=electron APP=forge BINARY=true MAC_UNIVERSAL=true tsx scripts/run-matrix.ts",
     "test:e2e:standard": "cross-env TEST_TYPE=standard tsx scripts/run-matrix.ts",

--- a/e2e/test/dioxus-browser/mock.spec.ts
+++ b/e2e/test/dioxus-browser/mock.spec.ts
@@ -1,0 +1,37 @@
+import { $, browser, expect } from '@wdio/globals';
+
+describe('Dioxus browser-mode E2E', () => {
+  it('should intercept a value-returning invoke via browser.dioxus.mock', async () => {
+    const mock = await browser.dioxus.mock('get_app_version');
+    await mock.mockResolvedValue('99.0.0-browser');
+
+    await $('[data-testid="fetch-version"]').click();
+
+    await browser.waitUntil(async () => (await $('[data-testid="version-output"]').getText()) === '99.0.0-browser', {
+      timeout: 5000,
+      timeoutMsg: 'expected mocked version to render',
+    });
+
+    await mock.update();
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should intercept an invoke with arguments via browser.dioxus.mock', async () => {
+    const mock = await browser.dioxus.mock('greet');
+    await mock.mockResolvedValue('Hello, WDIO');
+
+    await $('[data-testid="send-greeting"]').click();
+
+    await browser.waitUntil(
+      async () => (await $('[data-testid="greeting-output"]').getText()).includes('Hello, WDIO'),
+      {
+        timeout: 5000,
+        timeoutMsg: 'expected mocked greeting to render',
+      },
+    );
+
+    await mock.update();
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock.mock.calls[0][0]).toEqual({ name: 'WDIO' });
+  });
+});

--- a/e2e/wdio.dioxus-browser.conf.ts
+++ b/e2e/wdio.dioxus-browser.conf.ts
@@ -1,0 +1,134 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { dirname, extname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Options } from '@wdio/types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const fixtureRoot = resolvePath(__dirname, '..', 'fixtures', 'e2e-apps', 'dioxus-browser');
+const port = 8088;
+const devServerUrl = `http://localhost:${port}`;
+
+let staticServer: Server | undefined;
+
+function startStaticServer(rootPath: string): Promise<Server> {
+  const mimeTypes: Record<string, string> = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.mjs': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+  };
+  // Enumerate files up front and look them up by request URL into the map.
+  // Keeps user-controlled input out of `readFileSync` and satisfies CodeQL.
+  const allowed = new Map<string, string>();
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const abs = join(dir, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(abs, rel);
+      } else if (entry.isFile()) {
+        allowed.set(`/${rel}`, abs);
+        if (rel === 'index.html') allowed.set('/', abs);
+      }
+    }
+  };
+  walk(rootPath, '');
+
+  const server = createServer((req, res) => {
+    const key = (req.url ?? '/').split('?')[0];
+    const absolute = allowed.get(key);
+    if (!absolute) {
+      res.statusCode = 404;
+      res.end('Not Found');
+      return;
+    }
+    res.setHeader('Content-Type', mimeTypes[extname(absolute)] ?? 'application/octet-stream');
+    res.end(readFileSync(absolute));
+  });
+  return new Promise((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(port, '127.0.0.1', () => resolveListen(server));
+  });
+}
+
+/**
+ * On Linux/macOS, list running processes to confirm browser mode is not
+ * spawning the Dioxus driver stack — the embedded-driver app binary
+ * (`wdio-dioxus-*`), the external `wdio-dioxus-driver` proxy, or the platform
+ * webview driver (`msedgedriver` on Windows / `WebKitWebDriver` on Linux) the
+ * external provider drives. Browser mode runs real Chrome via chromedriver, so
+ * none of these should appear. Skip on Windows where `ps` doesn't exist; CI on
+ * Windows relies on the launcher integration test (no driver constructed in
+ * browser mode).
+ */
+function assertNoDioxusDriverProcesses(): void {
+  if (process.platform === 'win32') return;
+  try {
+    const psOutput = execSync('ps -A -o command=', { encoding: 'utf-8' });
+    const offenders = psOutput
+      .split('\n')
+      .filter((line) => /wdio-dioxus|dioxus-driver|msedgedriver|WebKitWebDriver/i.test(line))
+      .filter((line) => !line.includes('wdio.dioxus-browser.conf.ts'));
+    if (offenders.length > 0) {
+      throw new Error(`Browser-mode run should not spawn Dioxus driver processes, but found:\n${offenders.join('\n')}`);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Browser-mode run should')) {
+      throw error;
+    }
+    // ps failed for some other reason — log but don't fail the run.
+    console.warn(`Could not run ps for process-presence check: ${error}`);
+  }
+}
+
+export const config: Options.Testrunner = {
+  runner: 'local',
+  specs: ['./test/dioxus-browser/*.spec.ts'],
+  exclude: [],
+  maxInstances: 1,
+  capabilities: [
+    {
+      browserName: 'dioxus',
+      'wdio:dioxusServiceOptions': {
+        mode: 'browser',
+        devServerUrl,
+      },
+    },
+  ] as unknown as Options.Testrunner['capabilities'],
+  logLevel: 'info',
+  outputDir: join(__dirname, 'logs', 'dioxus-browser'),
+  bail: 0,
+  baseUrl: '',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 3,
+  autoXvfb: true,
+  services: ['@wdio/dioxus-service'],
+  framework: 'mocha',
+  reporters: ['spec'],
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+  },
+  async onPrepare() {
+    if (!existsSync(fixtureRoot)) {
+      throw new Error(`Fixture not found: ${fixtureRoot}`);
+    }
+    staticServer = await startStaticServer(fixtureRoot);
+    console.log(`Browser-mode static server listening on ${devServerUrl}`);
+  },
+  async beforeSession() {
+    assertNoDioxusDriverProcesses();
+  },
+  async onComplete() {
+    if (staticServer) {
+      await new Promise<void>((resolveClose) => staticServer?.close(() => resolveClose()));
+      console.log('Browser-mode static server stopped');
+    }
+  },
+};

--- a/fixtures/e2e-apps/dioxus-browser/index.html
+++ b/fixtures/e2e-apps/dioxus-browser/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Dioxus Browser-Mode E2E Fixture</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        margin: 0;
+        padding: 20px;
+        background: linear-gradient(135deg, #475569 0%, #0f172a 100%);
+        color: white;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(15px);
+        border-radius: 25px;
+        padding: 50px;
+        text-align: center;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        max-width: 800px;
+        width: 100%;
+      }
+      h1 {
+        margin: 0 0 25px 0;
+        font-size: 3em;
+        font-weight: 200;
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+      }
+      button {
+        background: rgba(255, 255, 255, 0.25);
+        border: 2px solid rgba(255, 255, 255, 0.4);
+        color: white;
+        padding: 15px 20px;
+        border-radius: 12px;
+        cursor: pointer;
+        font-size: 1em;
+        font-weight: 500;
+        transition: all 0.3s ease;
+        backdrop-filter: blur(5px);
+        margin: 8px;
+      }
+      button:hover {
+        background: rgba(255, 255, 255, 0.35);
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+      }
+      section {
+        margin: 20px 0;
+      }
+      pre {
+        margin-top: 12px;
+        padding: 12px 16px;
+        background: rgba(0, 0, 0, 0.25);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 10px;
+        font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+        font-size: 0.95em;
+        min-height: 1.2em;
+        text-align: left;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 data-testid="title">Dioxus Browser-Mode E2E</h1>
+
+      <section>
+        <button type="button" data-testid="fetch-version">Fetch version</button>
+        <pre data-testid="version-output"></pre>
+      </section>
+
+      <section>
+        <button type="button" data-testid="send-greeting">Send greeting</button>
+        <pre data-testid="greeting-output"></pre>
+      </section>
+    </div>
+
+    <script>
+      // In a real Dioxus app window.__WDIO_DIOXUS__.invoke is installed by
+      // @wdio/dioxus-bridge. In browser mode the service's injection script
+      // defines the same shape (and patches invoke to consult registered
+      // mocks), so frontend code is portable as-is. This fallback only matters
+      // if a button is clicked before injection ran.
+      if (!window.__WDIO_DIOXUS__) {
+        window.__WDIO_DIOXUS__ = { invoke: () => Promise.reject(new Error('Dioxus IPC not injected')) };
+      }
+
+      document.querySelector('[data-testid="fetch-version"]').addEventListener('click', async () => {
+        try {
+          const version = await window.__WDIO_DIOXUS__.invoke('get_app_version');
+          document.querySelector('[data-testid="version-output"]').textContent = version;
+        } catch (err) {
+          document.querySelector('[data-testid="version-output"]').textContent = `error: ${err.message}`;
+        }
+      });
+
+      document.querySelector('[data-testid="send-greeting"]').addEventListener('click', async () => {
+        try {
+          const reply = await window.__WDIO_DIOXUS__.invoke('greet', { name: 'WDIO' });
+          document.querySelector('[data-testid="greeting-output"]').textContent = String(reply);
+        } catch (err) {
+          document.querySelector('[data-testid="greeting-output"]').textContent = `error: ${err.message}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/fixtures/e2e-apps/dioxus-browser/package.json
+++ b/fixtures/e2e-apps/dioxus-browser/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dioxus-browser-e2e-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static HTML fixture served as a dev server for Dioxus browser-mode E2E tests"
+}

--- a/fixtures/package-tests/dioxus-app/browser/index.html
+++ b/fixtures/package-tests/dioxus-app/browser/index.html
@@ -7,5 +7,23 @@
   <body>
     <h1 id="app-title">WDIO Dioxus Browser Mode</h1>
     <div id="status">ready</div>
+
+    <button type="button" data-testid="fetch-info">Fetch info</button>
+    <pre data-testid="info"></pre>
+
+    <script type="module">
+      // In a real Dioxus app window.__WDIO_DIOXUS__.invoke is installed by
+      // @wdio/dioxus-bridge. In browser mode the service injects the same shape
+      // and patches invoke to consult registered mocks, so this frontend code is
+      // portable as-is. The fallback only fires if a click beats injection.
+      if (!window.__WDIO_DIOXUS__) {
+        window.__WDIO_DIOXUS__ = { invoke: () => Promise.reject(new Error('Dioxus IPC not injected')) };
+      }
+
+      document.querySelector('[data-testid="fetch-info"]').addEventListener('click', async () => {
+        const info = await window.__WDIO_DIOXUS__.invoke('get_info');
+        document.querySelector('[data-testid="info"]').textContent = JSON.stringify(info);
+      });
+    </script>
   </body>
 </html>

--- a/fixtures/package-tests/dioxus-app/browser/index.html
+++ b/fixtures/package-tests/dioxus-app/browser/index.html
@@ -21,8 +21,12 @@
       }
 
       document.querySelector('[data-testid="fetch-info"]').addEventListener('click', async () => {
-        const info = await window.__WDIO_DIOXUS__.invoke('get_info');
-        document.querySelector('[data-testid="info"]').textContent = JSON.stringify(info);
+        try {
+          const info = await window.__WDIO_DIOXUS__.invoke('get_info');
+          document.querySelector('[data-testid="info"]').textContent = JSON.stringify(info);
+        } catch (err) {
+          document.querySelector('[data-testid="info"]').textContent = `error: ${err.message}`;
+        }
       });
     </script>
   </body>

--- a/fixtures/package-tests/dioxus-app/test-browser/browser.spec.ts
+++ b/fixtures/package-tests/dioxus-app/test-browser/browser.spec.ts
@@ -1,4 +1,4 @@
-import { browser, expect } from '@wdio/globals';
+import { $, browser, expect } from '@wdio/globals';
 
 describe('Dioxus browser-mode smoke (package install)', () => {
   it('should load the page without error', async () => {
@@ -9,5 +9,23 @@ describe('Dioxus browser-mode smoke (package install)', () => {
   it('should have dioxus service available in browser mode', async () => {
     expect(browser.dioxus).toBeDefined();
     expect(typeof browser.dioxus.execute).toBe('function');
+  });
+
+  it('should mock a Dioxus command and surface the mocked response in the page', async () => {
+    const mock = await browser.dioxus.mock('get_info');
+    await mock.mockResolvedValue({ name: 'BrowserModeApp', version: '0.0.0' });
+
+    await $('[data-testid="fetch-info"]').click();
+
+    await browser.waitUntil(
+      async () => {
+        const text = await $('[data-testid="info"]').getText();
+        return text.includes('BrowserModeApp');
+      },
+      { timeout: 5000, timeoutMsg: 'expected mocked info to render' },
+    );
+
+    await mock.update();
+    expect(mock).toHaveBeenCalledTimes(1);
   });
 });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "e2e:electron-script": "pnpm --filter @repo/e2e run test:e2e:electron-script",
     "e2e:electron-browser": "pnpm --filter @repo/e2e run test:e2e:electron-browser",
     "e2e:tauri-browser": "pnpm --filter @repo/e2e run test:e2e:tauri-browser",
+    "e2e:dioxus-browser": "pnpm --filter @repo/e2e run test:e2e:dioxus-browser",
     "e2e:multiremote": "pnpm --filter @repo/e2e run test:e2e:multiremote",
     "e2e:standalone": "pnpm --filter @repo/e2e run test:e2e:standalone",
     "e2e:tauri": "pnpm protocol-install:tauri && pnpm --filter @repo/e2e run test:e2e:tauri",

--- a/packages/dioxus-service/docs/browser-mode.md
+++ b/packages/dioxus-service/docs/browser-mode.md
@@ -134,6 +134,10 @@ await mockReadFile.mockResolvedValue('default content');
 await mockReadFile.mockRestore();
 ```
 
+## Events
+
+Events are not supported in either mode — Dioxus has no native event bus, so there is no `browser.dioxus.emitEvent()` (see [`@wdio/native-types`](../../native-types/src/dioxus.ts)). This is a service-wide limitation, not specific to browser mode.
+
 ## Mock Lifecycle Across Tests
 
 ### `mock(command)` Is Idempotent

--- a/packages/dioxus-service/test/integration/browser-mode.integration.spec.ts
+++ b/packages/dioxus-service/test/integration/browser-mode.integration.spec.ts
@@ -1,0 +1,214 @@
+import type { DioxusMock } from '@wdio/native-types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import mockStore from '../../src/mockStore.js';
+import DioxusWorkerService from '../../src/service.js';
+import { createFakeBrowser, type FakeBrowser } from './helpers.js';
+
+vi.mock('@wdio/native-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@wdio/native-utils')>()),
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+}));
+
+const DEV_SERVER = 'http://localhost:8080';
+
+// The Dioxus browser-mode IPC injection script is the only one that installs the
+// __WDIO_DIOXUS__ invoke shim. Registration scripts touch __wdio_mocks__ but never
+// reference __WDIO_DIOXUS__, so this distinguishes the two.
+function isInjectionScript(arg: unknown): boolean {
+  return typeof arg === 'string' && arg.includes('__WDIO_DIOXUS__') && arg.includes('window.__wdio_spy__');
+}
+
+function isRegistrationScript(arg: unknown, command: string): boolean {
+  return (
+    typeof arg === 'string' &&
+    arg.includes(`window.__wdio_mocks__[${JSON.stringify(command)}]`) &&
+    !isInjectionScript(arg)
+  );
+}
+
+describe('browser mode — initialisation', () => {
+  let service: DioxusWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new DioxusWorkerService({}, { 'wdio:dioxusServiceOptions': { devServerUrl: DEV_SERVER } });
+    browser = createFakeBrowser();
+    // initBrowserMode calls browser.url(devServerUrl) before patchBrowserUrl
+    // replaces browser.url — capture the spy before the patch.
+    const urlSpy = browser.url;
+    await service.before({}, [], browser as unknown as WebdriverIO.Browser);
+    (browser as unknown as { __initialUrlSpy: typeof urlSpy }).__initialUrlSpy = urlSpy;
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  it('should navigate to the dev server URL on startup', () => {
+    const urlSpy = (browser as unknown as { __initialUrlSpy: ReturnType<typeof vi.fn> }).__initialUrlSpy;
+    expect(urlSpy).toHaveBeenCalledWith(DEV_SERVER);
+  });
+
+  it('should inject the IPC interception script after the initial navigation', () => {
+    expect(browser.execute.mock.calls.some((c) => isInjectionScript(c[0]))).toBe(true);
+  });
+
+  it('should install the browser.dioxus API surface', () => {
+    const dioxus = (browser as unknown as { dioxus?: Record<string, unknown> }).dioxus;
+    expect(dioxus).toBeDefined();
+    expect(typeof dioxus?.mock).toBe('function');
+    expect(typeof dioxus?.execute).toBe('function');
+    expect(typeof dioxus?.restoreAllMocks).toBe('function');
+  });
+
+  it('should register a url override so navigation re-injects the IPC script', () => {
+    expect(browser.overrides.has('url')).toBe(true);
+  });
+});
+
+describe('browser mode — navigation lifecycle', () => {
+  let service: DioxusWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new DioxusWorkerService({}, { 'wdio:dioxusServiceOptions': { devServerUrl: DEV_SERVER } });
+    browser = createFakeBrowser();
+    await service.before({}, [], browser as unknown as WebdriverIO.Browser);
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  it('should re-inject the IPC script after a navigation', async () => {
+    browser.execute.mockClear();
+    await browser.url(`${DEV_SERVER}/page2`);
+
+    const injectionCalls = browser.execute.mock.calls.filter((c) => isInjectionScript(c[0]));
+    expect(injectionCalls.length).toBeGreaterThan(0);
+  });
+
+  it('should not re-inject when url() is called without an href', async () => {
+    browser.execute.mockClear();
+    await browser.url();
+
+    expect(browser.execute.mock.calls.filter((c) => isInjectionScript(c[0]))).toHaveLength(0);
+  });
+
+  it('should call through to the original url before re-injecting', async () => {
+    const order: string[] = [];
+    browser.execute.mockImplementation(async (arg: unknown) => {
+      if (isInjectionScript(arg)) order.push('inject');
+      return undefined;
+    });
+    // The override calls the original url() (recorded as 'navigate') first, then re-injects.
+    const override = browser.overrides.get('url');
+    expect(override).toBeDefined();
+    const originalUrl = vi.fn(async () => {
+      order.push('navigate');
+    });
+    await override?.call(browser, originalUrl, `${DEV_SERVER}/page3`);
+
+    expect(order).toEqual(['navigate', 'inject']);
+  });
+
+  it('should not throw when re-injection fails after a navigation', async () => {
+    browser.execute.mockClear();
+    browser.execute.mockRejectedValueOnce(new Error('inject failed'));
+
+    // Re-injection failures are swallowed (logged) so a transient page state
+    // doesn't crash the worker mid-session — the navigation itself still resolves.
+    await expect(browser.url(`${DEV_SERVER}/page2`)).resolves.not.toThrow();
+  });
+});
+
+describe('browser mode — mock lifecycle', () => {
+  let service: DioxusWorkerService;
+  let browser: FakeBrowser;
+
+  beforeEach(async () => {
+    mockStore.clear();
+    service = new DioxusWorkerService({}, { 'wdio:dioxusServiceOptions': { devServerUrl: DEV_SERVER } });
+    browser = createFakeBrowser();
+    await service.before({}, [], browser as unknown as WebdriverIO.Browser);
+    browser.execute.mockClear();
+  });
+
+  afterEach(() => {
+    mockStore.clear();
+  });
+
+  function dioxusApi(): { mock: (c: string) => Promise<DioxusMock> } {
+    return (browser as unknown as { dioxus: { mock: (c: string) => Promise<DioxusMock> } }).dioxus;
+  }
+
+  it('should register the inner mock in the single shared context', async () => {
+    await dioxusApi().mock('read_file');
+
+    const registrationCalls = browser.execute.mock.calls.filter((c) => isRegistrationScript(c[0], 'read_file'));
+    expect(registrationCalls).toHaveLength(1);
+  });
+
+  it('should track the created mock in the shared store', async () => {
+    const mock = await dioxusApi().mock('read_file');
+
+    // Dioxus keys mocks globally (`dioxus.<command>`) in one shared store —
+    // there is no per-browser keying like Electron.
+    expect(mockStore.getMock('dioxus.read_file')).toBe(mock);
+  });
+
+  it('should sync call data from the inner mock on update()', async () => {
+    const mock = await dioxusApi().mock('read_file');
+
+    // The embedded driver wraps results in a { __wdio_value__ } envelope; the
+    // worker unwraps it before parsing the inner mock's call data.
+    browser.execute.mockResolvedValueOnce({
+      __wdio_value__: {
+        calls: [[{ path: '/some/file' }]],
+        results: [{ type: 'return', value: 'content' }],
+        invocationCallOrder: [1],
+      },
+    });
+    await mock.update();
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock.mock.calls[0]).toEqual([{ path: '/some/file' }]);
+  });
+
+  it('should drop the inner mock entry and the store entry on mockRestore()', async () => {
+    const mock = await dioxusApi().mock('read_file');
+    expect(() => mockStore.getMock('dioxus.read_file')).not.toThrow();
+
+    await mock.mockRestore();
+
+    const unregistration = browser.execute.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('delete window.__wdio_mocks__["read_file"]'),
+    );
+    expect(unregistration).toBeDefined();
+    expect(() => mockStore.getMock('dioxus.read_file')).toThrow();
+  });
+
+  it('should recover a mock after navigation via mockRestore() then mock()', async () => {
+    const mock = await dioxusApi().mock('read_file');
+
+    // A navigation wipes window.__wdio_mocks__; the browser-side entry is gone
+    // even though the JS handle is still valid. Restore drops the store entry,
+    // then mock() re-creates both sides.
+    await browser.url(`${DEV_SERVER}/page2`);
+    await mock.mockRestore();
+
+    browser.execute.mockClear();
+    const recovered = await dioxusApi().mock('read_file');
+
+    expect(browser.execute.mock.calls.filter((c) => isRegistrationScript(c[0], 'read_file'))).toHaveLength(1);
+    expect(mockStore.getMock('dioxus.read_file')).toBe(recovered);
+  });
+});

--- a/packages/dioxus-service/test/integration/helpers.ts
+++ b/packages/dioxus-service/test/integration/helpers.ts
@@ -1,0 +1,94 @@
+import type { DioxusMock } from '@wdio/native-types';
+import { vi } from 'vitest';
+
+export type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+export function defer<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export type OverrideFn = (
+  this: unknown,
+  originalCommand: (...args: readonly unknown[]) => Promise<unknown>,
+  ...args: readonly unknown[]
+) => Promise<unknown>;
+
+export interface FakeBrowser {
+  url: ReturnType<typeof vi.fn>;
+  execute: ReturnType<typeof vi.fn>;
+  overwriteCommand: ReturnType<typeof vi.fn>;
+  isMultiremote: boolean;
+  dioxus: Record<string, unknown>;
+  overrides: Map<string, OverrideFn>;
+  /**
+   * Invoke a registered command override (e.g. the patched `url`). The optional
+   * `ownerBrowser` is set as `this.browser` inside the override.
+   */
+  triggerCommand: (name: string, ...args: readonly unknown[]) => Promise<unknown>;
+}
+
+export function createFakeBrowser(): FakeBrowser {
+  const overrides = new Map<string, OverrideFn>();
+  const browser = {
+    url: vi.fn().mockResolvedValue(undefined),
+    execute: vi.fn().mockResolvedValue(undefined),
+    overwriteCommand: vi.fn((name: string, fn: OverrideFn, _isElement?: boolean) => {
+      overrides.set(name, fn);
+      // Mirror webdriverio: overwriting a browser command (e.g. url — read-only in wdio >=9.27,
+      // hence overwriteCommand) replaces it, calling through to the original.
+      if (name === 'url') {
+        const original = browser.url as unknown as (...args: readonly unknown[]) => Promise<unknown>;
+        browser.url = vi.fn((...args: readonly unknown[]) => fn.call(browser, original, ...args));
+      }
+    }),
+    isMultiremote: false,
+    dioxus: {} as Record<string, unknown>,
+    overrides,
+    triggerCommand: (name: string, ...args: readonly unknown[]) => {
+      const fn = overrides.get(name);
+      if (!fn) {
+        throw new Error(`No override registered for command "${name}"`);
+      }
+      const originalCommand = vi.fn().mockResolvedValue(undefined);
+      return fn.call(browser, originalCommand, ...args);
+    },
+  };
+  return browser;
+}
+
+export interface FakeMock {
+  mock: DioxusMock;
+  update: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Create a fake mock whose `update()` resolves immediately by default. Tests
+ * that need controllable timing can override via `.mockImplementationOnce`,
+ * `.mockResolvedValueOnce`, or `.mockRejectedValueOnce`.
+ */
+export function createFakeMock(name: string): FakeMock {
+  const update = vi.fn(async () => undefined);
+  const mock = {
+    getMockName: () => name,
+    update,
+  } as unknown as DioxusMock;
+  return { mock, update };
+}
+
+/**
+ * Flush the microtask queue. Two `setImmediate` flushes cover .then().then() chains.
+ */
+export async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/packages/dioxus-service/test/integration/helpers.ts
+++ b/packages/dioxus-service/test/integration/helpers.ts
@@ -1,21 +1,4 @@
-import type { DioxusMock } from '@wdio/native-types';
 import { vi } from 'vitest';
-
-export type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason: unknown) => void;
-};
-
-export function defer<T = void>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
 
 export type OverrideFn = (
   this: unknown,
@@ -64,31 +47,4 @@ export function createFakeBrowser(): FakeBrowser {
     },
   };
   return browser;
-}
-
-export interface FakeMock {
-  mock: DioxusMock;
-  update: ReturnType<typeof vi.fn>;
-}
-
-/**
- * Create a fake mock whose `update()` resolves immediately by default. Tests
- * that need controllable timing can override via `.mockImplementationOnce`,
- * `.mockResolvedValueOnce`, or `.mockRejectedValueOnce`.
- */
-export function createFakeMock(name: string): FakeMock {
-  const update = vi.fn(async () => undefined);
-  const mock = {
-    getMockName: () => name,
-    update,
-  } as unknown as DioxusMock;
-  return { mock, update };
-}
-
-/**
- * Flush the microtask queue. Two `setImmediate` flushes cover .then().then() chains.
- */
-export async function flushMicrotasks(): Promise<void> {
-  await new Promise<void>((resolve) => setImmediate(resolve));
-  await new Promise<void>((resolve) => setImmediate(resolve));
 }

--- a/packages/dioxus-service/test/integration/launcher.browser.integration.spec.ts
+++ b/packages/dioxus-service/test/integration/launcher.browser.integration.spec.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFakeBrowser } from './helpers.js';
+
+// Embedded-driver setup — none of these should run when mode is 'browser'.
+vi.mock('../../src/providers/embedded.js', () => ({
+  getEmbeddedPort: vi.fn().mockReturnValue(4444),
+  startEmbeddedDriver: vi.fn().mockResolvedValue({ proc: { pid: 1234, kill: vi.fn() }, logHandlers: [] }),
+  stopEmbeddedDriver: vi.fn().mockResolvedValue(undefined),
+  DEFAULT_EMBEDDED_PORT: 4444,
+  EMBEDDED_PORT_ENV_VAR: 'WDIO_EMBEDDED_PORT',
+}));
+
+vi.mock('@wdio/native-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@wdio/native-utils')>()),
+  createLogger: vi.fn(() => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), trace: vi.fn() })),
+}));
+
+import DioxusLaunchService from '../../src/launcher.js';
+import { startEmbeddedDriver } from '../../src/providers/embedded.js';
+import DioxusWorkerService from '../../src/service.js';
+import type { DioxusCapabilities, DioxusServiceGlobalOptions } from '../../src/types.js';
+
+const DEV_SERVER = 'http://localhost:8080';
+const baseConfig = {} as Parameters<DioxusLaunchService['onPrepare']>[0];
+
+function createLauncher(globalOpts: Partial<DioxusServiceGlobalOptions> = {}): DioxusLaunchService {
+  return new DioxusLaunchService(globalOpts as DioxusServiceGlobalOptions, {} as DioxusCapabilities, baseConfig);
+}
+
+describe('launcher → worker handshake (browser mode)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should transform the Dioxus capability into a Chrome capability and remove dioxus:options', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      {
+        browserName: 'dioxus',
+        'dioxus:options': { application: '/app/my-app' },
+        'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+      },
+    ];
+
+    await launcher.onPrepare(baseConfig, caps as never);
+
+    expect(caps[0].browserName).toBe('chrome');
+    expect(caps[0]['dioxus:options']).toBeUndefined();
+  });
+
+  it('should not spawn the embedded driver in onPrepare', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      { 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+    ];
+
+    await launcher.onPrepare(baseConfig, caps as never);
+
+    expect(startEmbeddedDriver).not.toHaveBeenCalled();
+  });
+
+  it('should detect browser mode set on a non-first capability', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      { 'wdio:dioxusServiceOptions': {} },
+      { 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+    ];
+
+    await launcher.onPrepare(baseConfig, caps as never);
+
+    // Every capability is rewritten to chrome when any one requests browser mode.
+    expect(caps[0].browserName).toBe('chrome');
+    expect(caps[1].browserName).toBe('chrome');
+    expect(startEmbeddedDriver).not.toHaveBeenCalled();
+  });
+
+  it('should throw a SevereServiceError when devServerUrl is missing', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [{ 'wdio:dioxusServiceOptions': { mode: 'browser' } }];
+
+    await expect(launcher.onPrepare(baseConfig, caps as never)).rejects.toThrow(/devServerUrl is required/);
+  });
+
+  it('should throw a SevereServiceError when devServerUrl is not a valid URL', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      { 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: 'not-a-url' } },
+    ];
+
+    await expect(launcher.onPrepare(baseConfig, caps as never)).rejects.toThrow(/not a valid URL/);
+  });
+
+  it('should propagate the launcher devServerUrl into the worker initial navigation', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      {
+        browserName: 'dioxus',
+        'dioxus:options': { application: '/app/my-app' },
+        'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+      },
+    ];
+    await launcher.onPrepare(baseConfig, caps as never);
+
+    // The worker is built from the transformed capability; the surviving
+    // wdio:dioxusServiceOptions still carries mode + devServerUrl.
+    const worker = new DioxusWorkerService({}, caps[0] as never);
+    const browser = createFakeBrowser();
+    // initBrowserMode calls browser.url(devServerUrl) before the url override
+    // replaces browser.url — capture the spy before the patch.
+    const urlSpy = browser.url;
+    await worker.before({}, [], browser as unknown as WebdriverIO.Browser);
+
+    expect(urlSpy).toHaveBeenCalledWith(DEV_SERVER);
+  });
+
+  it('should enter browser mode in the worker without any driver involvement', async () => {
+    const launcher = createLauncher();
+    const caps: Array<Record<string, unknown>> = [
+      { browserName: 'dioxus', 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+    ];
+    await launcher.onPrepare(baseConfig, caps as never);
+
+    const worker = new DioxusWorkerService({}, caps[0] as never);
+    const browser = createFakeBrowser();
+    await worker.before({}, [], browser as unknown as WebdriverIO.Browser);
+
+    expect((browser as unknown as { dioxus?: unknown }).dioxus).toBeDefined();
+    expect(browser.overrides.has('url')).toBe(true);
+    expect(startEmbeddedDriver).not.toHaveBeenCalled();
+  });
+
+  it('should accept devServerUrl via service-level global options', async () => {
+    const launcher = createLauncher({ mode: 'browser', devServerUrl: DEV_SERVER });
+    const caps: Array<Record<string, unknown>> = [{}];
+    await launcher.onPrepare(baseConfig, caps as never);
+
+    expect(caps[0].browserName).toBe('chrome');
+
+    const worker = new DioxusWorkerService({ mode: 'browser', devServerUrl: DEV_SERVER }, caps[0] as never);
+    const browser = createFakeBrowser();
+    const urlSpy = browser.url;
+    await worker.before({}, [], browser as unknown as WebdriverIO.Browser);
+
+    expect(urlSpy).toHaveBeenCalledWith(DEV_SERVER);
+  });
+});

--- a/scripts/detect-changes.ts
+++ b/scripts/detect-changes.ts
@@ -17,7 +17,7 @@
  *   - packages/native-*, packages/bundler        → shared (all services)
  *   - packages/<svc>[-...]/**                    → that service
  *   - packages/<unrecognised>/**                 → unknown (runs all — convention drift, fail loud)
- *   - e2e/test/<svc>/**, e2e/wdio.<svc>*.conf.ts → that service; other e2e/** → all (shared test infra)
+ *   - e2e/test/<svc>[-...]/**, e2e/wdio.<svc>*.conf.ts → that service; other e2e/** → all (shared test infra)
  *   - fixtures/{e2e-apps,package-tests}/<svc>[-...]/** → that service; unrecognised dir → unknown
  *   - .github/workflows/: core-infra list → all; meta list → none;
  *     actions/** → all; service token in filename → that service; else → unknown
@@ -180,7 +180,9 @@ export function classifyFile(file: string, services: string[]): Verdict {
 
   if (file.startsWith('e2e/')) {
     const test = file.match(/^e2e\/test\/([^/]+)\//);
-    if (test) return services.includes(test[1]) ? test[1] : 'all';
+    // serviceForDir (not exact match) so suffixed dirs like `dioxus-browser`
+    // route to their service — mirrors the wdio.<svc>-*.conf.ts rule below.
+    if (test) return serviceForDir(test[1], services) ?? 'all';
     const conf = file.match(/^e2e\/wdio\.([^/]+)\.conf\.ts$/);
     if (conf) return serviceForDir(conf[1], services) ?? 'all';
     return 'all';

--- a/test/scripts/detect-changes.spec.ts
+++ b/test/scripts/detect-changes.spec.ts
@@ -62,12 +62,15 @@ describe('classifyFile', () => {
     ['e2e/test/electron/api.spec.ts', 'electron'],
     ['e2e/wdio.electron.conf.ts', 'electron'],
     ['e2e/wdio.dioxus-embedded.conf.ts', 'dioxus'],
+    ['e2e/wdio.dioxus-browser.conf.ts', 'dioxus'],
+    ['e2e/test/dioxus-browser/mock.spec.ts', 'dioxus'],
     ['e2e/package.json', 'all'],
     ['e2e/test/helpers/shared.ts', 'all'],
     // fixtures
     ['fixtures/e2e-apps/electron-builder/package.json', 'electron'],
     ['fixtures/e2e-apps/tauri/src-tauri/Cargo.toml', 'tauri'],
     ['fixtures/package-tests/dioxus-app/docker/test.sh', 'dioxus'],
+    ['fixtures/e2e-apps/dioxus-browser/index.html', 'dioxus'],
     ['fixtures/package-tests/electrobun-app/wdio.conf.ts', 'electrobun'],
     ['fixtures/e2e-apps/mystery/app.ts', 'unknown'],
     // workflows


### PR DESCRIPTION
Closes #472.

Browser mode shipped for Tauri, Electron, and Dioxus, but Dioxus test coverage was asymmetric vs Electron. This brings Dioxus up to the Electron/Tauri template across all three tiers. **Dioxus has no native event bus, so the events tier is intentionally omitted** (matching how the Tauri/Electron docs handle events by explicit omission).

## Integration tests
`packages/dioxus-service/test/integration/` (new — only a no-op `setup.ts` existed before):
- **`launcher.browser.integration.spec.ts`** — launcher→worker handshake: capability→`chrome` transform + `dioxus:options` removal, browser mode detected on a non-first capability, `devServerUrl` required/valid-URL validation, `devServerUrl` propagation into the worker's initial navigation, and **no embedded driver spawned** (`startEmbeddedDriver` never called).
- **`browser-mode.integration.spec.ts`** — worker browser-mode machinery: initial navigation + IPC injection, the `browser.dioxus` API surface install, the `url()` override re-injecting the IPC script after navigation (and *not* on arg-less `url()`), navigate-then-inject ordering, swallowed re-injection failures, single shared mock store (global `dioxus.<command>` keying), and the mock register → `update()` → `mockRestore()` lifecycle incl. post-navigation recovery.
- **`helpers.ts`** — `createFakeBrowser` / `createFakeMock` / `defer` / `flushMicrotasks`, trimmed to Dioxus's machinery (Dioxus has no `MockUpdateScheduler`, per-browser store keying, or BiDi preload, so those Electron/Tauri suites don't apply).

**21 integration tests, all green.**

## E2E
- **`e2e/wdio.dioxus-browser.conf.ts`** — real Chrome via chromedriver, self-hosted static dev server (`:8088`), `autoXvfb`, and a `ps`-based assertion that **no Dioxus driver stack** (`wdio-dioxus*` app binary, `wdio-dioxus-driver`, `msedgedriver`/`WebKitWebDriver`) is spawned.
- **`e2e/test/dioxus-browser/mock.spec.ts`** — value-returning invoke + invoke-with-arguments via `browser.dioxus.mock` + `mock.update()`.
- **`fixtures/e2e-apps/dioxus-browser/`** — static fixture app driving `window.__WDIO_DIOXUS__.invoke('get_app_version' | 'greet')`.

## Package fixture
`fixtures/package-tests/dioxus-app/test-browser/browser.spec.ts` now actually exercises `browser.dioxus.mock('get_info')` + `mock.update()` (added a `fetch-info` button + invoke to `browser/index.html`), matching the Tauri/Electron fixtures (was page-load + service-presence only).

## Docs
`packages/dioxus-service/docs/browser-mode.md` — one-line Events note that events are unsupported (no native event bus; see `packages/native-types/src/dioxus.ts`).

## CI
- Wired `pnpm e2e:dioxus-browser` into `_ci-browser-mode.reusable.yml` (alongside the electron/tauri E2E steps) + the `e2e/`+root `package.json` scripts.
- `scripts/detect-changes.ts`: route `e2e/test/<svc>-*/` test dirs to their service via `serviceForDir` (so `dioxus-browser` specs trigger only `dioxus`, mirroring the existing `wdio.<svc>-*.conf.ts` rule) — with regression guards added in `detect-changes.spec.ts`.

## Verification
| Command | Result |
|---|---|
| `pnpm --filter @wdio/dioxus-service test:integration` | ✅ 21 passed |
| `pnpm --filter @wdio/dioxus-service test:unit` | ✅ 131 passed (no regression) |
| `pnpm --filter @wdio/dioxus-service typecheck` | ✅ clean |
| `pnpm test:scripts` (detect-changes) | ✅ 98 passed |
| `pnpm format:check` (repo-wide) | ✅ clean |
| `biome check` (linter) on all changed TS | ✅ 0 issues |

**Not run locally:** the live browser-mode E2E (`pnpm e2e:dioxus-browser`) — it needs real Chrome + the built service against a live dev server, which isn't available in this environment. The config + spec typecheck and are structurally identical to the shipping electron/tauri browser-mode E2E (same static-server + no-driver-assertion + cast patterns); they will exercise in CI's Browser Mode job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)