### PR TITLE
ci: skip CI on the releasekit standing PR (release/*)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,17 @@ env:
 jobs:
   # Detect which services are affected by changes
   detect-changes:
-    # Dependabot fans the full OS matrix out on every PR and drains the runners, so its PRs
-    # skip CI by default — every downstream job needs detect-changes, so gating it here skips
-    # the whole pipeline. Run it manually when you're ready to merge a bump: add the `ci:run`
-    # label (see dependabot-ci.yml) or Actions → CI → Run workflow on the PR's branch. Both
-    # arrive as a workflow_dispatch with no pull_request context, which bypasses this gate.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Two PR sources are skipped here — every downstream job needs detect-changes, so gating it
+    # here skips the whole pipeline:
+    #   - Dependabot: it fans the full OS matrix out on every bump and drains the runners. Run it
+    #     manually when you're ready to merge: add the `ci:run` label (see dependabot-ci.yml) or
+    #     Actions → CI → Run workflow on the PR's branch. Both arrive as a workflow_dispatch with
+    #     no pull_request context, which bypasses this gate.
+    #   - The releasekit standing PR (`release/*`): it only carries version bumps + changelogs on
+    #     top of main, already CI'd on each feeder PR and re-CI'd on push to main at merge, so
+    #     rebuilding the whole cross-platform matrix here is pure waste. `[skip ci]` can't be used
+    #     (a squash-merge would inherit it and suppress the publish workflow).
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && !startsWith(github.head_ref, 'release/')
     uses: ./.github/workflows/_ci-detect-changes.reusable.yml
     with:
       force_all: ${{ inputs.force_all || false }}


### PR DESCRIPTION
## What
Extend the `detect-changes` gate to skip the **releasekit standing PR** (`release/*` head), alongside the existing Dependabot skip.

## Why
The standing PR (`release/next`) force-pushes on every releasekit update, which is a `pull_request: synchronize` — so CI re-runs the **entire cross-platform build matrix on every update**. On the last standing-PR update that was **65 jobs** ([run](https://github.com/webdriverio/desktop-mobile/actions/runs/28510293646)), all wasted: the branch only carries version bumps + regenerated changelogs on top of `main`, whose code was already CI'd on each feeder PR and is CI'd again on push to `main` when the standing PR merges.

Change-detection can't help — a release commit touches version files + changelogs across every releasing package, so it reads as "everything changed" and fans the matrix out.

`[skip ci]` is **not** an option: a squash-merge inherits the standing PR's prep-commit message onto `main`, and `[skip ci]` there would suppress the publish workflow. So the skip has to live in CI's gate, not the commit — a head-ref guard.

## Change
```yaml
detect-changes:
  if: github.event.pull_request.user.login != 'dependabot[bot]' && !startsWith(github.head_ref, 'release/')
```
`github.head_ref` is empty on `push: main`, so main-branch CI is unaffected. Every downstream job `needs: [detect-changes]`, so gating it here skips the whole pipeline (same mechanism as the Dependabot skip). `actionlint` clean.

Guidance this follows: releasekit docs → [Keeping CI off the standing PR](https://github.com/goosewobbler/releasekit/blob/main/packages/release/docs/ci-setup.md).
