### PR TITLE
feat(tauri): support child webview handles

### DIFF
--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -36,6 +36,11 @@ interface WebDriverError {
   message: string;
 }
 
+interface WebDriverRawResponse<T> {
+  status: number;
+  value: T | WebDriverError;
+}
+
 interface WindowBounds {
   x: number;
   y: number;
@@ -115,8 +120,12 @@ async function deleteWebDriverSession(sessionId: string): Promise<void> {
   }
 }
 
-async function closeCurrentWindow(): Promise<string[]> {
-  return requestWebDriver<string[]>(`/session/${browser.sessionId}/window`, { method: 'DELETE' });
+async function closeCurrentWindowRaw(): Promise<WebDriverRawResponse<string[]>> {
+  const origin = `${browser.options.protocol ?? 'http'}://${browser.options.hostname ?? '127.0.0.1'}:${browser.options.port ?? 4445}`;
+  const response = await fetch(`${origin}/session/${browser.sessionId}/window`, { method: 'DELETE' });
+  const body = (await response.json()) as WebDriverResponse<string[]>;
+
+  return { status: response.status, value: body.value };
 }
 
 describeChildWebviews('child webview handles', () => {
@@ -231,12 +240,13 @@ describeChildWebviews('child webview handles', () => {
     await waitForHandles([CHILD_LEFT]);
     await browser.switchToWindow(CHILD_LEFT);
 
-    await expect(closeCurrentWindow()).rejects.toThrow(
-      /unsupported operation|Closing a child or shared-host webview is not supported/i,
-    );
-    expect(await browser.getWindowHandles()).toContain(CHILD_LEFT);
+    const response = await closeCurrentWindowRaw();
+    expect(response.status).toBe(500);
+    expect(response.value).toHaveProperty('error', 'unsupported operation');
+    expect(response.value).toHaveProperty('message', 'Closing a child or shared-host webview is not supported');
+    expect(await browser.getWindowHandles()).toEqual(expect.arrayContaining([MAIN_WINDOW, CHILD_LEFT, CHILD_RIGHT]));
     await switchToMain();
-    await expect(browser).toHaveTitle(/Tauri.*E2E Test App/);
+    await expect(browser).toHaveTitle('Tauri E2E Test App');
   });
 
   it('drops removed child handles and returns no such window', async () => {
@@ -290,9 +300,12 @@ describeChildWebviews('child webview handles', () => {
     await waitForHandles([MAIN_WINDOW, CHILD_LEFT, CHILD_RIGHT]);
     await switchToMain();
 
-    await expect(closeCurrentWindow()).rejects.toThrow(
-      /unsupported operation|Closing a child or shared-host webview is not supported/i,
-    );
+    const response = await closeCurrentWindowRaw();
+    expect(response.status).toBe(500);
+    expect(response.value).toHaveProperty('error', 'unsupported operation');
+    expect(response.value).toHaveProperty('message', 'Closing a child or shared-host webview is not supported');
     expect(await browser.getWindowHandles()).toEqual(expect.arrayContaining([MAIN_WINDOW, CHILD_LEFT, CHILD_RIGHT]));
+    await switchToMain();
+    await expect(browser).toHaveTitle('Tauri E2E Test App');
   });
 });

--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -172,14 +172,14 @@ describeChildWebviews('child webview handles', () => {
     }
   });
 
-  it('refuses to remove main or an independent WebviewWindow through the child fixture command', async () => {
+  it('refuses to remove primary webviews through the child fixture command', async () => {
     await createChildren();
 
     await expect(invokeFixture<void>('remove_child_webview', { label: MAIN_WINDOW })).rejects.toThrow(
-      /refusing to remove main/i,
+      /refusing to remove a primary webview/i,
     );
     await expect(invokeFixture<void>('remove_child_webview', { label: DISPOSABLE_WINDOW })).rejects.toThrow(
-      /refusing to remove an independent webviewwindow/i,
+      /refusing to remove a primary webview/i,
     );
     await removeChild(CHILD_LEFT);
     await removeChild(CHILD_RIGHT);

--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -36,6 +36,13 @@ interface WebDriverError {
   message: string;
 }
 
+interface WindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 async function invokeFixture<T>(command: string, args: Record<string, unknown> = {}): Promise<T> {
   const result = await browser.executeAsync<FixtureCommandResult<unknown>, [string, Record<string, unknown>]>(
     (commandName, commandArgs, done) => {
@@ -163,6 +170,8 @@ describeChildWebviews('child webview handles', () => {
     await waitForHandles([MAIN_WINDOW, DISPOSABLE_WINDOW, CHILD_LEFT, CHILD_RIGHT]);
 
     await browser.switchToWindow(CHILD_LEFT);
+    await expect(browser.$('#child-output')).toHaveText('idle');
+    expect(await browser.getWindowHandle()).toBe(CHILD_LEFT);
     await expect(browser).toHaveTitle(`Child WebView ${CHILD_LEFT}`);
     expect(await browser.execute(() => (globalThis as unknown as FixtureWindow).__childWebviewLabel)).toBe(CHILD_LEFT);
     await (await browser.$('#child-button')).click();
@@ -201,18 +210,16 @@ describeChildWebviews('child webview handles', () => {
     await createChildren();
     await waitForHandles([CHILD_LEFT]);
     await switchToMain();
-    const hostBefore = await browser.getWindowRect();
+    const nativeHostBefore = await invokeFixture<WindowBounds>('get_window_bounds');
+    expect(await browser.getWindowRect()).toEqual(nativeHostBefore);
 
     await browser.switchToWindow(CHILD_LEFT);
     expect(await browser.setWindowRect(20, 20, 240, 160)).toEqual({ x: 20, y: 20, width: 240, height: 160 });
     expect(await browser.getWindowRect()).toEqual({ x: 20, y: 20, width: 240, height: 160 });
 
     await switchToMain();
-    const hostAfter = await browser.getWindowRect();
-    expect(hostAfter.width).toBe(hostBefore.width);
-    expect(hostAfter.height).toBe(hostBefore.height);
-    expect(hostAfter.width).not.toBe(240);
-    expect(hostAfter.height).not.toBe(160);
+    expect(await browser.getWindowRect()).toEqual(nativeHostBefore);
+    expect(await invokeFixture<WindowBounds>('get_window_bounds')).toEqual(nativeHostBefore);
   });
 
   it('rejects closeWindow for a child without closing its host', async () => {

--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -128,6 +128,22 @@ async function closeCurrentWindowRaw(): Promise<WebDriverRawResponse<string[]>> 
   return { status: response.status, value: body.value };
 }
 
+async function switchToWindowRaw(handle: string): Promise<void> {
+  await requestWebDriver<null>(`/session/${browser.sessionId}/window`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ handle }),
+  });
+}
+
+async function switchToFrameRaw(id: number | null): Promise<void> {
+  await requestWebDriver<null>(`/session/${browser.sessionId}/frame`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id }),
+  });
+}
+
 describeChildWebviews('child webview handles', () => {
   afterEach(async () => {
     const handles = await browser.getWindowHandles().catch(() => [] as string[]);
@@ -194,6 +210,17 @@ describeChildWebviews('child webview handles', () => {
     await expect(browser).toHaveTitle(`Child WebView ${CHILD_RIGHT}`);
     expect(await browser.execute(() => (globalThis as unknown as FixtureWindow).__childWebviewLabel)).toBe(CHILD_RIGHT);
     await expect(browser.$('#child-output')).toHaveText('idle');
+  });
+
+  it('resets frame context when switching between child webviews', async () => {
+    await createChildren();
+    await waitForHandles([CHILD_LEFT, CHILD_RIGHT]);
+
+    await switchToWindowRaw(CHILD_LEFT);
+    await switchToFrameRaw(0);
+
+    await switchToWindowRaw(CHILD_RIGHT);
+    await expect(browser.$('#child-label')).toHaveText(CHILD_RIGHT);
   });
 
   it('creates a session with an initial child-webview label', async () => {
@@ -264,6 +291,18 @@ describeChildWebviews('child webview handles', () => {
         body: JSON.stringify({ handle: CHILD_RIGHT }),
       }),
     ).rejects.toThrow(/no such window/i);
+  });
+
+  it('returns no such window when the current child disappears from the registry', async () => {
+    await createChildren();
+    await waitForHandles([CHILD_RIGHT]);
+    await switchToWindowRaw(CHILD_RIGHT);
+    await (await browser.$('#remove-child')).click();
+    await browser.waitUntil(async () => !(await browser.getWindowHandles()).includes(CHILD_RIGHT), {
+      timeoutMsg: `Expected current ${CHILD_RIGHT} handle to be removed`,
+    });
+
+    await expect(requestWebDriver<string>(`/session/${browser.sessionId}/window`)).rejects.toThrow(/no such window/i);
   });
 
   it('preserves closeWindow for an independent WebviewWindow', async () => {

--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -265,6 +265,24 @@ describeChildWebviews('child webview handles', () => {
     expect(await invokeFixture<WindowBounds>('get_window_bounds')).toEqual(nativeHostBefore);
   });
 
+  it('returns the host bounds after maximizing a selected child webview', async () => {
+    await createChildren();
+    await waitForHandles([CHILD_LEFT]);
+    await switchToMain();
+    const hostBefore = await invokeFixture<WindowBounds>('get_window_bounds');
+
+    try {
+      await browser.switchToWindow(CHILD_LEFT);
+      const maximized = await browser.maximizeWindow();
+
+      await switchToMain();
+      expect(maximized).toEqual(await browser.getWindowRect());
+    } finally {
+      await switchToMain();
+      await browser.setWindowRect(hostBefore.x, hostBefore.y, hostBefore.width, hostBefore.height);
+    }
+  });
+
   it('rejects closeWindow for a child without closing its host', async () => {
     await createChildren();
     await waitForHandles([CHILD_LEFT]);

--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -115,6 +115,10 @@ async function deleteWebDriverSession(sessionId: string): Promise<void> {
   }
 }
 
+async function closeCurrentWindow(): Promise<string[]> {
+  return requestWebDriver<string[]>(`/session/${browser.sessionId}/window`, { method: 'DELETE' });
+}
+
 describeChildWebviews('child webview handles', () => {
   afterEach(async () => {
     const handles = await browser.getWindowHandles().catch(() => [] as string[]);
@@ -227,9 +231,12 @@ describeChildWebviews('child webview handles', () => {
     await waitForHandles([CHILD_LEFT]);
     await browser.switchToWindow(CHILD_LEFT);
 
-    await expect(browser.closeWindow()).rejects.toThrow(/unsupported operation/i);
+    await expect(closeCurrentWindow()).rejects.toThrow(
+      /unsupported operation|Closing a child or shared-host webview is not supported/i,
+    );
+    expect(await browser.getWindowHandles()).toContain(CHILD_LEFT);
     await switchToMain();
-    await expect(browser).toHaveTitle('Tauri E2E Test App');
+    await expect(browser).toHaveTitle(/Tauri.*E2E Test App/);
   });
 
   it('drops removed child handles and returns no such window', async () => {
@@ -255,8 +262,9 @@ describeChildWebviews('child webview handles', () => {
     await waitForHandles([DISPOSABLE_WINDOW]);
     await browser.switchToWindow(DISPOSABLE_WINDOW);
 
-    const remaining = await browser.closeWindow();
-    expect(remaining).toContain(MAIN_WINDOW);
+    const handles = await browser.closeWindow();
+    expect(handles).toContain(MAIN_WINDOW);
+    expect(handles).not.toContain(DISPOSABLE_WINDOW);
     await browser.waitUntil(async () => !(await browser.getWindowHandles()).includes(DISPOSABLE_WINDOW), {
       timeoutMsg: `Expected ${DISPOSABLE_WINDOW} handle to be removed`,
     });
@@ -275,5 +283,16 @@ describeChildWebviews('child webview handles', () => {
     await waitForHandles([MAIN_WINDOW, DISPOSABLE_WINDOW]);
     await switchToMain();
     await expect(browser).toHaveTitle('Tauri E2E Test App');
+  });
+
+  it('rejects closeWindow for a primary webview with child siblings', async () => {
+    await createChildren();
+    await waitForHandles([MAIN_WINDOW, CHILD_LEFT, CHILD_RIGHT]);
+    await switchToMain();
+
+    await expect(closeCurrentWindow()).rejects.toThrow(
+      /unsupported operation|Closing a child or shared-host webview is not supported/i,
+    );
+    expect(await browser.getWindowHandles()).toEqual(expect.arrayContaining([MAIN_WINDOW, CHILD_LEFT, CHILD_RIGHT]));
   });
 });

--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -181,6 +181,9 @@ describeChildWebviews('child webview handles', () => {
     await expect(invokeFixture<void>('remove_child_webview', { label: DISPOSABLE_WINDOW })).rejects.toThrow(
       /refusing to remove a primary webview/i,
     );
+    expect(await browser.getWindowHandles()).toContain(DISPOSABLE_WINDOW);
+    await browser.switchToWindow(DISPOSABLE_WINDOW);
+    expect(await browser.getWindowHandle()).toBe(DISPOSABLE_WINDOW);
     await removeChild(CHILD_LEFT);
     await removeChild(CHILD_RIGHT);
     await waitForHandles([MAIN_WINDOW]);

--- a/e2e/test/tauri/child-webview.spec.ts
+++ b/e2e/test/tauri/child-webview.spec.ts
@@ -1,0 +1,272 @@
+import { expect } from '@wdio/globals';
+import { browser } from '@wdio/tauri-service';
+
+const describeChildWebviews =
+  process.platform === 'darwin' && process.env.DRIVER_PROVIDER === 'embedded' ? describe : describe.skip;
+
+const CHILD_LEFT = 'child-left';
+const CHILD_RIGHT = 'child-right';
+const GENERIC_CHILD = 'generic-child';
+const DISPOSABLE_WINDOW = 'disposable-window';
+const MAIN_WINDOW = 'main';
+
+declare global {
+  interface Window {
+    __childWebviewLabel: string;
+  }
+}
+
+type FixtureCommandResult<T> = T | { __webdriverError: string };
+
+interface FixtureWindow {
+  __TAURI__: {
+    core: {
+      invoke<T>(command: string, args?: Record<string, unknown>): Promise<T>;
+    };
+  };
+  __childWebviewLabel: string;
+}
+
+interface WebDriverResponse<T> {
+  value: T | WebDriverError;
+}
+
+interface WebDriverError {
+  error: string;
+  message: string;
+}
+
+async function invokeFixture<T>(command: string, args: Record<string, unknown> = {}): Promise<T> {
+  const result = await browser.executeAsync<FixtureCommandResult<unknown>, [string, Record<string, unknown>]>(
+    (commandName, commandArgs, done) => {
+      (globalThis as unknown as FixtureWindow).__TAURI__.core
+        .invoke<unknown>(commandName, commandArgs)
+        .then(done)
+        .catch((error: unknown) => done({ __webdriverError: String(error) }));
+    },
+    command,
+    args,
+  );
+
+  if (typeof result === 'object' && result !== null && '__webdriverError' in result) {
+    throw new Error(String(result.__webdriverError));
+  }
+
+  return result as T;
+}
+
+async function switchToMain(): Promise<void> {
+  await browser.switchToWindow(MAIN_WINDOW);
+}
+
+async function createChildren(): Promise<void> {
+  await switchToMain();
+  await invokeFixture<void>('create_disposable_webview_window', { label: DISPOSABLE_WINDOW });
+  await waitForHandles([DISPOSABLE_WINDOW]);
+  await browser.switchToWindow(DISPOSABLE_WINDOW);
+  await invokeFixture<void>('create_child_webview', { label: CHILD_LEFT, slot: 0 });
+  await invokeFixture<void>('create_child_webview', { label: CHILD_RIGHT, slot: 1 });
+}
+
+async function removeChild(label: string): Promise<void> {
+  const handles = await browser.getWindowHandles();
+  await browser.switchToWindow(handles.includes(MAIN_WINDOW) ? MAIN_WINDOW : DISPOSABLE_WINDOW);
+  await invokeFixture<void>('remove_child_webview', { label });
+}
+
+async function waitForHandles(expected: string[]): Promise<string[]> {
+  let handles: string[] = [];
+  await browser.waitUntil(
+    async () => {
+      handles = await browser.getWindowHandles();
+      return expected.every((handle) => handles.includes(handle));
+    },
+    { timeoutMsg: `Expected window handles: ${expected.join(', ')}` },
+  );
+  return handles;
+}
+
+async function requestWebDriver<T>(path: string, init?: RequestInit): Promise<T> {
+  const origin = `${browser.options.protocol ?? 'http'}://${browser.options.hostname ?? '127.0.0.1'}:${browser.options.port ?? 4445}`;
+  const response = await fetch(`${origin}${path}`, init);
+  const body = (await response.json()) as WebDriverResponse<T>;
+
+  if (typeof body.value === 'object' && body.value !== null && 'error' in body.value) {
+    throw new Error(`${body.value.error}: ${body.value.message}`);
+  }
+  if (!response.ok) {
+    throw new Error(`WebDriver request failed with HTTP ${response.status} ${response.statusText}`);
+  }
+
+  return body.value;
+}
+
+async function deleteWebDriverSession(sessionId: string): Promise<void> {
+  const result = await requestWebDriver<null>(`/session/${sessionId}`, { method: 'DELETE' });
+  if (result !== null) {
+    throw new Error(`Expected session deletion to return null, received ${JSON.stringify(result)}`);
+  }
+}
+
+describeChildWebviews('child webview handles', () => {
+  afterEach(async () => {
+    const handles = await browser.getWindowHandles().catch(() => [] as string[]);
+    const controlWindow = handles.includes(MAIN_WINDOW)
+      ? MAIN_WINDOW
+      : handles.includes(DISPOSABLE_WINDOW)
+        ? DISPOSABLE_WINDOW
+        : undefined;
+
+    if (!controlWindow) {
+      return;
+    }
+
+    await browser.switchToWindow(controlWindow).catch(() => undefined);
+    for (const label of [CHILD_LEFT, CHILD_RIGHT, GENERIC_CHILD]) {
+      await invokeFixture<void>('remove_child_webview', { label }).catch(() => undefined);
+    }
+
+    const remainingHandles = await browser.getWindowHandles().catch(() => [] as string[]);
+    if (remainingHandles.includes(DISPOSABLE_WINDOW)) {
+      await browser.switchToWindow(DISPOSABLE_WINDOW).catch(() => undefined);
+      if ((await browser.getWindowHandle().catch(() => MAIN_WINDOW)) === DISPOSABLE_WINDOW) {
+        await browser.closeWindow().catch(() => undefined);
+      }
+      await switchToMain().catch(() => undefined);
+    }
+  });
+
+  it('refuses to remove main or an independent WebviewWindow through the child fixture command', async () => {
+    await createChildren();
+
+    await expect(invokeFixture<void>('remove_child_webview', { label: MAIN_WINDOW })).rejects.toThrow(
+      /refusing to remove main/i,
+    );
+    await expect(invokeFixture<void>('remove_child_webview', { label: DISPOSABLE_WINDOW })).rejects.toThrow(
+      /refusing to remove an independent webviewwindow/i,
+    );
+    await removeChild(CHILD_LEFT);
+    await removeChild(CHILD_RIGHT);
+    await waitForHandles([MAIN_WINDOW]);
+    await switchToMain();
+    await expect(browser).toHaveTitle('Tauri E2E Test App');
+  });
+
+  it('surfaces raw session cleanup errors', async () => {
+    await expect(deleteWebDriverSession('missing-session')).rejects.toThrow(/invalid session id/i);
+    await switchToMain();
+    await expect(browser).toHaveTitle('Tauri E2E Test App');
+  });
+
+  it('enumerates, switches, and executes in sibling child webviews', async () => {
+    await createChildren();
+    await waitForHandles([MAIN_WINDOW, DISPOSABLE_WINDOW, CHILD_LEFT, CHILD_RIGHT]);
+
+    await browser.switchToWindow(CHILD_LEFT);
+    await expect(browser).toHaveTitle(`Child WebView ${CHILD_LEFT}`);
+    expect(await browser.execute(() => (globalThis as unknown as FixtureWindow).__childWebviewLabel)).toBe(CHILD_LEFT);
+    await (await browser.$('#child-button')).click();
+    await expect(browser.$('#child-output')).toHaveText(`activated:${CHILD_LEFT}`);
+
+    await browser.switchToWindow(CHILD_RIGHT);
+    await expect(browser).toHaveTitle(`Child WebView ${CHILD_RIGHT}`);
+    expect(await browser.execute(() => (globalThis as unknown as FixtureWindow).__childWebviewLabel)).toBe(CHILD_RIGHT);
+    await expect(browser.$('#child-output')).toHaveText('idle');
+  });
+
+  it('creates a session with an initial child-webview label', async () => {
+    await createChildren();
+
+    const created = await requestWebDriver<{ sessionId: string }>('/session', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        capabilities: {
+          alwaysMatch: {
+            'wdio:tauriServiceOptions': { windowLabel: CHILD_LEFT },
+          },
+        },
+      }),
+    });
+    expect(created.sessionId).toBeTruthy();
+
+    try {
+      expect(await requestWebDriver<string>(`/session/${created.sessionId}/window`)).toBe(CHILD_LEFT);
+    } finally {
+      await deleteWebDriverSession(created.sessionId);
+    }
+  });
+
+  it('reports and updates child bounds without resizing the host', async () => {
+    await createChildren();
+    await waitForHandles([CHILD_LEFT]);
+    await switchToMain();
+    const hostBefore = await browser.getWindowRect();
+
+    await browser.switchToWindow(CHILD_LEFT);
+    expect(await browser.setWindowRect(20, 20, 240, 160)).toEqual({ x: 20, y: 20, width: 240, height: 160 });
+    expect(await browser.getWindowRect()).toEqual({ x: 20, y: 20, width: 240, height: 160 });
+
+    await switchToMain();
+    const hostAfter = await browser.getWindowRect();
+    expect(hostAfter.width).toBe(hostBefore.width);
+    expect(hostAfter.height).toBe(hostBefore.height);
+    expect(hostAfter.width).not.toBe(240);
+    expect(hostAfter.height).not.toBe(160);
+  });
+
+  it('rejects closeWindow for a child without closing its host', async () => {
+    await createChildren();
+    await waitForHandles([CHILD_LEFT]);
+    await browser.switchToWindow(CHILD_LEFT);
+
+    await expect(browser.closeWindow()).rejects.toThrow(/unsupported operation/i);
+    await switchToMain();
+    await expect(browser).toHaveTitle('Tauri E2E Test App');
+  });
+
+  it('drops removed child handles and returns no such window', async () => {
+    await createChildren();
+    await waitForHandles([CHILD_RIGHT]);
+    await removeChild(CHILD_RIGHT);
+
+    await browser.waitUntil(async () => !(await browser.getWindowHandles()).includes(CHILD_RIGHT), {
+      timeoutMsg: `Expected ${CHILD_RIGHT} handle to be removed`,
+    });
+    await expect(
+      requestWebDriver<null>(`/session/${browser.sessionId}/window`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ handle: CHILD_RIGHT }),
+      }),
+    ).rejects.toThrow(/no such window/i);
+  });
+
+  it('preserves closeWindow for an independent WebviewWindow', async () => {
+    await switchToMain();
+    await invokeFixture<void>('create_disposable_webview_window', { label: DISPOSABLE_WINDOW });
+    await waitForHandles([DISPOSABLE_WINDOW]);
+    await browser.switchToWindow(DISPOSABLE_WINDOW);
+
+    const remaining = await browser.closeWindow();
+    expect(remaining).toContain(MAIN_WINDOW);
+    await browser.waitUntil(async () => !(await browser.getWindowHandles()).includes(DISPOSABLE_WINDOW), {
+      timeoutMsg: `Expected ${DISPOSABLE_WINDOW} handle to be removed`,
+    });
+    await switchToMain();
+    await expect(browser).toHaveTitle('Tauri E2E Test App');
+  });
+
+  it('removes a managed child with an arbitrary label', async () => {
+    await switchToMain();
+    await invokeFixture<void>('create_disposable_webview_window', { label: DISPOSABLE_WINDOW });
+    await waitForHandles([DISPOSABLE_WINDOW]);
+    await browser.switchToWindow(DISPOSABLE_WINDOW);
+    await invokeFixture<void>('create_child_webview', { label: GENERIC_CHILD, slot: 0 });
+
+    await invokeFixture<void>('remove_child_webview', { label: GENERIC_CHILD });
+    await waitForHandles([MAIN_WINDOW, DISPOSABLE_WINDOW]);
+    await switchToMain();
+    await expect(browser).toHaveTitle('Tauri E2E Test App');
+  });
+});

--- a/final-review-boundary-fix-report
+++ b/final-review-boundary-fix-report
@@ -3,3 +3,6 @@
 - 2026-07-15: Added a characterization assertion that a rejected `remove_child_webview(disposable-window)` command preserves the independent primary handle and permits switching back to it.
 - TDD evidence: the new assertion was GREEN on its first run because the existing implementation already preserves the handle; no production change was needed.
 - Verification: Node v24.18.0 `pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded` passed (11 spec files); focused `pnpm exec biome check e2e/test/tauri/child-webview.spec.ts` passed.
+- 2026-07-15: Limited embedded WebDriver child webview exposure to macOS. Windows, Linux, Android, and iOS retain primary-webview-only behavior.
+- TDD evidence: the new pure platform-policy tests first failed because `child_webviews_are_exposed_for_platform` did not exist; after the minimal implementation, `cargo test --manifest-path packages/tauri-plugin-webdriver/Cargo.toml` passed (19 tests).
+- Verification: `cargo clippy --manifest-path packages/tauri-plugin-webdriver/Cargo.toml -- -D warnings`, focused `rustfmt --edition 2021 packages/tauri-plugin-webdriver/src/server/mod.rs`, Node v24.18.0 `pnpm lint`, macOS `pnpm --filter tauri-e2e-app build`, and Node v24.18.0 `pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded` passed (11 spec files).

--- a/final-review-boundary-fix-report
+++ b/final-review-boundary-fix-report
@@ -1,0 +1,5 @@
+# Final Review Boundary Fix Report
+
+- 2026-07-15: Added a characterization assertion that a rejected `remove_child_webview(disposable-window)` command preserves the independent primary handle and permits switching back to it.
+- TDD evidence: the new assertion was GREEN on its first run because the existing implementation already preserves the handle; no production change was needed.
+- Verification: Node v24.18.0 `pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded` passed (11 spec files); focused `pnpm exec biome check e2e/test/tauri/child-webview.spec.ts` passed.

--- a/final-review-boundary-fix-report
+++ b/final-review-boundary-fix-report
@@ -1,8 +1,0 @@
-# Final Review Boundary Fix Report
-
-- 2026-07-15: Added a characterization assertion that a rejected `remove_child_webview(disposable-window)` command preserves the independent primary handle and permits switching back to it.
-- TDD evidence: the new assertion was GREEN on its first run because the existing implementation already preserves the handle; no production change was needed.
-- Verification: Node v24.18.0 `pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded` passed (11 spec files); focused `pnpm exec biome check e2e/test/tauri/child-webview.spec.ts` passed.
-- 2026-07-15: Limited embedded WebDriver child webview exposure to macOS. Windows, Linux, Android, and iOS retain primary-webview-only behavior.
-- TDD evidence: the new pure platform-policy tests first failed because `child_webviews_are_exposed_for_platform` did not exist; after the minimal implementation, `cargo test --manifest-path packages/tauri-plugin-webdriver/Cargo.toml` passed (19 tests).
-- Verification: `cargo clippy --manifest-path packages/tauri-plugin-webdriver/Cargo.toml -- -D warnings`, focused `rustfmt --edition 2021 packages/tauri-plugin-webdriver/src/server/mod.rs`, Node v24.18.0 `pnpm lint`, macOS `pnpm --filter tauri-e2e-app build`, and Node v24.18.0 `pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded` passed (11 spec files).

--- a/final-review-last-p1-fix-report
+++ b/final-review-last-p1-fix-report
@@ -1,0 +1,6 @@
+# Final Review Last P1 Fix Report
+
+- 2026-07-15: Unified all frame-context mutations behind a commit guard that checks the captured selected webview still exists and the browsing-context generation still matches before clearing, pushing, or popping.
+- TDD evidence: the new null/parent commit tests first failed to compile because `FrameContextMutation` did not exist; after the minimal implementation, the missing-webview paths preserve frame context and normal top-level/parent paths mutate it.
+- Verification: `cargo test --manifest-path packages/tauri-plugin-webdriver/Cargo.toml` passed (27 tests); `cargo clippy --manifest-path packages/tauri-plugin-webdriver/Cargo.toml -- -D warnings` passed; targeted `rustfmt --edition 2021` passed.
+- Verification: Node v24.18.0 `pnpm --filter tauri-e2e-app build`, `pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded` (11/11 spec files), and `pnpm lint` passed. Lint emitted only the pre-existing Biome `linter.recommended` deprecation notice.

--- a/final-review-last-p1-fix-report
+++ b/final-review-last-p1-fix-report
@@ -1,6 +1,0 @@
-# Final Review Last P1 Fix Report
-
-- 2026-07-15: Unified all frame-context mutations behind a commit guard that checks the captured selected webview still exists and the browsing-context generation still matches before clearing, pushing, or popping.
-- TDD evidence: the new null/parent commit tests first failed to compile because `FrameContextMutation` did not exist; after the minimal implementation, the missing-webview paths preserve frame context and normal top-level/parent paths mutate it.
-- Verification: `cargo test --manifest-path packages/tauri-plugin-webdriver/Cargo.toml` passed (27 tests); `cargo clippy --manifest-path packages/tauri-plugin-webdriver/Cargo.toml -- -D warnings` passed; targeted `rustfmt --edition 2021` passed.
-- Verification: Node v24.18.0 `pnpm --filter tauri-e2e-app build`, `pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded` (11/11 spec files), and `pnpm lint` passed. Lint emitted only the pre-existing Biome `linter.recommended` deprecation notice.

--- a/fixtures/e2e-apps/tauri/Cargo.lock
+++ b/fixtures/e2e-apps/tauri/Cargo.lock
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-wdio"
-version = "1.0.0"
+version = "1.2.0"
 dependencies = [
  "log",
  "serde",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-wdio-webdriver"
-version = "1.0.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/fixtures/e2e-apps/tauri/child-webview.html
+++ b/fixtures/e2e-apps/tauri/child-webview.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Child WebView Fixture</title>
+  </head>
+  <body>
+    <h1 id="child-label"></h1>
+    <button id="child-button" type="button">Activate child</button>
+    <output id="child-output">idle</output>
+    <script>
+      const label = new URLSearchParams(window.location.search).get('label') ?? 'unknown';
+      window.__childWebviewLabel = label;
+      document.title = `Child WebView ${label}`;
+      document.querySelector('#child-label').textContent = label;
+      document.querySelector('#child-button').addEventListener('click', () => {
+        document.querySelector('#child-output').textContent = `activated:${label}`;
+      });
+    </script>
+  </body>
+</html>

--- a/fixtures/e2e-apps/tauri/child-webview.html
+++ b/fixtures/e2e-apps/tauri/child-webview.html
@@ -8,14 +8,20 @@
   <body>
     <h1 id="child-label">Child webview</h1>
     <button id="child-button" type="button">Activate child</button>
+    <button id="remove-child" type="button">Remove child</button>
     <output id="child-output">idle</output>
+    <iframe id="child-frame" title="Child frame"></iframe>
     <script>
       const label = new URLSearchParams(window.location.search).get('label') ?? 'unknown';
       window.__childWebviewLabel = label;
       document.title = `Child WebView ${label}`;
       document.querySelector('#child-label').textContent = label;
+      document.querySelector('#child-frame').srcdoc = `<body><p id="frame-label">Frame ${label}</p></body>`;
       document.querySelector('#child-button').addEventListener('click', () => {
         document.querySelector('#child-output').textContent = `activated:${label}`;
+      });
+      document.querySelector('#remove-child').addEventListener('click', () => {
+        void window.__TAURI__.core.invoke('remove_child_webview', { label });
       });
     </script>
   </body>

--- a/fixtures/e2e-apps/tauri/child-webview.html
+++ b/fixtures/e2e-apps/tauri/child-webview.html
@@ -6,7 +6,7 @@
     <title>Child WebView Fixture</title>
   </head>
   <body>
-    <h1 id="child-label"></h1>
+    <h1 id="child-label">Child webview</h1>
     <button id="child-button" type="button">Activate child</button>
     <output id="child-output">idle</output>
     <script>

--- a/fixtures/e2e-apps/tauri/src-tauri/Cargo.toml
+++ b/fixtures/e2e-apps/tauri/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.77"
 tauri-build = { version = "2.6.0", features = [] }
 
 [dependencies]
-tauri = { version = "2.11.1", features = ["tray-icon"] }
+tauri = { version = "2.11.1", features = ["tray-icon", "unstable"] }
 tauri-plugin-fs = "2.5.1"
 tauri-plugin-deep-link = "2"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }

--- a/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
+++ b/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
@@ -276,15 +276,14 @@ async fn create_child_webview(
 
 #[tauri::command]
 async fn remove_child_webview(app: tauri::AppHandle, label: String) -> Result<(), String> {
-    if label == "main" {
-        return Err("Refusing to remove main through the child fixture command".into());
-    }
-    if app.get_webview_window(&label).is_some() {
-        return Err("Refusing to remove an independent WebviewWindow as a child".into());
+    let webview = app
+        .get_webview(&label)
+        .ok_or_else(|| format!("Webview '{label}' not found"))?;
+    if webview.label() == webview.window().label() {
+        return Err("Refusing to remove a primary Webview through the child fixture command".into());
     }
 
-    app.get_webview(&label)
-        .ok_or_else(|| format!("Webview '{label}' not found"))?
+    webview
         .close()
         .map_err(|error| error.to_string())
 }

--- a/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
+++ b/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
@@ -247,6 +247,70 @@ fn create_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> tauri::We
 }
 
 #[tauri::command]
+async fn create_child_webview(
+    app: tauri::AppHandle,
+    label: String,
+    slot: u8,
+) -> Result<(), String> {
+    if app.get_webview(&label).is_some() {
+        return Ok(());
+    }
+
+    let main = app.get_webview("main").ok_or("Main webview not found")?;
+    let host = main.window();
+    let size = host.inner_size().map_err(|error| error.to_string())?;
+    let scale_factor = host.scale_factor().map_err(|error| error.to_string())?;
+    let logical_size = size.to_logical::<f64>(scale_factor);
+    let width = logical_size.width / 2.0;
+    let x = if slot == 0 { 0.0 } else { width };
+    let url = tauri::WebviewUrl::App(format!("child-webview.html?label={label}").into());
+
+    host.add_child(
+        tauri::webview::WebviewBuilder::new(label, url),
+        tauri::LogicalPosition::new(x, 0.0),
+        tauri::LogicalSize::new(width, logical_size.height),
+    )
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn remove_child_webview(app: tauri::AppHandle, label: String) -> Result<(), String> {
+    if label == "main" {
+        return Err("Refusing to remove main through the child fixture command".into());
+    }
+    if app.get_webview_window(&label).is_some() {
+        return Err("Refusing to remove an independent WebviewWindow as a child".into());
+    }
+
+    app.get_webview(&label)
+        .ok_or_else(|| format!("Webview '{label}' not found"))?
+        .close()
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+async fn create_disposable_webview_window(
+    app: tauri::AppHandle,
+    label: String,
+) -> Result<(), String> {
+    if app.get_webview_window(&label).is_some() {
+        return Ok(());
+    }
+
+    tauri::WebviewWindowBuilder::new(
+        &app,
+        &label,
+        tauri::WebviewUrl::App(format!("child-webview.html?label={label}").into()),
+    )
+    .title(format!("Disposable WebviewWindow {label}"))
+    .inner_size(360.0, 240.0)
+    .build()
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
 async fn switch_to_main(app: tauri::AppHandle) -> Result<(), String> {
     let main = app.get_webview_window("main")
         .ok_or_else(|| "Main window not found".to_string())?;
@@ -287,7 +351,7 @@ fn main() {
 
     // Add automation plugin for macOS CrabNebula testing (debug builds only)
     #[cfg(all(debug_assertions, target_os = "macos"))]
-    {
+    if !use_embedded_server {
         builder = builder.plugin(tauri_plugin_automation::init());
     }
 
@@ -388,6 +452,9 @@ fn main() {
             switch_to_main,
             get_deep_links,
             get_command_line_args,
+            create_child_webview,
+            remove_child_webview,
+            create_disposable_webview_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/fixtures/e2e-apps/tauri/vite.config.ts
+++ b/fixtures/e2e-apps/tauri/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         splash: resolve(__dirname, 'splash.html'),
+        childWebview: resolve(__dirname, 'child-webview.html'),
       },
     },
   },

--- a/packages/tauri-plugin-webdriver/Cargo.toml
+++ b/packages/tauri-plugin-webdriver/Cargo.toml
@@ -23,6 +23,7 @@ tempfile = "3"
 
 [dependencies.tauri]
 version = "2.10.0"
+features = [ "unstable" ]
 
 [dependencies.serde]
 version = "1.0"

--- a/packages/tauri-plugin-webdriver/README.md
+++ b/packages/tauri-plugin-webdriver/README.md
@@ -22,6 +22,7 @@ It is **not needed** if you use the `'official'` or `'crabnebula'` driver provid
 - **Native platform integration** — Uses native WebView APIs (WKWebView, WebView2, WebKitGTK)
 - **Zero configuration** — Add the plugin, and `@wdio/tauri-service` handles the rest
 - **No external drivers** — No need to install `tauri-driver`, `msedgedriver`, or `webkit2gtk-driver`
+- **Child webview handles on macOS** — Tauri child `Webview` labels are exposed as standard WebDriver window handles by the embedded provider. This requires Tauri's `unstable` feature because Tauri currently gates its managed-webview registry behind that feature.
 
 ### Supported Platforms
 
@@ -153,6 +154,16 @@ let builder = builder.plugin(tauri_plugin_wdio_webdriver::init_with_port(9515));
 Port resolution order:
 1. `init_with_port(port)` — uses the specified port (ignores env var)
 2. `init()` — checks `TAURI_WEBDRIVER_PORT` env var, falls back to 4445
+
+## Child WebViews
+
+Child webview runtime support is currently limited to macOS and the embedded driver provider. WebDriver handles identify webviews, so multiple child handles can share one native host window. Page, element, script, screenshot, cookie, and print commands target the selected webview. Rectangle commands target child bounds, while maximize, minimize, fullscreen, focus, and visibility commands affect the shared native host window.
+
+A primary webview uses the same label as its host window. Child webviews must use labels distinct from their host. Primary rectangle commands target the native outer window; child rectangle commands target child bounds.
+
+`closeWindow` closes only a standalone primary webview whose host contains no sibling webviews. It returns `unsupported operation` for child and shared-host primary webviews so it cannot destroy sibling browsing contexts. Applications should remove child webviews through their own lifecycle command.
+
+An explicit standard `switchToWindow` selection is preserved. Automatic focus recovery does not override it, and internal recovery switches are not recorded as explicit user selection.
 
 ## W3C WebDriver Endpoints
 

--- a/packages/tauri-plugin-webdriver/src/platform/android.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/android.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tauri::{Manager, Runtime, WebviewWindow};
+use tauri::{Manager, Runtime, Webview};
 
 use crate::mobile::{
     AlertResult, EvaluateJsArgs, JsResult, ScreenshotArgs, SendAlertTextArgs, TouchArgs, Webdriver,
@@ -16,15 +16,15 @@ use crate::webdriver::Timeouts;
 /// Android `WebView` executor using Tauri's mobile plugin bridge
 #[derive(Clone)]
 pub struct AndroidExecutor<R: Runtime> {
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 }
 
 impl<R: Runtime> AndroidExecutor<R> {
-    pub fn new(window: WebviewWindow<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
+    pub fn new(webview: Webview<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
         Self {
-            window,
+            webview,
             timeouts,
             frame_context,
         }
@@ -85,8 +85,8 @@ struct CookiesResult {
 
 #[async_trait]
 impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
-    fn window(&self) -> &WebviewWindow<R> {
-        &self.window
+    fn webview(&self) -> &Webview<R> {
+        &self.webview
     }
 
     fn script_timeout_ms(&self) -> u64 {
@@ -96,7 +96,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
     async fn evaluate_js(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
         let wrapped_script = wrap_script_for_frame_context(script, &self.frame_context);
 
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let args = EvaluateJsArgs {
             script: wrapped_script,
@@ -177,7 +177,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
             }})()"
         );
 
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let plugin_args = AsyncScriptArgs {
             async_id,
@@ -213,7 +213,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
     }
 
     async fn take_screenshot(&self) -> Result<String, WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let args = ScreenshotArgs {
             timeout_ms: self.timeouts.script_ms,
@@ -262,7 +262,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
     }
 
     async fn print_page(&self, options: PrintOptions) -> Result<String, WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let result: JsResult = webdriver
             .0
@@ -293,7 +293,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
         y: i32,
         _button: u32,
     ) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let touch_type = match event_type {
             PointerEventType::Down => "down",
@@ -318,7 +318,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
 
     // Alert handling via plugin
     async fn get_alert_text(&self) -> Result<String, WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let result: AlertResult = webdriver
             .0
@@ -338,7 +338,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
     }
 
     async fn accept_alert(&self) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -356,7 +356,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
     }
 
     async fn dismiss_alert(&self) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -374,7 +374,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
     }
 
     async fn send_alert_text(&self, text: &str) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -407,12 +407,12 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
 
     async fn get_all_cookies(&self) -> Result<Vec<Cookie>, WebDriverErrorResponse> {
         let url = self
-            .window
+            .webview
             .url()
             .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?
             .to_string();
 
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let result: CookiesResult = webdriver
             .0
@@ -446,7 +446,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
 
     async fn add_cookie(&self, mut cookie: Cookie) -> Result<(), WebDriverErrorResponse> {
         let url = self
-            .window
+            .webview
             .url()
             .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
 
@@ -460,7 +460,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
             cookie.path = Some("/".to_string());
         }
 
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -486,12 +486,12 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
 
     async fn delete_cookie(&self, name: &str) -> Result<(), WebDriverErrorResponse> {
         let url = self
-            .window
+            .webview
             .url()
             .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?
             .to_string();
 
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -509,7 +509,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
     }
 
     async fn delete_all_cookies(&self) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -526,7 +526,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for AndroidExecutor<R> {
 
     async fn get_window_rect(&self) -> Result<WindowRect, WebDriverErrorResponse> {
         // Get viewport size from Kotlin plugin
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         webdriver
             .0

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -38,7 +38,6 @@ pub(crate) fn is_primary_webview<R: Runtime>(webview: &Webview<R>) -> bool {
 }
 
 #[cfg(desktop)]
-#[allow(dead_code)]
 pub(crate) fn is_standalone_webview<R: Runtime>(webview: &Webview<R>) -> bool {
     is_primary_webview(webview) && webview.window().webviews().len() == 1
 }
@@ -1573,6 +1572,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         let window = self.webview().window();
         let _ = window.maximize();
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Native maximize applies to the host, unlike child-relative getWindowRect.
         host_outer_rect(self.webview())
     }
 
@@ -1590,6 +1590,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         let window = self.webview().window();
         let _ = window.set_fullscreen(true);
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Native fullscreen applies to the host, unlike child-relative getWindowRect.
         host_outer_rect(self.webview())
     }
 

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::webview::Cookie as TauriCookie;
-use tauri::{Runtime, WebviewWindow};
+use tauri::{Runtime, Webview};
 
 #[cfg(desktop)]
 use tauri::{PhysicalPosition, PhysicalSize};
@@ -128,8 +128,8 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     // Window Access
     // =========================================================================
 
-    /// Get a reference to the underlying window
-    fn window(&self) -> &WebviewWindow<R>;
+    /// Get a reference to the selected webview
+    fn webview(&self) -> &Webview<R>;
 
     /// Get the script timeout in milliseconds
     fn script_timeout_ms(&self) -> u64;
@@ -469,10 +469,9 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         );
         let result = self.evaluate_js(&script).await?;
 
-        let value = result
-            .get("value")
-            .cloned()
-            .ok_or_else(|| WebDriverErrorResponse::unknown_error("element center script returned no value"))?;
+        let value = result.get("value").cloned().ok_or_else(|| {
+            WebDriverErrorResponse::unknown_error("element center script returned no value")
+        })?;
 
         #[derive(serde::Deserialize)]
         struct Center {
@@ -1002,7 +1001,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         self.evaluate_js(&wrapper).await?;
 
         // Poll for the result with timeout
-        let poll_script = format!("window['{}']", result_var);
+        let poll_script = format!("window['{result_var}']");
         let timeout = std::time::Duration::from_millis(self.script_timeout_ms());
         let start = std::time::Instant::now();
         let poll_interval = std::time::Duration::from_millis(50);
@@ -1014,7 +1013,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
             // Check if we have a result
             if !inner.is_null() && inner.get("__wd_success").is_some() {
                 // Clean up the global variable
-                let cleanup_script = format!("delete window['{}']", result_var);
+                let cleanup_script = format!("delete window['{result_var}']");
                 let _ = self.evaluate_js(&cleanup_script).await;
 
                 return extract_script_result_from_inner(&inner);
@@ -1022,7 +1021,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
             if start.elapsed() > timeout {
                 // Clean up on timeout
-                let cleanup_script = format!("delete window['{}']", result_var);
+                let cleanup_script = format!("delete window['{result_var}']");
                 let _ = self.evaluate_js(&cleanup_script).await;
 
                 return Err(WebDriverErrorResponse::script_timeout());
@@ -1463,17 +1462,36 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Get window rectangle (position and size)
     #[cfg(desktop)]
     async fn get_window_rect(&self) -> Result<WindowRect, WebDriverErrorResponse> {
-        if let Ok(position) = self.window().outer_position() {
-            if let Ok(size) = self.window().outer_size() {
-                return Ok(WindowRect {
-                    x: position.x,
-                    y: position.y,
-                    width: size.width,
-                    height: size.height,
-                });
-            }
+        if self.is_independent_webview_window() {
+            let window = self.webview().window();
+            let position = window
+                .outer_position()
+                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+            let size = window
+                .outer_size()
+                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+            return Ok(WindowRect {
+                x: position.x,
+                y: position.y,
+                width: size.width,
+                height: size.height,
+            });
         }
-        Ok(WindowRect::default())
+
+        let position = self
+            .webview()
+            .position()
+            .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+        let size = self
+            .webview()
+            .size()
+            .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+        Ok(WindowRect {
+            x: position.x,
+            y: position.y,
+            width: size.width,
+            height: size.height,
+        })
     }
 
     #[cfg(mobile)]
@@ -1485,40 +1503,50 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         &self,
         rect: WindowRect,
     ) -> Result<WindowRect, WebDriverErrorResponse> {
-        // Exit fullscreen/maximized state before setting rect
-        // Otherwise the window manager may ignore our size/position request
-        if self.window().is_fullscreen().unwrap_or(false) {
-            let _ = self.window().set_fullscreen(false);
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-        if self.window().is_maximized().unwrap_or(false) {
-            let _ = self.window().unmaximize();
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
+        if self.is_independent_webview_window() {
+            let window = self.webview().window();
 
-        let _ = self
-            .window()
-            .set_position(PhysicalPosition::new(rect.x, rect.y));
+            // Exit fullscreen/maximized state before setting rect
+            // Otherwise the window manager may ignore our size/position request
+            if window.is_fullscreen().unwrap_or(false) {
+                let _ = window.set_fullscreen(false);
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            if window.is_maximized().unwrap_or(false) {
+                let _ = window.unmaximize();
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
 
-        // Calculate chrome/decoration size to set outer size correctly
-        // On Windows/Linux, set_size sets inner size, but we want to set outer size
-        let (chrome_width, chrome_height) = if let (Ok(outer), Ok(inner)) =
-            (self.window().outer_size(), self.window().inner_size())
-        {
-            (
-                outer.width.saturating_sub(inner.width),
-                outer.height.saturating_sub(inner.height),
-            )
+            window
+                .set_position(PhysicalPosition::new(rect.x, rect.y))
+                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+
+            // Calculate chrome/decoration size to set outer size correctly
+            // On Windows/Linux, set_size sets inner size, but we want to set outer size
+            let (outer, inner) = (window.outer_size(), window.inner_size());
+            let (chrome_width, chrome_height) = if let (Ok(outer), Ok(inner)) = (outer, inner) {
+                (
+                    outer.width.saturating_sub(inner.width),
+                    outer.height.saturating_sub(inner.height),
+                )
+            } else {
+                (0, 0)
+            };
+
+            // Set inner size = requested outer size - chrome
+            let inner_width = rect.width.saturating_sub(chrome_width);
+            let inner_height = rect.height.saturating_sub(chrome_height);
+            window
+                .set_size(PhysicalSize::new(inner_width, inner_height))
+                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
         } else {
-            (0, 0)
-        };
-
-        // Set inner size = requested outer size - chrome
-        let inner_width = rect.width.saturating_sub(chrome_width);
-        let inner_height = rect.height.saturating_sub(chrome_height);
-        let _ = self
-            .window()
-            .set_size(PhysicalSize::new(inner_width, inner_height));
+            self.webview()
+                .set_position(PhysicalPosition::new(rect.x, rect.y))
+                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+            self.webview()
+                .set_size(PhysicalSize::new(rect.width, rect.height))
+                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+        }
 
         self.get_window_rect().await
     }
@@ -1526,7 +1554,8 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Maximize window
     #[cfg(desktop)]
     async fn maximize_window(&self) -> Result<WindowRect, WebDriverErrorResponse> {
-        let _ = self.window().maximize();
+        let window = self.webview().window();
+        let _ = window.maximize();
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         self.get_window_rect().await
     }
@@ -1534,14 +1563,16 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Minimize window
     #[cfg(desktop)]
     async fn minimize_window(&self) -> Result<(), WebDriverErrorResponse> {
-        let _ = self.window().minimize();
+        let window = self.webview().window();
+        let _ = window.minimize();
         Ok(())
     }
 
     /// Set window to fullscreen
     #[cfg(desktop)]
     async fn fullscreen_window(&self) -> Result<WindowRect, WebDriverErrorResponse> {
-        let _ = self.window().set_fullscreen(true);
+        let window = self.webview().window();
+        let _ = window.set_fullscreen(true);
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         self.get_window_rect().await
     }
@@ -1635,7 +1666,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
     /// Get all cookies
     async fn get_all_cookies(&self) -> Result<Vec<Cookie>, WebDriverErrorResponse> {
-        self.window()
+        self.webview()
             .cookies()
             .map(|cookies| cookies.iter().map(tauri_cookie_to_webdriver).collect())
             .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))
@@ -1651,7 +1682,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     async fn add_cookie(&self, mut cookie: Cookie) -> Result<(), WebDriverErrorResponse> {
         // Per WebDriver spec: if no domain is specified, use the current page's domain
         if cookie.domain.is_none() {
-            if let Ok(url) = self.window().url() {
+            if let Ok(url) = self.webview().url() {
                 cookie.domain = url.host_str().map(String::from);
             }
         }
@@ -1662,7 +1693,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         }
 
         let tauri_cookie = webdriver_cookie_to_tauri(&cookie);
-        self.window()
+        self.webview()
             .set_cookie(tauri_cookie)
             .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))
     }
@@ -1671,13 +1702,13 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     async fn delete_cookie(&self, name: &str) -> Result<(), WebDriverErrorResponse> {
         // Find the cookie first to get its exact domain/path for deletion
         let cookies = self
-            .window()
+            .webview()
             .cookies()
             .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
 
         for cookie in cookies {
             if cookie.name() == name {
-                self.window()
+                self.webview()
                     .delete_cookie(cookie)
                     .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
                 return Ok(());
@@ -1689,12 +1720,12 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Delete all cookies
     async fn delete_all_cookies(&self) -> Result<(), WebDriverErrorResponse> {
         let cookies = self
-            .window()
+            .webview()
             .cookies()
             .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
 
         for cookie in cookies {
-            self.window()
+            self.webview()
                 .delete_cookie(cookie)
                 .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
         }
@@ -1707,8 +1738,8 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
     /// Dismiss the current alert (cancel)
     async fn dismiss_alert(&self) -> Result<(), WebDriverErrorResponse> {
-        let manager = self.window().app_handle().state::<AlertStateManager>();
-        let alert_state = manager.get_or_create(self.window().label());
+        let manager = self.webview().app_handle().state::<AlertStateManager>();
+        let alert_state = manager.get_or_create(self.webview().label());
         if alert_state.respond(false, None) {
             Ok(())
         } else {
@@ -1718,8 +1749,8 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
     /// Accept the current alert (OK)
     async fn accept_alert(&self) -> Result<(), WebDriverErrorResponse> {
-        let manager = self.window().app_handle().state::<AlertStateManager>();
-        let alert_state = manager.get_or_create(self.window().label());
+        let manager = self.webview().app_handle().state::<AlertStateManager>();
+        let alert_state = manager.get_or_create(self.webview().label());
         // For prompts, use input text if set, otherwise default text
         let prompt_text = alert_state
             .get_prompt_input()
@@ -1733,8 +1764,8 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
     /// Get the text of the current alert
     async fn get_alert_text(&self) -> Result<String, WebDriverErrorResponse> {
-        let manager = self.window().app_handle().state::<AlertStateManager>();
-        let alert_state = manager.get_or_create(self.window().label());
+        let manager = self.webview().app_handle().state::<AlertStateManager>();
+        let alert_state = manager.get_or_create(self.webview().label());
         match alert_state.get_message() {
             Some(msg) => Ok(msg),
             None => Err(WebDriverErrorResponse::no_such_alert()),
@@ -1743,8 +1774,8 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
     /// Send text to the current alert (for prompts)
     async fn send_alert_text(&self, text: &str) -> Result<(), WebDriverErrorResponse> {
-        let manager = self.window().app_handle().state::<AlertStateManager>();
-        let alert_state = manager.get_or_create(self.window().label());
+        let manager = self.webview().app_handle().state::<AlertStateManager>();
+        let alert_state = manager.get_or_create(self.webview().label());
         match alert_state.get_alert_type() {
             None => Err(WebDriverErrorResponse::no_such_alert()),
             Some(AlertType::Prompt) => {
@@ -1767,6 +1798,14 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
     /// Print page to PDF, returns base64-encoded PDF
     async fn print_page(&self, options: PrintOptions) -> Result<String, WebDriverErrorResponse>;
+
+    #[cfg(desktop)]
+    fn is_independent_webview_window(&self) -> bool {
+        self.webview()
+            .app_handle()
+            .get_webview_window(self.webview().label())
+            .is_some()
+    }
 }
 
 // =============================================================================
@@ -1936,7 +1975,7 @@ fn tauri_cookie_to_webdriver(cookie: &TauriCookie<'static>) -> Cookie {
         secure: cookie.secure().unwrap_or(false),
         http_only: cookie.http_only().unwrap_or(false),
         expiry: cookie.expires().and_then(|exp| match exp {
-            Expiration::DateTime(dt) => Some(dt.unix_timestamp().cast_unsigned()),
+            Expiration::DateTime(dt) => u64::try_from(dt.unix_timestamp()).ok(),
             Expiration::Session => None,
         }),
         same_site: cookie.same_site().map(|ss| match ss {
@@ -1970,8 +2009,10 @@ fn webdriver_cookie_to_tauri(cookie: &Cookie) -> TauriCookie<'static> {
     }
 
     if let Some(expiry) = cookie.expiry {
-        if let Ok(dt) = OffsetDateTime::from_unix_timestamp(expiry.cast_signed()) {
-            builder = builder.expires(Expiration::DateTime(dt));
+        if let Ok(expiry) = i64::try_from(expiry) {
+            if let Ok(dt) = OffsetDateTime::from_unix_timestamp(expiry) {
+                builder = builder.expires(Expiration::DateTime(dt));
+            }
         }
     }
 

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -32,6 +32,17 @@ pub struct WindowRect {
     pub height: u32,
 }
 
+#[cfg(desktop)]
+pub(crate) fn is_primary_webview<R: Runtime>(webview: &Webview<R>) -> bool {
+    webview.label() == webview.window().label()
+}
+
+#[cfg(desktop)]
+#[allow(dead_code)]
+pub(crate) fn is_standalone_webview<R: Runtime>(webview: &Webview<R>) -> bool {
+    is_primary_webview(webview) && webview.window().webviews().len() == 1
+}
+
 /// Frame identifier for switching frames
 #[derive(Debug, Clone)]
 pub enum FrameId {
@@ -1462,7 +1473,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Get window rectangle (position and size)
     #[cfg(desktop)]
     async fn get_window_rect(&self) -> Result<WindowRect, WebDriverErrorResponse> {
-        if self.is_independent_webview_window() {
+        if is_primary_webview(self.webview()) {
             let window = self.webview().window();
             let position = window
                 .outer_position()
@@ -1503,7 +1514,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         &self,
         rect: WindowRect,
     ) -> Result<WindowRect, WebDriverErrorResponse> {
-        if self.is_independent_webview_window() {
+        if is_primary_webview(self.webview()) {
             let window = self.webview().window();
 
             // Exit fullscreen/maximized state before setting rect
@@ -1798,14 +1809,6 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
 
     /// Print page to PDF, returns base64-encoded PDF
     async fn print_page(&self, options: PrintOptions) -> Result<String, WebDriverErrorResponse>;
-
-    #[cfg(desktop)]
-    fn is_independent_webview_window(&self) -> bool {
-        self.webview()
-            .app_handle()
-            .get_webview_window(self.webview().label())
-            .is_some()
-    }
 }
 
 // =============================================================================

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -43,6 +43,23 @@ pub(crate) fn is_standalone_webview<R: Runtime>(webview: &Webview<R>) -> bool {
     is_primary_webview(webview) && webview.window().webviews().len() == 1
 }
 
+#[cfg(desktop)]
+fn host_outer_rect<R: Runtime>(webview: &Webview<R>) -> Result<WindowRect, WebDriverErrorResponse> {
+    let window = webview.window();
+    let position = window
+        .outer_position()
+        .map_err(|error| WebDriverErrorResponse::unknown_error(&error.to_string()))?;
+    let size = window
+        .outer_size()
+        .map_err(|error| WebDriverErrorResponse::unknown_error(&error.to_string()))?;
+    Ok(WindowRect {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+    })
+}
+
 /// Frame identifier for switching frames
 #[derive(Debug, Clone)]
 pub enum FrameId {
@@ -1474,19 +1491,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     #[cfg(desktop)]
     async fn get_window_rect(&self) -> Result<WindowRect, WebDriverErrorResponse> {
         if is_primary_webview(self.webview()) {
-            let window = self.webview().window();
-            let position = window
-                .outer_position()
-                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
-            let size = window
-                .outer_size()
-                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
-            return Ok(WindowRect {
-                x: position.x,
-                y: position.y,
-                width: size.width,
-                height: size.height,
-            });
+            return host_outer_rect(self.webview());
         }
 
         let position = self
@@ -1568,7 +1573,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         let window = self.webview().window();
         let _ = window.maximize();
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        self.get_window_rect().await
+        host_outer_rect(self.webview())
     }
 
     /// Minimize window
@@ -1585,7 +1590,7 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         let window = self.webview().window();
         let _ = window.set_fullscreen(true);
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        self.get_window_rect().await
+        host_outer_rect(self.webview())
     }
 
     /// Set window rectangle (mobile unsupported)

--- a/packages/tauri-plugin-webdriver/src/platform/ios.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/ios.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tauri::{Manager, Runtime, WebviewWindow};
+use tauri::{Manager, Runtime, Webview};
 
 use crate::mobile::{
     AlertResult, EvaluateJsArgs, JsResult, ScreenshotArgs, SendAlertTextArgs, TouchArgs, Webdriver,
@@ -16,15 +16,15 @@ use crate::webdriver::Timeouts;
 /// iOS WKWebView executor using Tauri's mobile plugin bridge
 #[derive(Clone)]
 pub struct IOSExecutor<R: Runtime> {
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 }
 
 impl<R: Runtime> IOSExecutor<R> {
-    pub fn new(window: WebviewWindow<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
+    pub fn new(webview: Webview<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
         Self {
-            window,
+            webview,
             timeouts,
             frame_context,
         }
@@ -44,8 +44,8 @@ struct AsyncScriptArgs {
 
 #[async_trait]
 impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
-    fn window(&self) -> &WebviewWindow<R> {
-        &self.window
+    fn webview(&self) -> &Webview<R> {
+        &self.webview
     }
 
     fn script_timeout_ms(&self) -> u64 {
@@ -55,7 +55,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
     async fn evaluate_js(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
         let wrapped_script = wrap_script_for_frame_context(script, &self.frame_context);
 
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let args = EvaluateJsArgs {
             script: wrapped_script,
@@ -120,7 +120,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
             (function() {{ {script} }}).apply(null, __args);"
         );
 
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let plugin_args = AsyncScriptArgs {
             script: wrapper,
@@ -147,7 +147,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
     }
 
     async fn take_screenshot(&self) -> Result<String, WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let args = ScreenshotArgs {
             timeout_ms: self.timeouts.script_ms,
@@ -196,7 +196,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
     }
 
     async fn print_page(&self, options: PrintOptions) -> Result<String, WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let result: JsResult = webdriver
             .0
@@ -227,7 +227,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
         y: i32,
         _button: u32,
     ) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let touch_type = match event_type {
             PointerEventType::Down => "down",
@@ -252,7 +252,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
 
     // Alert handling via plugin
     async fn get_alert_text(&self) -> Result<String, WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let result: AlertResult = webdriver
             .0
@@ -272,7 +272,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
     }
 
     async fn accept_alert(&self) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -290,7 +290,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
     }
 
     async fn dismiss_alert(&self) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -308,7 +308,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
     }
 
     async fn send_alert_text(&self, text: &str) -> Result<(), WebDriverErrorResponse> {
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         let _result: Value = webdriver
             .0
@@ -344,7 +344,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for IOSExecutor<R> {
 
     async fn get_window_rect(&self) -> Result<WindowRect, WebDriverErrorResponse> {
         // Get viewport size from Swift plugin
-        let webdriver = self.window.app_handle().state::<Webdriver<R>>();
+        let webdriver = self.webview.app_handle().state::<Webdriver<R>>();
 
         webdriver
             .0

--- a/packages/tauri-plugin-webdriver/src/platform/linux.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/linux.rs
@@ -6,7 +6,7 @@ use base64::Engine as _;
 use glib::MainContext;
 use javascriptcore::ValueExt;
 use serde_json::Value;
-use tauri::{Manager, Runtime, WebviewWindow};
+use tauri::{Manager, Runtime, Webview};
 use tokio::sync::oneshot;
 use webkit2gtk::{
     PrintOperationExt, ScriptDialogType, SnapshotOptions, SnapshotRegion, WebViewExt,
@@ -18,10 +18,10 @@ use crate::server::response::WebDriverErrorResponse;
 use crate::webdriver::Timeouts;
 
 /// Convert a JavaScriptCore value to JSON with multiple fallback strategies.
-/// 
-/// WebKitGTK's `to_json()` can fail for certain types (functions, undefined, 
+///
+/// WebKitGTK's `to_json()` can fail for certain types (functions, undefined,
 /// circular refs, etc.). This function provides robust serialization:
-/// 
+///
 /// 1. Try `to_json(0)` first (handles most primitives and objects)
 /// 2. Try type-specific conversions for special cases
 /// 3. Fall back to string representation or null
@@ -81,15 +81,15 @@ fn js_value_to_json(js_value: &javascriptcore::Value) -> Result<Value, String> {
 /// Linux `WebKitGTK` executor
 #[derive(Clone)]
 pub struct LinuxExecutor<R: Runtime> {
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 }
 
 impl<R: Runtime> LinuxExecutor<R> {
-    pub fn new(window: WebviewWindow<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
+    pub fn new(webview: Webview<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
         Self {
-            window,
+            webview,
             timeouts,
             frame_context,
         }
@@ -188,8 +188,8 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for LinuxExecutor<R> {
     // Window Access
     // =========================================================================
 
-    fn window(&self) -> &WebviewWindow<R> {
-        &self.window
+    fn webview(&self) -> &Webview<R> {
+        &self.webview
     }
 
     fn script_timeout_ms(&self) -> u64 {
@@ -204,7 +204,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for LinuxExecutor<R> {
         let (tx, rx) = oneshot::channel();
         let script_owned = wrap_script_for_frame_context(script, &self.frame_context);
 
-        let result = self.window.with_webview(move |webview| {
+        let result = self.webview.with_webview(move |webview| {
             let webview = webview.inner().clone();
             let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
 
@@ -257,7 +257,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for LinuxExecutor<R> {
         // Use WebKitGTK's native snapshot API
         let (tx, rx) = oneshot::channel();
 
-        let result = self.window.with_webview(move |webview| {
+        let result = self.webview.with_webview(move |webview| {
             let webview = webview.inner().clone();
             let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
 
@@ -354,7 +354,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for LinuxExecutor<R> {
         let margin_left = options.margin_left;
         let margin_right = options.margin_right;
 
-        let result = self.window.with_webview(move |webview| {
+        let result = self.webview.with_webview(move |webview| {
             let webview = webview.inner().clone();
 
             // Create print operation
@@ -496,7 +496,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for LinuxExecutor<R> {
 
         let (tx, rx) = oneshot::channel();
 
-        let result = self.window.with_webview(move |webview| {
+        let result = self.webview.with_webview(move |webview| {
             let webview = webview.inner().clone();
             let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
 

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -14,7 +14,7 @@ use objc2_web_kit::{
     WKWebView,
 };
 use serde_json::Value;
-use tauri::{Manager, Runtime, WebviewWindow};
+use tauri::{Manager, Runtime, Webview};
 use tokio::sync::oneshot;
 
 use crate::platform::alert_state::{AlertState, AlertStateManager, AlertType, PendingAlert};
@@ -28,15 +28,15 @@ static DELEGATE_KEY: u8 = 0;
 /// macOS `WebView` executor using `WKWebView` native APIs
 #[derive(Clone)]
 pub struct MacOSExecutor<R: Runtime> {
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 }
 
 impl<R: Runtime> MacOSExecutor<R> {
-    pub fn new(window: WebviewWindow<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
+    pub fn new(webview: Webview<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
         Self {
-            window,
+            webview,
             timeouts,
             frame_context,
         }
@@ -82,8 +82,8 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
     // Window Access
     // =========================================================================
 
-    fn window(&self) -> &WebviewWindow<R> {
-        &self.window
+    fn webview(&self) -> &Webview<R> {
+        &self.webview
     }
 
     fn script_timeout_ms(&self) -> u64 {
@@ -98,7 +98,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
         let (tx, rx) = oneshot::channel();
         let script_owned = wrap_script_for_frame_context(script, &self.frame_context);
 
-        let result = self.window.with_webview(move |webview| unsafe {
+        let result = self.webview.with_webview(move |webview| unsafe {
             let wk_webview: &WKWebView = &*webview.inner().cast();
             let ns_script = NSString::from_str(&script_owned);
 
@@ -199,7 +199,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
 
         let (tx, rx) = oneshot::channel();
 
-        let result = self.window.with_webview(move |webview| unsafe {
+        let result = self.webview.with_webview(move |webview| unsafe {
             let wk_webview: &WKWebView = &*webview.inner().cast();
             let ns_script = NSString::from_str(&wrapper);
             let mtm = MainThreadMarker::new_unchecked();
@@ -262,7 +262,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
     async fn take_screenshot(&self) -> Result<String, WebDriverErrorResponse> {
         let (tx, rx) = oneshot::channel();
 
-        let result = self.window.with_webview(move |webview| unsafe {
+        let result = self.webview.with_webview(move |webview| unsafe {
             let wk_webview: &WKWebView = &*webview.inner().cast();
             let mtm = MainThreadMarker::new_unchecked();
             let config = WKSnapshotConfiguration::new(mtm);
@@ -373,7 +373,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
         // Now create PDF using WKWebView's native API
         let (tx, rx) = oneshot::channel();
 
-        let result = self.window.with_webview(move |webview| unsafe {
+        let result = self.webview.with_webview(move |webview| unsafe {
             let wk_webview: &WKWebView = &*webview.inner().cast();
             let mtm = MainThreadMarker::new_unchecked();
 

--- a/packages/tauri-plugin-webdriver/src/platform/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/mod.rs
@@ -25,66 +25,66 @@ mod android;
 mod ios;
 
 use std::sync::Arc;
-use tauri::{Runtime, WebviewWindow};
+use tauri::{Runtime, Webview};
 
 use crate::webdriver::Timeouts;
 
-/// Create a platform-specific executor for the given window
+/// Create a platform-specific executor for the given webview
 #[cfg(target_os = "macos")]
 pub fn create_executor<R: Runtime + 'static>(
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 ) -> Arc<dyn PlatformExecutor<R>> {
-    Arc::new(macos::MacOSExecutor::new(window, timeouts, frame_context))
+    Arc::new(macos::MacOSExecutor::new(webview, timeouts, frame_context))
 }
 
-/// Create a platform-specific executor for the given window
+/// Create a platform-specific executor for the given webview
 #[cfg(target_os = "windows")]
 pub fn create_executor<R: Runtime + 'static>(
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 ) -> Arc<dyn PlatformExecutor<R>> {
     Arc::new(windows::WindowsExecutor::new(
-        window,
+        webview,
         timeouts,
         frame_context,
     ))
 }
 
-/// Create a platform-specific executor for the given window
+/// Create a platform-specific executor for the given webview
 #[cfg(target_os = "linux")]
 pub fn create_executor<R: Runtime + 'static>(
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 ) -> Arc<dyn PlatformExecutor<R>> {
-    Arc::new(linux::LinuxExecutor::new(window, timeouts, frame_context))
+    Arc::new(linux::LinuxExecutor::new(webview, timeouts, frame_context))
 }
 
-/// Create a platform-specific executor for the given window
+/// Create a platform-specific executor for the given webview
 #[cfg(target_os = "android")]
 pub fn create_executor<R: Runtime + 'static>(
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 ) -> Arc<dyn PlatformExecutor<R>> {
     Arc::new(android::AndroidExecutor::new(
-        window,
+        webview,
         timeouts,
         frame_context,
     ))
 }
 
-/// Create a platform-specific executor for the given window
+/// Create a platform-specific executor for the given webview
 #[cfg(target_os = "ios")]
 pub fn create_executor<R: Runtime + 'static>(
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 ) -> Arc<dyn PlatformExecutor<R>> {
-    Arc::new(ios::IOSExecutor::new(window, timeouts, frame_context))
+    Arc::new(ios::IOSExecutor::new(webview, timeouts, frame_context))
 }
 
 /// Register platform-specific webview handlers at webview creation time.

--- a/packages/tauri-plugin-webdriver/src/platform/windows.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/windows.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine as _;
 use serde_json::Value;
-use tauri::{Manager, Runtime, WebviewWindow};
+use tauri::{Manager, Runtime, Webview};
 use tokio::sync::oneshot;
 use webview2_com::Microsoft::Web::WebView2::Win32::{
     ICoreWebView2, ICoreWebView2CapturePreviewCompletedHandler, ICoreWebView2Environment6,
@@ -113,15 +113,15 @@ impl SendableComPtr {
 /// Windows `WebView2` executor
 #[derive(Clone)]
 pub struct WindowsExecutor<R: Runtime> {
-    window: WebviewWindow<R>,
+    webview: Webview<R>,
     timeouts: Timeouts,
     frame_context: Vec<FrameId>,
 }
 
 impl<R: Runtime> WindowsExecutor<R> {
-    pub fn new(window: WebviewWindow<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
+    pub fn new(webview: Webview<R>, timeouts: Timeouts, frame_context: Vec<FrameId>) -> Self {
         Self {
-            window,
+            webview,
             timeouts,
             frame_context,
         }
@@ -139,7 +139,7 @@ impl<R: Runtime + 'static> WindowsExecutor<R> {
 
         let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
 
-        let result = self.window.with_webview({
+        let result = self.webview.with_webview({
             let tx = tx.clone();
             move |webview| unsafe {
                 let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
@@ -150,8 +150,13 @@ impl<R: Runtime + 'static> WindowsExecutor<R> {
                     let handler: ICoreWebView2ExecuteScriptCompletedHandler =
                         ExecuteScriptHandler::new(tx.clone()).into();
 
-                    if let Err(e) = webview2.ExecuteScript(PCWSTR(script_hstring.as_ptr()), &handler) {
-                        tracing::error!("ExecuteScript call failed for script '{}...': {e:?}", script_preview);
+                    if let Err(e) =
+                        webview2.ExecuteScript(PCWSTR(script_hstring.as_ptr()), &handler)
+                    {
+                        tracing::error!(
+                            "ExecuteScript call failed for script '{}...': {e:?}",
+                            script_preview
+                        );
                         if let Ok(mut guard) = tx.lock() {
                             if let Some(tx) = guard.take() {
                                 let _ = tx.send(Err(format!("ExecuteScript failed: {e:?}")));
@@ -188,7 +193,7 @@ impl<R: Runtime + 'static> WindowsExecutor<R> {
             Ok(Err(_)) => {
                 tracing::error!("Channel closed unexpectedly during script execution");
                 Err(WebDriverErrorResponse::unknown_error("Channel closed"))
-            },
+            }
             Err(_) => Err(WebDriverErrorResponse::script_timeout()),
         }
     }
@@ -239,8 +244,8 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for WindowsExecutor<R> {
     // Window Access
     // =========================================================================
 
-    fn window(&self) -> &WebviewWindow<R> {
-        &self.window
+    fn webview(&self) -> &Webview<R> {
+        &self.webview
     }
 
     fn script_timeout_ms(&self) -> u64 {
@@ -252,8 +257,8 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for WindowsExecutor<R> {
     // =========================================================================
 
     async fn evaluate_js(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
-        let locks = self.window.state::<ScriptExecutionLocks>();
-        let lock = locks.get(self.window.label());
+        let locks = self.webview.state::<ScriptExecutionLocks>();
+        let lock = locks.get(self.webview.label());
         let _guard = lock.lock().await;
         self.evaluate_js_inner(script).await
     }
@@ -266,7 +271,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for WindowsExecutor<R> {
         // Use WebView2's native CapturePreview API
         let (tx, rx) = oneshot::channel();
 
-        let result = self.window.with_webview(move |webview| {
+        let result = self.webview.with_webview(move |webview| {
             unsafe {
                 if let Ok(webview2) = webview.controller().CoreWebView2() {
                     // Create an in-memory stream for the PNG image
@@ -372,7 +377,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for WindowsExecutor<R> {
         let margin_left = options.margin_left;
         let margin_right = options.margin_right;
 
-        let result = self.window.with_webview(move |webview| unsafe {
+        let result = self.webview.with_webview(move |webview| unsafe {
             let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
 
             let webview2 = match webview.controller().CoreWebView2() {
@@ -539,14 +544,14 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for WindowsExecutor<R> {
         let async_id = uuid::Uuid::new_v4().to_string();
 
         // Get async state and register this operation
-        let app = self.window.app_handle().clone();
+        let app = self.webview.app_handle().clone();
         let async_state = app.state::<AsyncScriptState>();
-        let label = self.window.label().to_string();
+        let label = self.webview.label().to_string();
 
         // Register handler if not already registered for this window
         if !async_state.mark_handler_registered(&label) {
             let app_clone = app.clone();
-            let handler_result = self.window.with_webview(move |webview| unsafe {
+            let handler_result = self.webview.with_webview(move |webview| unsafe {
                 let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
 
                 if let Ok(webview2) = webview.controller().CoreWebView2() {
@@ -610,8 +615,8 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for WindowsExecutor<R> {
 
         // Acquire the per-webview lock and hold it across the entire async script lifecycle.
         // This prevents another ExecuteScript from preempting the in-flight async JS callback.
-        let locks = self.window.state::<ScriptExecutionLocks>();
-        let lock = locks.get(self.window.label());
+        let locks = self.webview.state::<ScriptExecutionLocks>();
+        let lock = locks.get(self.webview.label());
         let _guard = lock.lock().await;
 
         // Execute the wrapper using the unlocked inner method (we already hold the lock).

--- a/packages/tauri-plugin-webdriver/src/server/handlers/frame.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/frame.rs
@@ -26,6 +26,29 @@ fn browsing_context_changed_error<R: Runtime>(
     WebDriverErrorResponse::unknown_error("Browsing context changed while switching frame")
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum FrameContextCommitError {
+    WindowMissing,
+    BrowsingContextChanged,
+}
+
+fn commit_frame_context(
+    session: &mut crate::webdriver::session::Session,
+    browsing_context_generation: u64,
+    original_window_exists: bool,
+    frame_id: FrameId,
+) -> Result<(), FrameContextCommitError> {
+    if !original_window_exists {
+        return Err(FrameContextCommitError::WindowMissing);
+    }
+
+    if !session.append_frame_context_if_current(browsing_context_generation, frame_id) {
+        return Err(FrameContextCommitError::BrowsingContextChanged);
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SwitchFrameRequest {
     pub id: Value,
@@ -124,12 +147,24 @@ pub async fn switch_to_frame<R: Runtime + 'static>(
             js_var_for_element.expect("element frame IDs always have an element reference"),
         ),
     };
-    if !session.append_frame_context_if_current(browsing_context_generation, frame_id.clone()) {
-        return Err(browsing_context_changed_error(
-            &state,
-            &current_window,
-            Some(&frame_id),
-        ));
+    let original_window_exists = state.has_window_label(&current_window);
+    match commit_frame_context(
+        session,
+        browsing_context_generation,
+        original_window_exists,
+        frame_id.clone(),
+    ) {
+        Ok(()) => {}
+        Err(FrameContextCommitError::WindowMissing) => {
+            return Err(WebDriverErrorResponse::no_such_window());
+        }
+        Err(FrameContextCommitError::BrowsingContextChanged) => {
+            return Err(browsing_context_changed_error(
+                &state,
+                &current_window,
+                Some(&frame_id),
+            ));
+        }
     }
 
     Ok(WebDriverResponse::null())
@@ -155,4 +190,33 @@ pub async fn switch_to_parent_frame<R: Runtime + 'static>(
     executor.switch_to_parent_frame().await?;
 
     Ok(WebDriverResponse::null())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{commit_frame_context, FrameContextCommitError};
+    use crate::platform::FrameId;
+    use crate::webdriver::session::Session;
+
+    #[test]
+    fn refuses_to_commit_a_frame_after_the_original_window_is_removed() {
+        let mut session = Session::new("child-left".to_string());
+        let generation = session.browsing_context_generation;
+
+        let result = commit_frame_context(&mut session, generation, false, FrameId::Index(0));
+
+        assert_eq!(result, Err(FrameContextCommitError::WindowMissing));
+        assert!(session.frame_context.is_empty());
+    }
+
+    #[test]
+    fn prioritizes_a_removed_window_over_a_changed_browsing_context() {
+        let mut session = Session::new("child-left".to_string());
+        session.browsing_context_generation = 1;
+
+        let result = commit_frame_context(&mut session, 0, false, FrameId::Index(0));
+
+        assert_eq!(result, Err(FrameContextCommitError::WindowMissing));
+        assert!(session.frame_context.is_empty());
+    }
 }

--- a/packages/tauri-plugin-webdriver/src/server/handlers/frame.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/frame.rs
@@ -32,18 +32,32 @@ enum FrameContextCommitError {
     BrowsingContextChanged,
 }
 
+enum FrameContextMutation {
+    Clear,
+    Push(FrameId),
+    Pop,
+}
+
 fn commit_frame_context(
     session: &mut crate::webdriver::session::Session,
     browsing_context_generation: u64,
     original_window_exists: bool,
-    frame_id: FrameId,
+    mutation: FrameContextMutation,
 ) -> Result<(), FrameContextCommitError> {
     if !original_window_exists {
         return Err(FrameContextCommitError::WindowMissing);
     }
 
-    if !session.append_frame_context_if_current(browsing_context_generation, frame_id) {
+    if session.browsing_context_generation != browsing_context_generation {
         return Err(FrameContextCommitError::BrowsingContextChanged);
+    }
+
+    match mutation {
+        FrameContextMutation::Clear => session.frame_context.clear(),
+        FrameContextMutation::Push(frame_id) => session.frame_context.push(frame_id),
+        FrameContextMutation::Pop => {
+            session.frame_context.pop();
+        }
     }
 
     Ok(())
@@ -73,20 +87,29 @@ pub async fn switch_to_frame<R: Runtime + 'static>(
     // Parse the frame ID to determine what we're switching to
     let (frame_id, js_var_for_element) = match &request.id {
         Value::Null => {
-            // Switch to top-level context - no validation needed
             drop(sessions);
 
-            // Update session: clear frame context
             let mut sessions = state.sessions.write().await;
             let session = sessions.get_mut(&session_id)?;
-            if session.browsing_context_generation != browsing_context_generation {
-                return Err(browsing_context_changed_error(
-                    &state,
-                    &current_window,
-                    None,
-                ));
+            let original_window_exists = state.has_window_label(&current_window);
+            match commit_frame_context(
+                session,
+                browsing_context_generation,
+                original_window_exists,
+                FrameContextMutation::Clear,
+            ) {
+                Ok(()) => {}
+                Err(FrameContextCommitError::WindowMissing) => {
+                    return Err(WebDriverErrorResponse::no_such_window());
+                }
+                Err(FrameContextCommitError::BrowsingContextChanged) => {
+                    return Err(browsing_context_changed_error(
+                        &state,
+                        &current_window,
+                        None,
+                    ));
+                }
             }
-            session.frame_context.clear();
 
             return Ok(WebDriverResponse::null());
         }
@@ -152,7 +175,7 @@ pub async fn switch_to_frame<R: Runtime + 'static>(
         session,
         browsing_context_generation,
         original_window_exists,
-        frame_id.clone(),
+        FrameContextMutation::Push(frame_id.clone()),
     ) {
         Ok(()) => {}
         Err(FrameContextCommitError::WindowMissing) => {
@@ -175,26 +198,45 @@ pub async fn switch_to_parent_frame<R: Runtime + 'static>(
     State(state): State<Arc<AppState<R>>>,
     Path(session_id): Path<String>,
 ) -> WebDriverResult {
-    let mut sessions = state.sessions.write().await;
-    let session = sessions.get_mut(&session_id)?;
-
-    // Pop one level from frame context
-    session.frame_context.pop();
-
+    let sessions = state.sessions.read().await;
+    let session = sessions.get(&session_id)?;
     let current_window = session.current_window.clone();
     let timeouts = session.timeouts.clone();
     let frame_context = session.frame_context.clone();
+    let browsing_context_generation = session.browsing_context_generation;
     drop(sessions);
 
     let executor = state.get_executor_for_window(&current_window, timeouts, frame_context)?;
     executor.switch_to_parent_frame().await?;
+
+    let mut sessions = state.sessions.write().await;
+    let session = sessions.get_mut(&session_id)?;
+    let original_window_exists = state.has_window_label(&current_window);
+    match commit_frame_context(
+        session,
+        browsing_context_generation,
+        original_window_exists,
+        FrameContextMutation::Pop,
+    ) {
+        Ok(()) => {}
+        Err(FrameContextCommitError::WindowMissing) => {
+            return Err(WebDriverErrorResponse::no_such_window());
+        }
+        Err(FrameContextCommitError::BrowsingContextChanged) => {
+            return Err(browsing_context_changed_error(
+                &state,
+                &current_window,
+                None,
+            ));
+        }
+    }
 
     Ok(WebDriverResponse::null())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{commit_frame_context, FrameContextCommitError};
+    use super::{commit_frame_context, FrameContextCommitError, FrameContextMutation};
     use crate::platform::FrameId;
     use crate::webdriver::session::Session;
 
@@ -203,7 +245,12 @@ mod tests {
         let mut session = Session::new("child-left".to_string());
         let generation = session.browsing_context_generation;
 
-        let result = commit_frame_context(&mut session, generation, false, FrameId::Index(0));
+        let result = commit_frame_context(
+            &mut session,
+            generation,
+            false,
+            FrameContextMutation::Push(FrameId::Index(0)),
+        );
 
         assert_eq!(result, Err(FrameContextCommitError::WindowMissing));
         assert!(session.frame_context.is_empty());
@@ -214,9 +261,78 @@ mod tests {
         let mut session = Session::new("child-left".to_string());
         session.browsing_context_generation = 1;
 
-        let result = commit_frame_context(&mut session, 0, false, FrameId::Index(0));
+        let result = commit_frame_context(
+            &mut session,
+            0,
+            false,
+            FrameContextMutation::Push(FrameId::Index(0)),
+        );
 
         assert_eq!(result, Err(FrameContextCommitError::WindowMissing));
         assert!(session.frame_context.is_empty());
+    }
+
+    #[test]
+    fn preserves_frame_context_when_top_level_commit_loses_the_selected_window() {
+        let mut session = Session::new("child-left".to_string());
+        session.frame_context.push(FrameId::Index(0));
+        session.frame_context.push(FrameId::Index(1));
+        let generation = session.browsing_context_generation;
+
+        let result =
+            commit_frame_context(&mut session, generation, false, FrameContextMutation::Clear);
+
+        assert_eq!(result, Err(FrameContextCommitError::WindowMissing));
+        assert!(matches!(
+            session.frame_context.as_slice(),
+            [FrameId::Index(0), FrameId::Index(1)]
+        ));
+    }
+
+    #[test]
+    fn preserves_frame_context_when_parent_commit_loses_the_selected_window() {
+        let mut session = Session::new("child-left".to_string());
+        session.frame_context.push(FrameId::Index(0));
+        session.frame_context.push(FrameId::Index(1));
+        let generation = session.browsing_context_generation;
+
+        let result =
+            commit_frame_context(&mut session, generation, false, FrameContextMutation::Pop);
+
+        assert_eq!(result, Err(FrameContextCommitError::WindowMissing));
+        assert!(matches!(
+            session.frame_context.as_slice(),
+            [FrameId::Index(0), FrameId::Index(1)]
+        ));
+    }
+
+    #[test]
+    fn clears_frame_context_when_switching_to_top_level() {
+        let mut session = Session::new("child-left".to_string());
+        session.frame_context.push(FrameId::Index(0));
+        let generation = session.browsing_context_generation;
+
+        let result =
+            commit_frame_context(&mut session, generation, true, FrameContextMutation::Clear);
+
+        assert_eq!(result, Ok(()));
+        assert!(session.frame_context.is_empty());
+    }
+
+    #[test]
+    fn pops_one_frame_context_when_switching_to_parent() {
+        let mut session = Session::new("child-left".to_string());
+        session.frame_context.push(FrameId::Index(0));
+        session.frame_context.push(FrameId::Index(1));
+        let generation = session.browsing_context_generation;
+
+        let result =
+            commit_frame_context(&mut session, generation, true, FrameContextMutation::Pop);
+
+        assert_eq!(result, Ok(()));
+        assert!(matches!(
+            session.frame_context.as_slice(),
+            [FrameId::Index(0)]
+        ));
     }
 }

--- a/packages/tauri-plugin-webdriver/src/server/handlers/frame.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/frame.rs
@@ -10,6 +10,22 @@ use crate::platform::FrameId;
 use crate::server::response::{WebDriverErrorResponse, WebDriverResponse, WebDriverResult};
 use crate::server::AppState;
 
+fn browsing_context_changed_error<R: Runtime>(
+    state: &AppState<R>,
+    current_window: &str,
+    frame_id: Option<&FrameId>,
+) -> WebDriverErrorResponse {
+    if !state.has_window_label(current_window) {
+        return WebDriverErrorResponse::no_such_window();
+    }
+
+    if matches!(frame_id, Some(FrameId::Element(_))) {
+        return WebDriverErrorResponse::stale_element_reference();
+    }
+
+    WebDriverErrorResponse::unknown_error("Browsing context changed while switching frame")
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SwitchFrameRequest {
     pub id: Value,
@@ -29,6 +45,7 @@ pub async fn switch_to_frame<R: Runtime + 'static>(
     let current_window = session.current_window.clone();
     let timeouts = session.timeouts.clone();
     let current_frame_context = session.frame_context.clone();
+    let browsing_context_generation = session.browsing_context_generation;
 
     // Parse the frame ID to determine what we're switching to
     let (frame_id, js_var_for_element) = match &request.id {
@@ -39,6 +56,13 @@ pub async fn switch_to_frame<R: Runtime + 'static>(
             // Update session: clear frame context
             let mut sessions = state.sessions.write().await;
             let session = sessions.get_mut(&session_id)?;
+            if session.browsing_context_generation != browsing_context_generation {
+                return Err(browsing_context_changed_error(
+                    &state,
+                    &current_window,
+                    None,
+                ));
+            }
             session.frame_context.clear();
 
             return Ok(WebDriverResponse::null());
@@ -94,15 +118,18 @@ pub async fn switch_to_frame<R: Runtime + 'static>(
     let mut sessions = state.sessions.write().await;
     let session = sessions.get_mut(&session_id)?;
 
-    match &frame_id {
-        FrameId::Index(_) => {
-            session.frame_context.push(frame_id);
-        }
-        FrameId::Element(_) => {
-            if let Some(js_var) = js_var_for_element {
-                session.frame_context.push(FrameId::Element(js_var));
-            }
-        }
+    let frame_id = match frame_id {
+        FrameId::Index(index) => FrameId::Index(index),
+        FrameId::Element(_) => FrameId::Element(
+            js_var_for_element.expect("element frame IDs always have an element reference"),
+        ),
+    };
+    if !session.append_frame_context_if_current(browsing_context_generation, frame_id.clone()) {
+        return Err(browsing_context_changed_error(
+            &state,
+            &current_window,
+            Some(&frame_id),
+        ));
     }
 
     Ok(WebDriverResponse::null())

--- a/packages/tauri-plugin-webdriver/src/server/handlers/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/mod.rs
@@ -25,12 +25,12 @@ pub mod window;
 
 /// GET `/status` - `WebDriver` server status
 ///
-/// Returns ready=true only when at least one webview window is available.
+/// Returns ready=true only when at least one webview is available.
 /// This ensures the WebView2/WebKit/WKWebView is fully initialized before
 /// clients attempt to create sessions.
 pub async fn status<R: Runtime>(state: State<Arc<AppState<R>>>) -> WebDriverResult {
-    // Check if any webview windows are available
-    // This is a proxy for WebView2 readiness - windows become available
+    // Check if any webviews are available
+    // This is a proxy for WebView2 readiness - webviews become available
     // only after the webview is fully initialized
     let window_labels = state.get_window_labels();
     let ready = !window_labels.is_empty();

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 use serde_json::json;
 use tauri::{Manager, Runtime};
 
+#[cfg(desktop)]
+use crate::platform::is_standalone_webview;
 use crate::platform::WindowRect;
 use crate::server::response::{WebDriverErrorResponse, WebDriverResponse, WebDriverResult};
 use crate::server::AppState;
@@ -84,19 +86,31 @@ pub async fn close_window<R: Runtime>(
         let current_window = session.current_window.clone();
         drop(sessions);
 
-        // Close the current window
-        if let Some(window) = state.app.webview_windows().get(&current_window).cloned() {
-            window
-                .destroy()
-                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+        let webview = state
+            .app
+            .webviews()
+            .get(&current_window)
+            .cloned()
+            .ok_or_else(WebDriverErrorResponse::no_such_window)?;
 
-            // Return remaining window handles
-            let handles: Vec<String> = state.app.webview_windows().keys().cloned().collect();
-
-            Ok(WebDriverResponse::success(handles))
-        } else {
-            Err(WebDriverErrorResponse::no_such_window())
+        if !is_standalone_webview(&webview) {
+            return Err(WebDriverErrorResponse::unsupported_operation(
+                "Closing a child or shared-host webview is not supported",
+            ));
         }
+
+        webview
+            .window()
+            .destroy()
+            .map_err(|error| WebDriverErrorResponse::unknown_error(&error.to_string()))?;
+
+        let handles = state
+            .get_window_labels()
+            .into_iter()
+            .filter(|label| label != &current_window)
+            .collect::<Vec<_>>();
+
+        Ok(WebDriverResponse::success(handles))
     }
 }
 

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -58,7 +58,7 @@ pub async fn get_window_handles<R: Runtime>(
     drop(sessions);
 
     // Return all window labels as handles
-    let handles: Vec<String> = state.app.webview_windows().keys().cloned().collect();
+    let handles = state.get_window_labels();
 
     Ok(WebDriverResponse::success(handles))
 }
@@ -110,7 +110,7 @@ pub async fn switch_to_window<R: Runtime>(
     let session = sessions.get_mut(&session_id)?;
 
     // Verify the window exists
-    if !state.app.webview_windows().contains_key(&request.handle) {
+    if !state.app.webviews().contains_key(&request.handle) {
         return Err(WebDriverErrorResponse::no_such_window());
     }
 

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -128,7 +128,9 @@ pub async fn switch_to_window<R: Runtime>(
         return Err(WebDriverErrorResponse::no_such_window());
     }
 
-    session.switch_to_window(request.handle);
+    session.switch_to_window(request.handle).map_err(|_| {
+        WebDriverErrorResponse::unknown_error("Browsing context generation overflowed")
+    })?;
 
     Ok(WebDriverResponse::null())
 }

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -128,8 +128,7 @@ pub async fn switch_to_window<R: Runtime>(
         return Err(WebDriverErrorResponse::no_such_window());
     }
 
-    session.current_window = request.handle;
-    session.frame_context.clear();
+    session.switch_to_window(request.handle);
 
     Ok(WebDriverResponse::null())
 }

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -46,7 +46,10 @@ pub async fn get_window_handle<R: Runtime>(
     let current_window = session.current_window.clone();
     drop(sessions);
 
-    // Return the session's current window handle
+    if !state.app.webviews().contains_key(&current_window) {
+        return Err(WebDriverErrorResponse::no_such_window());
+    }
+
     Ok(WebDriverResponse::success(current_window))
 }
 
@@ -128,8 +131,8 @@ pub async fn switch_to_window<R: Runtime>(
         return Err(WebDriverErrorResponse::no_such_window());
     }
 
-    // Update session's current window
     session.current_window = request.handle;
+    session.frame_context.clear();
 
     Ok(WebDriverResponse::null())
 }

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -9,6 +9,8 @@ use tauri::Runtime;
 #[cfg(desktop)]
 use crate::platform::is_standalone_webview;
 use crate::platform::WindowRect;
+#[cfg(desktop)]
+use crate::server::close_protection_is_required;
 use crate::server::response::{WebDriverErrorResponse, WebDriverResponse, WebDriverResult};
 use crate::server::AppState;
 
@@ -93,7 +95,7 @@ pub async fn close_window<R: Runtime>(
             .get_webview(&current_window)
             .ok_or_else(WebDriverErrorResponse::no_such_window)?;
 
-        if !is_standalone_webview(&webview) {
+        if close_protection_is_required() && !is_standalone_webview(&webview) {
             return Err(WebDriverErrorResponse::unsupported_operation(
                 "Closing a child or shared-host webview is not supported",
             ));

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, State};
 use axum::Json;
 use serde::Deserialize;
 use serde_json::json;
-use tauri::{Manager, Runtime};
+use tauri::Runtime;
 
 #[cfg(desktop)]
 use crate::platform::is_standalone_webview;
@@ -46,7 +46,7 @@ pub async fn get_window_handle<R: Runtime>(
     let current_window = session.current_window.clone();
     drop(sessions);
 
-    if !state.app.webviews().contains_key(&current_window) {
+    if !state.has_window_label(&current_window) {
         return Err(WebDriverErrorResponse::no_such_window());
     }
 
@@ -90,10 +90,7 @@ pub async fn close_window<R: Runtime>(
         drop(sessions);
 
         let webview = state
-            .app
-            .webviews()
-            .get(&current_window)
-            .cloned()
+            .get_webview(&current_window)
             .ok_or_else(WebDriverErrorResponse::no_such_window)?;
 
         if !is_standalone_webview(&webview) {
@@ -127,7 +124,7 @@ pub async fn switch_to_window<R: Runtime>(
     let session = sessions.get_mut(&session_id)?;
 
     // Verify the window exists
-    if !state.app.webviews().contains_key(&request.handle) {
+    if !state.has_window_label(&request.handle) {
         return Err(WebDriverErrorResponse::no_such_window());
     }
 

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -78,6 +78,14 @@ fn child_webviews_are_exposed() -> bool {
     child_webviews_are_exposed_for_platform(std::env::consts::OS)
 }
 
+pub(crate) fn close_protection_is_required() -> bool {
+    close_protection_is_required_for_platform(std::env::consts::OS)
+}
+
+fn close_protection_is_required_for_platform(platform: &str) -> bool {
+    child_webviews_are_exposed_for_platform(platform)
+}
+
 fn child_webviews_are_exposed_for_platform(platform: &str) -> bool {
     platform == "macos"
 }
@@ -131,7 +139,10 @@ pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16) {
 
 #[cfg(test)]
 mod tests {
-    use super::{child_webviews_are_exposed_for_platform, is_webview_exposed};
+    use super::{
+        child_webviews_are_exposed_for_platform, close_protection_is_required_for_platform,
+        is_webview_exposed,
+    };
 
     #[test]
     fn primary_only_policy_hides_child_webviews() {
@@ -173,5 +184,25 @@ mod tests {
             "child",
             "main"
         ));
+    }
+
+    #[test]
+    fn close_protection_is_required_only_when_child_webviews_are_exposed() {
+        for (platform, expected) in [
+            ("macos", true),
+            ("windows", false),
+            ("linux", false),
+            ("android", false),
+            ("ios", false),
+        ] {
+            assert_eq!(
+                close_protection_is_required_for_platform(platform),
+                expected
+            );
+            assert_eq!(
+                close_protection_is_required_for_platform(platform),
+                child_webviews_are_exposed_for_platform(platform)
+            );
+        }
     }
 }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -34,18 +34,56 @@ impl<R: Runtime + 'static> AppState<R> {
         timeouts: Timeouts,
         frame_context: Vec<FrameId>,
     ) -> Result<Arc<dyn PlatformExecutor<R>>, WebDriverErrorResponse> {
-        self.app
-            .webviews()
-            .get(window_label)
-            .cloned()
+        self.get_webview(window_label)
             .map(|webview| create_executor(webview, timeouts, frame_context))
             .ok_or_else(WebDriverErrorResponse::no_such_window)
     }
 
+    pub fn get_webview(&self, window_label: &str) -> Option<tauri::Webview<R>> {
+        self.app
+            .webviews()
+            .get(window_label)
+            .filter(|webview| {
+                is_webview_exposed(
+                    child_webviews_are_exposed(),
+                    webview.label(),
+                    webview.window().label(),
+                )
+            })
+            .cloned()
+    }
+
+    pub fn has_window_label(&self, window_label: &str) -> bool {
+        self.get_webview(window_label).is_some()
+    }
+
     /// Get all window labels
     pub fn get_window_labels(&self) -> Vec<String> {
-        self.app.webviews().keys().cloned().collect()
+        self.app
+            .webviews()
+            .values()
+            .filter(|webview| {
+                is_webview_exposed(
+                    child_webviews_are_exposed(),
+                    webview.label(),
+                    webview.window().label(),
+                )
+            })
+            .map(|webview| webview.label().to_string())
+            .collect()
     }
+}
+
+fn child_webviews_are_exposed() -> bool {
+    cfg!(any(
+        target_os = "macos",
+        target_os = "android",
+        target_os = "ios"
+    ))
+}
+
+fn is_webview_exposed(expose_children: bool, webview_label: &str, window_label: &str) -> bool {
+    expose_children || webview_label == window_label
 }
 
 /// Start the `WebDriver` HTTP server on the specified port
@@ -89,4 +127,30 @@ pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16) {
             }
         });
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{child_webviews_are_exposed, is_webview_exposed};
+
+    #[test]
+    fn primary_only_policy_hides_child_webviews() {
+        assert!(is_webview_exposed(false, "main", "main"));
+        assert!(!is_webview_exposed(false, "child", "main"));
+    }
+
+    #[test]
+    fn all_webviews_policy_keeps_child_webviews_visible() {
+        assert!(is_webview_exposed(true, "main", "main"));
+        assert!(is_webview_exposed(true, "child", "main"));
+    }
+
+    #[test]
+    fn platform_policy_only_exposes_children_on_supported_platforms() {
+        #[cfg(any(target_os = "macos", target_os = "android", target_os = "ios"))]
+        assert!(child_webviews_are_exposed());
+
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        assert!(!child_webviews_are_exposed());
+    }
 }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -35,16 +35,16 @@ impl<R: Runtime + 'static> AppState<R> {
         frame_context: Vec<FrameId>,
     ) -> Result<Arc<dyn PlatformExecutor<R>>, WebDriverErrorResponse> {
         self.app
-            .webview_windows()
+            .webviews()
             .get(window_label)
             .cloned()
-            .map(|window| create_executor(window, timeouts, frame_context))
+            .map(|webview| create_executor(webview, timeouts, frame_context))
             .ok_or_else(WebDriverErrorResponse::no_such_window)
     }
 
     /// Get all window labels
     pub fn get_window_labels(&self) -> Vec<String> {
-        self.app.webview_windows().keys().cloned().collect()
+        self.app.webviews().keys().cloned().collect()
     }
 }
 
@@ -75,7 +75,8 @@ pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16) {
                 Err(e) => {
                     tracing::error!(
                         "Failed to bind WebDriver server to {} — port may already be in use: {}",
-                        addr, e
+                        addr,
+                        e
                     );
                     return;
                 }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -75,11 +75,11 @@ impl<R: Runtime + 'static> AppState<R> {
 }
 
 fn child_webviews_are_exposed() -> bool {
-    cfg!(any(
-        target_os = "macos",
-        target_os = "android",
-        target_os = "ios"
-    ))
+    child_webviews_are_exposed_for_platform(std::env::consts::OS)
+}
+
+fn child_webviews_are_exposed_for_platform(platform: &str) -> bool {
+    platform == "macos"
 }
 
 fn is_webview_exposed(expose_children: bool, webview_label: &str, window_label: &str) -> bool {
@@ -131,7 +131,7 @@ pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16) {
 
 #[cfg(test)]
 mod tests {
-    use super::{child_webviews_are_exposed, is_webview_exposed};
+    use super::{child_webviews_are_exposed_for_platform, is_webview_exposed};
 
     #[test]
     fn primary_only_policy_hides_child_webviews() {
@@ -146,11 +146,32 @@ mod tests {
     }
 
     #[test]
-    fn platform_policy_only_exposes_children_on_supported_platforms() {
-        #[cfg(any(target_os = "macos", target_os = "android", target_os = "ios"))]
-        assert!(child_webviews_are_exposed());
+    fn non_macos_platforms_expose_only_primary_webviews() {
+        for platform in ["windows", "linux", "android", "ios"] {
+            assert!(is_webview_exposed(
+                child_webviews_are_exposed_for_platform(platform),
+                "main",
+                "main"
+            ));
+            assert!(!is_webview_exposed(
+                child_webviews_are_exposed_for_platform(platform),
+                "child",
+                "main"
+            ));
+        }
+    }
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
-        assert!(!child_webviews_are_exposed());
+    #[test]
+    fn macos_exposes_all_webviews() {
+        assert!(is_webview_exposed(
+            child_webviews_are_exposed_for_platform("macos"),
+            "main",
+            "main"
+        ));
+        assert!(is_webview_exposed(
+            child_webviews_are_exposed_for_platform("macos"),
+            "child",
+            "main"
+        ));
     }
 }

--- a/packages/tauri-plugin-webdriver/src/webdriver/session.rs
+++ b/packages/tauri-plugin-webdriver/src/webdriver/session.rs
@@ -55,6 +55,8 @@ pub struct Session {
     pub current_window: String,
     /// Current frame context (stack of frame selectors)
     pub frame_context: Vec<FrameId>,
+    /// Increments whenever the selected top-level browsing context changes
+    pub browsing_context_generation: u64,
     /// Action state tracking for pressed keys/buttons
     pub action_state: ActionState,
 }
@@ -67,8 +69,27 @@ impl Session {
             elements: ElementStore::new(),
             current_window: initial_window,
             frame_context: Vec::new(),
+            browsing_context_generation: 0,
             action_state: ActionState::default(),
         }
+    }
+
+    pub fn switch_to_window(&mut self, window: String) {
+        self.current_window = window;
+        self.frame_context.clear();
+        self.browsing_context_generation = self
+            .browsing_context_generation
+            .checked_add(1)
+            .expect("browsing context generation overflowed");
+    }
+
+    pub fn append_frame_context_if_current(&mut self, generation: u64, frame_id: FrameId) -> bool {
+        if self.browsing_context_generation != generation {
+            return false;
+        }
+
+        self.frame_context.push(frame_id);
+        true
     }
 }
 
@@ -110,5 +131,34 @@ impl SessionManager {
     /// Delete a session
     pub fn delete(&mut self, id: &str) -> bool {
         self.sessions.remove(id).is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FrameId, Session};
+
+    #[test]
+    fn appends_a_validated_frame_when_the_browsing_context_is_unchanged() {
+        let mut session = Session::new("child-left".to_string());
+        let generation = session.browsing_context_generation;
+
+        assert!(session.append_frame_context_if_current(generation, FrameId::Index(0)));
+        assert!(matches!(
+            session.frame_context.as_slice(),
+            [FrameId::Index(0)]
+        ));
+    }
+
+    #[test]
+    fn rejects_a_validated_frame_after_switching_away_and_back_to_the_same_window() {
+        let mut session = Session::new("child-left".to_string());
+        let generation = session.browsing_context_generation;
+
+        session.switch_to_window("child-right".to_string());
+        session.switch_to_window("child-left".to_string());
+
+        assert!(!session.append_frame_context_if_current(generation, FrameId::Index(0)));
+        assert!(session.frame_context.is_empty());
     }
 }

--- a/packages/tauri-plugin-webdriver/src/webdriver/session.rs
+++ b/packages/tauri-plugin-webdriver/src/webdriver/session.rs
@@ -61,6 +61,11 @@ pub struct Session {
     pub action_state: ActionState,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum SwitchWindowError {
+    BrowsingContextGenerationOverflow,
+}
+
 impl Session {
     pub fn new(initial_window: String) -> Self {
         Self {
@@ -74,13 +79,17 @@ impl Session {
         }
     }
 
-    pub fn switch_to_window(&mut self, window: String) {
-        self.current_window = window;
-        self.frame_context.clear();
-        self.browsing_context_generation = self
+    pub fn switch_to_window(&mut self, window: String) -> Result<(), SwitchWindowError> {
+        let browsing_context_generation = self
             .browsing_context_generation
             .checked_add(1)
-            .expect("browsing context generation overflowed");
+            .ok_or(SwitchWindowError::BrowsingContextGenerationOverflow)?;
+
+        self.current_window = window;
+        self.frame_context.clear();
+        self.browsing_context_generation = browsing_context_generation;
+
+        Ok(())
     }
 
     pub fn append_frame_context_if_current(&mut self, generation: u64, frame_id: FrameId) -> bool {
@@ -136,7 +145,7 @@ impl SessionManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{FrameId, Session};
+    use super::{FrameId, Session, SwitchWindowError};
 
     #[test]
     fn appends_a_validated_frame_when_the_browsing_context_is_unchanged() {
@@ -155,10 +164,42 @@ mod tests {
         let mut session = Session::new("child-left".to_string());
         let generation = session.browsing_context_generation;
 
-        session.switch_to_window("child-right".to_string());
-        session.switch_to_window("child-left".to_string());
+        session.switch_to_window("child-right".to_string()).unwrap();
+        session.switch_to_window("child-left".to_string()).unwrap();
 
         assert!(!session.append_frame_context_if_current(generation, FrameId::Index(0)));
         assert!(session.frame_context.is_empty());
+    }
+
+    #[test]
+    fn switching_windows_updates_context_and_generation_together() {
+        let mut session = Session::new("child-left".to_string());
+        session.frame_context.push(FrameId::Index(0));
+
+        assert_eq!(session.switch_to_window("child-right".to_string()), Ok(()));
+
+        assert_eq!(session.current_window, "child-right");
+        assert!(session.frame_context.is_empty());
+        assert_eq!(session.browsing_context_generation, 1);
+    }
+
+    #[test]
+    fn switching_windows_at_max_generation_leaves_session_unchanged() {
+        let mut session = Session::new("child-left".to_string());
+        session.frame_context.push(FrameId::Index(0));
+        session.browsing_context_generation = u64::MAX;
+
+        let result = session.switch_to_window("child-right".to_string());
+
+        assert_eq!(
+            result,
+            Err(SwitchWindowError::BrowsingContextGenerationOverflow)
+        );
+        assert_eq!(session.current_window, "child-left");
+        assert!(matches!(
+            session.frame_context.as_slice(),
+            [FrameId::Index(0)]
+        ));
+        assert_eq!(session.browsing_context_generation, u64::MAX);
     }
 }

--- a/packages/tauri-plugin-webdriver/src/webdriver/session.rs
+++ b/packages/tauri-plugin-webdriver/src/webdriver/session.rs
@@ -91,15 +91,6 @@ impl Session {
 
         Ok(())
     }
-
-    pub fn append_frame_context_if_current(&mut self, generation: u64, frame_id: FrameId) -> bool {
-        if self.browsing_context_generation != generation {
-            return false;
-        }
-
-        self.frame_context.push(frame_id);
-        true
-    }
 }
 
 /// Manages `WebDriver` sessions
@@ -146,30 +137,6 @@ impl SessionManager {
 #[cfg(test)]
 mod tests {
     use super::{FrameId, Session, SwitchWindowError};
-
-    #[test]
-    fn appends_a_validated_frame_when_the_browsing_context_is_unchanged() {
-        let mut session = Session::new("child-left".to_string());
-        let generation = session.browsing_context_generation;
-
-        assert!(session.append_frame_context_if_current(generation, FrameId::Index(0)));
-        assert!(matches!(
-            session.frame_context.as_slice(),
-            [FrameId::Index(0)]
-        ));
-    }
-
-    #[test]
-    fn rejects_a_validated_frame_after_switching_away_and_back_to_the_same_window() {
-        let mut session = Session::new("child-left".to_string());
-        let generation = session.browsing_context_generation;
-
-        session.switch_to_window("child-right".to_string()).unwrap();
-        session.switch_to_window("child-left".to_string()).unwrap();
-
-        assert!(!session.append_frame_context_if_current(generation, FrameId::Index(0)));
-        assert!(session.frame_context.is_empty());
-    }
 
     #[test]
     fn switching_windows_updates_context_and_generation_together() {

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -113,6 +113,9 @@ export default class TauriWorkerService {
           this.addTauriApi(mrInstance);
           this.patchBrowserExecute(mrInstance);
           setCurrentWindowLabel(mrInstance, this.windowLabel);
+          if (this.windowLabel !== getDefaultWindowLabel()) {
+            suppressActiveWindowFocus(mrInstance);
+          }
           setSessionProvider(mrInstance, this.driverProvider ?? 'embedded');
           stage = `waitUntilWindowAvailable:${instanceName}`;
           await waitUntilWindowAvailable(mrInstance);
@@ -145,6 +148,9 @@ export default class TauriWorkerService {
         this.addTauriApi(browser as WebdriverIO.Browser);
         this.patchBrowserExecute(browser as WebdriverIO.Browser);
         setCurrentWindowLabel(browser as WebdriverIO.Browser, this.windowLabel);
+        if (this.windowLabel !== getDefaultWindowLabel()) {
+          suppressActiveWindowFocus(browser as WebdriverIO.Browser);
+        }
         setSessionProvider(browser as WebdriverIO.Browser, this.driverProvider ?? 'embedded');
         stage = 'waitUntilWindowAvailable:single';
         await waitUntilWindowAvailable(browser as WebdriverIO.Browser);

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -47,6 +47,7 @@ export default class TauriWorkerService {
   private windowLabel: string;
   private mode?: string;
   private devServerUrl?: string;
+  private pendingExternalWindowSwitches = new Map<string, string>();
 
   constructor(options: TauriServiceOptions & TauriServiceGlobalOptions, capabilities: TauriCapabilities) {
     // Options may be supplied service-level (services: [['tauri', {...}]]) or capability-level
@@ -227,7 +228,7 @@ export default class TauriWorkerService {
     }
   }
 
-  async beforeCommand(commandName: string, _args: unknown[]): Promise<void> {
+  async beforeCommand(commandName: string, args: unknown[]): Promise<void> {
     if (!this.browser || this.browser.isMultiremote) {
       return;
     }
@@ -236,7 +237,10 @@ export default class TauriWorkerService {
 
     if (commandName === 'switchToWindow') {
       if (!isInternalWindowSwitch(browser)) {
-        suppressActiveWindowFocus(browser);
+        const handle = args[0];
+        if (typeof handle === 'string') {
+          this.pendingExternalWindowSwitches.set(browser.sessionId || 'default', handle);
+        }
       }
       return;
     }
@@ -246,6 +250,29 @@ export default class TauriWorkerService {
       await ensureActiveWindowFocus(browser, commandName);
     } catch (error) {
       log.warn('Failed to ensure window focus before command:', error);
+    }
+  }
+
+  async afterCommand(commandName: string, _args: unknown[], _result: unknown, error?: Error): Promise<void> {
+    if (commandName !== 'switchToWindow' || !this.browser || this.browser.isMultiremote) {
+      return;
+    }
+
+    const browser = this.browser as WebdriverIO.Browser;
+    const sessionKey = browser.sessionId || 'default';
+    const handle = this.pendingExternalWindowSwitches.get(sessionKey);
+    if (!handle) {
+      return;
+    }
+
+    this.pendingExternalWindowSwitches.delete(sessionKey);
+    if (error) {
+      return;
+    }
+
+    suppressActiveWindowFocus(browser);
+    if ((this.driverProvider ?? 'embedded') === 'embedded') {
+      setCurrentWindowLabel(browser, handle);
     }
   }
 
@@ -290,6 +317,7 @@ export default class TauriWorkerService {
 
     if (!this.browser) {
       log.warn('No browser instance available for session cleanup');
+      this.pendingExternalWindowSwitches.clear();
       clearWindowState();
       return;
     }
@@ -298,6 +326,7 @@ export default class TauriWorkerService {
       // Delete WebDriver session explicitly for clean retry handling
       if (!this.browser.isMultiremote) {
         const stdBrowser = this.browser as WebdriverIO.Browser;
+        this.pendingExternalWindowSwitches.delete(stdBrowser.sessionId || 'default');
         clearWindowState(stdBrowser.sessionId);
         if (stdBrowser.sessionId) {
           log.debug(`Deleting session: ${stdBrowser.sessionId}`);
@@ -323,6 +352,7 @@ export default class TauriWorkerService {
         }
         // Clear all session IDs from cache
         for (const sid of sessionIds) {
+          this.pendingExternalWindowSwitches.delete(sid || 'default');
           clearWindowState(sid);
         }
       }

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -262,6 +262,10 @@ export default class TauriWorkerService {
     }
 
     const browser = this.browser as WebdriverIO.Browser;
+    if (isInternalWindowSwitch(browser)) {
+      return;
+    }
+
     const sessionKey = browser.sessionId || 'default';
     const handle = args[0];
     if (typeof handle !== 'string') {

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -234,8 +234,10 @@ export default class TauriWorkerService {
 
     const browser = this.browser as WebdriverIO.Browser;
 
-    if (commandName === 'switchToWindow' && !isInternalWindowSwitch(browser)) {
-      suppressActiveWindowFocus(browser);
+    if (commandName === 'switchToWindow') {
+      if (!isInternalWindowSwitch(browser)) {
+        suppressActiveWindowFocus(browser);
+      }
       return;
     }
 

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -47,7 +47,7 @@ export default class TauriWorkerService {
   private windowLabel: string;
   private mode?: string;
   private devServerUrl?: string;
-  private pendingExternalWindowSwitches = new Map<string, string>();
+  private pendingExternalWindowSwitches = new Map<string, Map<string, number>>();
 
   constructor(options: TauriServiceOptions & TauriServiceGlobalOptions, capabilities: TauriCapabilities) {
     // Options may be supplied service-level (services: [['tauri', {...}]]) or capability-level
@@ -239,7 +239,10 @@ export default class TauriWorkerService {
       if (!isInternalWindowSwitch(browser)) {
         const handle = args[0];
         if (typeof handle === 'string') {
-          this.pendingExternalWindowSwitches.set(browser.sessionId || 'default', handle);
+          const sessionKey = browser.sessionId || 'default';
+          const pendingByHandle = this.pendingExternalWindowSwitches.get(sessionKey) ?? new Map<string, number>();
+          pendingByHandle.set(handle, (pendingByHandle.get(handle) ?? 0) + 1);
+          this.pendingExternalWindowSwitches.set(sessionKey, pendingByHandle);
         }
       }
       return;
@@ -253,19 +256,33 @@ export default class TauriWorkerService {
     }
   }
 
-  async afterCommand(commandName: string, _args: unknown[], _result: unknown, error?: Error): Promise<void> {
+  async afterCommand(commandName: string, args: unknown[], _result: unknown, error?: Error): Promise<void> {
     if (commandName !== 'switchToWindow' || !this.browser || this.browser.isMultiremote) {
       return;
     }
 
     const browser = this.browser as WebdriverIO.Browser;
     const sessionKey = browser.sessionId || 'default';
-    const handle = this.pendingExternalWindowSwitches.get(sessionKey);
-    if (!handle) {
+    const handle = args[0];
+    if (typeof handle !== 'string') {
       return;
     }
 
-    this.pendingExternalWindowSwitches.delete(sessionKey);
+    const pendingByHandle = this.pendingExternalWindowSwitches.get(sessionKey);
+    const pendingCount = pendingByHandle?.get(handle) ?? 0;
+    if (pendingCount === 0 || !pendingByHandle) {
+      return;
+    }
+
+    if (pendingCount === 1) {
+      pendingByHandle.delete(handle);
+      if (pendingByHandle.size === 0) {
+        this.pendingExternalWindowSwitches.delete(sessionKey);
+      }
+    } else {
+      pendingByHandle.set(handle, pendingCount - 1);
+    }
+
     if (error) {
       return;
     }

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -20,6 +20,7 @@ import {
   listWindowLabels,
   setCurrentWindowLabel,
   setSessionProvider,
+  suppressActiveWindowFocus,
   switchWindowByLabel,
 } from './window.js';
 
@@ -231,6 +232,11 @@ export default class TauriWorkerService {
     }
 
     const browser = this.browser as WebdriverIO.Browser;
+
+    if (commandName === 'switchToWindow') {
+      suppressActiveWindowFocus(browser);
+      return;
+    }
 
     try {
       // Generic window focus detection like Electron - no app-specific knowledge

--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -17,6 +17,7 @@ import {
   clearWindowState,
   ensureActiveWindowFocus,
   getDefaultWindowLabel,
+  isInternalWindowSwitch,
   listWindowLabels,
   setCurrentWindowLabel,
   setSessionProvider,
@@ -233,7 +234,7 @@ export default class TauriWorkerService {
 
     const browser = this.browser as WebdriverIO.Browser;
 
-    if (commandName === 'switchToWindow') {
+    if (commandName === 'switchToWindow' && !isInternalWindowSwitch(browser)) {
       suppressActiveWindowFocus(browser);
       return;
     }

--- a/packages/tauri-service/src/window.ts
+++ b/packages/tauri-service/src/window.ts
@@ -17,6 +17,8 @@ const currentWindowLabelCache = new Map<string, string>();
 
 const userSwitchedWindowCache = new Set<string>();
 
+const internalWindowSwitchDepthCache = new Map<string, number>();
+
 const sessionProviderCache = new Map<string, DriverProvider>();
 
 const DEFAULT_WINDOW_LABEL = 'main';
@@ -36,6 +38,29 @@ export function setCurrentWindowLabel(browser: WebdriverIO.Browser, label: strin
 
 export function suppressActiveWindowFocus(browser: WebdriverIO.Browser): void {
   userSwitchedWindowCache.add(browser.sessionId || 'default');
+}
+
+export function isInternalWindowSwitch(browser: WebdriverIO.Browser): boolean {
+  return (internalWindowSwitchDepthCache.get(browser.sessionId || 'default') ?? 0) > 0;
+}
+
+export async function withInternalWindowSwitch<T>(
+  browser: WebdriverIO.Browser,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const sessionKey = browser.sessionId || 'default';
+  const depth = internalWindowSwitchDepthCache.get(sessionKey) ?? 0;
+  internalWindowSwitchDepthCache.set(sessionKey, depth + 1);
+  try {
+    return await operation();
+  } finally {
+    const nextDepth = (internalWindowSwitchDepthCache.get(sessionKey) ?? 1) - 1;
+    if (nextDepth === 0) {
+      internalWindowSwitchDepthCache.delete(sessionKey);
+    } else {
+      internalWindowSwitchDepthCache.set(sessionKey, nextDepth);
+    }
+  }
 }
 
 export function setSessionProvider(browser: WebdriverIO.Browser, provider: DriverProvider): void {
@@ -289,7 +314,7 @@ export async function ensureActiveWindowFocus(browser: WebdriverIO.Browser, comm
 
     // Switch to the active window
     log.debug(`[SERVICE] Switching to active window: ${activeWindow.title}`);
-    const switched = await switchToWindowByTitle(browser, activeWindow.title);
+    const switched = await withInternalWindowSwitch(browser, () => switchToWindowByTitle(browser, activeWindow.title));
 
     if (switched) {
       log.debug(`[SERVICE] Successfully switched to active window`);
@@ -317,11 +342,13 @@ export function clearWindowState(sessionId?: string): void {
     lastCommandCache.delete(sessionId);
     currentWindowLabelCache.delete(sessionId);
     userSwitchedWindowCache.delete(sessionId);
+    internalWindowSwitchDepthCache.delete(sessionId);
     sessionProviderCache.delete(sessionId);
   } else {
     lastCommandCache.clear();
     currentWindowLabelCache.clear();
     userSwitchedWindowCache.clear();
+    internalWindowSwitchDepthCache.clear();
     sessionProviderCache.clear();
   }
 }

--- a/packages/tauri-service/src/window.ts
+++ b/packages/tauri-service/src/window.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createLogger } from '@wdio/native-utils';
 import { clearPluginAvailabilityCache } from './pluginCache.js';
 import type { DriverProvider } from './types.js';
@@ -17,7 +18,7 @@ const currentWindowLabelCache = new Map<string, string>();
 
 const userSwitchedWindowCache = new Set<string>();
 
-const internalWindowSwitchDepthCache = new Map<string, number>();
+const internalWindowSwitchContext = new AsyncLocalStorage<string>();
 
 const sessionProviderCache = new Map<string, DriverProvider>();
 
@@ -41,7 +42,7 @@ export function suppressActiveWindowFocus(browser: WebdriverIO.Browser): void {
 }
 
 export function isInternalWindowSwitch(browser: WebdriverIO.Browser): boolean {
-  return (internalWindowSwitchDepthCache.get(browser.sessionId || 'default') ?? 0) > 0;
+  return internalWindowSwitchContext.getStore() === (browser.sessionId || 'default');
 }
 
 export async function withInternalWindowSwitch<T>(
@@ -49,18 +50,7 @@ export async function withInternalWindowSwitch<T>(
   operation: () => Promise<T>,
 ): Promise<T> {
   const sessionKey = browser.sessionId || 'default';
-  const depth = internalWindowSwitchDepthCache.get(sessionKey) ?? 0;
-  internalWindowSwitchDepthCache.set(sessionKey, depth + 1);
-  try {
-    return await operation();
-  } finally {
-    const nextDepth = (internalWindowSwitchDepthCache.get(sessionKey) ?? 1) - 1;
-    if (nextDepth === 0) {
-      internalWindowSwitchDepthCache.delete(sessionKey);
-    } else {
-      internalWindowSwitchDepthCache.set(sessionKey, nextDepth);
-    }
-  }
+  return internalWindowSwitchContext.run(sessionKey, operation);
 }
 
 export function setSessionProvider(browser: WebdriverIO.Browser, provider: DriverProvider): void {
@@ -342,13 +332,11 @@ export function clearWindowState(sessionId?: string): void {
     lastCommandCache.delete(sessionId);
     currentWindowLabelCache.delete(sessionId);
     userSwitchedWindowCache.delete(sessionId);
-    internalWindowSwitchDepthCache.delete(sessionId);
     sessionProviderCache.delete(sessionId);
   } else {
     lastCommandCache.clear();
     currentWindowLabelCache.clear();
     userSwitchedWindowCache.clear();
-    internalWindowSwitchDepthCache.clear();
     sessionProviderCache.clear();
   }
 }

--- a/packages/tauri-service/src/window.ts
+++ b/packages/tauri-service/src/window.ts
@@ -34,6 +34,10 @@ export function setCurrentWindowLabel(browser: WebdriverIO.Browser, label: strin
   log.debug(`Current window label set to: ${label}`);
 }
 
+export function suppressActiveWindowFocus(browser: WebdriverIO.Browser): void {
+  userSwitchedWindowCache.add(browser.sessionId || 'default');
+}
+
 export function setSessionProvider(browser: WebdriverIO.Browser, provider: DriverProvider): void {
   sessionProviderCache.set(browser.sessionId || 'default', provider);
   log.debug(`Session provider set to: ${provider}`);
@@ -93,7 +97,7 @@ export async function switchWindowByLabel(browser: WebdriverIO.Browser, label: s
 
   // Suppress auto-focus BEFORE any switching or iteration to prevent focus-change races
   // during handle discovery (ensureActiveWindowFocus checks this flag first).
-  userSwitchedWindowCache.add(sessionKey);
+  suppressActiveWindowFocus(browser);
 
   try {
     const originalHandle = await browser.getWindowHandle();

--- a/packages/tauri-service/test/commands/execute.spec.ts
+++ b/packages/tauri-service/test/commands/execute.spec.ts
@@ -11,7 +11,8 @@ import {
   getTauriVersion,
   isTauriApiAvailable,
 } from '../../src/commands/execute.js';
-import { clearWindowState, setSessionProvider } from '../../src/window.js';
+import TauriWorkerService from '../../src/service.js';
+import { clearWindowState, getCurrentWindowLabel, setSessionProvider } from '../../src/window.js';
 
 vi.mock('@wdio/native-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@wdio/native-utils')>();
@@ -134,6 +135,22 @@ describe('execute — embedded provider (direct eval)', () => {
       await execute(browser, '() => 1');
       const body = JSON.parse(mockFn.mock.calls[0][1].body as string) as Record<string, unknown>;
       expect(body.window_label).toBeUndefined();
+    });
+
+    it('should route direct eval to a successful external embedded switch', async () => {
+      const mockFn = mockFetch({ value: 'child-left' });
+      vi.stubGlobal('fetch', mockFn);
+      Object.assign(browser, { isMultiremote: false, sessionId: 'external-switch-session' });
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = browser;
+
+      await service.beforeCommand('switchToWindow', ['child-left']);
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+
+      expect(getCurrentWindowLabel(browser)).toBe('child-left');
+      await execute(browser, () => (globalThis as unknown as { __childWebviewLabel: string }).__childWebviewLabel);
+      const body = JSON.parse(mockFn.mock.calls[0][1].body as string) as Record<string, unknown>;
+      expect(body.window_label).toBe('child-left');
     });
   });
 

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -43,6 +43,7 @@ vi.mock('../src/window.js', () => ({
   listWindowLabels: vi.fn().mockResolvedValue(['main']),
   setCurrentWindowLabel: vi.fn(),
   setSessionProvider: vi.fn(),
+  suppressActiveWindowFocus: vi.fn(),
   switchWindowByLabel: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -51,7 +52,12 @@ import { execute as executeCommand } from '../src/commands/execute.js';
 import { clearAllMocks, resetAllMocks, restoreAllMocks } from '../src/commands/mock.js';
 import mockStore from '../src/mockStore.js';
 import TauriWorkerService from '../src/service.js';
-import { clearWindowState, ensureActiveWindowFocus, setCurrentWindowLabel } from '../src/window.js';
+import {
+  clearWindowState,
+  ensureActiveWindowFocus,
+  setCurrentWindowLabel,
+  suppressActiveWindowFocus,
+} from '../src/window.js';
 
 function createMockBrowser(overrides: Record<string, unknown> = {}): WebdriverIO.Browser {
   return {
@@ -913,6 +919,16 @@ describe('TauriWorkerService', () => {
       await service.beforeCommand('getTitle', []);
 
       expect(ensureActiveWindowFocus).toHaveBeenCalledWith(mockBrowser, 'getTitle');
+    });
+
+    it('should suppress auto-focus for a raw WebDriver window switch', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['child-left']);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
     });
 
     it('should return early when browser is multiremote', async () => {

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -923,14 +923,14 @@ describe('TauriWorkerService', () => {
       expect(ensureActiveWindowFocus).toHaveBeenCalledWith(mockBrowser, 'getTitle');
     });
 
-    it('should suppress auto-focus for a raw WebDriver window switch', async () => {
+    it('should defer auto-focus suppression for a raw WebDriver window switch', async () => {
       const mockBrowser = createMockBrowser();
       const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
       (service as any).browser = mockBrowser;
 
       await service.beforeCommand('switchToWindow', ['child-left']);
 
-      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
     });
 
     it('should not suppress auto-focus for an internal focus-recovery window switch', async () => {
@@ -940,9 +940,81 @@ describe('TauriWorkerService', () => {
       vi.mocked(isInternalWindowSwitch).mockReturnValueOnce(true);
 
       await service.beforeCommand('switchToWindow', ['main']);
+      await service.afterCommand('switchToWindow', ['main'], undefined);
 
       expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+      expect(setCurrentWindowLabel).not.toHaveBeenCalled();
       expect(ensureActiveWindowFocus).not.toHaveBeenCalled();
+    });
+
+    it('should commit an embedded raw window switch only after it succeeds', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['child-left']);
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+      expect(setCurrentWindowLabel).not.toHaveBeenCalled();
+
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
+      expect(setCurrentWindowLabel).toHaveBeenCalledWith(mockBrowser, 'child-left');
+    });
+
+    it('should treat the default provider as embedded after a successful raw switch', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['child-right']);
+      await service.afterCommand('switchToWindow', ['child-right'], undefined);
+
+      expect(setCurrentWindowLabel).toHaveBeenCalledWith(mockBrowser, 'child-right');
+    });
+
+    it('should discard a failed raw window switch without changing focus or label state', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['missing-child']);
+      await service.afterCommand('switchToWindow', ['missing-child'], undefined, new Error('no such window'));
+
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+      expect(setCurrentWindowLabel).not.toHaveBeenCalled();
+    });
+
+    it('should suppress successful non-embedded switches without treating opaque handles as labels', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'official' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['opaque-webdriver-handle']);
+      await service.afterCommand('switchToWindow', ['opaque-webdriver-handle'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
+      expect(setCurrentWindowLabel).not.toHaveBeenCalled();
+    });
+
+    it('should keep pending external switches isolated by session', async () => {
+      const firstBrowser = createMockBrowser({ sessionId: 'session-one' });
+      const secondBrowser = createMockBrowser({ sessionId: 'session-two' });
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+
+      (service as any).browser = firstBrowser;
+      await service.beforeCommand('switchToWindow', ['child-left']);
+
+      (service as any).browser = secondBrowser;
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+
+      (service as any).browser = firstBrowser;
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledTimes(1);
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(firstBrowser);
+      expect(setCurrentWindowLabel).toHaveBeenCalledWith(firstBrowser, 'child-left');
     });
 
     it('should return early when browser is multiremote', async () => {
@@ -1002,6 +1074,19 @@ describe('TauriWorkerService', () => {
       await service.afterSession({}, {} as any, []);
 
       expect(clearWindowState).toHaveBeenCalledWith('sess-abc');
+    });
+
+    it('should clear a pending external window switch for the completed session', async () => {
+      const mockBrowser = createMockBrowser({ sessionId: 'pending-session' });
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+      await service.beforeCommand('switchToWindow', ['child-left']);
+
+      await service.afterSession({}, {} as any, []);
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+      expect(setCurrentWindowLabel).not.toHaveBeenCalled();
     });
 
     it('should handle gracefully when no browser exists', async () => {

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -942,6 +942,7 @@ describe('TauriWorkerService', () => {
       await service.beforeCommand('switchToWindow', ['main']);
 
       expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+      expect(ensureActiveWindowFocus).not.toHaveBeenCalled();
     });
 
     it('should return early when browser is multiremote', async () => {

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -40,6 +40,7 @@ vi.mock('../src/window.js', () => ({
   clearWindowState: vi.fn(),
   ensureActiveWindowFocus: vi.fn().mockResolvedValue(undefined),
   getDefaultWindowLabel: vi.fn().mockReturnValue('main'),
+  isInternalWindowSwitch: vi.fn().mockReturnValue(false),
   listWindowLabels: vi.fn().mockResolvedValue(['main']),
   setCurrentWindowLabel: vi.fn(),
   setSessionProvider: vi.fn(),
@@ -55,6 +56,7 @@ import TauriWorkerService from '../src/service.js';
 import {
   clearWindowState,
   ensureActiveWindowFocus,
+  isInternalWindowSwitch,
   setCurrentWindowLabel,
   suppressActiveWindowFocus,
 } from '../src/window.js';
@@ -929,6 +931,17 @@ describe('TauriWorkerService', () => {
       await service.beforeCommand('switchToWindow', ['child-left']);
 
       expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
+    });
+
+    it('should not suppress auto-focus for an internal focus-recovery window switch', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+      vi.mocked(isInternalWindowSwitch).mockReturnValueOnce(true);
+
+      await service.beforeCommand('switchToWindow', ['main']);
+
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
     });
 
     it('should return early when browser is multiremote', async () => {

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -259,6 +259,31 @@ describe('TauriWorkerService', () => {
       expect(setCurrentWindowLabel).toHaveBeenCalledWith(mockBrowser, 'settings');
     });
 
+    it('should suppress focus recovery for an explicitly configured initial child label', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ windowLabel: 'child-left' }, { 'wdio:tauriServiceOptions': {} });
+
+      await service.before({} as any, [], mockBrowser);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
+    });
+
+    it('should suppress focus recovery for every multiremote instance with an initial child label', async () => {
+      const firstBrowser = createMockBrowser({ sessionId: 'first-child-session' });
+      const secondBrowser = createMockBrowser({ sessionId: 'second-child-session' });
+      const multiremoteBrowser = createMockBrowser({
+        isMultiremote: true,
+        instances: ['first', 'second'],
+        getInstance: vi.fn((name: string) => (name === 'first' ? firstBrowser : secondBrowser)),
+      }) as unknown as WebdriverIO.MultiRemoteBrowser;
+      const service = new TauriWorkerService({ windowLabel: 'child-left' }, { 'wdio:tauriServiceOptions': {} });
+
+      await service.before({} as any, [], multiremoteBrowser);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(firstBrowser);
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(secondBrowser);
+    });
+
     it('should default window label to main when not configured', async () => {
       const mockBrowser = createMockBrowser();
       const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
@@ -266,6 +291,7 @@ describe('TauriWorkerService', () => {
       await service.before({} as any, [], mockBrowser);
 
       expect(setCurrentWindowLabel).toHaveBeenCalledWith(mockBrowser, 'main');
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
     });
 
     it('should call patchBrowserExecute for standard browser', async () => {

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -997,6 +997,73 @@ describe('TauriWorkerService', () => {
       expect(setCurrentWindowLabel).not.toHaveBeenCalled();
     });
 
+    it('should commit each concurrent same-session switch only when its matching command succeeds', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['child-left']);
+      await service.beforeCommand('switchToWindow', ['child-right']);
+
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+      await service.afterCommand('switchToWindow', ['child-right'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledTimes(2);
+      expect(setCurrentWindowLabel).toHaveBeenCalledTimes(2);
+      expect(setCurrentWindowLabel).toHaveBeenNthCalledWith(1, mockBrowser, 'child-left');
+      expect(setCurrentWindowLabel).toHaveBeenNthCalledWith(2, mockBrowser, 'child-right');
+    });
+
+    it('should discard only the failed matching switch and preserve other pending switches', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['child-left']);
+      await service.beforeCommand('switchToWindow', ['child-right']);
+      await service.afterCommand('switchToWindow', ['child-left'], undefined, new Error('no such window'));
+      await service.afterCommand('switchToWindow', ['child-right'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledTimes(1);
+      expect(setCurrentWindowLabel).toHaveBeenCalledOnce();
+      expect(setCurrentWindowLabel).toHaveBeenCalledWith(mockBrowser, 'child-right');
+    });
+
+    it('should not consume a pending switch for an unknown afterCommand handle', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['child-left']);
+      await service.afterCommand('switchToWindow', ['unknown-child'], undefined);
+
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+      expect(setCurrentWindowLabel).not.toHaveBeenCalled();
+
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledOnce();
+      expect(setCurrentWindowLabel).toHaveBeenCalledWith(mockBrowser, 'child-left');
+    });
+
+    it('should retain a count for concurrent switches to the same handle', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['child-left']);
+      await service.beforeCommand('switchToWindow', ['child-left']);
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+      await service.afterCommand('switchToWindow', ['child-left'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledTimes(2);
+      expect(setCurrentWindowLabel).toHaveBeenCalledTimes(2);
+      expect(setCurrentWindowLabel).toHaveBeenNthCalledWith(1, mockBrowser, 'child-left');
+      expect(setCurrentWindowLabel).toHaveBeenNthCalledWith(2, mockBrowser, 'child-left');
+    });
+
     it('should keep pending external switches isolated by session', async () => {
       const firstBrowser = createMockBrowser({ sessionId: 'session-one' });
       const secondBrowser = createMockBrowser({ sessionId: 'session-two' });

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -36,17 +36,20 @@ vi.mock('../src/commands/execute.js', () => ({
   execute: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../src/window.js', () => ({
-  clearWindowState: vi.fn(),
-  ensureActiveWindowFocus: vi.fn().mockResolvedValue(undefined),
-  getDefaultWindowLabel: vi.fn().mockReturnValue('main'),
-  isInternalWindowSwitch: vi.fn().mockReturnValue(false),
-  listWindowLabels: vi.fn().mockResolvedValue(['main']),
-  setCurrentWindowLabel: vi.fn(),
-  setSessionProvider: vi.fn(),
-  suppressActiveWindowFocus: vi.fn(),
-  switchWindowByLabel: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('../src/window.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/window.js')>();
+  return {
+    ...actual,
+    clearWindowState: vi.fn(),
+    ensureActiveWindowFocus: vi.fn().mockResolvedValue(undefined),
+    getDefaultWindowLabel: vi.fn().mockReturnValue('main'),
+    listWindowLabels: vi.fn().mockResolvedValue(['main']),
+    setCurrentWindowLabel: vi.fn(),
+    setSessionProvider: vi.fn(),
+    suppressActiveWindowFocus: vi.fn(),
+    switchWindowByLabel: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 import { waitUntilWindowAvailable } from '@wdio/native-utils';
 import { execute as executeCommand } from '../src/commands/execute.js';
@@ -56,9 +59,9 @@ import TauriWorkerService from '../src/service.js';
 import {
   clearWindowState,
   ensureActiveWindowFocus,
-  isInternalWindowSwitch,
   setCurrentWindowLabel,
   suppressActiveWindowFocus,
+  withInternalWindowSwitch,
 } from '../src/window.js';
 
 function createMockBrowser(overrides: Record<string, unknown> = {}): WebdriverIO.Browser {
@@ -937,14 +940,42 @@ describe('TauriWorkerService', () => {
       const mockBrowser = createMockBrowser();
       const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
       (service as any).browser = mockBrowser;
-      vi.mocked(isInternalWindowSwitch).mockReturnValueOnce(true);
 
-      await service.beforeCommand('switchToWindow', ['main']);
-      await service.afterCommand('switchToWindow', ['main'], undefined);
+      await withInternalWindowSwitch(mockBrowser, async () => {
+        await service.beforeCommand('switchToWindow', ['main']);
+        await service.afterCommand('switchToWindow', ['main'], undefined);
+      });
 
       expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
       expect(setCurrentWindowLabel).not.toHaveBeenCalled();
       expect(ensureActiveWindowFocus).not.toHaveBeenCalled();
+    });
+
+    it('should commit an external matching switch that starts during internal focus recovery', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({ driverProvider: 'embedded' }, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      let releaseExternalBefore: () => void;
+      const externalBefore = new Promise<void>((resolve) => {
+        releaseExternalBefore = resolve;
+      }).then(() => service.beforeCommand('switchToWindow', ['main']));
+
+      await withInternalWindowSwitch(mockBrowser, async () => {
+        releaseExternalBefore();
+        await externalBefore;
+
+        await service.beforeCommand('switchToWindow', ['main']);
+        await service.afterCommand('switchToWindow', ['main'], undefined);
+
+        expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+        expect(setCurrentWindowLabel).not.toHaveBeenCalled();
+      });
+
+      await service.afterCommand('switchToWindow', ['main'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
+      expect(setCurrentWindowLabel).toHaveBeenCalledWith(mockBrowser, 'main');
     });
 
     it('should commit an embedded raw window switch only after it succeeds', async () => {

--- a/packages/tauri-service/test/window.spec.ts
+++ b/packages/tauri-service/test/window.spec.ts
@@ -8,12 +8,14 @@ import {
   getCurrentWindowLabel,
   getDefaultWindowLabel,
   getLastCommand,
+  isInternalWindowSwitch,
   listWindowLabels,
   setCurrentWindowLabel,
   setSessionProvider,
   suppressActiveWindowFocus,
   switchWindowByLabel,
   updateLastCommand,
+  withInternalWindowSwitch,
 } from '../src/window.js';
 
 describe('window management', () => {
@@ -423,6 +425,59 @@ describe('window management', () => {
 
       expect(getLastCommand(browser1)).toBeUndefined();
       expect(getLastCommand(browser2)).toBeUndefined();
+    });
+  });
+
+  describe('internal window switches', () => {
+    it('should expose internal state only while the callback is running', async () => {
+      const mockBrowser = { sessionId: 'internal-success' } as unknown as WebdriverIO.Browser;
+
+      expect(isInternalWindowSwitch(mockBrowser)).toBe(false);
+      await withInternalWindowSwitch(mockBrowser, async () => {
+        expect(isInternalWindowSwitch(mockBrowser)).toBe(true);
+      });
+      expect(isInternalWindowSwitch(mockBrowser)).toBe(false);
+    });
+
+    it('should clear internal state when the callback rejects', async () => {
+      const mockBrowser = { sessionId: 'internal-failure' } as unknown as WebdriverIO.Browser;
+
+      await expect(
+        withInternalWindowSwitch(mockBrowser, async () => {
+          expect(isInternalWindowSwitch(mockBrowser)).toBe(true);
+          throw new Error('switch failed');
+        }),
+      ).rejects.toThrow('switch failed');
+      expect(isInternalWindowSwitch(mockBrowser)).toBe(false);
+    });
+
+    it('should preserve internal state across nested callbacks', async () => {
+      const mockBrowser = { sessionId: 'internal-nested' } as unknown as WebdriverIO.Browser;
+
+      await withInternalWindowSwitch(mockBrowser, async () => {
+        await withInternalWindowSwitch(mockBrowser, async () => {
+          expect(isInternalWindowSwitch(mockBrowser)).toBe(true);
+        });
+        expect(isInternalWindowSwitch(mockBrowser)).toBe(true);
+      });
+      expect(isInternalWindowSwitch(mockBrowser)).toBe(false);
+    });
+
+    it('should not suppress later focus recovery', async () => {
+      const mockBrowser = {
+        sessionId: 'internal-focus-recovery',
+        tauri: {
+          execute: vi
+            .fn()
+            .mockResolvedValueOnce([{ label: 'main', title: 'Main Window', is_visible: true, is_focused: true }]),
+        },
+        getTitle: vi.fn().mockResolvedValue('Main Window'),
+      } as unknown as WebdriverIO.Browser;
+
+      await withInternalWindowSwitch(mockBrowser, async () => undefined);
+      await ensureActiveWindowFocus(mockBrowser, 'getTitle');
+
+      expect(mockBrowser.tauri.execute).toHaveBeenCalled();
     });
   });
 

--- a/packages/tauri-service/test/window.spec.ts
+++ b/packages/tauri-service/test/window.spec.ts
@@ -11,6 +11,7 @@ import {
   listWindowLabels,
   setCurrentWindowLabel,
   setSessionProvider,
+  suppressActiveWindowFocus,
   switchWindowByLabel,
   updateLastCommand,
 } from '../src/window.js';
@@ -349,6 +350,18 @@ describe('window management', () => {
         Object.defineProperty(focusBrowser, 'sessionId', { value: 'autofocus-session' });
         await ensureActiveWindowFocus(focusBrowser, 'getTitle');
         expect(focusBrowser.tauri.execute).not.toHaveBeenCalled();
+      });
+
+      it('should suppress ensureActiveWindowFocus after a raw WebDriver window switch', async () => {
+        const mockBrowser = {
+          sessionId: 'raw-switch-session',
+          tauri: { execute: vi.fn() },
+        } as unknown as WebdriverIO.Browser;
+
+        suppressActiveWindowFocus(mockBrowser);
+        await ensureActiveWindowFocus(mockBrowser, 'getTitle');
+
+        expect(mockBrowser.tauri.execute).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Summary

- expose managed Tauri child `Webview` labels as standard WebDriver handles
- execute page commands against the selected webview while preserving shared host-window behavior
- preserve primary outer-window and child-relative rectangle semantics using public label topology
- reject `closeWindow` for child and shared-host primary webviews while retaining standalone close behavior
- preserve explicit user handle selection across automatic focus recovery
- add generic macOS embedded-provider fixture and E2E coverage for child lifecycle, frames, and session switching

## Platform scope

Runtime child-webview support is validated on macOS only. Other targets continue
to expose primary webviews while their existing executor paths remain supported.

## Verification

- `cargo clippy --manifest-path packages/tauri-plugin-webdriver/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path packages/tauri-plugin-webdriver/Cargo.toml`
- `pnpm --filter @wdio/tauri-service test`
- `pnpm --filter @wdio/tauri-service typecheck`
- `pnpm lint`
- `pnpm format:check`
- local macOS embedded Tauri scenarios, including child handles, frames, lifecycle removal, rectangles, close safety, and explicit switching
- three consecutive external multi-child application probes against immutable revision `a40d85f589b3a982f852305f8411eb824f57368f`

`cargo fmt --check` still reports existing formatting drift in unchanged upstream
files `src/server/handlers/actions.rs` and `src/server/handlers/direct_eval.rs`.
