### PR TITLE
ci(ios): resilient simulator resolution — fall back when the pinned iPhone is absent

### DIFF
--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -110,10 +110,12 @@ jobs:
           UDID=$(echo "$DEVICES" | jq -r --arg name "$FLUTTER_IOS_DEVICE" \
             'first(.devices | to_entries | sort_by(.key) | reverse | .[].value[] | select(.name == $name) | .udid) // empty')
           if [ -z "$UDID" ]; then
+            # `|| true`: with an empty jq result `read` exits 1, which under `set -e` would kill the
+            # step before the guard below — losing the error annotation + device-list diagnostic.
             read -r UDID FLUTTER_IOS_DEVICE < <(echo "$DEVICES" | jq -r \
               '[.devices[][] | select(.name | test("^iPhone [0-9]"))]
                | (max_by([(.name | capture("^iPhone (?<n>[0-9]+)").n | tonumber), -(.name | length)])) as $c
-               | if $c == null then empty else "\($c.udid) \($c.name)" end')
+               | if $c == null then empty else "\($c.udid) \($c.name)" end') || true
             test -n "$UDID" || { echo "::error::No available iPhone simulator (requested '${{ inputs.ios-device }}')"; xcrun simctl list devices available; exit 1; }
             # Warn + write to the run summary (a passing job's annotations are easy to miss) so a
             # perpetually-absent default gets noticed and bumped. See #510.

--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -101,16 +101,34 @@ jobs:
           FLUTTER_IOS_DEVICE: ${{ inputs.ios-device }}
         run: |
           set -euo pipefail
-          if ! xcrun simctl boot "$FLUTTER_IOS_DEVICE" 2>/tmp/boot.err; then
+          # Resolve a concrete UDID and act on THAT throughout, so appium doesn't independently
+          # resolve the name to a different instance than we booted (#359). Prefer the requested
+          # device; fall back to the newest available "iPhone <N>" if the runner image doesn't carry
+          # it (Xcode versions drift across GitHub's macOS images). Export FLUTTER_IOS_UDID so the
+          # wdio config pins appium:udid to this exact simulator.
+          DEVICES=$(xcrun simctl list devices available --json)
+          UDID=$(echo "$DEVICES" | jq -r --arg name "$FLUTTER_IOS_DEVICE" \
+            'first(.devices | to_entries | sort_by(.key) | reverse | .[].value[] | select(.name == $name) | .udid) // empty')
+          if [ -z "$UDID" ]; then
+            read -r UDID FLUTTER_IOS_DEVICE < <(echo "$DEVICES" | jq -r \
+              '[.devices[][] | select(.name | test("^iPhone [0-9]"))]
+               | (max_by([(.name | capture("^iPhone (?<n>[0-9]+)").n | tonumber), -(.name | length)])) as $c
+               | if $c == null then empty else "\($c.udid) \($c.name)" end')
+            test -n "$UDID" || { echo "::error::No available iPhone simulator (requested '${{ inputs.ios-device }}')"; xcrun simctl list devices available; exit 1; }
+            echo "::warning::Requested simulator '${{ inputs.ios-device }}' not available on this runner; falling back to '$FLUTTER_IOS_DEVICE' ($UDID). See #510."
+          fi
+          echo "Using simulator $FLUTTER_IOS_DEVICE ($UDID)"
+          echo "FLUTTER_IOS_UDID=$UDID" >> "$GITHUB_ENV"
+          echo "FLUTTER_IOS_DEVICE=$FLUTTER_IOS_DEVICE" >> "$GITHUB_ENV"
+          if ! xcrun simctl boot "$UDID" 2>/tmp/boot.err; then
             if grep -qiE "already booted|current state: Booted" /tmp/boot.err; then
               echo "Simulator '$FLUTTER_IOS_DEVICE' already booted"
             else
-              echo "::error::Failed to boot simulator '$FLUTTER_IOS_DEVICE':"; cat /tmp/boot.err
-              echo "Available devices:"; xcrun simctl list devices available
+              echo "::error::Failed to boot simulator '$FLUTTER_IOS_DEVICE' ($UDID):"; cat /tmp/boot.err
               exit 1
             fi
           fi
-          xcrun simctl bootstatus "$FLUTTER_IOS_DEVICE" -b || { echo "::error::Simulator '$FLUTTER_IOS_DEVICE' did not reach Booted state"; exit 1; }
+          xcrun simctl bootstatus "$UDID" -b || { echo "::error::Simulator '$UDID' did not reach Booted state"; exit 1; }
 
       # Prime logd before Appium's first session. The first `simctl … log stream` on a freshly
       # booted sim routinely exceeds appium-xcuitest's 10s start window ("process did not start
@@ -171,10 +189,9 @@ jobs:
 
       - name: 🧪 Run E2E on iOS simulator
         shell: bash
-        env:
-          FLUTTER_IOS_DEVICE: ${{ inputs.ios-device }}
         run: |
           set -euo pipefail
+          # FLUTTER_IOS_DEVICE / FLUTTER_IOS_UDID are inherited from the boot step via $GITHUB_ENV.
           # Run the e2e suite and the package smoke DECOUPLED: capture each exit code with `|| rc=$?`
           # (so a failed e2e suite doesn't abort the step before the smoke runs) and fail at the end
           # if either failed. The smoke validates the PACKED tarball — its signal must survive an

--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -25,7 +25,7 @@ on:
       ios-device:
         description: 'Simulator device name'
         type: string
-        default: 'iPhone 16'
+        default: 'iPhone 17'
       build_id:
         type: string
         required: false
@@ -115,7 +115,11 @@ jobs:
                | (max_by([(.name | capture("^iPhone (?<n>[0-9]+)").n | tonumber), -(.name | length)])) as $c
                | if $c == null then empty else "\($c.udid) \($c.name)" end')
             test -n "$UDID" || { echo "::error::No available iPhone simulator (requested '${{ inputs.ios-device }}')"; xcrun simctl list devices available; exit 1; }
-            echo "::warning::Requested simulator '${{ inputs.ios-device }}' not available on this runner; falling back to '$FLUTTER_IOS_DEVICE' ($UDID). See #510."
+            # Warn + write to the run summary (a passing job's annotations are easy to miss) so a
+            # perpetually-absent default gets noticed and bumped. See #510.
+            DRIFT="Requested iOS simulator '${{ inputs.ios-device }}' not on this runner; using '$FLUTTER_IOS_DEVICE'. Refresh the ios-device default (#510) once it's absent across runner images."
+            echo "::warning::$DRIFT"
+            printf '⚠️ **iOS simulator drift (Flutter):** %s\n' "$DRIFT" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
           fi
           echo "Using simulator $FLUTTER_IOS_DEVICE ($UDID)"
           echo "FLUTTER_IOS_UDID=$UDID" >> "$GITHUB_ENV"

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -154,12 +154,23 @@ jobs:
           # booted here — a source of the "failed to finish booting" first-session flake (#359). We
           # export RN_IOS_UDID so the wdio config pins appium:udid to this exact simulator.
           # Prefer the newest runtime (highest SimRuntime key) when a name appears more than once.
-          UDID=$(xcrun simctl list devices available --json \
-            | jq -r --arg name "$RN_IOS_DEVICE" \
+          DEVICES=$(xcrun simctl list devices available --json)
+          UDID=$(echo "$DEVICES" | jq -r --arg name "$RN_IOS_DEVICE" \
                 'first(.devices | to_entries | sort_by(.key) | reverse | .[].value[] | select(.name == $name) | .udid) // empty')
-          test -n "$UDID" || { echo "::error::No available simulator named '$RN_IOS_DEVICE'"; xcrun simctl list devices available; exit 1; }
+          if [ -z "$UDID" ]; then
+            # Requested device absent on this runner image (Xcode versions drift across GitHub's
+            # macOS images), so fall back to the newest available "iPhone <N>" and pin its UDID.
+            read -r UDID RN_IOS_DEVICE < <(echo "$DEVICES" | jq -r \
+              '[.devices[][] | select(.name | test("^iPhone [0-9]"))]
+               | (max_by([(.name | capture("^iPhone (?<n>[0-9]+)").n | tonumber), -(.name | length)])) as $c
+               | if $c == null then empty else "\($c.udid) \($c.name)" end')
+            test -n "$UDID" || { echo "::error::No available iPhone simulator (requested '${{ inputs.ios-device }}')"; xcrun simctl list devices available; exit 1; }
+            echo "::warning::Requested simulator '${{ inputs.ios-device }}' not available on this runner; falling back to '$RN_IOS_DEVICE' ($UDID). See #510."
+          fi
           echo "Using simulator $RN_IOS_DEVICE ($UDID)"
           echo "RN_IOS_UDID=$UDID" >> "$GITHUB_ENV"
+          # Propagate the resolved name so the wdio config's appium:deviceName matches the pinned UDID.
+          echo "RN_IOS_DEVICE=$RN_IOS_DEVICE" >> "$GITHUB_ENV"
           # Tolerate "already booted" but fail loudly on a genuine error rather than masking it into
           # a later cryptic Appium "device not found".
           if ! xcrun simctl boot "$UDID" 2>/tmp/boot.err; then
@@ -222,10 +233,9 @@ jobs:
 
       - name: 🧪 Run E2E on iOS simulator
         shell: bash
-        env:
-          RN_IOS_DEVICE: ${{ inputs.ios-device }}
         run: |
           set -euo pipefail
+          # RN_IOS_DEVICE / RN_IOS_UDID are inherited from the boot step via $GITHUB_ENV.
           # Metro is now service-managed (manageMetro + prebundle): the @wdio/react-native-service
           # launcher starts `react-native start`, waits for /status, force-compiles the JS bundle
           # (so the first launch doesn't land on the "Bundling…" overlay), and tears it down. The

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -160,10 +160,12 @@ jobs:
           if [ -z "$UDID" ]; then
             # Requested device absent on this runner image (Xcode versions drift across GitHub's
             # macOS images), so fall back to the newest available "iPhone <N>" and pin its UDID.
+            # `|| true`: with an empty jq result `read` exits 1, which under `set -e` would kill the
+            # step before the guard below — losing the error annotation + device-list diagnostic.
             read -r UDID RN_IOS_DEVICE < <(echo "$DEVICES" | jq -r \
               '[.devices[][] | select(.name | test("^iPhone [0-9]"))]
                | (max_by([(.name | capture("^iPhone (?<n>[0-9]+)").n | tonumber), -(.name | length)])) as $c
-               | if $c == null then empty else "\($c.udid) \($c.name)" end')
+               | if $c == null then empty else "\($c.udid) \($c.name)" end') || true
             test -n "$UDID" || { echo "::error::No available iPhone simulator (requested '${{ inputs.ios-device }}')"; xcrun simctl list devices available; exit 1; }
             # Warn + write to the run summary (a passing job's annotations are easy to miss) so a
             # perpetually-absent default gets noticed and bumped. See #510.

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -38,7 +38,7 @@ on:
       ios-device:
         description: 'Simulator device name'
         type: string
-        default: 'iPhone 16'
+        default: 'iPhone 17'
       new-arch:
         description: 'Build the fixture with the New Architecture (Fabric/bridgeless) enabled'
         type: boolean
@@ -165,7 +165,11 @@ jobs:
                | (max_by([(.name | capture("^iPhone (?<n>[0-9]+)").n | tonumber), -(.name | length)])) as $c
                | if $c == null then empty else "\($c.udid) \($c.name)" end')
             test -n "$UDID" || { echo "::error::No available iPhone simulator (requested '${{ inputs.ios-device }}')"; xcrun simctl list devices available; exit 1; }
-            echo "::warning::Requested simulator '${{ inputs.ios-device }}' not available on this runner; falling back to '$RN_IOS_DEVICE' ($UDID). See #510."
+            # Warn + write to the run summary (a passing job's annotations are easy to miss) so a
+            # perpetually-absent default gets noticed and bumped. See #510.
+            DRIFT="Requested iOS simulator '${{ inputs.ios-device }}' not on this runner; using '$RN_IOS_DEVICE'. Refresh the ios-device default (#510) once it's absent across runner images."
+            echo "::warning::$DRIFT"
+            printf '⚠️ **iOS simulator drift (RN):** %s\n' "$DRIFT" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
           fi
           echo "Using simulator $RN_IOS_DEVICE ($UDID)"
           echo "RN_IOS_UDID=$UDID" >> "$GITHUB_ENV"

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -86,6 +86,7 @@ type FlutterCapability = {
   'appium:app': string;
   'appium:newCommandTimeout': number;
   'appium:deviceName'?: string;
+  'appium:udid'?: string;
   'appium:dartVmServicePort'?: number;
   'appium:wdaLaunchTimeout'?: number;
   'appium:simulatorStartupTimeout'?: number;
@@ -113,6 +114,10 @@ const capabilities: FlutterCapability[] = [
     ...(isIos
       ? {
           'appium:deviceName': process.env.FLUTTER_IOS_DEVICE ?? 'iPhone 16',
+          // CI pins the exact booted simulator (the boot step resolves + exports FLUTTER_IOS_UDID),
+          // so appium doesn't independently resolve the deviceName to a different instance (#359).
+          // Omitted locally (appium resolves by name).
+          ...(process.env.FLUTTER_IOS_UDID ? { 'appium:udid': process.env.FLUTTER_IOS_UDID } : {}),
           'appium:simulatorStartupTimeout': 240000,
           // Prebuilt WDA just launches (no compile), so a tight per-attempt ceiling lets several
           // startup retries fit inside connectionRetryTimeout below; non-prebuilt (local) must

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -113,7 +113,7 @@ const capabilities: FlutterCapability[] = [
     // cold/slow runners.
     ...(isIos
       ? {
-          'appium:deviceName': process.env.FLUTTER_IOS_DEVICE ?? 'iPhone 16',
+          'appium:deviceName': process.env.FLUTTER_IOS_DEVICE ?? 'iPhone 17',
           // CI pins the exact booted simulator (the boot step resolves + exports FLUTTER_IOS_UDID),
           // so appium doesn't independently resolve the deviceName to a different instance (#359).
           // Omitted locally (appium resolves by name).

--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -128,10 +128,10 @@ const capabilities: ReactNativeCapability[] = [
     'appium:automationName': isIos ? 'XCUITest' : 'UiAutomator2',
     'appium:app': appPath,
     'appium:newCommandTimeout': 240,
-    // iOS needs a target simulator; CI sets RN_IOS_DEVICE (e.g. 'iPhone 16').
+    // iOS needs a target simulator; CI sets RN_IOS_DEVICE (e.g. 'iPhone 17').
     ...(isIos
       ? {
-          'appium:deviceName': process.env.RN_IOS_DEVICE ?? 'iPhone 16',
+          'appium:deviceName': process.env.RN_IOS_DEVICE ?? 'iPhone 17',
           // Pin the exact simulator the workflow already booted. Without a udid, appium resolves
           // the deviceName independently and — when the runner image carries duplicate device names
           // across runtimes — can monitor/boot a *different* instance than CI pre-booted, surfacing


### PR DESCRIPTION
Fixes #510.

## Problem

Both iOS E2E legs hardcode `ios-device: 'iPhone 16'` and fail at the **📲 Boot iOS simulator** step with `No available simulator named 'iPhone 16'` on runner images that don't carry it. GitHub's macOS images drift across Xcode versions — **Xcode 26.5** ships the iPhone 17 family + iPhone 16e + iPhone Air, with **no plain "iPhone 16"**. It's deterministic on those images; a re-run only passes while older images are still in rotation (a shrinking pool). Not covered by #428 (boot-cap timeouts) or #421 (Flutter session-create WDA wedge).

## Fix

Resolve the simulator instead of assuming the name exists:
- Prefer the requested `ios-device`; if absent, **fall back to the newest available `iPhone <N>`** (highest model number, plain variant), pin its **UDID**, and emit a `::warning::` naming the fallback.
- Applied to both `_ci-e2e-react-native-ios.reusable.yml` and `_ci-e2e-flutter-ios.reusable.yml`. The resolved name + UDID flow to the test steps via `$GITHUB_ENV` (the step-local `ios-device` overrides are dropped so they inherit the resolved values).
- **Flutter** now also boots by UDID and pins `appium:udid` to the booted sim (mirrors the RN leg), removing the boot-by-name duplicate-name ambiguity (#359).

## Validation

The fallback jq was tested against real `xcrun simctl list devices available --json` on a Mac whose simulator set matches the failing runner (iPhone 17 family + 17e + Air, no plain iPhone 16) — it correctly resolves to **`iPhone 17`**; exact-match returns empty for a bogus name → triggers the fallback. Both reusable workflows parse; `e2e/wdio.flutter.conf.ts` is biome-clean and the `appium:udid` spread mirrors the existing RN pattern.

Note: this doesn't affect a run using the reusable workflows from a PR branch that predates it (e.g. #503) until that branch rebases — re-run clears those while older images exist. It fixes the repo going forward on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)