### PR TITLE
fix(browser-mode): clear errors for non-chrome browserName and unreachable dev server

### DIFF
--- a/packages/dioxus-service/src/launcher.ts
+++ b/packages/dioxus-service/src/launcher.ts
@@ -1,7 +1,14 @@
 import { join } from 'node:path';
 
-import { BaseLauncher, closeLogWriter, getLogWriter, isLogWriterInitialized } from '@wdio/native-core';
-import { createLogger } from '@wdio/native-utils';
+import {
+  BaseLauncher,
+  closeLogWriter,
+  getLogWriter,
+  isLogWriterInitialized,
+  nonChromeBrowserNameError,
+  probeDevServerReachable,
+} from '@wdio/native-core';
+import { createLogger, isErr } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
 import { SevereServiceError } from 'webdriverio';
 
@@ -55,6 +62,19 @@ export default class DioxusLaunchService extends BaseLauncher {
         new URL(devServerUrl);
       } catch {
         throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+      }
+      for (const cap of capsList) {
+        const browserNameError = nonChromeBrowserNameError((cap as { browserName?: string }).browserName, [
+          'chrome',
+          'dioxus',
+        ]);
+        if (browserNameError) {
+          throw new SevereServiceError(browserNameError);
+        }
+      }
+      const reachable = await probeDevServerReachable(devServerUrl);
+      if (isErr(reachable)) {
+        throw new SevereServiceError(reachable.error.message);
       }
       for (const cap of capsList) {
         (cap as { browserName?: string }).browserName = 'chrome';

--- a/packages/dioxus-service/test/launcher.browser.spec.ts
+++ b/packages/dioxus-service/test/launcher.browser.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/providers/embedded.js', () => ({
+  getEmbeddedPort: vi.fn().mockReturnValue(4444),
+  startEmbeddedDriver: vi.fn().mockResolvedValue({ proc: { pid: 1234, kill: vi.fn() }, logHandlers: [] }),
+  stopEmbeddedDriver: vi.fn().mockResolvedValue(undefined),
+  DEFAULT_EMBEDDED_PORT: 4444,
+  EMBEDDED_PORT_ENV_VAR: 'WDIO_EMBEDDED_PORT',
+}));
+
+import DioxusLaunchService from '../src/launcher.js';
+import { startEmbeddedDriver } from '../src/providers/embedded.js';
+import type { DioxusCapabilities, DioxusServiceGlobalOptions } from '../src/types.js';
+
+const DEV_SERVER = 'http://localhost:1420';
+const baseConfig = {} as Parameters<DioxusLaunchService['onPrepare']>[0];
+
+function createLauncher(globalOpts: Partial<DioxusServiceGlobalOptions> = {}): DioxusLaunchService {
+  return new DioxusLaunchService(globalOpts as DioxusServiceGlobalOptions, {} as DioxusCapabilities, baseConfig);
+}
+
+describe('DioxusLaunchService — browser mode', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('mutates browserName to "chrome" and removes dioxus:options', async () => {
+    const launcher = createLauncher();
+    const caps: any[] = [
+      {
+        'dioxus:options': { application: '/app/my-app' },
+        'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER },
+      },
+    ];
+    await launcher.onPrepare(baseConfig, caps);
+    expect(caps[0].browserName).toBe('chrome');
+    expect(caps[0]['dioxus:options']).toBeUndefined();
+  });
+
+  it('does not start the embedded driver in browser mode', async () => {
+    const launcher = createLauncher();
+    const caps: any[] = [{ 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } }];
+    await launcher.onPrepare(baseConfig, caps);
+    expect(startEmbeddedDriver).not.toHaveBeenCalled();
+  });
+
+  it('accepts mode and devServerUrl from global options', async () => {
+    const launcher = createLauncher({ mode: 'browser', devServerUrl: DEV_SERVER });
+    const caps: any[] = [{}];
+    await launcher.onPrepare(baseConfig, caps);
+    expect(caps[0].browserName).toBe('chrome');
+  });
+
+  it('throws SevereServiceError when devServerUrl is missing', async () => {
+    const launcher = createLauncher();
+    const caps: any[] = [{ 'wdio:dioxusServiceOptions': { mode: 'browser' } }];
+    await expect(launcher.onPrepare(baseConfig, caps)).rejects.toThrow('devServerUrl is required');
+  });
+
+  it('throws SevereServiceError when devServerUrl is not a valid URL', async () => {
+    const launcher = createLauncher();
+    const caps: any[] = [{ 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: 'not-a-url' } }];
+    await expect(launcher.onPrepare(baseConfig, caps)).rejects.toThrow('not a valid URL');
+  });
+
+  it('throws SevereServiceError when browserName is a non-chrome value', async () => {
+    const launcher = createLauncher();
+    const caps: any[] = [
+      { browserName: 'firefox', 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+    ];
+    await expect(launcher.onPrepare(baseConfig, caps)).rejects.toThrow('Browser mode only supports');
+  });
+
+  it('throws SevereServiceError when the dev server is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const launcher = createLauncher();
+    const caps: any[] = [{ 'wdio:dioxusServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } }];
+    await expect(launcher.onPrepare(baseConfig, caps)).rejects.toThrow('Dev server not reachable');
+  });
+});

--- a/packages/dioxus-service/test/launcher.spec.ts
+++ b/packages/dioxus-service/test/launcher.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/providers/embedded.js', () => ({
   getEmbeddedPort: vi.fn().mockReturnValue(4444),
@@ -24,6 +24,7 @@ describe('DioxusLaunchService', () => {
   afterEach(() => {
     setPlatform(originalPlatform);
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('onPrepare', () => {
@@ -154,6 +155,10 @@ describe('DioxusLaunchService', () => {
   });
 
   describe('browser mode', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+    });
+
     it('should set browserName=chrome and return early when mode=browser', async () => {
       const launcher = new DioxusLaunchService(
         { mode: 'browser', devServerUrl: 'http://localhost:3000' } as DioxusServiceGlobalOptions,

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -1,3 +1,4 @@
+import { nonChromeBrowserNameError, probeDevServerReachable } from '@wdio/native-core';
 import type {
   AppBuildInfo,
   BinaryPathResult,
@@ -5,7 +6,13 @@ import type {
   ElectronServiceGlobalOptions,
   PathGenerationError,
 } from '@wdio/native-types';
-import { createLogger, formatDiagnosticResults, type NormalizedReadResult, readPackageUp } from '@wdio/native-utils';
+import {
+  createLogger,
+  formatDiagnosticResults,
+  isErr,
+  type NormalizedReadResult,
+  readPackageUp,
+} from '@wdio/native-utils';
 import { getAppBuildInfo } from './appBuildInfo.js';
 import { getBinaryPath } from './binaryPath.js';
 import { getElectronVersion } from './electronVersion.js';
@@ -133,6 +140,10 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
 
     if (mode === 'browser') {
       for (const cap of caps) {
+        const browserNameError = nonChromeBrowserNameError(cap.browserName, ['chrome', 'electron']);
+        if (browserNameError) {
+          throw new SevereServiceError(browserNameError);
+        }
         const capOpts = ((cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME] ??
           {}) as ElectronServiceGlobalOptions;
         const devServerUrl = capOpts.devServerUrl ?? this.#globalOptions.devServerUrl;
@@ -143,6 +154,10 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
           new URL(devServerUrl);
         } catch {
           throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+        }
+        const reachable = await probeDevServerReachable(devServerUrl);
+        if (isErr(reachable)) {
+          throw new SevereServiceError(reachable.error.message);
         }
         cap.browserName = 'chrome';
         // Preserve user-supplied goog:chromeOptions (args, extensions, prefs, etc.)

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -139,11 +139,17 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
     const mode = modes[0] ?? 'native';
 
     if (mode === 'browser') {
+      // Reject a non-chrome browserName on any cap before any network probe, so the actionable
+      // misconfig error surfaces immediately rather than after a (up to 3s) dev-server probe.
       for (const cap of caps) {
         const browserNameError = nonChromeBrowserNameError(cap.browserName, ['chrome', 'electron']);
         if (browserNameError) {
           throw new SevereServiceError(browserNameError);
         }
+      }
+      // Validate + probe each distinct devServerUrl once (caps may share one under multiremote).
+      const probedUrls = new Set<string>();
+      for (const cap of caps) {
         const capOpts = ((cap as Record<string, unknown>)[CUSTOM_CAPABILITY_NAME] ??
           {}) as ElectronServiceGlobalOptions;
         const devServerUrl = capOpts.devServerUrl ?? this.#globalOptions.devServerUrl;
@@ -155,14 +161,19 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
         } catch {
           throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
         }
-        const reachable = await probeDevServerReachable(devServerUrl);
-        if (isErr(reachable)) {
-          throw new SevereServiceError(reachable.error.message);
+        if (!probedUrls.has(devServerUrl)) {
+          const reachable = await probeDevServerReachable(devServerUrl);
+          if (isErr(reachable)) {
+            throw new SevereServiceError(reachable.error.message);
+          }
+          probedUrls.add(devServerUrl);
         }
+      }
+      // Rewrite every cap to a system-Chrome session.
+      for (const cap of caps) {
         cap.browserName = 'chrome';
-        // Preserve user-supplied goog:chromeOptions (args, extensions, prefs, etc.)
-        // but strip `binary` — in browser mode we want system Chrome, not the
-        // Electron binary that may have been passed in for native mode.
+        // Preserve user-supplied goog:chromeOptions (args, extensions, prefs, etc.) but strip
+        // `binary` — browser mode wants system Chrome, not the Electron binary passed for native mode.
         const chromeOpts = (cap as Record<string, unknown>)['goog:chromeOptions'] as
           | Record<string, unknown>
           | undefined;

--- a/packages/electron-service/test/integration/launcher.browser.integration.spec.ts
+++ b/packages/electron-service/test/integration/launcher.browser.integration.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeBrowser } from './helpers.js';
 
 // Launcher native-mode dependencies — should NOT be invoked when mode is 'browser'.
@@ -62,6 +62,12 @@ const DEV_SERVER = 'http://localhost:5173';
 describe('launcher → worker handshake (browser mode)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Launcher onPrepare now preflights the dev server; stub it as reachable.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('should transform the Electron capability into a Chrome capability', async () => {

--- a/packages/electron-service/test/launcher.browser.spec.ts
+++ b/packages/electron-service/test/launcher.browser.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@wdio/native-utils', async () => {
   const actual = await vi.importActual('@wdio/native-utils');
@@ -33,6 +33,14 @@ function makeLauncher(globalOpts: Record<string, unknown> = {}): ElectronLaunchS
 }
 
 describe('ElectronLaunchService — browser mode', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe('onPrepare', () => {
     it('should set browserName to "chrome" and strip Electron-specific capability bits', async () => {
       const launcher = makeLauncher();
@@ -138,6 +146,24 @@ describe('ElectronLaunchService — browser mode', () => {
       await launcher.onPrepare({} as any, caps);
       expect(caps[0].browserName).toBe('chrome');
       expect(caps[1].browserName).toBe('chrome');
+    });
+
+    it('accepts the native detection browserName "electron" and rewrites it to chrome', async () => {
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+      ];
+      await launcher.onPrepare({} as any, caps);
+      expect(caps[0].browserName).toBe('chrome');
+    });
+
+    it('throws SevereServiceError when the dev server is unreachable', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+      const launcher = makeLauncher();
+      const caps: any[] = [
+        { browserName: 'electron', 'wdio:electronServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+      ];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('Dev server not reachable');
     });
   });
 

--- a/packages/native-core/src/browserMode.ts
+++ b/packages/native-core/src/browserMode.ts
@@ -27,9 +27,11 @@ export function nonChromeBrowserNameError(
   if (typeof browserName !== 'string' || allowed.includes(browserName.toLowerCase())) {
     return undefined;
   }
-  const supported = allowed.map((name) => `'${name}'`).join(' or ');
+  // `allowed` also carries each service's native detection name (e.g. 'electron', 'wry') so a
+  // carried-over native cap isn't rejected — but those aren't something to advise setting, so the
+  // message guides the user to 'chrome' (or removal), not the full allow-list.
   return (
-    `Browser mode only supports browserName: ${supported}, but got '${browserName}'. ` +
+    `Browser mode only supports browserName: '${BROWSER_MODE_SUPPORTED_BROWSER}', but got '${browserName}'. ` +
     `Remove the browserName from your capability (it is set automatically) or set it to '${BROWSER_MODE_SUPPORTED_BROWSER}'.`
   );
 }

--- a/packages/native-core/src/browserMode.ts
+++ b/packages/native-core/src/browserMode.ts
@@ -1,0 +1,55 @@
+import { Err, Ok, type Result } from '@wdio/native-utils';
+
+// Browser mode drives the app's web UI through a real Chrome session (WDIO enables
+// BiDi by default for browserName: 'chrome'). Any other browserName is a
+// misconfiguration the launcher must reject rather than silently overwrite.
+export const BROWSER_MODE_SUPPORTED_BROWSER = 'chrome';
+
+const DEV_SERVER_PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * Validate a user-supplied `browserName` for browser mode.
+ *
+ * Returns an actionable error message when `browserName` is set to a value the
+ * service can't drive in browser mode; returns `undefined` when the value is
+ * acceptable (unset, or one of `allowed`). Each launcher throws its own
+ * `SevereServiceError` with this message so the runner stops with a clear
+ * explanation instead of silently rewriting the capability.
+ *
+ * `allowed` defaults to `['chrome']`. Electron passes its native detection
+ * value too (`['chrome', 'electron']`), since the launcher rewrites a
+ * legitimate `browserName: 'electron'` to chrome for the browser-mode session.
+ */
+export function nonChromeBrowserNameError(
+  browserName: unknown,
+  allowed: readonly string[] = [BROWSER_MODE_SUPPORTED_BROWSER],
+): string | undefined {
+  if (typeof browserName !== 'string' || allowed.includes(browserName.toLowerCase())) {
+    return undefined;
+  }
+  const supported = allowed.map((name) => `'${name}'`).join(' or ');
+  return (
+    `Browser mode only supports browserName: ${supported}, but got '${browserName}'. ` +
+    `Remove the browserName from your capability (it is set automatically) or set it to '${BROWSER_MODE_SUPPORTED_BROWSER}'.`
+  );
+}
+
+/**
+ * Preflight the dev server before the worker navigates to it.
+ *
+ * A HEAD request with a short timeout. Any non-network response (even 404/405)
+ * proves the server is listening, so only a thrown fetch error (connection
+ * refused, DNS failure, timeout) counts as unreachable. Runs in the launcher's
+ * main process where outbound network is available.
+ */
+export async function probeDevServerReachable(
+  url: string,
+  timeoutMs: number = DEV_SERVER_PROBE_TIMEOUT_MS,
+): Promise<Result<void, Error>> {
+  try {
+    await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(timeoutMs) });
+    return Ok(undefined);
+  } catch (error) {
+    return Err(new Error(`Dev server not reachable at ${url} — is it running? (${(error as Error).message})`));
+  }
+}

--- a/packages/native-core/src/browserMode.ts
+++ b/packages/native-core/src/browserMode.ts
@@ -52,6 +52,7 @@ export async function probeDevServerReachable(
     await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(timeoutMs) });
     return Ok(undefined);
   } catch (error) {
-    return Err(new Error(`Dev server not reachable at ${url} — is it running? (${(error as Error).message})`));
+    const detail = error instanceof Error ? error.message : String(error);
+    return Err(new Error(`Dev server not reachable at ${url} — is it running? (${detail})`));
   }
 }

--- a/packages/native-core/src/index.ts
+++ b/packages/native-core/src/index.ts
@@ -6,6 +6,7 @@
 // electron-service; reconciliation notes live next to each module.
 
 export * from './baseLauncher.js';
+export * from './browserMode.js';
 export * from './deeplink.js';
 export * from './driverPool.js';
 export * from './driverProcess.js';

--- a/packages/native-core/test/browserMode.spec.ts
+++ b/packages/native-core/test/browserMode.spec.ts
@@ -19,8 +19,11 @@ describe('nonChromeBrowserNameError', () => {
 
   it('honours a custom allow list', () => {
     expect(nonChromeBrowserNameError('electron', ['chrome', 'electron'])).toBeUndefined();
+    // A genuinely foreign browserName still errors; the message guides to chrome (not the
+    // tolerated native names in the allow-list).
     const message = nonChromeBrowserNameError('firefox', ['chrome', 'electron']);
-    expect(message).toContain("'chrome' or 'electron'");
+    expect(message).toContain("got 'firefox'");
+    expect(message).toContain("'chrome'");
   });
 });
 

--- a/packages/native-core/test/browserMode.spec.ts
+++ b/packages/native-core/test/browserMode.spec.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { nonChromeBrowserNameError, probeDevServerReachable } from '../src/browserMode.js';
+
+describe('nonChromeBrowserNameError', () => {
+  it('returns undefined when browserName is unset', () => {
+    expect(nonChromeBrowserNameError(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for chrome (case-insensitive)', () => {
+    expect(nonChromeBrowserNameError('chrome')).toBeUndefined();
+    expect(nonChromeBrowserNameError('Chrome')).toBeUndefined();
+  });
+
+  it('returns an actionable message for a non-chrome browserName', () => {
+    const message = nonChromeBrowserNameError('firefox');
+    expect(message).toContain("got 'firefox'");
+    expect(message).toContain("'chrome'");
+  });
+
+  it('honours a custom allow list', () => {
+    expect(nonChromeBrowserNameError('electron', ['chrome', 'electron'])).toBeUndefined();
+    const message = nonChromeBrowserNameError('firefox', ['chrome', 'electron']);
+    expect(message).toContain("'chrome' or 'electron'");
+  });
+});
+
+describe('probeDevServerReachable', () => {
+  const url = 'http://localhost:1420';
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves Ok when the dev server responds', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await probeDevServerReachable(url);
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(url, expect.objectContaining({ method: 'HEAD' }));
+  });
+
+  it('resolves Ok even on a 404/405 (server is listening)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+
+    const result = await probeDevServerReachable(url);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('resolves Err with an actionable message when the server is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const result = await probeDevServerReachable(url);
+
+    expect(result.ok).toBe(false);
+    const message = result.ok ? '' : result.error.message;
+    expect(message).toContain(`Dev server not reachable at ${url}`);
+    expect(message).toContain('is it running?');
+  });
+});

--- a/packages/tauri-service/src/launcher.ts
+++ b/packages/tauri-service/src/launcher.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { nonChromeBrowserNameError, probeDevServerReachable } from '@wdio/native-core';
 import type { LogLevel } from '@wdio/native-types';
 import { createLogger, formatDiagnosticResults, isErr } from '@wdio/native-utils';
 import type { Options } from '@wdio/types';
@@ -168,6 +169,20 @@ export default class TauriLaunchService {
         new URL(devServerUrl);
       } catch {
         throw new SevereServiceError(`devServerUrl is not a valid URL: ${devServerUrl}`);
+      }
+      for (const cap of capsList) {
+        const browserNameError = nonChromeBrowserNameError((cap as { browserName?: string }).browserName, [
+          'chrome',
+          'tauri',
+          'wry',
+        ]);
+        if (browserNameError) {
+          throw new SevereServiceError(browserNameError);
+        }
+      }
+      const reachable = await probeDevServerReachable(devServerUrl);
+      if (isErr(reachable)) {
+        throw new SevereServiceError(reachable.error.message);
       }
       this.browserMode = true;
       for (const cap of capsList) {

--- a/packages/tauri-service/test/integration/launcher.browser.integration.spec.ts
+++ b/packages/tauri-service/test/integration/launcher.browser.integration.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeBrowser } from './helpers.js';
 
 // Native-mode setup modules — none should be touched when mode is 'browser'.
@@ -85,6 +85,12 @@ describe('launcher → worker handshake (browser mode)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockStore.clear();
+    // Launcher onPrepare now preflights the dev server; stub it as reachable.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('should transform the Tauri capability into a Chrome capability and remove tauri:options', async () => {

--- a/packages/tauri-service/test/launcher.browser.spec.ts
+++ b/packages/tauri-service/test/launcher.browser.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/embeddedProvider.js', () => ({
   checkEmbeddedServerAlive: vi.fn(),
@@ -15,8 +15,8 @@ vi.mock('../src/diagnostics.js', () => ({
 vi.mock('@wdio/native-utils', () => ({
   createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   formatDiagnosticResults: vi.fn(),
-  isErr: vi.fn().mockReturnValue(false),
-  isOk: vi.fn().mockReturnValue(true),
+  isErr: (r: { ok: boolean }) => r.ok === false,
+  isOk: (r: { ok: boolean }) => r.ok === true,
   Ok: (v: unknown) => ({ ok: true, value: v }),
   Err: (e: unknown) => ({ ok: false, error: e }),
 }));
@@ -78,6 +78,15 @@ function createLauncher(globalOpts: Record<string, unknown> = {}): TauriLaunchSe
 }
 
 describe('TauriLaunchService — browser mode', () => {
+  beforeEach(() => {
+    // Dev server reachable by default; individual tests override for the unreachable case.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe('onPrepare', () => {
     it('mutates browserName to "chrome" and removes tauri:options', async () => {
       const launcher = createLauncher();
@@ -116,6 +125,21 @@ describe('TauriLaunchService — browser mode', () => {
       const caps: any[] = [{}];
       await launcher.onPrepare({} as any, caps);
       expect(caps[0].browserName).toBe('chrome');
+    });
+
+    it('throws SevereServiceError when browserName is a non-chrome value', async () => {
+      const launcher = createLauncher();
+      const caps: any[] = [
+        { browserName: 'firefox', 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } },
+      ];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('Browser mode only supports');
+    });
+
+    it('throws SevereServiceError when the dev server is unreachable', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+      const launcher = createLauncher();
+      const caps: any[] = [{ 'wdio:tauriServiceOptions': { mode: 'browser', devServerUrl: DEV_SERVER } }];
+      await expect(launcher.onPrepare({} as any, caps)).rejects.toThrow('Dev server not reachable');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #416.

Two browser-mode (#260) misconfigurations failed in ways that didn't match the acceptance criterion ("a misconfiguration surfaces a clear, actionable error"). Both are now fixed across the **Tauri, Electron, and Dioxus** launchers via a single shared helper in `@wdio/native-core`.

### Fix 1 — non-chrome `browserName` was silently overwritten
Previously, setting `mode: 'browser'` while leaving `browserName: 'firefox'` (or any non-chrome value) was silently rewritten to `'chrome'`. The launcher now **throws `SevereServiceError`** explaining that browser mode only supports Chrome.

Each service allows its own framework display/detection name in addition to `chrome`, so legitimate native-mode capabilities that a user carries over into browser mode are not rejected:
- **Electron**: `['chrome', 'electron']` — `'electron'` is the cap-detection value the launcher rewrites to chrome.
- **Tauri**: `['chrome', 'tauri', 'wry']`.
- **Dioxus**: `['chrome', 'dioxus']`.

Only genuinely foreign browsers (e.g. `firefox`) error.

### Fix 2 — unreachable dev server failed late and cryptically
There was no preflight on `devServerUrl`; a non-running dev server surfaced deep inside `browser.url(devServerUrl)` as a generic WebDriver navigation error. The launcher now preflights in `onPrepare` (main process) with a lightweight HEAD probe (`fetch` + `AbortSignal.timeout`, 3s) and throws `SevereServiceError("Dev server not reachable at <url> — is it running?")` before any session is created. A non-network response (even 404/405) counts as reachable — only a thrown fetch error (connection refused, DNS failure, timeout) is treated as unreachable.

## warn-vs-throw decision: **throw**

Matched the existing fatal-misconfig pattern already used for the missing/invalid `devServerUrl` cases in all three launchers (`throw new SevereServiceError(...)`), which stops the runner with a clear message rather than warning and proceeding into a confusing downstream failure. This is also the decision recorded in the issue.

## DRY

The three launchers each hand-rolled the browser-mode block (no pre-existing shared helper). The new logic lives once in `packages/native-core/src/browserMode.ts`:
- `nonChromeBrowserNameError(browserName, allowed?)` → actionable message string | `undefined`
- `probeDevServerReachable(url, timeoutMs?)` → `Promise<Result<void, Error>>`

Each launcher throws its own `SevereServiceError` at the call site, consistent with how the existing inline `devServerUrl` handling already constructs it from each package's own `webdriverio` import. `native-core` gains no `webdriverio` dependency (the helper returns `Result` / a message).

## Tests

- New `packages/native-core/test/browserMode.spec.ts` covers both helpers (chrome/non-chrome/custom allow-list; reachable / 404-reachable / unreachable).
- Extended `launcher.browser.spec.ts` (Tauri, Electron) and added one for Dioxus with the non-chrome-throw and unreachable-probe branches.
- Stubbed `fetch` in the pre-existing Tauri/Electron browser-mode integration specs and the Dioxus `launcher.spec.ts` browser-mode block (they call real `onPrepare`, which now probes the dev server).

Per the coordination note, this PR is scoped to launcher/worker **source error-handling + its unit tests** only — no browser-mode integration/E2E tests (those are #472).

## Verification (all run locally, in the worktree after `pnpm install`)

- `pnpm --filter @wdio/native-core --filter @wdio/tauri-service --filter @wdio/electron-service --filter @wdio/dioxus-service test` → all pass (native-core 40, dioxus 138, electron 520, tauri 631).
- `pnpm ... typecheck` (all four) → clean.
- `pnpm lint` (biome + eslint) → exit 0; no findings on changed files (pre-existing warnings only in untouched files).
- `biome check --formatter` on changed files → clean.
- `pnpm ... build` (all four) → clean.
- `pnpm test:scripts` → 95 pass (detect-changes unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
