### PR TITLE
chore(release): switch framework version groups from linked to independent

### DIFF
--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -15,7 +15,7 @@
           "wdio-dioxus-embedded-driver",
           "wdio-dioxus-driver"
         ],
-        "sync": "linked"
+        "sync": "independent"
       },
       "tauri": {
         "packages": [
@@ -23,14 +23,14 @@
           "@wdio/tauri-plugin",
           "tauri-plugin-wdio-webdriver"
         ],
-        "sync": "linked"
+        "sync": "independent"
       },
       "flutter": {
         "packages": [
           "@wdio/flutter-service",
           "wdio_flutter"
         ],
-        "sync": "linked"
+        "sync": "independent"
       }
     },
     "versionPrefix": "v",


### PR DESCRIPTION
Switches the `dioxus`, `tauri`, and `flutter` version groups from `"sync": "linked"` to `"sync": "independent"` in `releasekit.config.json`.

## Why
These groups exist to ship a service **bundled atomically with its app-side plugins/bridges** as one release unit — that presentation (the `ships N coupled` nesting under the service row + a single hold-back toggle) comes from `ci.standingPr.primaryPackages = ["@wdio/*-service"]` + **group membership**, and is **preserved under `independent`**. The only thing `linked` adds is a forced shared version across members, which none of these groups justify:

- **No service→plugin dependency.** `@wdio/{tauri,dioxus,flutter}-service` don't depend on (or version-check) their plugins/bridges — the IPC/contract surface is additive-by-convention, not equal-version.
- **Members are orthogonal.** e.g. `tauri-plugin-wdio-webdriver` (embedded mode) vs `@wdio/tauri-plugin` (backend/mocking) share nothing; lockstep republished one whenever the other changed.
- **The one real edge is range-based.** `wdio-dioxus-embedded-driver → wdio-dioxus-bridge` is a semver-range cargo dep; ReleaseKit's dependency graph already pulls the bridge in as a changed *prerequisite*, so no lockstep is needed for compatibility.

Net effect: each package versions on its own commit-driven line, but the set still ships atomically and renders as a coupled unit. An unchanged member (e.g. `@wdio/tauri-plugin` this cycle) correctly stays at its current version instead of being force-bumped.

Electron and react-native stay **ungrouped** — their shared `@wdio/native-*` packages are real dependencies (prerequisites the dep-graph handles), not bundled app-side plugins.

The standing PR regenerates on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)