### PR TITLE
fix(tauri): correct malformed fixture CSP (root cause) + harden macOS DirectEval against WebKit code-4 (#540)

### DIFF
--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -388,26 +388,6 @@ jobs:
             pkill -9 -f tauri-e2e-app || true
           fi
 
-      # #540: the embedded standalone/deeplink legs intermittently wedge on the macos-26 image — the
-      # app hangs mid-execute and its WebDriver server stops responding. Sample the app in the
-      # background so a hang leaves stuck-thread stacks in the artifacts (sample needs no root).
-      - name: 🩺 Start hang sampler [Embedded]
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
-          (
-            for _ in $(seq 1 90); do
-              pid=$(pgrep -x tauri-e2e-app | head -1 || true)
-              if [ -n "$pid" ]; then
-                /usr/bin/sample "$pid" 2 -mayDie \
-                  -file "$GITHUB_WORKSPACE/e2e/logs/diag/sample-embedded-$pid-$(date +%s).log" >/dev/null 2>&1 || true
-              fi
-              sleep 4
-            done
-          ) &
-          echo $! > /tmp/tauri-hang-sampler.pid
-
       - name: 🧪 E2E Tests [Embedded]
         id: test-embedded
         continue-on-error: true
@@ -424,21 +404,6 @@ jobs:
           } else {
             pnpm run ${{ steps.gen-test.outputs.embedded }}
           }
-
-      - name: 🩺 Collect hang diagnostics [Embedded]
-        if: always() && runner.os == 'macOS'
-        shell: bash
-        run: |
-          # Stop the sampler and gather any crash/hang reports for the app (#540).
-          if [ -f /tmp/tauri-hang-sampler.pid ]; then
-            kill "$(cat /tmp/tauri-hang-sampler.pid)" 2>/dev/null || true
-          fi
-          mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
-          shopt -s nullglob
-          for f in "$HOME"/Library/Logs/DiagnosticReports/tauri-e2e-app*; do
-            cp "$f" "$GITHUB_WORKSPACE/e2e/logs/diag/$(basename "$f").log" 2>/dev/null || true
-          done
-          echo "diag artifacts:"; ls -la "$GITHUB_WORKSPACE/e2e/logs/diag" 2>/dev/null || echo "  (none)"
 
       - name: 🧹 Post-cleanup [Embedded]
         if: always()

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -396,9 +396,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
+          # Write as .log so the "Upload Test Logs" step (e2e/logs/**/*.log) actually collects it.
           /usr/bin/log stream --level debug --style compact \
             --predicate 'subsystem == "com.apple.WebKit" OR process == "com.apple.WebKit.WebContent" OR process == "com.apple.WebKit.GPU"' \
-            > "$GITHUB_WORKSPACE/e2e/logs/diag/webkit-log.txt" 2>&1 &
+            > "$GITHUB_WORKSPACE/e2e/logs/diag/webkit-log.log" 2>&1 &
           echo $! > /tmp/webkit-log.pid
 
       - name: 🧪 E2E Tests [Embedded]
@@ -430,11 +431,16 @@ jobs:
           fi
           mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
           shopt -s nullglob
-          for f in "$HOME"/Library/Logs/DiagnosticReports/*.ips "$HOME"/Library/Logs/DiagnosticReports/*.crash; do
-            case "$(basename "$f")" in
-              tauri-e2e-app*|*WebContent*|*WebKit*|*GPU*|*Networking*)
-                cp "$f" "$GITHUB_WORKSPACE/e2e/logs/diag/$(basename "$f").log" 2>/dev/null || true ;;
-            esac
+          # Helper-process (WebContent/GPU) crashes land in the ROOT DiagnosticReports, not $HOME —
+          # scan both. The runner user is admin, so sudo -n reads root-owned reports.
+          for dir in "$HOME/Library/Logs/DiagnosticReports" "/Library/Logs/DiagnosticReports"; do
+            for f in "$dir"/*.ips "$dir"/*.crash; do
+              case "$(basename "$f")" in
+                tauri-e2e-app*|*WebContent*|*WebKit*|*GPU*|*Networking*)
+                  sudo -n cp "$f" "$GITHUB_WORKSPACE/e2e/logs/diag/$(basename "$f").log" 2>/dev/null \
+                    || cp "$f" "$GITHUB_WORKSPACE/e2e/logs/diag/$(basename "$f").log" 2>/dev/null || true ;;
+              esac
+            done
           done
           echo "diag artifacts:"; ls -la "$GITHUB_WORKSPACE/e2e/logs/diag" 2>/dev/null || echo "  (none)"
 

--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -388,6 +388,19 @@ jobs:
             pkill -9 -f tauri-e2e-app || true
           fi
 
+      # #540 discriminator (macOS): passively stream the WebKit unified log during the embedded run so
+      # a hang shows whether the WebContent process was SUSPENDED (throttling) or CRASHED — sampling the
+      # app instead risks keeping the process warm. No `sample`; just a log stream we tear down after.
+      - name: 🩺 Start WebKit log stream [Embedded]
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
+          /usr/bin/log stream --level debug --style compact \
+            --predicate 'subsystem == "com.apple.WebKit" OR process == "com.apple.WebKit.WebContent" OR process == "com.apple.WebKit.GPU"' \
+            > "$GITHUB_WORKSPACE/e2e/logs/diag/webkit-log.txt" 2>&1 &
+          echo $! > /tmp/webkit-log.pid
+
       - name: 🧪 E2E Tests [Embedded]
         id: test-embedded
         continue-on-error: true
@@ -404,6 +417,26 @@ jobs:
           } else {
             pnpm run ${{ steps.gen-test.outputs.embedded }}
           }
+
+      # #540 discriminator (macOS): stop the log stream and collect crash reports for ALL WebKit
+      # helper processes (WebContent / GPU / Networking), not just the app — the earlier diag missed
+      # exactly the process whose state is in question.
+      - name: 🩺 Collect WebKit diagnostics [Embedded]
+        if: always() && runner.os == 'macOS'
+        shell: bash
+        run: |
+          if [ -f /tmp/webkit-log.pid ]; then
+            kill "$(cat /tmp/webkit-log.pid)" 2>/dev/null || true
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/e2e/logs/diag"
+          shopt -s nullglob
+          for f in "$HOME"/Library/Logs/DiagnosticReports/*.ips "$HOME"/Library/Logs/DiagnosticReports/*.crash; do
+            case "$(basename "$f")" in
+              tauri-e2e-app*|*WebContent*|*WebKit*|*GPU*|*Networking*)
+                cp "$f" "$GITHUB_WORKSPACE/e2e/logs/diag/$(basename "$f").log" 2>/dev/null || true ;;
+            esac
+          done
+          echo "diag artifacts:"; ls -la "$GITHUB_WORKSPACE/e2e/logs/diag" 2>/dev/null || echo "  (none)"
 
       - name: 🧹 Post-cleanup [Embedded]
         if: always()

--- a/e2e/test/tauri/standalone/api.spec.ts
+++ b/e2e/test/tauri/standalone/api.spec.ts
@@ -5,7 +5,7 @@ import url from 'node:url';
 import { cleanupWdioSession, createTauriCapabilities, startWdioSession } from '@wdio/tauri-service';
 import '@wdio/native-types';
 import { xvfb } from '@wdio/xvfb';
-import { resolveTauriFixtureBinary } from '../../../lib/utils.js';
+import { getLogDirName, resolveTauriFixtureBinary } from '../../../lib/utils.js';
 
 // Get the directory name once at the top
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
@@ -32,6 +32,23 @@ const sessionOptions = createTauriCapabilities(appBinaryPath, {
   driverProvider,
   autoInstallTauriDriver: true,
 });
+
+// #540: capture the app's backend/frontend logs (incl. the plugin's occlusion/activation tracing) so
+// a hang leaves evidence in the uploaded artifacts. Writes under e2e/logs/ (CI "Upload Test Logs").
+const logDir = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'logs',
+  getLogDirName('standalone', path.basename(appDir), driverProvider),
+);
+if (sessionOptions['wdio:tauriServiceOptions']) {
+  sessionOptions['wdio:tauriServiceOptions'].captureBackendLogs = true;
+  sessionOptions['wdio:tauriServiceOptions'].captureFrontendLogs = true;
+  sessionOptions['wdio:tauriServiceOptions'].backendLogLevel = 'info';
+  sessionOptions['wdio:tauriServiceOptions'].logDir = logDir;
+}
 
 // Initialize xvfb if running on Linux
 if (process.platform === 'linux') {

--- a/e2e/test/tauri/standalone/api.spec.ts
+++ b/e2e/test/tauri/standalone/api.spec.ts
@@ -5,7 +5,7 @@ import url from 'node:url';
 import { cleanupWdioSession, createTauriCapabilities, startWdioSession } from '@wdio/tauri-service';
 import '@wdio/native-types';
 import { xvfb } from '@wdio/xvfb';
-import { getLogDirName, resolveTauriFixtureBinary } from '../../../lib/utils.js';
+import { resolveTauriFixtureBinary } from '../../../lib/utils.js';
 
 // Get the directory name once at the top
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
@@ -32,24 +32,6 @@ const sessionOptions = createTauriCapabilities(appBinaryPath, {
   driverProvider,
   autoInstallTauriDriver: true,
 });
-
-// #540: capture the app's backend/frontend logs so an intermittent macOS-26.4 embedded hang (the
-// app wedges mid-execute and its WebDriver server stops responding) leaves evidence in the uploaded
-// artifacts. Writes under e2e/logs/, which the CI "Upload Test Logs" step collects.
-const logDir = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'logs',
-  getLogDirName('standalone', path.basename(appDir), driverProvider),
-);
-if (sessionOptions['wdio:tauriServiceOptions']) {
-  sessionOptions['wdio:tauriServiceOptions'].captureBackendLogs = true;
-  sessionOptions['wdio:tauriServiceOptions'].captureFrontendLogs = true;
-  sessionOptions['wdio:tauriServiceOptions'].backendLogLevel = 'info';
-  sessionOptions['wdio:tauriServiceOptions'].logDir = logDir;
-}
 
 // Initialize xvfb if running on Linux
 if (process.platform === 'linux') {

--- a/fixtures/e2e-apps/tauri/src-tauri/tauri.conf.json
+++ b/fixtures/e2e-apps/tauri/src-tauri/tauri.conf.json
@@ -16,9 +16,10 @@
         ],
         "connect-src": [
           "'self'",
-          "ipc:*",
-          "plugin:*",
-          "tauri:*"
+          "ipc:",
+          "http://ipc.localhost",
+          "plugin:",
+          "tauri:"
         ],
         "img-src": [
           "'self'",

--- a/fixtures/package-tests/tauri-app/src-tauri/tauri.conf.json
+++ b/fixtures/package-tests/tauri-app/src-tauri/tauri.conf.json
@@ -16,9 +16,10 @@
         ],
         "connect-src": [
           "'self'",
-          "ipc:*",
-          "plugin:*",
-          "tauri:*"
+          "ipc:",
+          "http://ipc.localhost",
+          "plugin:",
+          "tauri:"
         ],
         "img-src": [
           "'self'",

--- a/packages/tauri-plugin-webdriver/Cargo.toml
+++ b/packages/tauri-plugin-webdriver/Cargo.toml
@@ -50,7 +50,7 @@ features = [ "NSImage", "NSImageRep", "NSBitmapImageRep" ]
 
 [target."cfg(target_os = \"macos\")".dependencies.objc2-web-kit]
 version = "0.3"
-features = [ "WKWebView", "WKSnapshotConfiguration", "WKUIDelegate", "WKPDFConfiguration", "WKFrameInfo", "WKContentWorld", "block2", "objc2-app-kit" ]
+features = [ "WKWebView", "WKWebViewConfiguration", "WKSnapshotConfiguration", "WKUIDelegate", "WKPDFConfiguration", "WKFrameInfo", "WKContentWorld", "WKUserContentController", "WKScriptMessage", "WKScriptMessageHandler", "block2", "objc2-app-kit" ]
 
 [target."cfg(target_os = \"windows\")".dependencies]
 webview2-com = "0.38"

--- a/packages/tauri-plugin-webdriver/src/eval_channel.rs
+++ b/packages/tauri-plugin-webdriver/src/eval_channel.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use serde_json::Value;
+use tokio::sync::oneshot;
+
+/// Correlates DirectEval results the webview reports back out-of-band, keyed by id.
+///
+/// The macOS DirectEval path runs its script via `callAsyncJavaScript` to keep the run loop pumping
+/// (so the app's own `core.invoke` IPC resolves on a headless runner) but must NOT read the result
+/// from that call's completion handler — macOS 26.4's WebKit reclaims it intermittently. Instead the
+/// script posts `{ id, result }` to a `WKScriptMessageHandler`, which calls `complete` to wake the
+/// executor awaiting `register`. Mirrors the Windows `AsyncScriptState` native-handler pattern.
+/// Removable once the upstream reclaim is resolved:
+/// https://github.com/webdriverio/desktop-mobile/issues/540
+#[derive(Default)]
+pub struct EvalResultRegistry {
+    pending: Mutex<HashMap<String, oneshot::Sender<Value>>>,
+}
+
+impl EvalResultRegistry {
+    pub fn register(&self, id: String) -> oneshot::Receiver<Value> {
+        let (tx, rx) = oneshot::channel();
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.insert(id, tx);
+        }
+        rx
+    }
+
+    /// No-op if `id` is unknown or already completed, so a duplicate or late report is harmless.
+    pub fn complete(&self, id: &str, result: Value) {
+        if let Ok(mut pending) = self.pending.lock() {
+            if let Some(tx) = pending.remove(id) {
+                let _ = tx.send(result);
+            }
+        }
+    }
+
+    /// Drop a pending registration (e.g. on timeout) so its sender doesn't leak.
+    pub fn cancel(&self, id: &str) {
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.remove(id);
+        }
+    }
+}

--- a/packages/tauri-plugin-webdriver/src/lib.rs
+++ b/packages/tauri-plugin-webdriver/src/lib.rs
@@ -9,6 +9,8 @@ mod desktop;
 mod mobile;
 
 mod error;
+#[cfg(target_os = "macos")]
+mod eval_channel;
 mod platform;
 mod server;
 mod webdriver;
@@ -58,6 +60,10 @@ pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
 
             // Manage per-window alert state
             app.manage(platform::AlertStateManager::default());
+
+            // Arc so the (non-generic) objc2 message handler can hold its own clone; see eval_channel.
+            #[cfg(target_os = "macos")]
+            app.manage(std::sync::Arc::new(eval_channel::EvalResultRegistry::default()));
 
             // Start the WebDriver HTTP server
             let app_handle = app.app_handle().clone();

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -56,6 +56,22 @@ pub fn register_webview_handlers<R: Runtime>(webview: &tauri::Webview<R>) {
     let _ = webview.with_webview(move |webview| unsafe {
         let wk_webview: &WKWebView = &*webview.inner().cast();
 
+        // #540: on macOS 26.4 WebKit throttles/suspends the WebContent process of an *occluded* page,
+        // so in-webview evaluateJavaScript wedges on the headless CI runner — the app sends the
+        // RunJavaScriptInFrameInScriptWorld IPC and never gets a reply because the WebContent process
+        // is suspended. Disable window-occlusion detection so this webview's page is always treated as
+        // visible and its WebContent process keeps running. Private WKWebView SPI, so guard it with
+        // respondsToSelector (a no-op if a future WebKit drops it).
+        let occlusion_sel = objc2::sel!(_setWindowOcclusionDetectionEnabled:);
+        if wk_webview.respondsToSelector(occlusion_sel) {
+            let _: () = msg_send![wk_webview, _setWindowOcclusionDetectionEnabled: false];
+            tracing::info!("Disabled WKWebView window-occlusion detection to keep WebContent live (#540)");
+        } else {
+            tracing::warn!(
+                "_setWindowOcclusionDetectionEnabled: unavailable — occlusion throttling not disabled (#540)"
+            );
+        }
+
         let delegate = WebDriverUIDelegate::new(alert_state);
         let delegate_protocol: Retained<ProtocolObject<dyn WKUIDelegate>> =
             ProtocolObject::from_retained(delegate);

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -10,13 +10,14 @@ use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOn
 use objc2_app_kit::{NSBitmapImageFileType, NSBitmapImageRep, NSImage};
 use objc2_foundation::{NSData, NSDictionary, NSError, NSObject, NSObjectProtocol, NSString};
 use objc2_web_kit::{
-    WKContentWorld, WKFrameInfo, WKPDFConfiguration, WKSnapshotConfiguration, WKUIDelegate,
-    WKWebView,
+    WKContentWorld, WKFrameInfo, WKPDFConfiguration, WKScriptMessage, WKScriptMessageHandler,
+    WKSnapshotConfiguration, WKUIDelegate, WKUserContentController, WKWebView,
 };
 use serde_json::Value;
 use tauri::{Manager, Runtime, WebviewWindow};
 use tokio::sync::oneshot;
 
+use crate::eval_channel::EvalResultRegistry;
 use crate::platform::alert_state::{AlertState, AlertStateManager, AlertType, PendingAlert};
 use crate::platform::{wrap_script_for_frame_context, FrameId, PlatformExecutor, PrintOptions};
 use crate::server::response::WebDriverErrorResponse;
@@ -52,6 +53,12 @@ pub fn register_webview_handlers<R: Runtime>(webview: &tauri::Webview<R>) {
     // Get per-window alert state from the manager
     let manager = webview.app_handle().state::<AlertStateManager>();
     let alert_state = manager.get_or_create(webview.label());
+    // Cloned Arc so the (non-generic) objc2 message handler can hold it for the webview's lifetime.
+    let eval_registry = webview
+        .app_handle()
+        .state::<Arc<EvalResultRegistry>>()
+        .inner()
+        .clone();
 
     let _ = webview.with_webview(move |webview| unsafe {
         let wk_webview: &WKWebView = &*webview.inner().cast();
@@ -72,7 +79,17 @@ pub fn register_webview_handlers<R: Runtime>(webview: &tauri::Webview<R>) {
             OBJC_ASSOCIATION_RETAIN_NONATOMIC,
         );
 
-        tracing::debug!("Registered UI delegate for webview");
+        // The DirectEval result channel (see execute_direct_eval). WKUserContentController retains the
+        // handler for the webview's lifetime, so — unlike the UI delegate — it needs no associated object.
+        let eval_handler = EvalMessageHandler::new(eval_registry);
+        let eval_proto: Retained<ProtocolObject<dyn WKScriptMessageHandler>> =
+            ProtocolObject::from_retained(eval_handler);
+        wk_webview
+            .configuration()
+            .userContentController()
+            .addScriptMessageHandler_name(&eval_proto, &NSString::from_str("wdioEvalResult"));
+
+        tracing::debug!("Registered UI delegate + eval message handler for webview");
     });
 }
 
@@ -253,48 +270,55 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
         }
     }
 
-    /// DirectEval (`/wdio/eval`) via `callAsyncJavaScript` — the same WebKit-driven mechanism the
-    /// session `execute_async_script` path uses, which works on macos-26 (26.4). WebKit holds a
-    /// run-loop activity until the returned promise settles, and that pumps Tauri's `core.invoke`
-    /// response IPC. The prior fire-and-forget + poll approach left nothing driving that pump, so on
-    /// the slow/headless 26.4 runner the awaited invoke never resolved and the poll spun to timeout
-    /// (#540) — independent of poll rate.
+    /// DirectEval (`/wdio/eval`) with out-of-band result delivery.
     ///
-    /// The pre-wrapped script (`wrapScriptForDirectEval`) is callback-style: `arguments[last]` is its
-    /// done-callback. Bridge it to callAsyncJavaScript's promise contract by passing `resolve` as that
-    /// callback and **returning the promise object directly** (`return new Promise(...)`, not
-    /// `return await ...`), exactly as the working session `execute_async_script` path does. On 26.4
-    /// the extra `await` hop makes WebKit lose the completion handler's reachability ("Completion
-    /// handler for function call is no longer reachable", WKError code 4) — which is what #549 hit and
-    /// wrongly attributed to callAsyncJavaScript itself.
+    /// Runs the pre-wrapped script via `callAsyncJavaScript` solely to keep the run loop pumping — on a
+    /// headless runner the app's own `core.invoke` IPC response only completes while WebKit holds a
+    /// run-loop activity. The result is NOT taken from that call's completion handler: macOS 26.4's
+    /// WebKit intermittently reclaims it ("Completion handler for function call is no longer
+    /// reachable"). Instead the wrapper posts `{ id, result }` to the `wdioEvalResult`
+    /// `WKScriptMessageHandler`, which completes the `oneshot` awaited here, so a reclaim is harmless.
+    /// Mirrors the Windows native-handler path (`AsyncScriptState`).
+    /// https://github.com/webdriverio/desktop-mobile/issues/540
+    ///
+    /// `wrapScriptForDirectEval` produces a callback-style script (`arguments[last]` is its
+    /// done-callback); `__report` forwards the result to the message handler then `resolve`s so the
+    /// `callAsyncJavaScript` promise settles.
     async fn execute_direct_eval(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = format!("wdio_de_{}", COUNTER.fetch_add(1, Ordering::Relaxed));
+
+        // Register the waiter before dispatching, so a fast report can't arrive before we're listening.
+        let registry = self
+            .window
+            .state::<Arc<EvalResultRegistry>>()
+            .inner()
+            .clone();
+        let rx = registry.register(id.clone());
+
+        // id is alphanumeric + '_', so it needs no escaping in the JS string literal below.
         let wrapper = format!(
-            "return new Promise((resolve) => {{ (function () {{ {script} }}).apply(null, [resolve]); }});"
+            r#"return new Promise((resolve) => {{
+  var __report = function (r) {{
+    try {{ window.webkit.messageHandlers.wdioEvalResult.postMessage({{ id: "{id}", result: r }}); }} catch (e) {{}}
+    resolve(r);
+  }};
+  (function () {{ {script} }}).apply(null, [__report]);
+}});"#
         );
 
-        let (tx, rx) = oneshot::channel();
-
-        let result = self.window.with_webview(move |webview| unsafe {
+        let dispatch = self.window.with_webview(move |webview| unsafe {
             let wk_webview: &WKWebView = &*webview.inner().cast();
             let ns_script = NSString::from_str(&wrapper);
             let mtm = MainThreadMarker::new_unchecked();
             let empty_dict: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::new();
             let content_world = WKContentWorld::pageWorld(mtm);
 
-            let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
-            let block = RcBlock::new(move |result: *mut AnyObject, error: *mut NSError| {
-                let response = if !error.is_null() {
-                    Err(describe_ns_error(&*error))
-                } else if result.is_null() {
-                    Ok(Value::Null)
-                } else {
-                    Ok(ns_object_to_json(&*result))
-                };
-
-                if let Ok(mut guard) = tx.lock() {
-                    if let Some(tx) = guard.take() {
-                        let _ = tx.send(response);
-                    }
+            // Observability only — the result arrives via the message channel, not this handler.
+            let block = RcBlock::new(move |_result: *mut AnyObject, error: *mut NSError| {
+                if !error.is_null() {
+                    tracing::debug!("DirectEval completion error (ignored): {}", describe_ns_error(&*error));
                 }
             });
 
@@ -307,16 +331,22 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
             );
         });
 
-        if let Err(e) = result {
+        if let Err(e) = dispatch {
+            registry.cancel(&id);
             return Err(WebDriverErrorResponse::javascript_error(&e.to_string(), None));
         }
 
         let timeout = std::time::Duration::from_millis(self.timeouts.script_ms);
         match tokio::time::timeout(timeout, rx).await {
-            Ok(Ok(Ok(value))) => Ok(value),
-            Ok(Ok(Err(error))) => Err(WebDriverErrorResponse::javascript_error(&error, None)),
-            Ok(Err(_)) => Err(WebDriverErrorResponse::unknown_error("Channel closed")),
-            Err(_) => Err(WebDriverErrorResponse::script_timeout()),
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(_)) => {
+                registry.cancel(&id);
+                Err(WebDriverErrorResponse::unknown_error("Eval result channel closed"))
+            }
+            Err(_) => {
+                registry.cancel(&id);
+                Err(WebDriverErrorResponse::script_timeout())
+            }
         }
     }
 
@@ -787,6 +817,55 @@ impl WebDriverUIDelegate {
         let mtm = MainThreadMarker::new_unchecked();
         let this = Self::alloc(mtm);
         let this = this.set_ivars(WebDriverUIDelegateIvars { alert_state });
+        msg_send![super(this), init]
+    }
+}
+
+struct EvalMessageHandlerIvars {
+    registry: Arc<EvalResultRegistry>,
+}
+
+// SAFETY: Arc<EvalResultRegistry> is Send + Sync
+unsafe impl Send for EvalMessageHandlerIvars {}
+unsafe impl Sync for EvalMessageHandlerIvars {}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[name = "WdioEvalMessageHandler"]
+    #[ivars = EvalMessageHandlerIvars]
+    struct EvalMessageHandler;
+
+    unsafe impl NSObjectProtocol for EvalMessageHandler {}
+
+    #[allow(non_snake_case)]
+    unsafe impl WKScriptMessageHandler for EvalMessageHandler {
+        /// Delivers `{ id, result }` posted by the DirectEval wrapper to the waiting executor.
+        #[unsafe(method(userContentController:didReceiveScriptMessage:))]
+        fn userContentController_didReceiveScriptMessage(
+            &self,
+            _controller: &WKUserContentController,
+            message: &WKScriptMessage,
+        ) {
+            let json = unsafe { ns_object_to_json(&message.body()) };
+            let (Some(id), Some(result)) =
+                (json.get("id").and_then(Value::as_str), json.get("result").cloned())
+            else {
+                tracing::warn!("wdioEvalResult message missing id/result");
+                return;
+            };
+            self.ivars().registry.complete(id, result);
+        }
+    }
+);
+
+impl EvalMessageHandler {
+    /// # Safety
+    /// Must be called from the main thread.
+    unsafe fn new(registry: Arc<EvalResultRegistry>) -> Retained<Self> {
+        let mtm = MainThreadMarker::new_unchecked();
+        let this = Self::alloc(mtm);
+        let this = this.set_ivars(EvalMessageHandlerIvars { registry });
         msg_send![super(this), init]
     }
 }

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -7,7 +7,7 @@ use block2::{DynBlock, RcBlock};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
-use objc2_app_kit::{NSApplication, NSBitmapImageFileType, NSBitmapImageRep, NSImage};
+use objc2_app_kit::{NSBitmapImageFileType, NSBitmapImageRep, NSImage};
 use objc2_foundation::{NSData, NSDictionary, NSError, NSObject, NSObjectProtocol, NSString};
 use objc2_web_kit::{
     WKContentWorld, WKFrameInfo, WKPDFConfiguration, WKSnapshotConfiguration, WKUIDelegate,
@@ -55,27 +55,6 @@ pub fn register_webview_handlers<R: Runtime>(webview: &tauri::Webview<R>) {
 
     let _ = webview.with_webview(move |webview| unsafe {
         let wk_webview: &WKWebView = &*webview.inner().cast();
-
-        // #540: on the headless macos-26 (26.4) CI runner the WebContent process of the (never-shown)
-        // webview page wedges — the app sends RunJavaScriptInFrameInScriptWorld and never gets a reply,
-        // so in-webview evaluateJavaScript hangs. Two mitigations for the "WebKit treats the page as
-        // background/occluded and throttles its WebContent process" hypothesis:
-        //   1. disable window-occlusion detection so the page is always treated as visible;
-        //   2. mark the app as active/foreground so its windows aren't background.
-        // Both are guarded (SPI / no-op off-screen) and harmless when a real display is present.
-        let occlusion_sel = objc2::sel!(_setWindowOcclusionDetectionEnabled:);
-        if wk_webview.respondsToSelector(occlusion_sel) {
-            let _: () = msg_send![wk_webview, _setWindowOcclusionDetectionEnabled: false];
-            tracing::info!("#540: disabled WKWebView window-occlusion detection");
-        } else {
-            tracing::warn!("#540: _setWindowOcclusionDetectionEnabled: unavailable");
-        }
-
-        if let Some(mtm) = MainThreadMarker::new() {
-            let app = NSApplication::sharedApplication(mtm);
-            app.activate();
-            tracing::info!("#540: activated app to keep windows foreground");
-        }
 
         let delegate = WebDriverUIDelegate::new(alert_state);
         let delegate_protocol: Retained<ProtocolObject<dyn WKUIDelegate>> =
@@ -313,12 +292,18 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
         let fire = FIRE.replace("__KEY__", &key).replace("__SCRIPT__", script);
         self.evaluate_js(&fire).await?;
 
-        // Read the result back with short synchronous evals until present or the script deadline.
+        // Read the result back with periodic reads until present or the script deadline. Poll
+        // gently: each read is an evaluateJavaScript on the page, and Tauri delivers its
+        // core.invoke responses by eval-ing into the *same* webview — a tight poll (the original
+        // 15ms) starves that response eval on a slow/headless runner, so the awaited invoke never
+        // resolves and this loop spins to timeout (#540). Wait before the first read so the fired
+        // async work gets a turn, then read at a wide interval that leaves the webview free.
         let poll = POLL.replace("__KEY__", &key);
-        let poll_interval = std::time::Duration::from_millis(15);
+        let poll_interval = std::time::Duration::from_millis(150);
         let deadline =
             std::time::Instant::now() + std::time::Duration::from_millis(self.timeouts.script_ms);
         loop {
+            tokio::time::sleep(poll_interval).await;
             let res = self.evaluate_js(&poll).await?;
             if let Some(value) = res.get("value") {
                 if !value.is_null() {
@@ -328,7 +313,6 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
             if std::time::Instant::now() >= deadline {
                 return Err(WebDriverErrorResponse::script_timeout());
             }
-            tokio::time::sleep(poll_interval).await;
         }
     }
 

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -261,14 +261,15 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
     /// (#540) — independent of poll rate.
     ///
     /// The pre-wrapped script (`wrapScriptForDirectEval`) is callback-style: `arguments[last]` is its
-    /// done-callback. Bridge it to callAsyncJavaScript's promise contract with a single minimal wrap,
-    /// passing `resolve` as that callback. (#549 abandoned callAsyncJavaScript after routing this
-    /// script through `execute_async_script`, whose extra wrapping double-wrapped it and tripped the
-    /// "completion handler no longer reachable" reclaim; the session path — a simple single wrap —
-    /// never hit that, and neither does this one.)
+    /// done-callback. Bridge it to callAsyncJavaScript's promise contract by passing `resolve` as that
+    /// callback and **returning the promise object directly** (`return new Promise(...)`, not
+    /// `return await ...`), exactly as the working session `execute_async_script` path does. On 26.4
+    /// the extra `await` hop makes WebKit lose the completion handler's reachability ("Completion
+    /// handler for function call is no longer reachable", WKError code 4) — which is what #549 hit and
+    /// wrongly attributed to callAsyncJavaScript itself.
     async fn execute_direct_eval(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
         let wrapper = format!(
-            "return await new Promise((resolve) => {{ (function () {{ {script} }}).apply(null, [resolve]); }});"
+            "return new Promise((resolve) => {{ (function () {{ {script} }}).apply(null, [resolve]); }});"
         );
 
         let (tx, rx) = oneshot::channel();

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -7,7 +7,7 @@ use block2::{DynBlock, RcBlock};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
-use objc2_app_kit::{NSBitmapImageFileType, NSBitmapImageRep, NSImage};
+use objc2_app_kit::{NSApplication, NSBitmapImageFileType, NSBitmapImageRep, NSImage};
 use objc2_foundation::{NSData, NSDictionary, NSError, NSObject, NSObjectProtocol, NSString};
 use objc2_web_kit::{
     WKContentWorld, WKFrameInfo, WKPDFConfiguration, WKSnapshotConfiguration, WKUIDelegate,
@@ -56,20 +56,25 @@ pub fn register_webview_handlers<R: Runtime>(webview: &tauri::Webview<R>) {
     let _ = webview.with_webview(move |webview| unsafe {
         let wk_webview: &WKWebView = &*webview.inner().cast();
 
-        // #540: on macOS 26.4 WebKit throttles/suspends the WebContent process of an *occluded* page,
-        // so in-webview evaluateJavaScript wedges on the headless CI runner — the app sends the
-        // RunJavaScriptInFrameInScriptWorld IPC and never gets a reply because the WebContent process
-        // is suspended. Disable window-occlusion detection so this webview's page is always treated as
-        // visible and its WebContent process keeps running. Private WKWebView SPI, so guard it with
-        // respondsToSelector (a no-op if a future WebKit drops it).
+        // #540: on the headless macos-26 (26.4) CI runner the WebContent process of the (never-shown)
+        // webview page wedges — the app sends RunJavaScriptInFrameInScriptWorld and never gets a reply,
+        // so in-webview evaluateJavaScript hangs. Two mitigations for the "WebKit treats the page as
+        // background/occluded and throttles its WebContent process" hypothesis:
+        //   1. disable window-occlusion detection so the page is always treated as visible;
+        //   2. mark the app as active/foreground so its windows aren't background.
+        // Both are guarded (SPI / no-op off-screen) and harmless when a real display is present.
         let occlusion_sel = objc2::sel!(_setWindowOcclusionDetectionEnabled:);
         if wk_webview.respondsToSelector(occlusion_sel) {
             let _: () = msg_send![wk_webview, _setWindowOcclusionDetectionEnabled: false];
-            tracing::info!("Disabled WKWebView window-occlusion detection to keep WebContent live (#540)");
+            tracing::info!("#540: disabled WKWebView window-occlusion detection");
         } else {
-            tracing::warn!(
-                "_setWindowOcclusionDetectionEnabled: unavailable — occlusion throttling not disabled (#540)"
-            );
+            tracing::warn!("#540: _setWindowOcclusionDetectionEnabled: unavailable");
+        }
+
+        if let Some(mtm) = MainThreadMarker::new() {
+            let app = NSApplication::sharedApplication(mtm);
+            app.activate();
+            tracing::info!("#540: activated app to keep windows foreground");
         }
 
         let delegate = WebDriverUIDelegate::new(alert_state);

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -253,66 +253,69 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
         }
     }
 
-    /// DirectEval (`/wdio/eval`) override that avoids a long-lived `callAsyncJavaScript`
-    /// completion handler. The macos-26 (26.4) WebKit reclaims that handler while the async
-    /// script is still pending ("Completion handler for function call is no longer reachable",
-    /// WKError code 4), which fails every async execute on the standalone DirectEval channel.
+    /// DirectEval (`/wdio/eval`) via `callAsyncJavaScript` — the same WebKit-driven mechanism the
+    /// session `execute_async_script` path uses, which works on macos-26 (26.4). WebKit holds a
+    /// run-loop activity until the returned promise settles, and that pumps Tauri's `core.invoke`
+    /// response IPC. The prior fire-and-forget + poll approach left nothing driving that pump, so on
+    /// the slow/headless 26.4 runner the awaited invoke never resolved and the poll spun to timeout
+    /// (#540) — independent of poll rate.
     ///
-    /// Instead we drive the pre-wrapped script fire-and-forget — routing its done-callback
-    /// (`arguments[last]`) to a `window` global — then read the result back with short
-    /// synchronous evals, whose completion handlers fire immediately and are never held long
-    /// enough to be reclaimed.
+    /// The pre-wrapped script (`wrapScriptForDirectEval`) is callback-style: `arguments[last]` is its
+    /// done-callback. Bridge it to callAsyncJavaScript's promise contract with a single minimal wrap,
+    /// passing `resolve` as that callback. (#549 abandoned callAsyncJavaScript after routing this
+    /// script through `execute_async_script`, whose extra wrapping double-wrapped it and tripped the
+    /// "completion handler no longer reachable" reclaim; the session path — a simple single wrap —
+    /// never hit that, and neither does this one.)
     async fn execute_direct_eval(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
-        use std::sync::atomic::{AtomicU64, Ordering};
+        let wrapper = format!(
+            "return await new Promise((resolve) => {{ (function () {{ {script} }}).apply(null, [resolve]); }});"
+        );
 
-        const FIRE: &str = r#"(function () {
-  var __k = "__KEY__";
-  try { delete window[__k]; } catch (e) {}
-  var __stash = function (r) {
-    try { window[__k] = (r === undefined ? { ok: true, value: null, undef: true } : r); } catch (e) {}
-  };
-  try {
-    (function () { __SCRIPT__ }).apply(null, [__stash]);
-  } catch (e) {
-    window[__k] = { ok: false, error: (e && e.message) || String(e) };
-  }
-})(); undefined;"#;
+        let (tx, rx) = oneshot::channel();
 
-        const POLL: &str = r#"(function () {
-  var __k = "__KEY__";
-  var r = window[__k];
-  if (r !== undefined && r !== null) { try { delete window[__k]; } catch (e) {} return r; }
-  return null;
-})()"#;
+        let result = self.window.with_webview(move |webview| unsafe {
+            let wk_webview: &WKWebView = &*webview.inner().cast();
+            let ns_script = NSString::from_str(&wrapper);
+            let mtm = MainThreadMarker::new_unchecked();
+            let empty_dict: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::new();
+            let content_world = WKContentWorld::pageWorld(mtm);
 
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let key = format!("__wdio_de_{}__", COUNTER.fetch_add(1, Ordering::Relaxed));
+            let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
+            let block = RcBlock::new(move |result: *mut AnyObject, error: *mut NSError| {
+                let response = if !error.is_null() {
+                    Err(describe_ns_error(&*error))
+                } else if result.is_null() {
+                    Ok(Value::Null)
+                } else {
+                    Ok(ns_object_to_json(&*result))
+                };
 
-        // Kick the async work; its done-callback stashes the result on window[key].
-        let fire = FIRE.replace("__KEY__", &key).replace("__SCRIPT__", script);
-        self.evaluate_js(&fire).await?;
-
-        // Read the result back with periodic reads until present or the script deadline. Poll
-        // gently: each read is an evaluateJavaScript on the page, and Tauri delivers its
-        // core.invoke responses by eval-ing into the *same* webview — a tight poll (the original
-        // 15ms) starves that response eval on a slow/headless runner, so the awaited invoke never
-        // resolves and this loop spins to timeout (#540). Wait before the first read so the fired
-        // async work gets a turn, then read at a wide interval that leaves the webview free.
-        let poll = POLL.replace("__KEY__", &key);
-        let poll_interval = std::time::Duration::from_millis(150);
-        let deadline =
-            std::time::Instant::now() + std::time::Duration::from_millis(self.timeouts.script_ms);
-        loop {
-            tokio::time::sleep(poll_interval).await;
-            let res = self.evaluate_js(&poll).await?;
-            if let Some(value) = res.get("value") {
-                if !value.is_null() {
-                    return Ok(value.clone());
+                if let Ok(mut guard) = tx.lock() {
+                    if let Some(tx) = guard.take() {
+                        let _ = tx.send(response);
+                    }
                 }
-            }
-            if std::time::Instant::now() >= deadline {
-                return Err(WebDriverErrorResponse::script_timeout());
-            }
+            });
+
+            wk_webview.callAsyncJavaScript_arguments_inFrame_inContentWorld_completionHandler(
+                &ns_script,
+                Some(&empty_dict),
+                None,
+                &content_world,
+                Some(&block),
+            );
+        });
+
+        if let Err(e) = result {
+            return Err(WebDriverErrorResponse::javascript_error(&e.to_string(), None));
+        }
+
+        let timeout = std::time::Duration::from_millis(self.timeouts.script_ms);
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(Ok(value))) => Ok(value),
+            Ok(Ok(Err(error))) => Err(WebDriverErrorResponse::javascript_error(&error, None)),
+            Ok(Err(_)) => Err(WebDriverErrorResponse::unknown_error("Channel closed")),
+            Err(_) => Err(WebDriverErrorResponse::script_timeout()),
         }
     }
 


### PR DESCRIPTION
Addresses the macOS-26.4 embedded-DirectEval flake (#540) — `browser.tauri.execute` in standalone/deeplink/package modes. Root-caused from the WebKit unified log + local reproduction.

## 1. Root cause — malformed fixture CSP (the real fix)

Both Tauri fixtures (`fixtures/e2e-apps/tauri` and `fixtures/package-tests/tauri-app`) used `connect-src: ["ipc:*", "plugin:*", "tauri:*"]`. The stray `*` makes them malformed CSP scheme-sources that don't match the IPC custom-protocol URL (macOS/Linux fetch `ipc://localhost/<cmd>`; Windows/Android `http://ipc.localhost`). WebKit blocked that `fetch`, so Tauri **sticky-fell-back to the postMessage IPC interface** — whose response is delivered by eval-ing into the webview and only completes while the run loop is pumping. On the **idle headless macos-26.4 runner** it isn't, so `core.invoke` stalled and DirectEval timed out. Locally a real display keeps the loop pumping, which is why it never reproduced — the custom-protocol failure was present locally too (66×/run).

Fix: `ipc:` / `plugin:` / `tauri:` (+ `http://ipc.localhost`). **Verified as a controlled A/B on CI:** with the e2e fixture's CSP fixed, every DirectEval macOS leg went green and IPC-custom-protocol failures dropped to **0** on the runner, while the package-test leg — CSP still malformed — failed with the same `Script execution timed out` stall; fixing its CSP greened it too.

## 2. Harden the DirectEval result path against WebKit code-4 (defense-in-depth)

Independently, macOS 26.4's WebKit intermittently reclaims `callAsyncJavaScript`'s completion handler (`Completion handler for function call is no longer reachable`, WKError code 4). This delivers the DirectEval result **out-of-band** instead, mirroring the Windows `AsyncScriptState` native-handler path: `EvalResultRegistry` (`eval_channel.rs`, keyed `oneshot`) + a `wdioEvalResult` `WKScriptMessageHandler` (macos.rs); `execute_direct_eval` runs the script via `callAsyncJavaScript` (to pump) but takes the result from the message channel, so a reclaim is harmless. macOS-only.

## Residual — tracked separately

A residual intermittent stall remains on the **off-screen headless 26.4 runner**: with nothing driving the run loop, WebKit doesn't promptly schedule work (page-load / eval), so a DirectEval leg can still occasionally time out. This is environmental (no display → idle run loop), re-runnable, and unrelated to the two fixes here. A follow-up PR attempts a run-loop-pump mitigation; the WebKit-log diagnostics are **retained** on this branch for that work.

Refs https://github.com/webdriverio/desktop-mobile/issues/540

🤖 Generated with [Claude Code](https://claude.com/claude-code)