### PR TITLE
fix(tauri): diagnose + harden macOS 26.4 embedded standalone regression (#540)

### DIFF
--- a/e2e/test/tauri/standalone/api.spec.ts
+++ b/e2e/test/tauri/standalone/api.spec.ts
@@ -71,8 +71,11 @@ try {
 
   console.log('✅ Simple execute test passed');
 } finally {
-  // Clean up - quit the app and stop tauri-driver
-  await browser.deleteSession();
+  // Clean up - quit the app and stop tauri-driver. cleanupWdioSession() drives the
+  // service's afterSession, which restores mocks (a live-session round-trip) and then
+  // deletes the session itself — so we must NOT deleteSession() first, or that mock
+  // restore runs against a dead session and retries "Session not found" for the full
+  // connectionRetryCount (~60s) before teardown continues.
   await cleanupWdioSession(browser);
   console.log('✅ Cleanup complete');
 }

--- a/e2e/test/tauri/standalone/logging.spec.ts
+++ b/e2e/test/tauri/standalone/logging.spec.ts
@@ -162,8 +162,11 @@ try {
 
   console.log('✅ All Tauri standalone logging tests passed');
 } finally {
-  // Clean up - quit the app and stop tauri-driver
-  await browser.deleteSession();
+  // Clean up - quit the app and stop tauri-driver. cleanupWdioSession() drives the
+  // service's afterSession, which restores mocks (a live-session round-trip) and then
+  // deletes the session itself — so we must NOT deleteSession() first, or that mock
+  // restore runs against a dead session and retries "Session not found" for the full
+  // connectionRetryCount (~60s) before teardown continues.
   await cleanupWdioSession(browser);
   console.log('✅ Cleanup complete');
 }

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -106,8 +106,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
             let block = RcBlock::new(move |result: *mut AnyObject, error: *mut NSError| {
                 let response = if !error.is_null() {
                     let error_ref = &*error;
-                    let description = error_ref.localizedDescription();
-                    Err(description.to_string())
+                    Err(describe_ns_error(error_ref))
                 } else if result.is_null() {
                     Ok(Value::Null)
                 } else {
@@ -214,8 +213,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
             let block = RcBlock::new(move |result: *mut AnyObject, error: *mut NSError| {
                 let response = if !error.is_null() {
                     let error_ref = &*error;
-                    let description = error_ref.localizedDescription();
-                    Err(description.to_string())
+                    Err(describe_ns_error(error_ref))
                 } else if result.is_null() {
                     Ok(Value::Null)
                 } else {
@@ -271,8 +269,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
             let block = RcBlock::new(move |image: *mut NSImage, error: *mut NSError| {
                 let response = if !error.is_null() {
                     let error_ref = &*error;
-                    let description = error_ref.localizedDescription();
-                    Err(description.to_string())
+                    Err(describe_ns_error(error_ref))
                 } else if image.is_null() {
                     Err("No image returned".to_string())
                 } else {
@@ -386,8 +383,7 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
             let block = RcBlock::new(move |data: *mut NSData, error: *mut NSError| {
                 let response = if !error.is_null() {
                     let error_ref = &*error;
-                    let description = error_ref.localizedDescription();
-                    Err(description.to_string())
+                    Err(describe_ns_error(error_ref))
                 } else if data.is_null() {
                     Err("No PDF data returned".to_string())
                 } else {
@@ -454,6 +450,49 @@ unsafe fn image_to_png_base64(image: &NSImage) -> Result<String, String> {
 
     let bytes = png_data.to_vec();
     Ok(BASE64_STANDARD.encode(&bytes))
+}
+
+/// Build a diagnostic string for an `NSError` returned by a `WKWebView` completion handler.
+///
+/// `localizedDescription` for a script failure is frequently the opaque
+/// "A JavaScript exception occurred." with no detail. WebKit stashes the real
+/// exception text (and source location) in `userInfo` under the `WKJavaScriptException*`
+/// keys, so surface those when present. Without this, a script failure on the embedded
+/// executor is undiagnosable from the WDIO side (all we get back is the opaque string).
+unsafe fn describe_ns_error(error: &NSError) -> String {
+    let mut out = format!(
+        "{} (code {})",
+        error.localizedDescription().to_string(),
+        error.code()
+    );
+
+    let user_info = error.userInfo();
+    let get = |key: &str| -> Option<String> {
+        let ns_key = NSString::from_str(key);
+        // v is Retained<AnyObject>; ns_object_to_json takes &AnyObject. The explicit
+        // unsafe block is required because a closure body does not inherit the enclosing
+        // unsafe fn's context.
+        user_info
+            .objectForKey(&ns_key)
+            .and_then(|v| match unsafe { ns_object_to_json(&v) } {
+                Value::String(s) if !s.is_empty() => Some(s),
+                Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+    };
+
+    if let Some(message) = get("WKJavaScriptExceptionMessage") {
+        out.push_str(": ");
+        out.push_str(&message);
+    }
+    if let (Some(line), Some(column)) = (
+        get("WKJavaScriptExceptionLineNumber"),
+        get("WKJavaScriptExceptionColumnNumber"),
+    ) {
+        out.push_str(&format!(" @ {line}:{column}"));
+    }
+
+    out
 }
 
 /// Convert an `NSObject` to a JSON value

--- a/packages/tauri-service/src/commands/execute.ts
+++ b/packages/tauri-service/src/commands/execute.ts
@@ -109,7 +109,14 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
       } catch (error) {
         lastError = error;
         const message = error instanceof Error ? error.message : String(error);
-        if (attempt >= maxAttempts || !/javascript exception occurred/i.test(message)) {
+        // Only the *opaque* cold-webview error is retriable — the bare
+        // "A JavaScript exception occurred. (code N)" with no detail. describe_ns_error
+        // (macos.rs) enriches a genuine WKWebView exception with the real message/location
+        // after the code (": …" / " @ line:col"), so an enriched message is a deterministic
+        // error and must fail immediately rather than retry the full budget.
+        const isOpaqueColdWebviewError =
+          /javascript exception occurred/i.test(message) && !/\(code \d+\)\s*[:@]/.test(message);
+        if (attempt >= maxAttempts || !isOpaqueColdWebviewError) {
           throw error;
         }
         log.warn(

--- a/packages/tauri-service/src/commands/execute.ts
+++ b/packages/tauri-service/src/commands/execute.ts
@@ -91,9 +91,34 @@ export async function execute<ReturnValue, InnerArguments extends unknown[] = un
     const port = getDirectEvalPort();
     const client = getOrCreateDirectEvalClient(browser, port);
     const wrapped = wrapScriptForDirectEval(scriptString, JSON.stringify(userArgs));
-    return (await client.eval(wrapped, {
-      windowLabel: executeOptions.windowLabel,
-    })) as ReturnValue;
+
+    // On macOS the first direct eval against a freshly-spawned WKWebView can return the
+    // opaque WKErrorJavaScriptExceptionOccurred ("A JavaScript exception occurred") before
+    // the page's main world is fully ready. This shows up in standalone mode, where the
+    // first tauri.execute runs seconds after launch — the test-runner path never hits it
+    // because before() warms the webview first. A real script error surfaces its own
+    // message through the wrapper's try/catch, so retrying only this opaque WebKit error
+    // is safe. Tracking: webdriverio/desktop-mobile#540.
+    const maxAttempts = 4;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return (await client.eval(wrapped, {
+          windowLabel: executeOptions.windowLabel,
+        })) as ReturnValue;
+      } catch (error) {
+        lastError = error;
+        const message = error instanceof Error ? error.message : String(error);
+        if (attempt >= maxAttempts || !/javascript exception occurred/i.test(message)) {
+          throw error;
+        }
+        log.warn(
+          `Direct eval returned an opaque WebKit JS exception (attempt ${attempt}/${maxAttempts}); retrying: ${message}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+      }
+    }
+    throw lastError;
   }
 
   // Non-embedded path: use IPC via browser.execute (official/crabnebula providers)

--- a/packages/tauri-service/test/commands/execute.spec.ts
+++ b/packages/tauri-service/test/commands/execute.spec.ts
@@ -131,7 +131,7 @@ describe('execute — embedded provider (direct eval)', () => {
           ok: !failing,
           status: failing ? 500 : 200,
           statusText: failing ? 'Internal Server Error' : 'OK',
-          json: vi.fn().mockResolvedValue(failing ? { error: 'A JavaScript exception occurred' } : { value }),
+          json: vi.fn().mockResolvedValue(failing ? { error: 'A JavaScript exception occurred. (code 4)' } : { value }),
         });
       });
     }
@@ -172,6 +172,21 @@ describe('execute — embedded provider (direct eval)', () => {
     it('does not retry a genuine script error', async () => {
       vi.stubGlobal('fetch', mockFetch({ error: 'ReferenceError: foo is not defined' }, false, 500));
       await expect(execute(browser, '() => foo')).rejects.toThrow('ReferenceError: foo is not defined');
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry an enriched WebKit exception (real detail after the code)', async () => {
+      // describe_ns_error appends the real message/location after "(code N)", so this is a
+      // deterministic exception, not the opaque cold-webview one — it must fail immediately.
+      vi.stubGlobal(
+        'fetch',
+        mockFetch(
+          { error: 'A JavaScript exception occurred. (code 4): ReferenceError: foo is not defined @ 5:10' },
+          false,
+          500,
+        ),
+      );
+      await expect(execute(browser, '() => foo')).rejects.toThrow(/ReferenceError: foo is not defined/);
       expect(fetch).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/tauri-service/test/commands/execute.spec.ts
+++ b/packages/tauri-service/test/commands/execute.spec.ts
@@ -119,6 +119,63 @@ describe('execute — embedded provider (direct eval)', () => {
     });
   });
 
+  // Regression: on macOS the first direct eval against a freshly-spawned WKWebView can
+  // return the opaque WKErrorJavaScriptExceptionOccurred before the page is ready (#540).
+  describe('macOS cold-webview retry (#540)', () => {
+    function evalErrorThenValue(failures: number, value: unknown): ReturnType<typeof vi.fn> {
+      let call = 0;
+      return vi.fn().mockImplementation(() => {
+        call++;
+        const failing = call <= failures;
+        return Promise.resolve({
+          ok: !failing,
+          status: failing ? 500 : 200,
+          statusText: failing ? 'Internal Server Error' : 'OK',
+          json: vi.fn().mockResolvedValue(failing ? { error: 'A JavaScript exception occurred' } : { value }),
+        });
+      });
+    }
+
+    it('retries the opaque WebKit JS exception and succeeds once the webview is ready', async () => {
+      vi.useFakeTimers();
+      const fetchMock = evalErrorThenValue(2, 7);
+      vi.stubGlobal('fetch', fetchMock);
+
+      const promise = execute<number>(browser, '() => 7');
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+      const result = await promise;
+
+      expect(result).toBe(7);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      vi.useRealTimers();
+    });
+
+    it('gives up after the retry budget and rethrows the WebKit JS exception', async () => {
+      vi.useFakeTimers();
+      const fetchMock = evalErrorThenValue(Number.POSITIVE_INFINITY, undefined);
+      vi.stubGlobal('fetch', fetchMock);
+
+      const promise = execute(browser, '() => 1').catch((e: Error) => e);
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+      const result = await promise;
+
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).message).toMatch(/javascript exception occurred/i);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      vi.useRealTimers();
+    });
+
+    it('does not retry a genuine script error', async () => {
+      vi.stubGlobal('fetch', mockFetch({ error: 'ReferenceError: foo is not defined' }, false, 500));
+      await expect(execute(browser, '() => foo')).rejects.toThrow('ReferenceError: foo is not defined');
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('window label routing', () => {
     it('should send window_label when per-call option is provided', async () => {
       const mockFn = mockFetch({ value: 1 });


### PR DESCRIPTION
> **Draft.** The failure reproduces **only on the macOS-26.4 CI runner** — I could not reproduce or fully verify the fix locally. This PR exists so CI validates the candidate on the real image. Please read "What CI must confirm" and "Could NOT verify locally" below before merging.

Refs #540.

## TL;DR — the diagnosis in #540 was off

#540 says the **deeplink** suite is the broken embedded suite (`open testapp://…` losing the session under 26.4). The CI evidence says otherwise:

On the most recent run on the 26.4 image — **run [30008190121](https://github.com/webdriverio/desktop-mobile/actions/runs/30008190121)** (PR #538, branch already on `macos-26` 26.4):

| Embedded suite (macOS-ARM) | Result |
|---|---|
| standard | ✅ pass (18m) |
| window | ✅ pass |
| multiremote | ✅ pass |
| **deeplink** | ✅ **pass — 12/12** |
| **standalone** | ❌ **FAIL** |

- **Embedded deeplink is green.** It never calls `open testapp://` — in embedded mode `triggerDeeplink` injects via `browser.execute` (`window.receivedDeeplinks.push(...)`), confirmed in the job log (`12 passing`). `isEmbeddedProvider()` *does* resolve in the worker (the launcher sets `__WDIO_TAURI_EMBEDDED__` in `onPrepare`, which is inherited by the forked worker). The `open` path only runs for the tauri-driver/official provider. So there is nothing to fix for deeplink.
- **Embedded standalone is the real 26.4 regression.**

(The branch name keeps the `…-deeplink` slug from the original task framing; the fix targets standalone.)

## Root cause (standalone)

The standalone suite (`e2e/test/tauri/standalone/api.spec.ts`, run directly via `tsx`, not the wdio test-runner) dies here:

```ts
// api.spec.ts:50
const platformInfo = await browser.tauri.execute(({ core }) => core.invoke('get_platform_info'));
```

The thrown error is the opaque WebKit **`WKErrorJavaScriptExceptionOccurred`** — `"A JavaScript exception occurred"` — surfaced through the embedded direct-eval channel (`/wdio/eval` → `callAsyncJavaScript`). Full stack terminates at `DirectEvalClient.eval` ← `api.spec.ts:50`.

Key asymmetry: **the identical call passes in the `standard` suite** (`api.spec.ts:7`). The difference is webview warmth:
- `standard`: the embedded app is spawned once in `onPrepare` and persists; by the time `get_platform_info` runs, prior specs have exercised the WKWebView.
- `standalone`: `startWdioSession()` freshly spawns the app and `get_platform_info` is the **first** direct eval, ~2s after launch, against a cold WKWebView.

The reported `Session … not found on execute/sync` in #540 is a **secondary** symptom, not the root — see change 3.

## Changes

**1. `tauri-plugin-webdriver` (`macos.rs`) — make the failure diagnosable.** The WKWebView completion-handler error path returned only `NSError.localizedDescription`, which for a script failure is the useless `"A JavaScript exception occurred."`. Now it appends the `NSError` code and the real detail WebKit stores in `userInfo` (`WKJavaScriptExceptionMessage` + line/column). This is the key change: right now the runner tells us nothing about *what* threw. Applies to all four `WKWebView` completion handlers.

**2. `tauri-service` (`execute.ts`) — candidate fix.** Bounded retry (4 attempts, 250ms·n backoff) of the embedded direct eval, **scoped only to the opaque `/javascript exception occurred/i` message** — the exact cold-webview symptom. A genuine script error (e.g. `invalid_command`, a `ReferenceError`) surfaces its own message through the wrapper's `try/catch` and is thrown immediately, never retried. Unit-tested (retry-succeeds / retry-exhausts / no-retry-on-real-error).

**3. `e2e` standalone specs — kill the ~60s "Session not found" storm.** `api.spec.ts` / `logging.spec.ts` did `await browser.deleteSession(); await cleanupWdioSession(browser);`. `cleanupWdioSession` already drives `afterSession`, which restores mocks (a live-session `execute/sync`) **and then** deletes the session. Deleting first makes that mock-restore run against a dead session and retry `Session not found` for the full `connectionRetryCount` (~60s) — on **every** standalone run, pass or fail. Dropped the redundant pre-delete. (`browser.sessionId` is *not* cleared by `deleteSession()` in wdio 9.29, so a session-id guard in the service wouldn't have worked — fixed at the source instead.)

## Could NOT verify locally (26.4-only)

- **Whether change 2 actually turns standalone green.** If the cold-webview failure is a readiness *race*, the retry recovers it. If it's *deterministic* on 26.4 (the task notes standalone went "flaky→consistent"), the retry will not help — but it's harmless, and **change 1 will then print the real `WKJavaScriptExceptionMessage`** so the true fix can be pinned in a follow-up.
- **Whether 26.4 actually populates the `WKJavaScriptException*` userInfo keys.** They're standard WebKit keys, but if 26.4 omits them the message simply falls back to `"A JavaScript exception occurred (code 4)"` — still strictly more than before.

## What CI must confirm (on the macos-26 / 26.4 runner)

1. **`E2E - Tauri [macOS-ARM] - standalone`** — does it go green (retry fixed it) or still fail?
2. If it still fails, the **enriched error text** in that job's log (the real `WKJavaScriptExceptionMessage` / line:col) — that's the payload for the follow-up fix.
3. The **fixture app rebuilds** with change 1 (the plugin crate change) — build job must stay green.
4. **`standalone` job wall-time drops** (~65s → a few seconds) from change 3, on pass and fail.
5. No regression on the other embedded suites (standard/window/multiremote/deeplink) or on Linux/Windows.

## Verified locally

- `cargo check` on `tauri-plugin-wdio-webdriver` (macOS) — passes.
- `biome check` on all touched TS — passes.
- New `execute.ts` retry unit tests added (not executed here — worktree has no `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
