### PR TITLE
fix(ios): build WDA in-session (usePreinstalledWDA walls at :8100 on iOS 26)

### DIFF
--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -40,7 +40,6 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-  FLUTTER_WDA_DD: ${{ github.workspace }}/wda_dd
   FLUTTER_APP_DIR: ${{ github.workspace }}/flutter-ios-app
 
 jobs:
@@ -165,41 +164,14 @@ jobs:
           installed=$(pnpm --filter @repo/e2e exec appium driver list --installed 2>&1 || true)
           echo "$installed" | grep -qi xcuitest || pnpm --filter @repo/e2e exec appium driver install xcuitest
 
-      # WDA DerivedData cache keyed on e2e/package.json (driver pins) + the runner image version.
-      - name: 💾 Restore WDA DerivedData cache
-        id: wda-cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.FLUTTER_WDA_DD }}
-          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v2
-
-      # Pre-build WebDriverAgent deterministically (no appium session, so no socket fragility).
-      # The run consumes it via appium:usePreinstalledWDA + prebuiltWDAPath (simctl install/launch,
-      # no in-session xcodebuild), skipping the multi-minute compile on the first session (which
-      # under WDIO's undici client dropped the POST /session socket on the RN leg).
-      - name: 🏎️ Pre-build WebDriverAgent
-        if: steps.wda-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          WDA_PROJ=$(find node_modules/.pnpm -maxdepth 6 -path '*/appium-webdriveragent/WebDriverAgent.xcodeproj' -type d 2>/dev/null | head -1)
-          test -n "$WDA_PROJ" || { echo "::error::WebDriverAgent.xcodeproj not found under node_modules"; exit 1; }
-          xcodebuild build-for-testing \
-            -project "$WDA_PROJ" \
-            -scheme WebDriverAgentRunner \
-            -derivedDataPath "$FLUTTER_WDA_DD" \
-            -destination 'generic/platform=iOS Simulator' \
-            CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO GCC_TREAT_WARNINGS_AS_ERRORS=0 2>&1 | (xcbeautify || cat)
-          test -d "$FLUTTER_WDA_DD/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app" \
-            || { echo "::error::prebuilt WDA runner not found"; exit 1; }
-
+      # WDA is built in-session by appium-xcuitest (which appium-flutter-driver wraps). The prebuilt-WDA
+      # optimisation (appium:usePreinstalledWDA + a pre-built Runner.app) deterministically walls at
+      # :8100 on the iOS-26 / Xcode-26 runner — the preinstalled WDA launches but its server never
+      # comes up (appium/WebDriverAgent#1147 class). The in-session build works; the wdio config falls
+      # back to it (longer wda/connection timeouts) when FLUTTER_WDA_DD is unset — which it now always
+      # is. Re-introduce the pre-build + usePreinstalledWDA once the upstream path is fixed. See #548.
       - name: 🧪 Run E2E on iOS simulator
         shell: bash
-        # SPIKE (#421): blank FLUTTER_WDA_DD so the wdio config takes the in-session WDA build path
-        # (usePreinstalledWDA off + longer timeouts) — tests whether an in-session WDA build works
-        # on iOS 26, where the preinstalled-WDA path deterministically walls at :8100.
-        env:
-          FLUTTER_WDA_DD: ''
         run: |
           set -euo pipefail
           # FLUTTER_IOS_DEVICE / FLUTTER_IOS_UDID are inherited from the boot step via $GITHUB_ENV.
@@ -208,8 +180,8 @@ jobs:
           # if either failed. The smoke validates the PACKED tarball — its signal must survive an
           # (occasionally flaky) e2e failure. It stays second so it runs on a sim the suite warmed.
           e2e_rc=0; pnpm --filter @repo/e2e run test:e2e:flutter:ios || e2e_rc=$?
-          # Packed @wdio/flutter-service against THIS booted sim, reusing the prebuilt WDA
-          # (FLUTTER_WDA_DD, read by the fixture config).
+          # Packed @wdio/flutter-service against THIS booted sim; WDA is built in-session (like the
+          # suite above — usePreinstalledWDA is off, see #548).
           smoke_rc=0
           FLUTTER_PLATFORM=ios FLUTTER_DEVICE_NAME="$FLUTTER_IOS_DEVICE" pnpm test:package:flutter || smoke_rc=$?
           if [ "$e2e_rc" != 0 ] || [ "$smoke_rc" != 0 ]; then exit 1; fi

--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -195,6 +195,11 @@ jobs:
 
       - name: 🧪 Run E2E on iOS simulator
         shell: bash
+        # SPIKE (#421): blank FLUTTER_WDA_DD so the wdio config takes the in-session WDA build path
+        # (usePreinstalledWDA off + longer timeouts) — tests whether an in-session WDA build works
+        # on iOS 26, where the preinstalled-WDA path deterministically walls at :8100.
+        env:
+          FLUTTER_WDA_DD: ''
         run: |
           set -euo pipefail
           # FLUTTER_IOS_DEVICE / FLUTTER_IOS_UDID are inherited from the boot step via $GITHUB_ENV.

--- a/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-flutter-ios.reusable.yml
@@ -167,7 +167,7 @@ jobs:
       # WDA is built in-session by appium-xcuitest (which appium-flutter-driver wraps). The prebuilt-WDA
       # optimisation (appium:usePreinstalledWDA + a pre-built Runner.app) deterministically walls at
       # :8100 on the iOS-26 / Xcode-26 runner — the preinstalled WDA launches but its server never
-      # comes up (appium/WebDriverAgent#1147 class). The in-session build works; the wdio config falls
+      # comes up (appium/WebDriverAgent#1177; #1147 is the real-device variant). The in-session build works; the wdio config falls
       # back to it (longer wda/connection timeouts) when FLUTTER_WDA_DD is unset — which it now always
       # is. Re-introduce the pre-build + usePreinstalledWDA once the upstream path is fixed. See #548.
       - name: 🧪 Run E2E on iOS simulator

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -239,6 +239,11 @@ jobs:
 
       - name: 🧪 Run E2E on iOS simulator
         shell: bash
+        # SPIKE (#421): blank RN_WDA_DD so the wdio config takes the in-session WDA build path
+        # (usePreinstalledWDA off + longer timeouts) — tests whether an in-session WDA build works
+        # on iOS 26, where the preinstalled-WDA path deterministically walls at :8100.
+        env:
+          RN_WDA_DD: ''
         run: |
           set -euo pipefail
           # RN_IOS_DEVICE / RN_IOS_UDID are inherited from the boot step via $GITHUB_ENV.

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -201,7 +201,7 @@ jobs:
       # WDA is built in-session by appium-xcuitest. The prebuilt-WDA optimisation
       # (appium:usePreinstalledWDA + a pre-built Runner.app) deterministically walls at :8100 on the
       # iOS-26 / Xcode-26 runner — the preinstalled WDA launches but its server never comes up
-      # (appium/WebDriverAgent#1147 class). The in-session build works; the wdio config falls back to
+      # (appium/WebDriverAgent#1177; #1147 is the real-device variant). The in-session build works; the wdio config falls back to
       # it (with longer wda/connection timeouts) when RN_WDA_DD is unset — which it now always is.
       # Re-introduce the pre-build + usePreinstalledWDA once the upstream path is fixed. See #548.
       - name: 🧪 Run E2E on iOS simulator

--- a/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
+++ b/.github/workflows/_ci-e2e-react-native-ios.reusable.yml
@@ -58,10 +58,6 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
   RN_BUILD_DIR: ${{ github.workspace }}/rn-build
-  # Explicit, shared DerivedData for the prebuilt WebDriverAgent: the pre-build step writes here and
-  # the run reads the Runner.app under it (appium:prebuiltWDAPath), so the cached WDA is reused, not
-  # rebuilt.
-  RN_WDA_DD: ${{ github.workspace }}/wda_dd
 
 jobs:
   run:
@@ -202,48 +198,14 @@ jobs:
             pnpm --filter @repo/e2e exec appium driver install xcuitest
           fi
 
-      # WDA DerivedData is keyed on e2e/package.json (xcuitest driver pin) AND the runner
-      # image version. ImageVersion is set automatically on GitHub-hosted macOS runners and
-      # encodes the Xcode major — a stale DerivedData compiled against a previous SDK causes
-      # cryptic E2E failures rather than a clean miss-and-rebuild.
-      - name: 💾 Restore WDA DerivedData cache
-        id: wda-cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.RN_WDA_DD }}
-          key: wda-dd-${{ runner.os }}-${{ env.ImageVersion }}-${{ hashFiles('e2e/package.json') }}-v2
-
-      # Pre-build WebDriverAgent deterministically with a plain xcodebuild (no appium session, so no
-      # socket fragility — it runs to completion). appium-xcuitest otherwise compiles WDA (several
-      # minutes) on the first graded session, and under WDIO's undici client that long POST /session
-      # dropped the socket (UND_ERR_SOCKET) and failed the first spec. Building here, then launching
-      # the Runner.app via appium:usePreinstalledWDA + prebuiltWDAPath (simctl install/launch, no
-      # in-session xcodebuild), means the graded sessions skip the build and are fast.
-      - name: 🏎️ Pre-build WebDriverAgent
-        if: steps.wda-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          WDA_PROJ=$(find node_modules/.pnpm -maxdepth 6 -path '*/appium-webdriveragent/WebDriverAgent.xcodeproj' -type d 2>/dev/null | head -1)
-          test -n "$WDA_PROJ" || { echo "::error::WebDriverAgent.xcodeproj not found under node_modules"; exit 1; }
-          echo "WDA project: $WDA_PROJ"
-          xcodebuild build-for-testing \
-            -project "$WDA_PROJ" \
-            -scheme WebDriverAgentRunner \
-            -derivedDataPath "$RN_WDA_DD" \
-            -destination 'generic/platform=iOS Simulator' \
-            CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO GCC_TREAT_WARNINGS_AS_ERRORS=0 2>&1 | (xcbeautify || cat)
-          RUNNER_APP="$RN_WDA_DD/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app"
-          test -d "$RUNNER_APP" || { echo "::error::prebuilt WDA runner not found at $RUNNER_APP"; find "$RN_WDA_DD/Build/Products" 2>/dev/null | head -40; exit 1; }
-          echo "✅ WDA prebuilt at $RUNNER_APP"
-
+      # WDA is built in-session by appium-xcuitest. The prebuilt-WDA optimisation
+      # (appium:usePreinstalledWDA + a pre-built Runner.app) deterministically walls at :8100 on the
+      # iOS-26 / Xcode-26 runner — the preinstalled WDA launches but its server never comes up
+      # (appium/WebDriverAgent#1147 class). The in-session build works; the wdio config falls back to
+      # it (with longer wda/connection timeouts) when RN_WDA_DD is unset — which it now always is.
+      # Re-introduce the pre-build + usePreinstalledWDA once the upstream path is fixed. See #548.
       - name: 🧪 Run E2E on iOS simulator
         shell: bash
-        # SPIKE (#421): blank RN_WDA_DD so the wdio config takes the in-session WDA build path
-        # (usePreinstalledWDA off + longer timeouts) — tests whether an in-session WDA build works
-        # on iOS 26, where the preinstalled-WDA path deterministically walls at :8100.
-        env:
-          RN_WDA_DD: ''
         run: |
           set -euo pipefail
           # RN_IOS_DEVICE / RN_IOS_UDID are inherited from the boot step via $GITHUB_ENV.
@@ -259,10 +221,10 @@ jobs:
           # (occasionally flaky) e2e failure. It stays second so it runs on a sim+Metro the suite warmed.
           e2e_rc=0; pnpm --filter @repo/e2e run test:e2e:react-native:ios || e2e_rc=$?
           # Validate the PACKED @wdio/react-native-service tarball against THIS booted simulator +
-          # Metro, reusing the prebuilt WDA. test-package.ts installs it into the isolated fixture,
-          # whose own devDeps provide appium + the xcuitest driver (Appium detects drivers from
-          # node_modules). The fixture config reads RN_IOS_UDID + RN_WDA_DD (already exported) to pin
-          # the sim and reuse the WDA. Gated to the new-arch leg so it runs once per service
+          # Metro. test-package.ts installs it into the isolated fixture, whose own devDeps provide
+          # appium + the xcuitest driver (Appium detects drivers from node_modules). The fixture
+          # config reads RN_IOS_UDID (already exported) to pin the sim; WDA is built in-session, like
+          # the suite above. Gated to the new-arch leg so it runs once per service
           # (packaging is arch-independent).
           smoke_rc=0
           if [ "${{ inputs.new-arch }}" = "true" ]; then

--- a/fixtures/package-tests/flutter-app/wdio.conf.ts
+++ b/fixtures/package-tests/flutter-app/wdio.conf.ts
@@ -38,23 +38,30 @@ const capabilities: FlutterCapabilities[] = [
     'appium:automationName': 'Flutter',
     'appium:deviceName': process.env.FLUTTER_DEVICE_NAME ?? (platform === 'ios' ? 'iPhone 16' : 'emulator-5554'),
     'appium:app': appPath,
-    // iOS in CI reuses an already-booted simulator's prebuilt WebDriverAgent (FLUTTER_WDA_DD) so a
-    // session doesn't rebuild WDA. Unset locally, where Appium builds WDA itself.
-    ...(platform === 'ios' && process.env.FLUTTER_WDA_DD
+    // iOS in CI reuses an already-booted simulator; WDA is prebuilt (FLUTTER_WDA_DD) or built
+    // in-session. Unset locally, where Appium builds WDA itself.
+    ...(platform === 'ios'
       ? {
-          // usePreinstalledWDA simctl-installs + launches the prebuilt Runner.app the workflow
-          // leaves under FLUTTER_WDA_DD — no xcodebuild at session time (usePrebuiltWDA still shells
-          // out to `xcodebuild test`, whose first launch overran undici's ~300s POST /session socket
-          // cap → UND_ERR_SOCKET on cold sessions). The reusable strips its embedded XCTest
-          // frameworks so it resolves the simulator's local ones.
-          'appium:usePreinstalledWDA': true,
-          'appium:prebuiltWDAPath': `${process.env.FLUTTER_WDA_DD}/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app`,
-          'appium:wdaLaunchTimeout': 120000,
+          // WDA on CI sims often fails to come up on the first attempt (ECONNREFUSED 8100 / session
+          // timeout) and appium's default is only 2 startup retries — bump it, with a generous
+          // sim-boot margin. Applies whether WDA is prebuilt or built in-session.
           'appium:simulatorStartupTimeout': 240000,
-          // WDA on CI sims often fails to come up on the first attempt (ECONNREFUSED 8100 /
-          // session timeout); appium's default is only 2 startup retries — bump it.
           'appium:wdaStartupRetries': 5,
           'appium:wdaStartupRetryInterval': 20000,
+          // Prebuilt WDA launches fast; the in-session build (FLUTTER_WDA_DD unset) needs the full
+          // xcodebuild-test budget — match e2e/wdio.flutter.conf.ts.
+          'appium:wdaLaunchTimeout': process.env.FLUTTER_WDA_DD ? 120000 : 720000,
+          ...(process.env.FLUTTER_WDA_DD
+            ? {
+                // usePreinstalledWDA simctl-installs + launches the prebuilt Runner.app the workflow
+                // leaves under FLUTTER_WDA_DD — no xcodebuild at session time (usePrebuiltWDA still
+                // shells out to `xcodebuild test`, whose first launch overran undici's ~300s POST
+                // /session socket cap → UND_ERR_SOCKET on cold sessions). The reusable strips its
+                // embedded XCTest frameworks so it resolves the simulator's local ones.
+                'appium:usePreinstalledWDA': true,
+                'appium:prebuiltWDAPath': `${process.env.FLUTTER_WDA_DD}/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app`,
+              }
+            : {}),
         }
       : {}),
     'wdio:flutterServiceOptions': flutterServiceOptions,
@@ -71,10 +78,10 @@ export const config = {
   bail: 0,
   baseUrl: '',
   waitforTimeout: 30000,
-  // Generous per-command ceiling for iOS, but kept below the inflated value that fed the cold
-  // session-create timeout: with usePreinstalledWDA there's no in-session xcodebuild, so POST
-  // /session lands well within undici's ~300s socket cap and doesn't need the WDA-compile budget.
-  connectionRetryTimeout: platform === 'ios' ? 420000 : 180000,
+  // iOS session-create ceiling. Prebuilt WDA (FLUTTER_WDA_DD) lands quickly within undici's ~300s
+  // POST /session socket cap; the in-session build (FLUTTER_WDA_DD unset) needs the full WDA-compile
+  // budget, so match the e2e conf's 15-min window when it's unset.
+  connectionRetryTimeout: platform === 'ios' ? (process.env.FLUTTER_WDA_DD ? 420000 : 900000) : 180000,
   // 0 (not 3): a failed iOS session-create otherwise retries the full 13-min timeout 3× — use the
   // spec retry below (fresh session) instead.
   connectionRetryCount: 0,

--- a/fixtures/package-tests/react-native-app/wdio.conf.ts
+++ b/fixtures/package-tests/react-native-app/wdio.conf.ts
@@ -52,6 +52,15 @@ const capabilities: ReactNativeCapabilities[] = [
         // (RN_IOS_UDID) and reuse the WDA build (RN_WDA_DD) so a session neither re-boots a sim nor
         // rebuilds WDA. Both are unset locally, where Appium resolves by name and builds WDA itself.
         ...(process.env.RN_IOS_UDID ? { 'appium:udid': process.env.RN_IOS_UDID } : {}),
+        // WDA on CI sims often fails to come up on the first attempt (ECONNREFUSED 8100 / session
+        // timeout) and appium's default is only 2 startup retries — bump it, with a generous
+        // sim-boot margin. Applies whether WDA is prebuilt (RN_WDA_DD) or built in-session.
+        'appium:simulatorStartupTimeout': 240000,
+        'appium:wdaStartupRetries': 5,
+        'appium:wdaStartupRetryInterval': 20000,
+        // Prebuilt WDA launches fast; the in-session build (RN_WDA_DD unset) needs the full
+        // xcodebuild-test budget — match e2e/wdio.react-native.conf.ts.
+        'appium:wdaLaunchTimeout': process.env.RN_WDA_DD ? 120000 : 720000,
         ...(process.env.RN_WDA_DD
           ? {
               // usePreinstalledWDA simctl-installs + launches the prebuilt Runner.app the workflow
@@ -61,14 +70,6 @@ const capabilities: ReactNativeCapabilities[] = [
               // XCTest frameworks so it resolves the simulator's local ones.
               'appium:usePreinstalledWDA': true,
               'appium:prebuiltWDAPath': `${process.env.RN_WDA_DD}/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app`,
-              'appium:wdaLaunchTimeout': 120000,
-              // Safety margin for appium's sim-boot monitor on a cold/slow runner (matches the
-              // Flutter fixture + the e2e confs).
-              'appium:simulatorStartupTimeout': 240000,
-              // WDA on CI sims often fails to come up on the first attempt (ECONNREFUSED 8100 /
-              // session timeout); appium's default is only 2 startup retries — bump it.
-              'appium:wdaStartupRetries': 5,
-              'appium:wdaStartupRetryInterval': 20000,
             }
           : {}),
         'wdio:reactNativeServiceOptions': rnServiceOptions,
@@ -93,10 +94,10 @@ export const config = {
   bail: 0,
   baseUrl: '',
   waitforTimeout: 30000,
-  // Generous per-command ceiling for iOS, but kept below the inflated value that fed the cold
-  // session-create timeout: with usePreinstalledWDA there's no in-session xcodebuild, so POST
-  // /session lands well within undici's ~300s socket cap and doesn't need the WDA-compile budget.
-  connectionRetryTimeout: platform === 'ios' ? 420000 : 180000,
+  // iOS session-create ceiling. Prebuilt WDA (RN_WDA_DD) lands quickly within undici's ~300s POST
+  // /session socket cap; the in-session build (RN_WDA_DD unset) needs the full WDA-compile budget,
+  // so match the e2e conf's 15-min window when it's unset.
+  connectionRetryTimeout: platform === 'ios' ? (process.env.RN_WDA_DD ? 420000 : 900000) : 180000,
   // 0 (not 3): a failed iOS session-create otherwise retries the full 13-min timeout 3× — use the
   // spec retry below (fresh session) instead.
   connectionRetryCount: 0,


### PR DESCRIPTION
## Problem

On the `macos-26` runner (iOS 26 / Xcode 26 / iPhone 17), the prebuilt-WDA optimisation (`appium:usePreinstalledWDA` + `prebuiltWDAPath`) **deterministically** fails: the preinstalled WDA launches but its `:8100` server never comes up → session-create times out (120s) on **all** iOS legs. Confirmed even with the correct **WDA 15.1.3**, on the original run **and** a retry — same class as [appium/WebDriverAgent#1147](https://github.com/appium/WebDriverAgent/issues/1147). iOS was green on the pre-July-15 image (`20260630`), so it's the **image upgrade** that broke it.

## Fix

Build WDA **in-session** instead (appium-xcuitest's normal path). Remove the WDA pre-build + DerivedData cache steps and the `*_WDA_DD` env from both iOS workflows — the wdio config already falls back to the in-session build (with longer `wdaLaunchTimeout`/`connectionRetryTimeout`) when the WDA dir is unset.

**Verified green** as a spike: `6 passed, 6 total`, real sessions, no `:8100`. Net wall-time ≈ equal (in-session build lands inside the E2E vs a separate ~5-min pre-build).

## Follow-ups / relations
- **#548** — re-introduce the pre-build + `usePreinstalledWDA` once the upstream path works on iOS 26 (a speed optimisation, not a correctness need).
- **Supersedes #545** — its WDA version-select fix only mattered for the prebuilt path this removes.
- **Unblocks #421** — this clears the WDA wall that was masking the iOS legs; the #421 CoreSimulator-wedge *transient* is separate and remains (retryable, as before). Not closed by this PR.