### PR TITLE
feat(native-core): DevServerProcess + startManagedDevServer for browser mode (#417)

### DIFF
--- a/packages/native-core/src/browserMode.ts
+++ b/packages/native-core/src/browserMode.ts
@@ -1,4 +1,8 @@
-import { Err, Ok, type Result } from '@wdio/native-utils';
+import type { DevServer } from '@wdio/native-types';
+import { createLogger, Err, isErr, isOk, Ok, type Result } from '@wdio/native-utils';
+import { DevServerProcess, type DevServerReadyProbe } from './devServerProcess.js';
+
+const log = createLogger('native-core', 'launcher');
 
 // Browser mode drives the app's web UI through a real Chrome session (WDIO enables
 // BiDi by default for browserName: 'chrome'). Any other browserName is a
@@ -55,4 +59,86 @@ export async function probeDevServerReachable(
     const detail = error instanceof Error ? error.message : String(error);
     return Err(new Error(`Dev server not reachable at ${url} — is it running? (${detail})`));
   }
+}
+
+const DEV_SERVER_READY_TIMEOUT_MS = 60_000;
+const DEV_SERVER_READY_POLL_MS = 500;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll {@link probeDevServerReachable} until the server answers or the budget elapses.
+ *
+ * The single-shot `probeDevServerReachable` is a preflight for a server the user already started;
+ * this is the "wait for a server we (or the user's function) just started to come up" variant.
+ */
+export async function waitForDevServerReachable(
+  url: string,
+  {
+    timeoutMs = DEV_SERVER_READY_TIMEOUT_MS,
+    pollMs = DEV_SERVER_READY_POLL_MS,
+  }: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<Result<void, Error>> {
+  const start = Date.now();
+  let last = await probeDevServerReachable(url);
+  while (isErr(last) && Date.now() - start < timeoutMs) {
+    await delay(pollMs);
+    last = await probeDevServerReachable(url);
+  }
+  return last;
+}
+
+/**
+ * Start (or reuse) a dev server for browser mode and return a handle to tear it down.
+ *
+ * Handles all three {@link DevServer} forms so each launcher stays a few lines:
+ * - **function** — call it, poll its returned `url` for readiness, and teardown is its `close()`
+ *   (no subprocess spawn/kill involved). The returned `url` supplies/overrides `devServerUrl`.
+ * - **string / object** — if `reuseExistingServer` (default `!CI`) and `devServerUrl` is already
+ *   reachable, skip the spawn; otherwise spawn a {@link DevServerProcess} and poll `devServerUrl`.
+ *
+ * The caller stores the returned `stop` and must call it in `onComplete` *and* on an `onPrepare`
+ * failure (WDIO does not call `onComplete` after `onPrepare` throws). `stop` is idempotent.
+ */
+export async function startManagedDevServer(
+  devServer: DevServer,
+  devServerUrl: string,
+  deps: {
+    spawn?: typeof import('node:child_process').spawn;
+    probe?: DevServerReadyProbe;
+    isCI?: boolean;
+    readinessTimeoutMs?: number;
+    readinessPollMs?: number;
+  } = {},
+): Promise<{ url: string; stop: () => Promise<void> }> {
+  if (typeof devServer === 'function') {
+    const { url, close } = await devServer();
+    const ready = await waitForDevServerReachable(url, {
+      timeoutMs: deps.readinessTimeoutMs,
+      pollMs: deps.readinessPollMs,
+    });
+    if (isErr(ready)) {
+      await close();
+      throw ready.error;
+    }
+    return { url, stop: close };
+  }
+
+  const config = typeof devServer === 'string' ? { command: devServer } : devServer;
+  const isCI = deps.isCI ?? Boolean(process.env.CI);
+  const reuseExisting = config.reuseExistingServer ?? !isCI;
+  if (reuseExisting && isOk(await probeDevServerReachable(devServerUrl))) {
+    log.info(`Reusing dev server already reachable at ${devServerUrl}`);
+    return { url: devServerUrl, stop: async () => {} };
+  }
+
+  const proc = new DevServerProcess({ spawn: deps.spawn, probe: deps.probe });
+  await proc.start({
+    command: config.command,
+    cwd: config.cwd,
+    env: config.env,
+    url: devServerUrl,
+    timeoutMs: config.timeoutMs,
+  });
+  return { url: devServerUrl, stop: () => proc.stop() };
 }

--- a/packages/native-core/src/browserMode.ts
+++ b/packages/native-core/src/browserMode.ts
@@ -133,12 +133,19 @@ export async function startManagedDevServer(
   }
 
   const proc = new DevServerProcess({ spawn: deps.spawn, probe: deps.probe });
-  await proc.start({
-    command: config.command,
-    cwd: config.cwd,
-    env: config.env,
-    url: devServerUrl,
-    timeoutMs: config.timeoutMs,
-  });
+  try {
+    await proc.start({
+      command: config.command,
+      cwd: config.cwd,
+      env: config.env,
+      url: devServerUrl,
+      timeoutMs: config.timeoutMs,
+    });
+  } catch (error) {
+    // start() can throw *after* the process spawned (readiness timeout) — stop the live-but-unready
+    // process before propagating, or it orphans (holding the port). Mirrors the function form's close().
+    await proc.stop();
+    throw error;
+  }
   return { url: devServerUrl, stop: () => proc.stop() };
 }

--- a/packages/native-core/src/devServerProcess.ts
+++ b/packages/native-core/src/devServerProcess.ts
@@ -1,0 +1,213 @@
+// Dev-server lifecycle for browser mode (opt-in) — spawns a user command (e.g. `pnpm dev`), polls
+// `devServerUrl` for readiness, and tears the process *tree* down. Mirrors the SIGTERM→SIGKILL
+// discipline of native-core's DriverProcess / react-native-service's MetroProcess, but a free-form
+// shell command + a full-URL readiness probe don't fit DriverProcess.start()'s fixed arg shape, so
+// the process handling is local. Unlike those, a shell-spawned dev server spawns grandchildren
+// (`pnpm dev` → vite → esbuild), so teardown kills the process group, not just the direct child.
+
+import { type ChildProcess, spawn as nodeSpawn } from 'node:child_process';
+import { createLogger } from '@wdio/native-utils';
+
+const log = createLogger('native-core', 'launcher');
+
+const isWindows = process.platform === 'win32';
+const DEFAULT_READY_TIMEOUT_MS = 60_000;
+const CI_READY_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_MS = 500;
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** A reachability probe — resolves `true` once the dev server answers at `url`. */
+export type DevServerReadyProbe = (url: string) => Promise<boolean>;
+
+/** Kill a spawned child (and, where possible, its process group) with `signal`. */
+export type DevServerKill = (proc: ChildProcess, signal: NodeJS.Signals) => void;
+
+export interface DevServerStartOptions {
+  /** Command run in a shell to start the dev server, e.g. `'pnpm dev'`. */
+  command: string;
+  /** Working directory. Default `process.cwd()`. */
+  cwd?: string;
+  /** Extra environment variables, merged over `process.env`. */
+  env?: Record<string, string>;
+  /** Readiness target — the URL polled until reachable (i.e. `devServerUrl`). */
+  url: string;
+  /** Readiness budget (ms). Default 60s locally, 120s in CI. */
+  timeoutMs?: number;
+  /** Readiness poll interval (ms). Default 500. */
+  pollMs?: number;
+}
+
+/** Default readiness probe: a HEAD request — any HTTP response (even 404) means the server is listening. */
+const defaultProbe: DevServerReadyProbe = async (url) => {
+  try {
+    await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(DEFAULT_PROBE_TIMEOUT_MS) });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Kill the whole process tree. The child is spawned `detached` on POSIX so it leads its own process
+ * group (pgid === pid); signalling `-pid` reaches the shell *and* its grandchildren. Windows has no
+ * POSIX groups — `taskkill /T /F` walks the tree instead. Falls back to a direct child kill.
+ */
+const defaultKill: DevServerKill = (proc, signal) => {
+  const pid = proc.pid;
+  if (pid === undefined) {
+    proc.kill(signal);
+    return;
+  }
+  if (isWindows) {
+    nodeSpawn('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' }).on('error', () => {});
+    return;
+  }
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    // Group already gone, or the child never became a group leader — signal it directly.
+    proc.kill(signal);
+  }
+};
+
+export class DevServerProcess {
+  #proc?: ChildProcess;
+  // A spawn 'error' (e.g. ENOENT) leaves exitCode/signalCode null, so the readiness loop would spin
+  // to the full timeout. Capture it to fail fast.
+  #spawnError?: Error;
+  // Last few stderr lines so a startup failure (port in use, bad config) surfaces its real cause in
+  // the thrown error rather than only at debug level.
+  #stderrTail: string[] = [];
+  readonly #spawn: typeof nodeSpawn;
+  readonly #probe: DevServerReadyProbe;
+  readonly #kill: DevServerKill;
+
+  constructor(deps: { spawn?: typeof nodeSpawn; probe?: DevServerReadyProbe; kill?: DevServerKill } = {}) {
+    this.#spawn = deps.spawn ?? nodeSpawn;
+    this.#probe = deps.probe ?? defaultProbe;
+    this.#kill = deps.kill ?? defaultKill;
+  }
+
+  isRunning(): boolean {
+    // A failed spawn fires 'error' but leaves exitCode/signalCode/killed in their "never started"
+    // state, so guard on #spawnError first.
+    if (this.#spawnError) {
+      return false;
+    }
+    const p = this.#proc;
+    if (!p) {
+      return false;
+    }
+    if (p.exitCode !== null || p.signalCode !== null) {
+      return false;
+    }
+    return !p.killed;
+  }
+
+  async start(options: DevServerStartOptions): Promise<void> {
+    const cwd = options.cwd ?? process.cwd();
+    this.#spawnError = undefined;
+    this.#stderrTail = [];
+
+    log.info(`Starting dev server: ${options.command} (cwd: ${cwd})`);
+    const proc = this.#spawn(options.command, {
+      cwd,
+      shell: true,
+      // Own process group so teardown can kill the tree (see defaultKill).
+      detached: !isWindows,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...options.env },
+    });
+    this.#proc = proc;
+    proc.stdout?.on('data', (d: Buffer) => log.debug(`[dev-server] ${d.toString().trim()}`));
+    proc.stderr?.on('data', (d: Buffer) => {
+      const line = d.toString().trim();
+      log.debug(`[dev-server] ${line}`);
+      if (line) {
+        this.#stderrTail.push(line);
+        if (this.#stderrTail.length > 20) {
+          this.#stderrTail.shift();
+        }
+      }
+    });
+    proc.on('error', (e) => {
+      this.#spawnError = e;
+      log.error(`Dev server spawn error: ${e.message}`);
+    });
+
+    await this.#waitForReady(options);
+  }
+
+  async #waitForReady(options: DevServerStartOptions): Promise<void> {
+    const timeout = options.timeoutMs ?? (process.env.CI ? CI_READY_TIMEOUT_MS : DEFAULT_READY_TIMEOUT_MS);
+    const interval = options.pollMs ?? DEFAULT_POLL_MS;
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      if (this.#spawnError) {
+        throw new Error(`Dev server failed to start: ${this.#spawnError.message}`);
+      }
+      const p = this.#proc;
+      if (p && (p.exitCode !== null || p.signalCode !== null)) {
+        throw new Error(this.#withStderr('Dev server process exited during startup'));
+      }
+      if (await this.#probe(options.url)) {
+        // A spawn 'error' may have fired during the probe await; assert to defeat the stale
+        // control-flow narrowing from the loop-top guard.
+        const spawnError = this.#spawnError as Error | undefined;
+        if (spawnError) {
+          throw new Error(`Dev server failed to start: ${spawnError.message}`);
+        }
+        log.info(`Dev server ready at ${options.url}`);
+        return;
+      }
+      await delay(interval);
+    }
+    throw new Error(this.#withStderr(`Dev server did not become ready within ${timeout}ms at ${options.url}`));
+  }
+
+  /** Append the buffered stderr tail to a startup-failure message so the cause is visible. */
+  #withStderr(message: string): string {
+    return this.#stderrTail.length > 0 ? `${message}\nDev server stderr:\n${this.#stderrTail.join('\n')}` : message;
+  }
+
+  async stop(): Promise<void> {
+    const proc = this.#proc;
+    if (!proc || proc.killed) {
+      return;
+    }
+    if (this.#spawnError) {
+      // Spawn failed: Node fired 'error' but never will fire 'exit' — no live process to kill.
+      this.#proc = undefined;
+      return;
+    }
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      this.#proc = undefined;
+      return;
+    }
+    log.debug('Stopping dev server...');
+    this.#kill(proc, 'SIGTERM');
+    await this.#waitForExit(proc);
+    this.#proc = undefined;
+  }
+
+  #waitForExit(proc: ChildProcess): Promise<void> {
+    const stopTimeout = process.env.CI ? 10_000 : 5_000;
+    return new Promise<void>((resolve) => {
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      const graceTimer = setTimeout(() => {
+        log.warn(`Dev server did not stop gracefully after ${stopTimeout}ms, forcing kill`);
+        this.#kill(proc, 'SIGKILL');
+        killTimer = setTimeout(resolve, 5_000);
+      }, stopTimeout);
+      proc.once('exit', () => {
+        clearTimeout(graceTimer);
+        if (killTimer) {
+          clearTimeout(killTimer);
+        }
+        resolve();
+      });
+    });
+  }
+}

--- a/packages/native-core/src/devServerProcess.ts
+++ b/packages/native-core/src/devServerProcess.ts
@@ -159,6 +159,12 @@ export class DevServerProcess {
         if (spawnError) {
           throw new Error(`Dev server failed to start: ${spawnError.message}`);
         }
+        // Likewise, the owned process may have exited during the probe await while a pre-existing
+        // server answered the URL — a fresh read of #proc reflects its current exit state.
+        const proc = this.#proc;
+        if (proc && (proc.exitCode !== null || proc.signalCode !== null)) {
+          throw new Error(this.#withStderr('Dev server process exited during startup'));
+        }
         log.info(`Dev server ready at ${options.url}`);
         return;
       }

--- a/packages/native-core/src/index.ts
+++ b/packages/native-core/src/index.ts
@@ -8,6 +8,7 @@
 export * from './baseLauncher.js';
 export * from './browserMode.js';
 export * from './deeplink.js';
+export * from './devServerProcess.js';
 export * from './driverPool.js';
 export * from './driverProcess.js';
 export * from './logCapture.js';

--- a/packages/native-core/test/browserMode.spec.ts
+++ b/packages/native-core/test/browserMode.spec.ts
@@ -90,13 +90,13 @@ describe('waitForDevServerReachable', () => {
   const url = 'http://localhost:1420';
   afterEach(() => vi.unstubAllGlobals());
 
-  it('resolves Ok as soon as the server is reachable', async () => {
+  it('should resolve Ok as soon as the server is reachable', async () => {
     vi.stubGlobal('fetch', reachable());
     const result = await waitForDevServerReachable(url, { timeoutMs: 1000, pollMs: 10 });
     expect(result.ok).toBe(true);
   });
 
-  it('polls until the server comes up', async () => {
+  it('should poll until the server comes up', async () => {
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
@@ -107,7 +107,7 @@ describe('waitForDevServerReachable', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('resolves Err after the timeout when never reachable', async () => {
+  it('should resolve Err after the timeout when never reachable', async () => {
     vi.stubGlobal('fetch', unreachable());
     const result = await waitForDevServerReachable(url, { timeoutMs: 30, pollMs: 10 });
     expect(result.ok).toBe(false);
@@ -118,7 +118,7 @@ describe('startManagedDevServer', () => {
   const url = 'http://localhost:1420';
   afterEach(() => vi.unstubAllGlobals());
 
-  it('function form: awaits readiness and returns close() as the teardown', async () => {
+  it('should await readiness and return close() as the teardown for the function form', async () => {
     vi.stubGlobal('fetch', reachable());
     const close = vi.fn(async () => {});
     const devServer = async () => ({ url: 'http://localhost:5173', close });
@@ -130,7 +130,7 @@ describe('startManagedDevServer', () => {
     expect(close).toHaveBeenCalledOnce();
   });
 
-  it('function form: closes and throws when the returned url never becomes reachable', async () => {
+  it('should close and throw when the function-form url never becomes reachable', async () => {
     vi.stubGlobal('fetch', unreachable());
     const close = vi.fn(async () => {});
     const devServer = async () => ({ url: 'http://localhost:5173', close });
@@ -141,7 +141,7 @@ describe('startManagedDevServer', () => {
     expect(close).toHaveBeenCalledOnce();
   });
 
-  it('string/object form: reuses an already-reachable server (no spawn) when not in CI', async () => {
+  it('should reuse an already-reachable server (no spawn) for the string/object form when not in CI', async () => {
     vi.stubGlobal('fetch', reachable());
     const spawn = vi.fn();
     const managed = await startManagedDevServer('pnpm dev', url, { spawn: spawn as never, isCI: false });
@@ -149,7 +149,7 @@ describe('startManagedDevServer', () => {
     await expect(managed.stop()).resolves.toBeUndefined();
   });
 
-  it('string/object form: spawns even if reachable when in CI (no reuse)', async () => {
+  it('should spawn even if reachable in CI for the string/object form (no reuse)', async () => {
     vi.stubGlobal('fetch', reachable());
     const spawn = vi.fn(() => fakeChild()) as never;
     const managed = await startManagedDevServer({ command: 'pnpm dev', timeoutMs: 1000 }, url, {
@@ -161,7 +161,7 @@ describe('startManagedDevServer', () => {
     expect(managed.url).toBe(url);
   });
 
-  it('string/object form: reuseExistingServer:false spawns even when reachable', async () => {
+  it('should spawn even when reachable if reuseExistingServer is false (string/object form)', async () => {
     vi.stubGlobal('fetch', reachable());
     const spawn = vi.fn(() => fakeChild()) as never;
     await startManagedDevServer({ command: 'pnpm dev', reuseExistingServer: false, timeoutMs: 1000 }, url, {

--- a/packages/native-core/test/browserMode.spec.ts
+++ b/packages/native-core/test/browserMode.spec.ts
@@ -1,5 +1,27 @@
+import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { nonChromeBrowserNameError, probeDevServerReachable } from '../src/browserMode.js';
+import {
+  nonChromeBrowserNameError,
+  probeDevServerReachable,
+  startManagedDevServer,
+  waitForDevServerReachable,
+} from '../src/browserMode.js';
+
+const reachable = () => vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+const unreachable = () => vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+/** A minimal fake child process for the command-form (DevServerProcess) spawn path. */
+function fakeChild() {
+  const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 4242;
+  proc.exitCode = null;
+  proc.signalCode = null;
+  proc.killed = false;
+  return proc;
+}
 
 describe('nonChromeBrowserNameError', () => {
   it('returns undefined when browserName is unset', () => {
@@ -61,5 +83,92 @@ describe('probeDevServerReachable', () => {
     const message = result.ok ? '' : result.error.message;
     expect(message).toContain(`Dev server not reachable at ${url}`);
     expect(message).toContain('is it running?');
+  });
+});
+
+describe('waitForDevServerReachable', () => {
+  const url = 'http://localhost:1420';
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('resolves Ok as soon as the server is reachable', async () => {
+    vi.stubGlobal('fetch', reachable());
+    const result = await waitForDevServerReachable(url, { timeoutMs: 1000, pollMs: 10 });
+    expect(result.ok).toBe(true);
+  });
+
+  it('polls until the server comes up', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await waitForDevServerReachable(url, { timeoutMs: 1000, pollMs: 5 });
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves Err after the timeout when never reachable', async () => {
+    vi.stubGlobal('fetch', unreachable());
+    const result = await waitForDevServerReachable(url, { timeoutMs: 30, pollMs: 10 });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('startManagedDevServer', () => {
+  const url = 'http://localhost:1420';
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('function form: awaits readiness and returns close() as the teardown', async () => {
+    vi.stubGlobal('fetch', reachable());
+    const close = vi.fn(async () => {});
+    const devServer = async () => ({ url: 'http://localhost:5173', close });
+
+    const managed = await startManagedDevServer(devServer, url);
+
+    expect(managed.url).toBe('http://localhost:5173'); // function url overrides devServerUrl
+    await managed.stop();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('function form: closes and throws when the returned url never becomes reachable', async () => {
+    vi.stubGlobal('fetch', unreachable());
+    const close = vi.fn(async () => {});
+    const devServer = async () => ({ url: 'http://localhost:5173', close });
+
+    await expect(
+      startManagedDevServer(devServer, url, { readinessTimeoutMs: 30, readinessPollMs: 10 }),
+    ).rejects.toThrow(/not reachable/);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('string/object form: reuses an already-reachable server (no spawn) when not in CI', async () => {
+    vi.stubGlobal('fetch', reachable());
+    const spawn = vi.fn();
+    const managed = await startManagedDevServer('pnpm dev', url, { spawn: spawn as never, isCI: false });
+    expect(spawn).not.toHaveBeenCalled();
+    await expect(managed.stop()).resolves.toBeUndefined();
+  });
+
+  it('string/object form: spawns even if reachable when in CI (no reuse)', async () => {
+    vi.stubGlobal('fetch', reachable());
+    const spawn = vi.fn(() => fakeChild()) as never;
+    const managed = await startManagedDevServer({ command: 'pnpm dev', timeoutMs: 1000 }, url, {
+      spawn,
+      probe: async () => true,
+      isCI: true,
+    });
+    expect(spawn).toHaveBeenCalledWith('pnpm dev', expect.objectContaining({ shell: true }));
+    expect(managed.url).toBe(url);
+  });
+
+  it('string/object form: reuseExistingServer:false spawns even when reachable', async () => {
+    vi.stubGlobal('fetch', reachable());
+    const spawn = vi.fn(() => fakeChild()) as never;
+    await startManagedDevServer({ command: 'pnpm dev', reuseExistingServer: false, timeoutMs: 1000 }, url, {
+      spawn,
+      probe: async () => true,
+      isCI: false,
+    });
+    expect(spawn).toHaveBeenCalled();
   });
 });

--- a/packages/native-core/test/browserMode.spec.ts
+++ b/packages/native-core/test/browserMode.spec.ts
@@ -171,4 +171,28 @@ describe('startManagedDevServer', () => {
     });
     expect(spawn).toHaveBeenCalled();
   });
+
+  it('should stop the spawned process and rethrow when it never becomes ready (no orphan)', async () => {
+    const proc = fakeChild();
+    // Stays alive (exitCode null) but never answers the probe → start() times out while the process
+    // is still running, which is the orphan case. pid undefined forces the direct-child kill branch
+    // so the test never signals a real process group; emit 'exit' so stop()'s teardown resolves.
+    proc.pid = undefined;
+    proc.kill = vi.fn(() => {
+      queueMicrotask(() => {
+        proc.exitCode = 143;
+        proc.emit('exit', null, 'SIGTERM');
+      });
+    });
+    const spawn = vi.fn(() => proc) as never;
+
+    await expect(
+      startManagedDevServer({ command: 'pnpm dev', timeoutMs: 20 }, url, {
+        spawn,
+        probe: async () => false,
+        isCI: true,
+      }),
+    ).rejects.toThrow(/did not become ready/);
+    expect(proc.kill).toHaveBeenCalled();
+  });
 });

--- a/packages/native-core/test/devServerProcess.spec.ts
+++ b/packages/native-core/test/devServerProcess.spec.ts
@@ -102,6 +102,19 @@ describe('DevServerProcess.start', () => {
     const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe });
     await expect(dsp.start({ command: 'x', url: URL, timeoutMs: 1000, pollMs: 10 })).rejects.toThrow(/ENOENT/);
   });
+
+  it('should throw when the owned process exits during the probe even if a pre-existing server answers', async () => {
+    const proc = fakeProc();
+    const probe = vi.fn(async () => {
+      proc.exitCode = 1;
+      return true;
+    });
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe });
+    await expect(dsp.start({ command: 'x', url: URL, timeoutMs: 1000, pollMs: 10 })).rejects.toThrow(
+      /exited during startup/,
+    );
+    expect(dsp.isRunning()).toBe(false);
+  });
 });
 
 describe('DevServerProcess.stop', () => {

--- a/packages/native-core/test/devServerProcess.spec.ts
+++ b/packages/native-core/test/devServerProcess.spec.ts
@@ -31,7 +31,12 @@ function fakeProc() {
   return proc;
 }
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+  // Restore real timers even if a fake-timer test threw before its own restore, so leaked fake
+  // timers don't hang the next test.
+  vi.useRealTimers();
+});
 
 describe('DevServerProcess.start', () => {
   it('should spawn the command in a shell and resolve once the server is reachable', async () => {
@@ -140,7 +145,9 @@ describe('DevServerProcess.stop', () => {
     await dsp.start({ command: 'x', url: URL, timeoutMs: 1000, pollMs: 10 });
 
     const stopping = dsp.stop();
-    await vi.advanceTimersByTimeAsync(5000); // grace timeout → SIGKILL
+    // #waitForExit's grace timeout is 10s in CI (5s locally); advance past the larger value so the
+    // SIGKILL fires deterministically regardless of process.env.CI.
+    await vi.advanceTimersByTimeAsync(10_000); // grace timeout → SIGKILL
     expect(kill).toHaveBeenCalledWith(proc, 'SIGKILL');
     await vi.advanceTimersByTimeAsync(5000); // post-SIGKILL grace → resolve
     await stopping;

--- a/packages/native-core/test/devServerProcess.spec.ts
+++ b/packages/native-core/test/devServerProcess.spec.ts
@@ -1,0 +1,152 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return { ...actual, createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) };
+});
+
+import { DevServerProcess } from '../src/devServerProcess.js';
+
+const URL = 'http://localhost:1420';
+
+/** A fake long-lived child process. */
+function fakeProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+    exitCode: number | null;
+    signalCode: string | null;
+    killed: boolean;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  proc.pid = 4242;
+  proc.exitCode = null;
+  proc.signalCode = null;
+  proc.killed = false;
+  return proc;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('DevServerProcess.start', () => {
+  it('should spawn the command in a shell and resolve once the server is reachable', async () => {
+    const proc = fakeProc();
+    const spawn = vi.fn(() => proc) as never;
+    const probe = vi.fn(async () => true);
+    const dsp = new DevServerProcess({ spawn, probe });
+
+    await dsp.start({ command: 'pnpm dev', url: URL, cwd: '/proj', timeoutMs: 1000, pollMs: 10 });
+
+    expect(spawn).toHaveBeenCalledWith('pnpm dev', expect.objectContaining({ shell: true, cwd: '/proj' }));
+    expect(probe).toHaveBeenCalledWith(URL);
+    expect(dsp.isRunning()).toBe(true);
+  });
+
+  it('should merge env over process.env', async () => {
+    const proc = fakeProc();
+    const spawn = vi.fn(() => proc) as never;
+    const dsp = new DevServerProcess({ spawn, probe: async () => true });
+    await dsp.start({ command: 'pnpm dev', url: URL, env: { FOO: 'bar' }, timeoutMs: 1000, pollMs: 10 });
+    expect(spawn).toHaveBeenCalledWith(
+      'pnpm dev',
+      expect.objectContaining({ env: expect.objectContaining({ FOO: 'bar', PATH: process.env.PATH }) }),
+    );
+  });
+
+  it('should throw when the server never becomes reachable', async () => {
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => fakeProc()) as never, probe: async () => false });
+    await expect(dsp.start({ command: 'x', url: URL, timeoutMs: 40, pollMs: 10 })).rejects.toThrow(
+      /did not become ready/,
+    );
+  });
+
+  it('should throw when the process exits during startup', async () => {
+    const proc = fakeProc();
+    proc.exitCode = 1;
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
+    await expect(dsp.start({ command: 'x', url: URL, timeoutMs: 1000, pollMs: 10 })).rejects.toThrow(
+      /exited during startup/,
+    );
+  });
+
+  it('should surface captured stderr in a startup-failure error', async () => {
+    const proc = fakeProc();
+    queueMicrotask(() => {
+      proc.stderr.emit('data', Buffer.from('error: listen EADDRINUSE: address already in use :::1420'));
+      proc.exitCode = 1;
+    });
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
+    await expect(dsp.start({ command: 'x', url: URL, timeoutMs: 1000, pollMs: 10 })).rejects.toThrow(/EADDRINUSE/);
+  });
+
+  it('should fail fast with the spawn error instead of timing out (ENOENT)', async () => {
+    const proc = fakeProc();
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false });
+    const starting = dsp.start({ command: 'x', url: URL, timeoutMs: 5000, pollMs: 20 });
+    proc.emit('error', new Error('spawn sh ENOENT'));
+    await expect(starting).rejects.toThrow(/ENOENT/);
+    expect(dsp.isRunning()).toBe(false);
+  });
+
+  it('should surface a spawn error even when a pre-existing server answers the probe', async () => {
+    const proc = fakeProc();
+    const probe = vi.fn(async () => {
+      proc.emit('error', new Error('spawn sh ENOENT'));
+      return true;
+    });
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe });
+    await expect(dsp.start({ command: 'x', url: URL, timeoutMs: 1000, pollMs: 10 })).rejects.toThrow(/ENOENT/);
+  });
+});
+
+describe('DevServerProcess.stop', () => {
+  it('should kill the process tree with SIGTERM and resolve on exit', async () => {
+    const proc = fakeProc();
+    const kill = vi.fn();
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe: async () => true, kill });
+    await dsp.start({ command: 'pnpm dev', url: URL, timeoutMs: 1000, pollMs: 10 });
+
+    const stopping = dsp.stop();
+    proc.emit('exit', 0);
+    await stopping;
+
+    expect(kill).toHaveBeenCalledWith(proc, 'SIGTERM');
+    expect(dsp.isRunning()).toBe(false);
+  });
+
+  it('should escalate to SIGKILL when the process does not exit in time', async () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const kill = vi.fn();
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe: async () => true, kill });
+    await dsp.start({ command: 'x', url: URL, timeoutMs: 1000, pollMs: 10 });
+
+    const stopping = dsp.stop();
+    await vi.advanceTimersByTimeAsync(5000); // grace timeout → SIGKILL
+    expect(kill).toHaveBeenCalledWith(proc, 'SIGKILL');
+    await vi.advanceTimersByTimeAsync(5000); // post-SIGKILL grace → resolve
+    await stopping;
+    vi.useRealTimers();
+  });
+
+  it('should early-return after a spawn error without attempting a kill', async () => {
+    const proc = fakeProc();
+    const kill = vi.fn();
+    const dsp = new DevServerProcess({ spawn: vi.fn(() => proc) as never, probe: async () => false, kill });
+    const starting = dsp.start({ command: 'x', url: URL, timeoutMs: 5000, pollMs: 20 });
+    proc.emit('error', new Error('spawn sh ENOENT'));
+    await expect(starting).rejects.toThrow(/ENOENT/);
+    await dsp.stop();
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('should be a no-op when nothing is running', async () => {
+    const dsp = new DevServerProcess();
+    await expect(dsp.stop()).resolves.toBeUndefined();
+  });
+});

--- a/packages/native-types/src/index.ts
+++ b/packages/native-types/src/index.ts
@@ -110,6 +110,8 @@ export type {
   BaseServiceOptions,
   BaseWithExecute,
   BrowserBase,
+  DevServer,
+  DevServerObject,
   DriverProviderConfig,
   Fn,
   LogCaptureConfig,

--- a/packages/native-types/src/shared.ts
+++ b/packages/native-types/src/shared.ts
@@ -194,9 +194,44 @@ export interface MockLifecycleConfig {
 }
 
 /**
+ * Object form of {@link DevServer} — the command to spawn plus its environment and readiness knobs.
+ */
+export interface DevServerObject {
+  /** Command run in a shell to start the dev server, e.g. `'pnpm dev'`. */
+  command: string;
+  /** Working directory for the command. Default `process.cwd()`. */
+  cwd?: string;
+  /** Extra environment variables, merged over `process.env`. */
+  env?: Record<string, string>;
+  /** Readiness timeout in ms (how long to wait for `devServerUrl`). Default 60000 (120000 in CI). */
+  timeoutMs?: number;
+  /**
+   * Reuse a server already reachable at `devServerUrl` instead of spawning a new one.
+   * @default true locally, false in CI (`!process.env.CI`)
+   */
+  reuseExistingServer?: boolean;
+}
+
+/**
+ * Optional dev-server management for browser mode. When set, the service spawns the dev server in
+ * `onPrepare`, waits until `devServerUrl` is reachable, and tears it down on completion / failure.
+ *
+ * - `string` — a shell command, e.g. `'pnpm dev'`.
+ * - {@link DevServerObject} — the command plus `cwd` / `env` / `timeoutMs` / `reuseExistingServer`.
+ * - function — start the server yourself and return `{ url, close }`; the returned `url` supplies or
+ *   overrides `devServerUrl`, and `close` is the teardown (no subprocess/child-kill involved).
+ */
+export type DevServer = string | DevServerObject | (() => Promise<{ url: string; close: () => Promise<void> }>);
+
+/**
  * Base service options shared between Electron and Tauri
  */
 export interface BaseServiceOptions extends LogCaptureConfig, MockLifecycleConfig {
+  /**
+   * Auto-manage the dev server in browser mode (spawn in `onPrepare`, wait for `devServerUrl`,
+   * tear down on completion). Ignored outside browser mode.
+   */
+  devServer?: DevServer;
   /**
    * The path to the application binary for testing
    */
@@ -225,6 +260,11 @@ export interface BaseServiceGlobalOptions extends LogCaptureConfig, MockLifecycl
    * Root directory of the project
    */
   rootDir?: string;
+  /**
+   * Auto-manage the dev server in browser mode (spawn in `onPrepare`, wait for `devServerUrl`,
+   * tear down on completion). Ignored outside browser mode.
+   */
+  devServer?: DevServer;
 }
 
 // ============================================================================


### PR DESCRIPTION
PR1 of 2 for #417 (browser-mode dev-server auto-start). **Shared infra only — no launcher wiring yet**, so this is behavior-neutral (nothing calls it). PR2 wires the four browser-mode launchers.

## What
Adds an optional `devServer` that lets browser mode spawn the dev server, wait for `devServerUrl`, and tear it down — reusing #416's `probeDevServerReachable` and mirroring `react-native-service`'s `MetroProcess`.

- **`DevServerProcess`** (`packages/native-core/src/devServerProcess.ts`) — spawns a shell command, polls the URL for readiness (fast-fails on spawn error / early exit, surfaces the stderr tail in failures), and tears down the **process tree**: POSIX process-group kill (`detached` + `process.kill(-pid)`) / Windows `taskkill /T /F`, with the SIGTERM→SIGKILL + CI-aware timing lifted from `MetroProcess`. DI-constructed (`spawn`/`probe`/`kill`) so it's unit-testable with a fake child.
- **`startManagedDevServer` / `waitForDevServerReachable`** (`browserMode.ts`) — the "once in the shared layer" orchestrator across the three `DevServer` forms:
  - **function** — call it, poll the returned `url`, teardown is its `close()` (no subprocess/kill).
  - **string / object** — `reuseExistingServer` (default `!CI`) skips the spawn when already reachable; else spawn a `DevServerProcess`.
  - Returns `{ url, stop }`; callers store `stop` for `onComplete` **and** the `onPrepare` catch (WDIO won't call `onComplete` after an `onPrepare` throw).
- **Types** (`native-types/src/shared.ts`) — `DevServer` / `DevServerObject` + `devServer?` on the shared option bases.

## Decisions (confirmed with maintainer)
Full API surface (`string | object | function`); function `url` overrides `devServerUrl`; `reuseExistingServer` defaults to `!process.env.CI`.

## Tests
`devServerProcess.spec.ts` (mirrors `metroProcess.spec.ts`) + `startManagedDevServer`/`waitForDevServerReachable` in `browserMode.spec.ts`. `pnpm --filter @wdio/native-core test`: **59/59**. Typecheck + lint + build green on native-core and native-types. No new deps (`pnpm-lock.yaml` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)