### PR TITLE
fix(native-utils): don't false-flag Windows binaries as non-executable (#513)

### DIFF
--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -49,15 +49,26 @@ export function diagnoseBinary(binaryPath: string): DiagnosticResult[] {
   try {
     const stats = statSync(binaryPath);
     const mode = (stats.mode & 0o777).toString(8);
-    const isExecutable = (stats.mode & 0o111) !== 0;
     const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
 
-    results.push({
-      category: 'Binary Permissions',
-      status: isExecutable ? 'ok' : 'error',
-      message: mode,
-      details: isExecutable ? 'Binary is executable' : 'Binary is not executable. Run chmod +x on Unix systems.',
-    });
+    // The Unix execute bit (0o111) is meaningless on Windows — `fs.stat` reports `0o666`
+    // there whether or not the binary is runnable, so the check would false-error.
+    if (process.platform === 'win32') {
+      results.push({
+        category: 'Binary Permissions',
+        status: 'ok',
+        message: mode,
+        details: 'Executability is not gated by file mode on Windows.',
+      });
+    } else {
+      const isExecutable = (stats.mode & 0o111) !== 0;
+      results.push({
+        category: 'Binary Permissions',
+        status: isExecutable ? 'ok' : 'error',
+        message: mode,
+        details: isExecutable ? 'Binary is executable' : 'Binary is not executable. Run chmod +x on Unix systems.',
+      });
+    }
 
     results.push({
       category: 'Binary Size',

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -1,0 +1,49 @@
+import { statSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { diagnoseBinary } from '../src/diagnostics.js';
+
+vi.mock('node:fs', async (importActual) => {
+  const actual = await importActual<typeof import('node:fs')>();
+  return { ...actual, statSync: vi.fn() };
+});
+
+vi.mock('../src/log.js', () => import('./__mock__/log.js'));
+
+const setPlatform = (platform: NodeJS.Platform): void => {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+};
+
+const stubMode = (mode: number, size = 100 * 1024 * 1024): void => {
+  vi.mocked(statSync).mockReturnValue({ mode, size } as unknown as ReturnType<typeof statSync>);
+};
+
+const binaryPermissions = (path: string) => diagnoseBinary(path).find((r) => r.category === 'Binary Permissions');
+
+describe('diagnoseBinary', () => {
+  const realPlatform = process.platform;
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+    vi.clearAllMocks();
+  });
+
+  it('should not flag a Windows binary as non-executable — the Unix execute bit is meaningless there', () => {
+    setPlatform('win32');
+    stubMode(0o666); // what Windows reports for an .exe — rw-rw-rw-, no execute bit
+    const perms = binaryPermissions('C:/app/app.exe');
+    expect(perms?.status).toBe('ok');
+    expect(perms?.details).toMatch(/Windows/);
+  });
+
+  it('should flag a non-executable binary on Unix (mode 644)', () => {
+    setPlatform('darwin');
+    stubMode(0o644);
+    expect(binaryPermissions('/app/app')?.status).toBe('error');
+  });
+
+  it('should accept an executable binary on Unix (mode 755)', () => {
+    setPlatform('darwin');
+    stubMode(0o755);
+    expect(binaryPermissions('/app/app')?.status).toBe('ok');
+  });
+});


### PR DESCRIPTION
Fixes #513.

## The bug (confirmed)

`diagnoseBinary` (`@wdio/native-utils`) gates the "Binary Permissions" check on the **Unix execute bit**:

```ts
const isExecutable = (stats.mode & 0o111) !== 0;
```

`0o111` is meaningless on Windows — `fs.stat` reports `0o666` (or `0o444`) regardless of whether the binary runs — so `0o666 & 0o111 === 0` → a status-`error` result, logging a false `❌ Binary Permissions: 666` / "Binary is not executable. Run chmod +x…" on **every** Windows run.

## Does it stop test execution? No — verified

It's a **log-only diagnostic, not a hard failure**. `formatDiagnosticResults` (native-utils/diagnostics.ts) is `void` and purely logs — `ok→debug`, `warn→warn`, `error→error` via `logger[level](...)`, with no `throw`/`process.exit`/return. The electron launcher just calls it and never inspects the results; its `try/catch` only fires if the call *throws*, which a status-`error` result can't. So the app still launches on Windows and the run stays green — which is why it shipped and why the reporter saw a *log line*, not a test failure. It's misleading noise (an ERROR-level log that looks like a real problem), worth fixing regardless.

## Why the tests missed it

Two independent gaps: (1) it never fails anything (above), and (2) nothing exercised the OS-specific branch — `native-utils` had **no diagnostics test at all**, and `electron-service`'s diagnostics tests **mock `native-utils`**, so the real `diagnoseBinary` never ran; any test that did run it executes on Linux CI, where `0o111` is correct.

## Scope

Root cause is in **shared `@wdio/native-utils`** (Tauri-origin diagnostics, extracted + adopted by electron in #158, 2026-02-16). It affects **electron-service 10.0.0 and 10.1.0** (verified: the buggy line + the launcher call are both present at the `v10.0.0` tag) and **any service running `diagnoseBinary` on Windows** — Tauri/Dioxus/Electrobun. (Hence the added `scope:native-utils` label.)

## Fix

- Gate the execute-bit check **off-Windows only** (mirroring the file's existing `process.platform` guards); on Windows, report the mode informationally (`status: 'ok'`).
- Add `packages/native-utils/test/diagnostics.spec.ts` (native-utils had none): Windows `0o666` → `ok`, Unix `0o644` → `error`, Unix `0o755` → `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
