### PR TITLE
fix(e2e): relax macOS window-height lower bound to 660 for runner work-area variance

### DIFF
--- a/fixtures/package-tests/electron-builder-app-cjs/test/app.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-cjs/test/app.spec.ts
@@ -85,8 +85,8 @@ describe('Builder App Example', () => {
     expect(result).not.toBeNull();
     expect(result?.width).toBe(900);
     if (process.platform === 'darwin') {
-      // Allow minor variance on macOS due to frame metrics and work area fitting
-      expect(result.height).toBeGreaterThanOrEqual(680);
+      // Band accommodates macOS runner work-area fit (window fits to a shrinking work area) — see #543
+      expect(result.height).toBeGreaterThanOrEqual(660);
       expect(result.height).toBeLessThanOrEqual(720);
     } else {
       expect(result?.height).toBe(700);

--- a/fixtures/package-tests/electron-builder-app-esm/test/app.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/test/app.spec.ts
@@ -85,8 +85,8 @@ describe('Builder App Example', () => {
     expect(result).not.toBeNull();
     expect(result?.width).toBe(900);
     if (process.platform === 'darwin') {
-      // Allow minor variance on macOS due to frame metrics and work area fitting
-      expect(result.height).toBeGreaterThanOrEqual(680);
+      // Band accommodates macOS runner work-area fit (window fits to a shrinking work area) — see #543
+      expect(result.height).toBeGreaterThanOrEqual(660);
       expect(result.height).toBeLessThanOrEqual(720);
     } else {
       expect(result?.height).toBe(700);

--- a/fixtures/package-tests/electron-forge-app-cjs/test/app.spec.ts
+++ b/fixtures/package-tests/electron-forge-app-cjs/test/app.spec.ts
@@ -85,7 +85,8 @@ describe('Forge App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      // Band accommodates macOS runner work-area fit (window fits to a shrinking work area) — see #543
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(660);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);

--- a/fixtures/package-tests/electron-forge-app-esm/test/app.spec.ts
+++ b/fixtures/package-tests/electron-forge-app-esm/test/app.spec.ts
@@ -85,7 +85,8 @@ describe('Forge App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      // Band accommodates macOS runner work-area fit (window fits to a shrinking work area) — see #543
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(660);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);

--- a/fixtures/package-tests/electron-script-app-cjs/test/app.spec.ts
+++ b/fixtures/package-tests/electron-script-app-cjs/test/app.spec.ts
@@ -100,7 +100,8 @@ describe('Script App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      // Band accommodates macOS runner work-area fit (window fits to a shrinking work area) — see #543
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(660);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);

--- a/fixtures/package-tests/electron-script-app-esm/test/app.spec.ts
+++ b/fixtures/package-tests/electron-script-app-esm/test/app.spec.ts
@@ -100,7 +100,8 @@ describe('Script App Example', () => {
     expect(windowSize).not.toBeNull();
     expect(windowSize?.width).toBe(900);
     if (process.platform === 'darwin') {
-      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(680);
+      // Band accommodates macOS runner work-area fit (window fits to a shrinking work area) — see #543
+      expect(windowSize?.height ?? 0).toBeGreaterThanOrEqual(660);
       expect(windowSize?.height ?? 0).toBeLessThanOrEqual(720);
     } else {
       expect(windowSize?.height).toBe(700);


### PR DESCRIPTION
## Problem

The Electron package-test `should have correct window configuration` asserts, on macOS, `height >= 680` (band 680–720). On the current `macos-26` runner (macOS 26.4), Electron 42.2.0 fits the window to the runner's (shrunken) work-area and returns **674** — 6px short — so the cjs + esm package tests fail **consistently**.

This is environmental, not a real bug: the *same* Electron 42.2.0 returned ≥680 on the older image (`20260630`); the macOS-26.4 image update shrank the work-area the window is fit to. It's a too-tight macOS test tolerance.

## Change

Relax the macOS **lower** bound from `680` to `660` across all electron package-test fixtures (builder / forge / script, each cjs + esm) to absorb runner work-area variance. A short comment on each notes the band accommodates macOS runner work-area fit, referencing this issue.

- Upper bound (`720`) unchanged.
- Non-darwin (`else`) assertions (`height === 700`) untouched.

Files changed (6):
- `fixtures/package-tests/electron-builder-app-cjs/test/app.spec.ts`
- `fixtures/package-tests/electron-builder-app-esm/test/app.spec.ts`
- `fixtures/package-tests/electron-forge-app-cjs/test/app.spec.ts`
- `fixtures/package-tests/electron-forge-app-esm/test/app.spec.ts`
- `fixtures/package-tests/electron-script-app-cjs/test/app.spec.ts`
- `fixtures/package-tests/electron-script-app-esm/test/app.spec.ts`

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKc4JHZKXfyqCiiU4C2b7V