### PR TITLE
fix(e2e): surface real binary-path resolution errors instead of `[object Object]`

### DIFF
--- a/e2e/wdio.electron.conf.ts
+++ b/e2e/wdio.electron.conf.ts
@@ -77,6 +77,11 @@ async function getElectronConfigContext(): Promise<ElectronConfigContext> {
   } else {
     console.log('🔍 Setting up binary test with app binary path');
 
+    // Serialize structured/Result errors: interpolating them renders `[object Object]` and hides
+    // the candidate paths that pinpoint a resolution failure.
+    const describeError = (err: unknown): string =>
+      err instanceof Error ? (err.stack ?? err.message) : JSON.stringify(err, null, 2);
+
     try {
       // Import async utilities and resolve binary path directly
       const { getBinaryPath, getAppBuildInfo, getElectronVersion } = await import('@wdio/electron-service');
@@ -89,13 +94,14 @@ async function getElectronConfigContext(): Promise<ElectronConfigContext> {
 
       // Extract the actual path string from the result object
       if (!isOk(binaryResult)) {
-        throw new Error(`Failed to resolve binary path: ${binaryResult.error}`);
+        throw new Error(`Failed to resolve binary path: ${describeError(binaryResult.error)}`);
       }
       appBinaryPath = binaryResult.value.binaryPath;
 
       console.log('🔍 Found app binary at:', appBinaryPath);
     } catch (error) {
-      throw new Error(`Failed to resolve binary path: ${error instanceof Error ? error.message : error}`);
+      // Preserve the already-formatted error from above (don't double-wrap the message).
+      throw error instanceof Error ? error : new Error(`Failed to resolve binary path: ${describeError(error)}`);
     }
   }
 

--- a/e2e/wdio.electron.conf.ts
+++ b/e2e/wdio.electron.conf.ts
@@ -79,8 +79,17 @@ async function getElectronConfigContext(): Promise<ElectronConfigContext> {
 
     // Serialize structured/Result errors: interpolating them renders `[object Object]` and hides
     // the candidate paths that pinpoint a resolution failure.
-    const describeError = (err: unknown): string =>
-      err instanceof Error ? (err.stack ?? err.message) : JSON.stringify(err, null, 2);
+    const describeError = (err: unknown): string => {
+      if (err instanceof Error) {
+        return err.stack ?? err.message;
+      }
+      // JSON.stringify throws on circular refs / BigInt; a diagnostic helper must never itself throw.
+      try {
+        return JSON.stringify(err, null, 2);
+      } catch {
+        return String(err);
+      }
+    };
 
     try {
       // Import async utilities and resolve binary path directly


### PR DESCRIPTION
`getBinaryPath` returns a `Result` whose `error` is a **structured object**. `e2e/wdio.electron.conf.ts` interpolated it straight into the message → `[object Object]`, and the surrounding `catch` re-wrapped that into a double-prefixed, still-opaque string. When binary resolution fails in CI (e.g. the intermittent macOS-ARM electron-forge failures), the logs said nothing actionable.

## Change
- Serialize structured/`Result` errors (via a small `describeError` helper) so the **generated candidate paths** — the thing that pinpoints a resolution regression — are visible.
- Re-throw already-`Error` values as-is in the `catch` instead of re-wrapping, killing the `Failed to resolve binary path: Failed to resolve binary path: …` double prefix.

## Testing
- biome + eslint clean; e2e typecheck unaffected (error-handling-only change).

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)