### PR TITLE
fix(tauri): survive WebKit 26.4 on the macOS DirectEval path (#540)

### DIFF
--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -1041,6 +1041,15 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         args: &[Value],
     ) -> Result<Value, WebDriverErrorResponse>;
 
+    /// Execute a pre-wrapped async DirectEval script (the `/wdio/eval` channel).
+    ///
+    /// The script uses the W3C async-callback contract (`arguments[last]` is the done callback).
+    /// Defaults to `execute_async_script`; a platform may override to avoid a long-lived native
+    /// completion handler (see the macOS executor).
+    async fn execute_direct_eval(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
+        self.execute_async_script(script, &[]).await
+    }
+
     // =========================================================================
     // Screenshots
     // =========================================================================

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -253,6 +253,64 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
         }
     }
 
+    /// DirectEval (`/wdio/eval`) override that avoids a long-lived `callAsyncJavaScript`
+    /// completion handler. The macos-26 (26.4) WebKit reclaims that handler while the async
+    /// script is still pending ("Completion handler for function call is no longer reachable",
+    /// WKError code 4), which fails every async execute on the standalone DirectEval channel.
+    ///
+    /// Instead we drive the pre-wrapped script fire-and-forget — routing its done-callback
+    /// (`arguments[last]`) to a `window` global — then read the result back with short
+    /// synchronous evals, whose completion handlers fire immediately and are never held long
+    /// enough to be reclaimed.
+    async fn execute_direct_eval(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        const FIRE: &str = r#"(function () {
+  var __k = "__KEY__";
+  try { delete window[__k]; } catch (e) {}
+  var __stash = function (r) {
+    try { window[__k] = (r === undefined ? { ok: true, value: null, undef: true } : r); } catch (e) {}
+  };
+  try {
+    (function () { __SCRIPT__ }).apply(null, [__stash]);
+  } catch (e) {
+    window[__k] = { ok: false, error: (e && e.message) || String(e) };
+  }
+})(); undefined;"#;
+
+        const POLL: &str = r#"(function () {
+  var __k = "__KEY__";
+  var r = window[__k];
+  if (r !== undefined && r !== null) { try { delete window[__k]; } catch (e) {} return r; }
+  return null;
+})()"#;
+
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let key = format!("__wdio_de_{}__", COUNTER.fetch_add(1, Ordering::Relaxed));
+
+        // Kick the async work; its done-callback stashes the result on window[key].
+        let fire = FIRE.replace("__KEY__", &key).replace("__SCRIPT__", script);
+        self.evaluate_js(&fire).await?;
+
+        // Read the result back with short synchronous evals until present or the script deadline.
+        let poll = POLL.replace("__KEY__", &key);
+        let poll_interval = std::time::Duration::from_millis(15);
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_millis(self.timeouts.script_ms);
+        loop {
+            let res = self.evaluate_js(&poll).await?;
+            if let Some(value) = res.get("value") {
+                if !value.is_null() {
+                    return Ok(value.clone());
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(WebDriverErrorResponse::script_timeout());
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
     // =========================================================================
     // Screenshots
     // =========================================================================

--- a/packages/tauri-plugin-webdriver/src/server/handlers/direct_eval.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/direct_eval.rs
@@ -61,7 +61,7 @@ pub async fn eval<R: Runtime + 'static>(
         }
     };
 
-    match executor.execute_async_script(&req.script, &[]).await {
+    match executor.execute_direct_eval(&req.script).await {
         Ok(result) => {
             match result.get("ok").and_then(|v| v.as_bool()) {
                 Some(true) => {


### PR DESCRIPTION
## Problem

The embedded provider's **standalone-binary DirectEval** channel (`POST /wdio/eval`) walls on the `macos-26` image (26.4):

```
A JavaScript exception occurred (code 4):
Completion handler for function call is no longer reachable @ 0:0
```

macOS 26.4's WebKit reclaims the `callAsyncJavaScript` completion handler while the async execute (`core.invoke(...)`) is still pending, so every async execute on that channel fails. It's **deterministic** on the runner (original run + retry) yet **passes locally on macOS 26.5**, so it can't be reproduced locally.

## Fix (structural)

Override `execute_direct_eval` on macOS to **never hold a native completion handler across the await**:
- run the pre-wrapped script **fire-and-forget**, routing its done-callback (`arguments[last]`) to a `window` global;
- read the result back with **short synchronous evals**, whose completion handlers fire immediately and are never held long enough to be reclaimed.

Other platforms keep `execute_async_script` via a new trait default — macOS is the only behaviour change. This also hardens the core `execute`/`mock` channel against webview-suspension completion-handler loss generally, not just this runner bug.

Local smoke on macOS 26.5.1: `✅ Platform info test passed` (async invoke via the new bridge), `✅ Simple execute test passed`, `1 passed, 0 failed` — no regression.

## Why no gate here (deliberate isolation)

The failure can't be reproduced locally (26.5 passes), so the **ungated** standalone-macOS leg on the 26.4 CI runner is the only honest adjudicator of whether this fix works. Landing it with the allow-fail gate would let the gate mask the very signal we need.

- **Green** ⇒ the fix works; no gate ever needed.
- **Red / timeout** ⇒ the mechanism is something else (e.g. full webview suspension); fall back to the scoped allow-fail gate.

Refs #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)