### PR TITLE
ci: allow-fail Windows WebView2-150 lanes (Tauri + Electrobun) + macOS crabnebula (#542/#540)

### DIFF
--- a/.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
@@ -230,8 +230,17 @@ jobs:
               echo "Electrobun E2E passed"
               ;;
             failure)
-              echo "::error::Electrobun E2E tests failed"
-              exit 1
+              # WebView2 Runtime 150 dropped the CDP --remote-debugging-port for
+              # elevated hosts (Windows runners run as admin), so Electrobun's native
+              # WebView2/CDP session creation times out on Windows. Allow it to fail on
+              # Windows only until the fix lands; macOS (CEF) stays required.
+              # See https://github.com/webdriverio/desktop-mobile/issues/542
+              if [ "$RUNNER_OS" = "Windows" ]; then
+                echo "::warning::Electrobun E2E tests failed — allowed on Windows (WebView2 150 elevated-host regression; see https://github.com/webdriverio/desktop-mobile/issues/542)"
+              else
+                echo "::error::Electrobun E2E tests failed"
+                exit 1
+              fi
               ;;
             cancelled)
               echo "::error::Electrobun E2E tests were cancelled"

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -558,7 +558,7 @@ jobs:
           #    elevated hosts (runners run as admin), breaking the msedgedriver-based
           #    official + crabnebula providers. See https://github.com/tauri-apps/wry/issues/1782.
           #  - macOS: the macos-26 image (26.4) broke the closed-source CrabNebula
-          #    driver's session setup. See #540.
+          #    driver's session setup. See https://github.com/webdriverio/desktop-mobile/issues/540.
           allow_official=false; official_reason=""
           allow_crabnebula=false; crabnebula_reason=""
           case "$RUNNER_OS" in

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -533,12 +533,12 @@ jobs:
           failed=false
 
           check_result() {
-            local provider="$1" outcome="$2" allow_fail="${3:-false}"
+            local provider="$1" outcome="$2" allow_fail="${3:-false}" reason="${4:-}"
             case "$outcome" in
               success|skipped|"") ;;
               failure)
                 if [ "$allow_fail" = "true" ]; then
-                  echo "::warning::$provider provider tests failed (allowed on Windows — WebView2 150 elevated-host regression; see tauri-apps/wry#1782 and MicrosoftEdge/WebView2Feedback#5645)"
+                  echo "::warning::$provider provider tests failed (allowed on $RUNNER_OS — $reason)"
                 else
                   echo "::error::$provider provider tests failed"
                   failed=true
@@ -552,19 +552,26 @@ jobs:
             esac
           }
 
-          # WebView2 Runtime 150 stopped honoring the CDP --remote-debugging-port for
-          # elevated hosts (GitHub runners run as admin), which breaks the msedgedriver-
-          # based official + crabnebula providers on Windows only. Allow those to fail
-          # here until the upstream fix lands; embedded (in-process, immune) stays
-          # required and is our Windows signal. See tauri-apps/wry#1782.
-          allow_cdp_fail=false
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            allow_cdp_fail=true
-          fi
+          # Known upstream/environmental breakages of the third-party CDP/WebDriver
+          # providers; embedded (in-process, immune) stays required and is our signal.
+          #  - Windows: WebView2 Runtime 150 dropped the CDP --remote-debugging-port for
+          #    elevated hosts (runners run as admin), breaking the msedgedriver-based
+          #    official + crabnebula providers. See tauri-apps/wry#1782.
+          #  - macOS: the macos-26 image (26.4) broke the closed-source CrabNebula
+          #    driver's session setup. See #540.
+          allow_official=false; official_reason=""
+          allow_crabnebula=false; crabnebula_reason=""
+          case "$RUNNER_OS" in
+            Windows)
+              allow_official=true;   official_reason="WebView2 150 elevated-host regression; see tauri-apps/wry#1782"
+              allow_crabnebula=true; crabnebula_reason="WebView2 150 elevated-host regression; see tauri-apps/wry#1782" ;;
+            macOS)
+              allow_crabnebula=true; crabnebula_reason="macos-26 image (26.4) broke the CrabNebula driver; see #540" ;;
+          esac
 
-          check_result "Official" "$official" "$allow_cdp_fail"
+          check_result "Official" "$official" "$allow_official" "$official_reason"
           check_result "Embedded" "$embedded"
-          check_result "CrabNebula" "$crabnebula" "$allow_cdp_fail"
+          check_result "CrabNebula" "$crabnebula" "$allow_crabnebula" "$crabnebula_reason"
 
           if [ "$failed" = "true" ]; then
             exit 1

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -556,17 +556,17 @@ jobs:
           # providers; embedded (in-process, immune) stays required and is our signal.
           #  - Windows: WebView2 Runtime 150 dropped the CDP --remote-debugging-port for
           #    elevated hosts (runners run as admin), breaking the msedgedriver-based
-          #    official + crabnebula providers. See tauri-apps/wry#1782.
+          #    official + crabnebula providers. See https://github.com/tauri-apps/wry/issues/1782.
           #  - macOS: the macos-26 image (26.4) broke the closed-source CrabNebula
           #    driver's session setup. See #540.
           allow_official=false; official_reason=""
           allow_crabnebula=false; crabnebula_reason=""
           case "$RUNNER_OS" in
             Windows)
-              allow_official=true;   official_reason="WebView2 150 elevated-host regression; see tauri-apps/wry#1782"
-              allow_crabnebula=true; crabnebula_reason="WebView2 150 elevated-host regression; see tauri-apps/wry#1782" ;;
+              allow_official=true;   official_reason="WebView2 150 elevated-host regression; see https://github.com/tauri-apps/wry/issues/1782"
+              allow_crabnebula=true; crabnebula_reason="WebView2 150 elevated-host regression; see https://github.com/tauri-apps/wry/issues/1782" ;;
             macOS)
-              allow_crabnebula=true; crabnebula_reason="macos-26 image (26.4) broke the CrabNebula driver; see #540" ;;
+              allow_crabnebula=true; crabnebula_reason="macos-26 image (26.4) broke the CrabNebula driver; see https://github.com/webdriverio/desktop-mobile/issues/540" ;;
           esac
 
           check_result "Official" "$official" "$allow_official" "$official_reason"

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -556,15 +556,15 @@ jobs:
           # providers; embedded (in-process, immune) stays required and is our signal.
           #  - Windows: WebView2 Runtime 150 dropped the CDP --remote-debugging-port for
           #    elevated hosts (runners run as admin), breaking the msedgedriver-based
-          #    official + crabnebula providers. See https://github.com/tauri-apps/wry/issues/1782.
+          #    official + crabnebula providers. See https://github.com/webdriverio/desktop-mobile/issues/542.
           #  - macOS: the macos-26 image (26.4) broke the closed-source CrabNebula
           #    driver's session setup. See https://github.com/webdriverio/desktop-mobile/issues/540.
           allow_official=false; official_reason=""
           allow_crabnebula=false; crabnebula_reason=""
           case "$RUNNER_OS" in
             Windows)
-              allow_official=true;   official_reason="WebView2 150 elevated-host regression; see https://github.com/tauri-apps/wry/issues/1782"
-              allow_crabnebula=true; crabnebula_reason="WebView2 150 elevated-host regression; see https://github.com/tauri-apps/wry/issues/1782" ;;
+              allow_official=true;   official_reason="WebView2 150 elevated-host regression; see https://github.com/webdriverio/desktop-mobile/issues/542"
+              allow_crabnebula=true; crabnebula_reason="WebView2 150 elevated-host regression; see https://github.com/webdriverio/desktop-mobile/issues/542" ;;
             macOS)
               allow_crabnebula=true; crabnebula_reason="macos-26 image (26.4) broke the CrabNebula driver; see https://github.com/webdriverio/desktop-mobile/issues/540" ;;
           esac

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -347,11 +347,11 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          # Fixed-version 149 x64 CAB from the WebView2 "Fixed Version" download page
-          # (https://developer.microsoft.com/microsoft-edge/webview2/ → Fixed Version).
-          # Left blank until the URL is filled in; when blank we skip the pin so the
-          # embedded provider (which does not need it) still runs.
-          $url = ''
+          # Fixed-version 149.0.4022.98 x64 CAB from the WebView2 "Fixed Version"
+          # download page (https://developer.microsoft.com/microsoft-edge/webview2/).
+          # If blank — e.g. once the link is retired at Edge 151 GA — the step skips
+          # so the embedded provider (which does not need it) still runs.
+          $url = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/2943b6d1-31d1-42c5-8cfa-c2c31485974d/Microsoft.WebView2.FixedVersionRuntime.149.0.4022.98.x64.cab'
           if ([string]::IsNullOrWhiteSpace($url)) {
             Write-Warning "WebView2 fixed-runtime URL not set — official/crabnebula will run against Evergreen (expected to fail on Edge >=150). See WebView2Feedback#5645."
             exit 0

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -322,52 +322,6 @@ jobs:
             core.setOutput('crabnebula', `test:e2e:tauri-basic-crabnebula${suffix}`);
 
       # ══════════════════════════════════════════════════════════════
-      # PIN WEBVIEW2 FIXED RUNTIME (official + crabnebula only) — Windows
-      # ══════════════════════════════════════════════════════════════
-      #
-      # WebView2 Runtime 150 added a security hardening: an *elevated* host
-      # process (GitHub Windows runners run as admin) no longer honors the
-      # --remote-debugging-port supplied via command line / HKCU / WEBVIEW2_*
-      # env vars — only HKLM policy and args passed via the WebView2 API survive.
-      # The official (tauri-driver → msedgedriver) and crabnebula CDP drivers
-      # reach the webview through that debug port, so on Evergreen ≥150 their
-      # session creation times out. See MicrosoftEdge/WebView2Feedback#5645.
-      #
-      # A fixed-version runtime that predates the hardening restores the port.
-      # We point ONLY the two CDP providers at it via WEBVIEW2_BROWSER_EXECUTABLE_FOLDER;
-      # the embedded provider drives the webview in-process (ICoreWebView2::ExecuteScript,
-      # no debug port) so it is immune and intentionally stays on Evergreen to keep
-      # proving that.
-      #
-      # STOPGAP: fixed-version CABs are published only for the latest + second-latest
-      # major, so the 149 link dies once Edge 151 ships (and by then 150/151 both carry
-      # the hardening, so no pin can help). Durable fix = upstream tauri-driver passing
-      # the debug arg via the WebView2 API. Bump/retire this step at Edge 151 GA.
-      - name: 📌 Pin WebView2 fixed runtime 149 (official + crabnebula)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # Fixed-version 149.0.4022.98 x64 CAB from the WebView2 "Fixed Version"
-          # download page (https://developer.microsoft.com/microsoft-edge/webview2/).
-          # If blank — e.g. once the link is retired at Edge 151 GA — the step skips
-          # so the embedded provider (which does not need it) still runs.
-          $url = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/2943b6d1-31d1-42c5-8cfa-c2c31485974d/Microsoft.WebView2.FixedVersionRuntime.149.0.4022.98.x64.cab'
-          if ([string]::IsNullOrWhiteSpace($url)) {
-            Write-Warning "WebView2 fixed-runtime URL not set — official/crabnebula will run against Evergreen (expected to fail on Edge >=150). See WebView2Feedback#5645."
-            exit 0
-          }
-          $cab = "$env:RUNNER_TEMP\wv2.cab"
-          $dest = "$env:RUNNER_TEMP\wv2-fixed"
-          Invoke-WebRequest -Uri $url -OutFile $cab
-          New-Item -ItemType Directory -Force -Path $dest | Out-Null
-          expand $cab -F:* $dest | Out-Null
-          # The CAB unpacks to a versioned subfolder containing msedgewebview2.exe.
-          $runtime = (Get-ChildItem $dest -Recurse -Filter msedgewebview2.exe | Select-Object -First 1).DirectoryName
-          if (-not $runtime) { throw "msedgewebview2.exe not found under $dest after expanding the fixed-version CAB" }
-          "WEBVIEW2_FIXED_RUNTIME_DIR=$runtime" | Out-File -FilePath $env:GITHUB_ENV -Append
-          Write-Host "Pinned WebView2 fixed runtime: $runtime"
-
-      # ══════════════════════════════════════════════════════════════
       # PROVIDER 1: OFFICIAL (tauri-driver) — skipped on macOS
       # ══════════════════════════════════════════════════════════════
 
@@ -393,9 +347,6 @@ jobs:
           RUST_BACKTRACE: '1'
           NO_AT_BRIDGE: '1'
           DRIVER_PROVIDER: 'official'
-          # Route this CDP driver at the pinned fixed runtime (see the pin step above).
-          # Empty on non-Windows / when unpinned → a harmless no-op the loader ignores.
-          WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: ${{ env.WEBVIEW2_FIXED_RUNTIME_DIR }}
         run: |
           if ($env:RUNNER_OS -eq "Linux") {
             xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" `
@@ -499,9 +450,6 @@ jobs:
           NO_AT_BRIDGE: '1'
           DRIVER_PROVIDER: 'crabnebula'
           CN_API_KEY: ${{ secrets.CN_API_KEY }}
-          # Route this CDP driver at the pinned fixed runtime (see the pin step above).
-          # Empty on non-Windows / when unpinned → a harmless no-op the loader ignores.
-          WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: ${{ env.WEBVIEW2_FIXED_RUNTIME_DIR }}
         run: |
           if ($env:RUNNER_OS -eq "Linux") {
             xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" `
@@ -585,12 +533,16 @@ jobs:
           failed=false
 
           check_result() {
-            local provider="$1" outcome="$2"
+            local provider="$1" outcome="$2" allow_fail="${3:-false}"
             case "$outcome" in
               success|skipped|"") ;;
               failure)
-                echo "::error::$provider provider tests failed"
-                failed=true ;;
+                if [ "$allow_fail" = "true" ]; then
+                  echo "::warning::$provider provider tests failed (allowed on Windows — WebView2 150 elevated-host regression; see tauri-apps/wry#1782 and MicrosoftEdge/WebView2Feedback#5645)"
+                else
+                  echo "::error::$provider provider tests failed"
+                  failed=true
+                fi ;;
               cancelled)
                 echo "::error::$provider provider tests were cancelled"
                 failed=true ;;
@@ -600,9 +552,19 @@ jobs:
             esac
           }
 
-          check_result "Official" "$official"
+          # WebView2 Runtime 150 stopped honoring the CDP --remote-debugging-port for
+          # elevated hosts (GitHub runners run as admin), which breaks the msedgedriver-
+          # based official + crabnebula providers on Windows only. Allow those to fail
+          # here until the upstream fix lands; embedded (in-process, immune) stays
+          # required and is our Windows signal. See tauri-apps/wry#1782.
+          allow_cdp_fail=false
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            allow_cdp_fail=true
+          fi
+
+          check_result "Official" "$official" "$allow_cdp_fail"
           check_result "Embedded" "$embedded"
-          check_result "CrabNebula" "$crabnebula"
+          check_result "CrabNebula" "$crabnebula" "$allow_cdp_fail"
 
           if [ "$failed" = "true" ]; then
             exit 1

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -322,6 +322,52 @@ jobs:
             core.setOutput('crabnebula', `test:e2e:tauri-basic-crabnebula${suffix}`);
 
       # ══════════════════════════════════════════════════════════════
+      # PIN WEBVIEW2 FIXED RUNTIME (official + crabnebula only) — Windows
+      # ══════════════════════════════════════════════════════════════
+      #
+      # WebView2 Runtime 150 added a security hardening: an *elevated* host
+      # process (GitHub Windows runners run as admin) no longer honors the
+      # --remote-debugging-port supplied via command line / HKCU / WEBVIEW2_*
+      # env vars — only HKLM policy and args passed via the WebView2 API survive.
+      # The official (tauri-driver → msedgedriver) and crabnebula CDP drivers
+      # reach the webview through that debug port, so on Evergreen ≥150 their
+      # session creation times out. See MicrosoftEdge/WebView2Feedback#5645.
+      #
+      # A fixed-version runtime that predates the hardening restores the port.
+      # We point ONLY the two CDP providers at it via WEBVIEW2_BROWSER_EXECUTABLE_FOLDER;
+      # the embedded provider drives the webview in-process (ICoreWebView2::ExecuteScript,
+      # no debug port) so it is immune and intentionally stays on Evergreen to keep
+      # proving that.
+      #
+      # STOPGAP: fixed-version CABs are published only for the latest + second-latest
+      # major, so the 149 link dies once Edge 151 ships (and by then 150/151 both carry
+      # the hardening, so no pin can help). Durable fix = upstream tauri-driver passing
+      # the debug arg via the WebView2 API. Bump/retire this step at Edge 151 GA.
+      - name: 📌 Pin WebView2 fixed runtime 149 (official + crabnebula)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Fixed-version 149 x64 CAB from the WebView2 "Fixed Version" download page
+          # (https://developer.microsoft.com/microsoft-edge/webview2/ → Fixed Version).
+          # Left blank until the URL is filled in; when blank we skip the pin so the
+          # embedded provider (which does not need it) still runs.
+          $url = ''
+          if ([string]::IsNullOrWhiteSpace($url)) {
+            Write-Warning "WebView2 fixed-runtime URL not set — official/crabnebula will run against Evergreen (expected to fail on Edge >=150). See WebView2Feedback#5645."
+            exit 0
+          }
+          $cab = "$env:RUNNER_TEMP\wv2.cab"
+          $dest = "$env:RUNNER_TEMP\wv2-fixed"
+          Invoke-WebRequest -Uri $url -OutFile $cab
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          expand $cab -F:* $dest | Out-Null
+          # The CAB unpacks to a versioned subfolder containing msedgewebview2.exe.
+          $runtime = (Get-ChildItem $dest -Recurse -Filter msedgewebview2.exe | Select-Object -First 1).DirectoryName
+          if (-not $runtime) { throw "msedgewebview2.exe not found under $dest after expanding the fixed-version CAB" }
+          "WEBVIEW2_FIXED_RUNTIME_DIR=$runtime" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "Pinned WebView2 fixed runtime: $runtime"
+
+      # ══════════════════════════════════════════════════════════════
       # PROVIDER 1: OFFICIAL (tauri-driver) — skipped on macOS
       # ══════════════════════════════════════════════════════════════
 
@@ -347,6 +393,9 @@ jobs:
           RUST_BACKTRACE: '1'
           NO_AT_BRIDGE: '1'
           DRIVER_PROVIDER: 'official'
+          # Route this CDP driver at the pinned fixed runtime (see the pin step above).
+          # Empty on non-Windows / when unpinned → a harmless no-op the loader ignores.
+          WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: ${{ env.WEBVIEW2_FIXED_RUNTIME_DIR }}
         run: |
           if ($env:RUNNER_OS -eq "Linux") {
             xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" `
@@ -450,6 +499,9 @@ jobs:
           NO_AT_BRIDGE: '1'
           DRIVER_PROVIDER: 'crabnebula'
           CN_API_KEY: ${{ secrets.CN_API_KEY }}
+          # Route this CDP driver at the pinned fixed runtime (see the pin step above).
+          # Empty on non-Windows / when unpinned → a harmless no-op the loader ignores.
+          WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: ${{ env.WEBVIEW2_FIXED_RUNTIME_DIR }}
         run: |
           if ($env:RUNNER_OS -eq "Linux") {
             xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x16" `

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -247,10 +247,11 @@ jobs:
       - name: 🧪 Execute Package Tests
         id: package-tests
         # WebView2 Runtime 150 dropped the CDP --remote-debugging-port for elevated
-        # hosts (Windows runners run as admin), breaking the msedgedriver-based Tauri
-        # package test — the same regression as the E2E official provider. Allow it to
-        # fail on Windows only until the upstream fix lands. See https://github.com/tauri-apps/wry/issues/1782.
-        continue-on-error: ${{ inputs.service == 'tauri' && runner.os == 'Windows' }}
+        # hosts (Windows runners run as admin), breaking the WebView2/CDP-driven Tauri
+        # and Electrobun package tests on Windows (session creation times out). Allow
+        # those two on Windows only until the fixes land; every other service/OS stays
+        # required. See https://github.com/webdriverio/desktop-mobile/issues/542
+        continue-on-error: ${{ (inputs.service == 'tauri' || inputs.service == 'electrobun') && runner.os == 'Windows' }}
         shell: bash
         env:
           # Enable Rust backtraces for debugging Tauri/GTK issues
@@ -314,10 +315,10 @@ jobs:
               ;;
           esac
 
-      - name: ⚠️ Note allowed Tauri Windows failure
-        if: always() && inputs.service == 'tauri' && runner.os == 'Windows' && steps.package-tests.outcome == 'failure'
+      - name: ⚠️ Note allowed WebView2-150 Windows failure
+        if: always() && (inputs.service == 'tauri' || inputs.service == 'electrobun') && runner.os == 'Windows' && steps.package-tests.outcome == 'failure'
         shell: bash
-        run: echo "::warning::Tauri Windows package test failed — allowed (WebView2 150 elevated-host regression; see https://github.com/tauri-apps/wry/issues/1782)"
+        run: echo "::warning::${{ inputs.service }} Windows package test failed — allowed (WebView2 150 elevated-host regression; see https://github.com/webdriverio/desktop-mobile/issues/542)"
 
       # Upload logs as artifacts for later analysis (same as E2E tests)
       # This helps debug issues without cluttering the GitHub Actions console

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -249,7 +249,7 @@ jobs:
         # WebView2 Runtime 150 dropped the CDP --remote-debugging-port for elevated
         # hosts (Windows runners run as admin), breaking the msedgedriver-based Tauri
         # package test — the same regression as the E2E official provider. Allow it to
-        # fail on Windows only until the upstream fix lands. See tauri-apps/wry#1782.
+        # fail on Windows only until the upstream fix lands. See https://github.com/tauri-apps/wry/issues/1782.
         continue-on-error: ${{ inputs.service == 'tauri' && runner.os == 'Windows' }}
         shell: bash
         env:
@@ -317,7 +317,7 @@ jobs:
       - name: ⚠️ Note allowed Tauri Windows failure
         if: always() && inputs.service == 'tauri' && runner.os == 'Windows' && steps.package-tests.outcome == 'failure'
         shell: bash
-        run: echo "::warning::Tauri Windows package test failed — allowed (WebView2 150 elevated-host regression; see tauri-apps/wry#1782)"
+        run: echo "::warning::Tauri Windows package test failed — allowed (WebView2 150 elevated-host regression; see https://github.com/tauri-apps/wry/issues/1782)"
 
       # Upload logs as artifacts for later analysis (same as E2E tests)
       # This helps debug issues without cluttering the GitHub Actions console

--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -245,6 +245,12 @@ jobs:
       # All apps are built in isolated environments (Electron always, Tauri if not skipBuild)
       # Tauri uses skipBuild to copy pre-built binaries from separate build jobs
       - name: 🧪 Execute Package Tests
+        id: package-tests
+        # WebView2 Runtime 150 dropped the CDP --remote-debugging-port for elevated
+        # hosts (Windows runners run as admin), breaking the msedgedriver-based Tauri
+        # package test — the same regression as the E2E official provider. Allow it to
+        # fail on Windows only until the upstream fix lands. See tauri-apps/wry#1782.
+        continue-on-error: ${{ inputs.service == 'tauri' && runner.os == 'Windows' }}
         shell: bash
         env:
           # Enable Rust backtraces for debugging Tauri/GTK issues
@@ -307,6 +313,11 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: ⚠️ Note allowed Tauri Windows failure
+        if: always() && inputs.service == 'tauri' && runner.os == 'Windows' && steps.package-tests.outcome == 'failure'
+        shell: bash
+        run: echo "::warning::Tauri Windows package test failed — allowed (WebView2 150 elevated-host regression; see tauri-apps/wry#1782)"
 
       # Upload logs as artifacts for later analysis (same as E2E tests)
       # This helps debug issues without cluttering the GitHub Actions console


### PR DESCRIPTION
## What

Handle the **WebView2 Runtime 150** elevated-host regression across **every framework that drives WebView2/CDP on Windows** — Tauri *and* Electrobun — plus the separate macOS-crabnebula breakage. Affected lanes are allow-failed (scoped to service/OS, with a `::warning::`); embedded / Linux / macOS-CEF lanes stay **required**.

| Lane | Allowed to fail | Cause |
|---|---|---|
| E2E Windows — Tauri (official + crabnebula) | ✅ | WebView2 150 ([#542]) |
| E2E Windows — Electrobun | ✅ | WebView2 150 ([#542]) |
| Package Windows — Tauri + Electrobun | ✅ | WebView2 150 ([#542]) |
| E2E macOS — Tauri crabnebula | ✅ | macos-26 (26.4) broke the closed-source driver ([#540]) |

All WebView2-150 allowances point at the cross-framework tracker **[#542]** (root: `MicrosoftEdge/WebView2Feedback#5645`; Tauri fix: `tauri-apps/wry#1782`; Electrobun fix TBD). Every allowance is scoped and emits a `::warning::` — nothing else is masked.

## Still red — separate, pre-existing issues (NOT WebView2-150)

Because the shared package workflow is `CORE_INFRA`, this PR triggers the **full** cross-service matrix, which surfaces unrelated environmental failures that are **out of scope** here and need their own follow-ups:

- Package Electron macOS cjs/esm — window-height drift (`674 < 680`).
- E2E Flutter iOS / React Native iOS — iOS environmental/flaky.
- Package Dioxus (Docker) Fedora — flaky.
- E2E Tauri macOS `standalone` — embedded session-death on 26.4 ([#540]).

[#542]: https://github.com/webdriverio/desktop-mobile/issues/542
[#540]: https://github.com/webdriverio/desktop-mobile/issues/540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
