### PR TITLE
test(tauri): capture app hang diagnostics on the embedded macOS standalone leg (#540)

### DIFF
--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -430,7 +430,9 @@ jobs:
         shell: bash
         run: |
           # Stop the sampler and gather any crash/hang reports for the app (#540).
-          [ -f /tmp/tauri-hang-sampler.pid ] && kill "$(cat /tmp/tauri-hang-sampler.pid)" 2>/dev/null || true
+          if [ -f /tmp/tauri-hang-sampler.pid ]; then
+            kill "$(cat /tmp/tauri-hang-sampler.pid)" 2>/dev/null || true
+          fi
           mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
           shopt -s nullglob
           for f in "$HOME"/Library/Logs/DiagnosticReports/tauri-e2e-app*; do

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -388,6 +388,26 @@ jobs:
             pkill -9 -f tauri-e2e-app || true
           fi
 
+      # #540: the embedded standalone/deeplink legs intermittently wedge on the macos-26 image — the
+      # app hangs mid-execute and its WebDriver server stops responding. Sample the app in the
+      # background so a hang leaves stuck-thread stacks in the artifacts (sample needs no root).
+      - name: 🩺 Start hang sampler [Embedded]
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
+          (
+            for _ in $(seq 1 90); do
+              pid=$(pgrep -x tauri-e2e-app | head -1 || true)
+              if [ -n "$pid" ]; then
+                /usr/bin/sample "$pid" 2 -mayDie \
+                  -file "$GITHUB_WORKSPACE/e2e/logs/diag/sample-embedded-$pid-$(date +%s).log" >/dev/null 2>&1 || true
+              fi
+              sleep 4
+            done
+          ) &
+          echo $! > /tmp/tauri-hang-sampler.pid
+
       - name: 🧪 E2E Tests [Embedded]
         id: test-embedded
         continue-on-error: true
@@ -404,6 +424,19 @@ jobs:
           } else {
             pnpm run ${{ steps.gen-test.outputs.embedded }}
           }
+
+      - name: 🩺 Collect hang diagnostics [Embedded]
+        if: always() && runner.os == 'macOS'
+        shell: bash
+        run: |
+          # Stop the sampler and gather any crash/hang reports for the app (#540).
+          [ -f /tmp/tauri-hang-sampler.pid ] && kill "$(cat /tmp/tauri-hang-sampler.pid)" 2>/dev/null || true
+          mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
+          shopt -s nullglob
+          for f in "$HOME"/Library/Logs/DiagnosticReports/tauri-e2e-app*; do
+            cp "$f" "$GITHUB_WORKSPACE/e2e/logs/diag/$(basename "$f").log" 2>/dev/null || true
+          done
+          echo "diag artifacts:"; ls -la "$GITHUB_WORKSPACE/e2e/logs/diag" 2>/dev/null || echo "  (none)"
 
       - name: 🧹 Post-cleanup [Embedded]
         if: always()

--- a/e2e/test/tauri/standalone/api.spec.ts
+++ b/e2e/test/tauri/standalone/api.spec.ts
@@ -5,7 +5,7 @@ import url from 'node:url';
 import { cleanupWdioSession, createTauriCapabilities, startWdioSession } from '@wdio/tauri-service';
 import '@wdio/native-types';
 import { xvfb } from '@wdio/xvfb';
-import { resolveTauriFixtureBinary } from '../../../lib/utils.js';
+import { getLogDirName, resolveTauriFixtureBinary } from '../../../lib/utils.js';
 
 // Get the directory name once at the top
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
@@ -32,6 +32,24 @@ const sessionOptions = createTauriCapabilities(appBinaryPath, {
   driverProvider,
   autoInstallTauriDriver: true,
 });
+
+// #540: capture the app's backend/frontend logs so an intermittent macOS-26.4 embedded hang (the
+// app wedges mid-execute and its WebDriver server stops responding) leaves evidence in the uploaded
+// artifacts. Writes under e2e/logs/, which the CI "Upload Test Logs" step collects.
+const logDir = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'logs',
+  getLogDirName('standalone', path.basename(appDir), driverProvider),
+);
+if (sessionOptions['wdio:tauriServiceOptions']) {
+  sessionOptions['wdio:tauriServiceOptions'].captureBackendLogs = true;
+  sessionOptions['wdio:tauriServiceOptions'].captureFrontendLogs = true;
+  sessionOptions['wdio:tauriServiceOptions'].backendLogLevel = 'info';
+  sessionOptions['wdio:tauriServiceOptions'].logDir = logDir;
+}
 
 // Initialize xvfb if running on Linux
 if (process.platform === 'linux') {


### PR DESCRIPTION
## Why

The embedded **standalone + deeplink** macOS legs intermittently (~1 in 3) wedge on the `macos-26` image (26.4). Traced lifecycle on a failing run:

- App spawns, `WebDriver server ready on :4445`, diagnostics pass, session created, `before() complete` ✅
- Then `api.spec.ts:50` `execute(get_platform_info)` **hangs ~31 s** → hits the 30 s `commandTimeout`
- The app's HTTP server (:4445) then goes unresponsive → `failed to send request` for ~35 s until cleanup kills it

So the app **hangs mid-execute**, it doesn't fail to start. It's **not reproducible locally** (macOS 26.5.1 is immune — likely a 26.4 WebKit bug fixed in 26.5) and it's **independent of #549's fix** (standard/window/multiremote pass with the same binary; #549 fixed the *deterministic* completion-handler variant, this is the residual *hang*).

**Blocker:** CI captured **zero app-side evidence** — `api.spec.ts` didn't set `captureBackendLogs`, and a background hang doesn't auto-generate a macOS report. So we can't tell if the WebContent process is *suspended* (App-Nap/occlusion), *deadlocked*, or *crashed*.

## What this adds (diagnostic-only)

- **`api.spec.ts`** — enable `captureBackendLogs` / `captureFrontendLogs` so the app's stderr lands in the uploaded artifacts.
- **`_ci-e2e-tauri-all-providers.reusable.yml`** — during the embedded step on macOS, **`sample` the app process in the background** so a hang leaves stuck-thread stacks (`sample` needs no root and works on wedged processes — exactly the tool for a hang), and collect any `DiagnosticReports` crash/hang reports on teardown. Both land under `e2e/logs/diag/*.log`, which the existing upload collects.

No behaviour change. The next flake occurrence should yield the stuck stacks → the real fix (App-Nap disable vs wait-for-26.5). Refs #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)