### PR TITLE
fix(ci): build the WebDriverAgent matching the loaded xcuitest driver on iOS E2E

### DIFF
--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -165,15 +165,16 @@ jobs:
           installed=$(pnpm --filter @repo/e2e exec appium driver list --installed 2>&1 || true)
           echo "$installed" | grep -qi xcuitest || pnpm --filter @repo/e2e exec appium driver install xcuitest
 
-      # WDA DerivedData cache keyed on e2e/package.json (driver pins) + the runner image version.
-      # -v3: the pre-build now selects the WDA matching the loaded driver (was building a stale
-      # transitive copy); bump forces a rebuild so a v2 entry holding the wrong WDA isn't reused.
+      # WDA DerivedData cache keyed on e2e/package.json + pnpm-lock.yaml (the WDA/xcuitest versions
+      # resolve through the lockfile — incl. transitive copies — not just package.json) + the runner
+      # image version. -v3: the pre-build now selects the WDA matching the loaded driver (was building
+      # a stale transitive copy); bump forces a rebuild so a v2 entry holding the wrong WDA isn't reused.
       - name: 💾 Restore WDA DerivedData cache
         id: wda-cache
         uses: actions/cache@v6
         with:
           path: ${{ env.FLUTTER_WDA_DD }}
-          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v3
+          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json', 'pnpm-lock.yaml') }}-v3
 
       # Pre-build WebDriverAgent deterministically (no appium session, so no socket fragility).
       # The run consumes it via appium:usePreinstalledWDA + prebuiltWDAPath (simctl install/launch,

--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -166,12 +166,14 @@ jobs:
           echo "$installed" | grep -qi xcuitest || pnpm --filter @repo/e2e exec appium driver install xcuitest
 
       # WDA DerivedData cache keyed on e2e/package.json (driver pins) + the runner image version.
+      # -v3: the pre-build now selects the WDA matching the loaded driver (was building a stale
+      # transitive copy); bump forces a rebuild so a v2 entry holding the wrong WDA isn't reused.
       - name: 💾 Restore WDA DerivedData cache
         id: wda-cache
         uses: actions/cache@v6
         with:
           path: ${{ env.FLUTTER_WDA_DD }}
-          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v2
+          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v3
 
       # Pre-build WebDriverAgent deterministically (no appium session, so no socket fragility).
       # The run consumes it via appium:usePreinstalledWDA + prebuiltWDAPath (simctl install/launch,
@@ -182,8 +184,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          WDA_PROJ=$(find node_modules/.pnpm -maxdepth 6 -path '*/appium-webdriveragent/WebDriverAgent.xcodeproj' -type d 2>/dev/null | head -1)
-          test -n "$WDA_PROJ" || { echo "::error::WebDriverAgent.xcodeproj not found under node_modules"; exit 1; }
+          # Build the WebDriverAgent that the appium-xcuitest-driver Appium actually loads depends
+          # on. Two appium-webdriveragent copies coexist in the pnpm store: the pinned xcuitest
+          # driver's (15.x) and an older one pulled transitively via appium-flutter-driver's bundled
+          # xcuitest (11.x). A bare `find | head -1` picked the stale 11.x project, so the
+          # preinstalled WDA never matched the 15.x launcher — it launched but its :8100 server never
+          # came up and session-create timed out at wdaLaunchTimeout on every spec. Resolve the
+          # project from the driver; fall back to the newest copy by version if resolution fails.
+          WDA_PROJ=""
+          WDA_DIR=$(pnpm --filter @repo/e2e exec node -e "const p=require('path');const x=require.resolve('appium-xcuitest-driver/package.json');process.stdout.write(p.dirname(require.resolve('appium-webdriveragent/package.json',{paths:[p.dirname(x)]})))" 2>/dev/null || true)
+          if [ -n "$WDA_DIR" ] && [ -d "$WDA_DIR/WebDriverAgent.xcodeproj" ]; then
+            WDA_PROJ="$WDA_DIR/WebDriverAgent.xcodeproj"
+          else
+            WDA_PROJ=$(find node_modules/.pnpm -maxdepth 6 -path '*/appium-webdriveragent/WebDriverAgent.xcodeproj' -type d 2>/dev/null | sort -V | tail -1)
+          fi
+          test -n "$WDA_PROJ" && test -d "$WDA_PROJ" || { echo "::error::WebDriverAgent.xcodeproj not found under node_modules"; exit 1; }
+          echo "WDA project: $WDA_PROJ"
           xcodebuild build-for-testing \
             -project "$WDA_PROJ" \
             -scheme WebDriverAgentRunner \

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -206,12 +206,14 @@ jobs:
       # image version. ImageVersion is set automatically on GitHub-hosted macOS runners and
       # encodes the Xcode major — a stale DerivedData compiled against a previous SDK causes
       # cryptic E2E failures rather than a clean miss-and-rebuild.
+      # -v3: the pre-build now selects the WDA matching the loaded driver (was building a stale
+      # transitive copy); bump forces a rebuild so a v2 entry holding the wrong WDA isn't reused.
       - name: 💾 Restore WDA DerivedData cache
         id: wda-cache
         uses: actions/cache@v6
         with:
           path: ${{ env.RN_WDA_DD }}
-          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v2
+          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v3
 
       # Pre-build WebDriverAgent deterministically with a plain xcodebuild (no appium session, so no
       # socket fragility — it runs to completion). appium-xcuitest otherwise compiles WDA (several
@@ -224,8 +226,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          WDA_PROJ=$(find node_modules/.pnpm -maxdepth 6 -path '*/appium-webdriveragent/WebDriverAgent.xcodeproj' -type d 2>/dev/null | head -1)
-          test -n "$WDA_PROJ" || { echo "::error::WebDriverAgent.xcodeproj not found under node_modules"; exit 1; }
+          # Build the WebDriverAgent that the appium-xcuitest-driver Appium actually loads depends
+          # on. Two appium-webdriveragent copies coexist in the pnpm store: the pinned xcuitest
+          # driver's (15.x) and an older one pulled transitively via appium-flutter-driver's bundled
+          # xcuitest (11.x). A bare `find | head -1` picked the stale 11.x project, so the
+          # preinstalled WDA never matched the 15.x launcher — it launched but its :8100 server never
+          # came up and session-create timed out at wdaLaunchTimeout on every spec. Resolve the
+          # project from the driver; fall back to the newest copy by version if resolution fails.
+          WDA_PROJ=""
+          WDA_DIR=$(pnpm --filter @repo/e2e exec node -e "const p=require('path');const x=require.resolve('appium-xcuitest-driver/package.json');process.stdout.write(p.dirname(require.resolve('appium-webdriveragent/package.json',{paths:[p.dirname(x)]})))" 2>/dev/null || true)
+          if [ -n "$WDA_DIR" ] && [ -d "$WDA_DIR/WebDriverAgent.xcodeproj" ]; then
+            WDA_PROJ="$WDA_DIR/WebDriverAgent.xcodeproj"
+          else
+            WDA_PROJ=$(find node_modules/.pnpm -maxdepth 6 -path '*/appium-webdriveragent/WebDriverAgent.xcodeproj' -type d 2>/dev/null | sort -V | tail -1)
+          fi
+          test -n "$WDA_PROJ" && test -d "$WDA_PROJ" || { echo "::error::WebDriverAgent.xcodeproj not found under node_modules"; exit 1; }
           echo "WDA project: $WDA_PROJ"
           xcodebuild build-for-testing \
             -project "$WDA_PROJ" \

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -206,6 +206,8 @@ jobs:
       # image version. ImageVersion is set automatically on GitHub-hosted macOS runners and
       # encodes the Xcode major — a stale DerivedData compiled against a previous SDK causes
       # cryptic E2E failures rather than a clean miss-and-rebuild.
+      # Key also hashes pnpm-lock.yaml — the WDA/xcuitest versions resolve through the lockfile
+      # (incl. transitive copies), so a lockfile-only bump must bust the cache too.
       # -v3: the pre-build now selects the WDA matching the loaded driver (was building a stale
       # transitive copy); bump forces a rebuild so a v2 entry holding the wrong WDA isn't reused.
       - name: 💾 Restore WDA DerivedData cache
@@ -213,7 +215,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.RN_WDA_DD }}
-          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v3
+          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json', 'pnpm-lock.yaml') }}-v3
 
       # Pre-build WebDriverAgent deterministically with a plain xcodebuild (no appium session, so no
       # socket fragility — it runs to completion). appium-xcuitest otherwise compiles WDA (several


### PR DESCRIPTION
## Problem

All three iOS E2E jobs fail **consistently** (every spec, every retry) at
session-create:

- `E2E - React Native [iOS] - standard (old-arch)` — **gating**
- `E2E - React Native [iOS] - standard (new-arch)` — **gating**
- `E2E - Flutter [iOS] - standard` — quarantined per #421 (still runs, shows red)

Because the two RN legs gate `ci-status`, this turns CI red on `main`.

### Symptom (identical across all three)

```
[WD Proxy] Proxying [GET /status] to [GET http://127.0.0.1:8100/status]
[WD Proxy] connect ECONNREFUSED 127.0.0.1:8100      (repeated ~120s)
[XCUITestDriver] Failed to get the status endpoint in 120000 ms …
Error: Failed to start the preinstalled WebDriverAgent in 120000 ms …
    at launchPreinstalled (…/appium-webdriveragent@15.1.3/…/wda-strategies.js:214)
WebDriverError: Unable to launch WebDriverAgent … POST /session 500
```

The preinstalled WDA **launches** (there is no `simctl launch … timed out after
600000ms` and no `XCTDaemonErrorDomain Code=5`), but its `:8100` HTTP server
never comes up. This is **not** the random per-session CoreSimulator
simctl-launch wedge described in #421 — it is a 100%-consistent WDA **version
mismatch**.

## Root cause

The iOS reusable workflows pre-build WebDriverAgent and hand it to Appium via
`appium:usePreinstalledWDA` + `appium:prebuiltWDAPath`. They located the Xcode
project with:

```bash
find node_modules/.pnpm … appium-webdriveragent/WebDriverAgent.xcodeproj | head -1
```

Two `appium-webdriveragent` copies now coexist in the pnpm store:

| version | pulled by |
|---------|-----------|
| **15.1.3** | pinned `appium-xcuitest-driver@11.17.1` (the driver Appium loads at runtime) |
| **11.4.3** | transitively via `appium-flutter-driver@3.8.0 → appium-xcuitest-driver@10.43.1` |

`head -1` selected the **stale 11.4.3** project. So the workflow built and
preinstalled an 11.4.3 WDA, while the driver Appium actually loads is
`appium-xcuitest-driver@11.17.1` → `appium-webdriveragent@15.1.3` (confirmed in
every failing job's stack trace). Four majors of drift between the installed
WDA bundle and the 15.1.3 launcher → the WDA process starts but never serves,
so `Failed to start the preinstalled WebDriverAgent`.

This latent bug was exposed when the dependency graph gained a second WDA copy
(`appium-flutter-driver@3.8.0`, then the `appium-xcuitest-driver ^11.9.0 →
^11.17.1` bump in #516). The `macos-latest → macos-26` / Xcode 26.5 / iPhone 17
runner image (also in play for the current Tauri/Electron macOS breakages) is
the environment this surfaced on, but the fault here is the WDA selection, not
the image.

## Fix

Both `_ci-e2e-react-native-ios.reusable.yml` and `_ci-e2e-flutter-ios.reusable.yml`:

1. **Select the WDA that matches the loaded driver** — resolve
   `appium-webdriveragent` from the `appium-xcuitest-driver` Appium loads
   (`require.resolve` chain), with a `sort -V | tail -1` (newest) fallback if
   resolution fails. Both paths yield the 15.1.3 project on the current tree;
   the old `head -1` yielded 11.4.3.
2. **Bump the WDA DerivedData cache key `v2 → v3`** — the key does not hash the
   workflow file, so without this the cached (wrong) 11.4.3 build would be
   restored and the corrected pre-build step skipped, masking the fix.

## What CI must confirm

This is **CI-only-reproducible** (no local iOS sim), so this is a **draft** for
the iOS legs to validate:

- If the three iOS jobs go green → the version mismatch was the cause; fixed.
- If they still fail with the same `:8100`-never-serves signature after building
  15.1.3 → there is an additional WDA-15.1.3-on-iOS-26 wall to escalate upstream
  (appium-xcuitest / appium-webdriveragent), separate from this workflow bug.

Refs #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKc4JHZKXfyqCiiU4C2b7V
