### PR TITLE
fix(e2e): disable electron-forge prune on the forge fixture to fix flaky CI packaging

### DIFF
--- a/fixtures/e2e-apps/electron-forge/forge.config.js
+++ b/fixtures/e2e-apps/electron-forge/forge.config.js
@@ -10,6 +10,10 @@ const config = {
     asar: true,
     icon,
     osxSign: false,
+    // Skip electron-packager's native-dependency prune (flora-colossus) — it can't traverse
+    // pnpm's symlinked workspace store and intermittently fails packaging in CI. A larger
+    // package is fine for a fixture that only needs to launch.
+    prune: false,
   },
   rebuildConfig: {},
   makers: [],


### PR DESCRIPTION
The e2e electron-forge app packaging is **intermittently** failing on macOS-ARM in CI — `electron-forge package`'s "Preparing native dependencies" / "Finalizing package" steps start but never complete, and the run then fails at `Failed to resolve binary path` (there's no built app to resolve).

## Cause
Those steps run electron-packager's native-dependency prune walk (**flora-colossus**), which can't traverse pnpm's symlinked workspace store. It fails intermittently there (the "electron-forge no-binary" flaky class). Locally the same fixture packages fine — the difference is CI's install layout.

## Fix
`prune: false` in the fixture's `packagerConfig` skips that walk — the same fix already applied to the **package-test** forge fixtures (see #517). A fatter package is irrelevant for a fixture that only needs to launch for E2E.

## Notes
- Only touches the e2e forge fixture config; no service/source changes.
- Independent follow-up from the dep-update work; complements the diagnostics improvement in #518 (which makes the *next* such failure legible instead of `[object Object]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)