### PR TITLE
ci(rust): run clippy on the first-party Rust crates

### DIFF
--- a/.github/workflows/_ci-rust-clippy.reusable.yml
+++ b/.github/workflows/_ci-rust-clippy.reusable.yml
@@ -1,0 +1,88 @@
+name: Rust Clippy (Reusable)
+
+permissions:
+  contents: read
+
+# Lints the first-party Rust crates with `cargo clippy --all-targets -- -D warnings`.
+#
+# Nothing else in CI lints Rust. The only Rust that gets compiled today is the
+# dioxus crates on Linux and the fixture apps, so the platform modules in
+# tauri-plugin-webdriver (macos.rs / windows.rs / linux.rs) are each seen by
+# exactly one runner and never under lint — which is how `clippy::incompatible_msrv`
+# violations reached `main` unnoticed. Hence the per-OS call sites in ci.yml:
+# linting on one OS would leave two thirds of that crate unchecked.
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system to run on'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      crates:
+        description: 'Newline-separated crate directories to lint (also used as the rust-cache workspaces)'
+        required: true
+        type: string
+
+jobs:
+  clippy:
+    name: cargo clippy
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
+    steps:
+      - name: 👷 Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: 🦀 Install Rust toolchain
+        shell: bash
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add clippy
+
+      - name: 🦀 Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ inputs.crates }}
+          cache-on-failure: true
+          # ~/.cargo/bin/ can carry over stale binaries (e.g. rustup-init in
+          # place of cargo) across runs on macOS, breaking the toolchain.
+          cache-bin: false
+
+      - name: 🦀 Install Linux system dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        # webkit2gtk/soup/javascriptcoregtk back the Linux webview for both the
+        # tauri plugin and the dioxus crates. libxdo is a hard link dependency
+        # dioxus-desktop picks up transitively (via muda/tray-icon) for X11
+        # keyboard automation.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            libxdo-dev \
+            libayatana-appindicator3-dev
+
+      - name: 🔍 Run clippy
+        shell: bash
+        env:
+          CRATES: ${{ inputs.crates }}
+        run: |
+          set -euo pipefail
+          status=0
+          while IFS= read -r crate; do
+            [ -n "$crate" ] || continue
+            echo "::group::cargo clippy ($crate)"
+            if ! cargo clippy --manifest-path "$crate/Cargo.toml" --all-targets -- -D warnings; then
+              echo "::error file=$crate/Cargo.toml::clippy failed for $crate"
+              status=1
+            fi
+            echo "::endgroup::"
+          done <<< "$CRATES"
+          exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1255,6 +1255,10 @@ jobs:
       - package-electrobun-macos-arm
       - package-electrobun-windows
       - build-matrix
+      - clippy-tauri-crates-linux
+      - clippy-tauri-crates-windows
+      - clippy-tauri-crates-macos-arm
+      - clippy-dioxus-crates-linux
       - build-dioxus-crates-linux
       - build-tauri-e2e-app-linux
       - build-tauri-e2e-app-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,60 @@ jobs:
       artifact_size: ${{ needs.build.outputs.artifact_size }}
       cache_key: ${{ needs.build.outputs.cache_key }}
 
+  # Lint the Tauri Rust crates. Runs on all three OSes on purpose: the plugin's
+  # platform modules are `#[cfg]`-gated, so a single-OS run would leave two of
+  # macos.rs / windows.rs / linux.rs unlinted.
+  clippy-tauri-crates-linux:
+    name: Clippy Tauri Crates [Linux]
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-rust-clippy.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
+      crates: |
+        packages/tauri-plugin
+        packages/tauri-plugin-webdriver
+
+  clippy-tauri-crates-windows:
+    name: Clippy Tauri Crates [Windows]
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-rust-clippy.reusable.yml
+    secrets: inherit
+    with:
+      os: 'windows-latest'
+      crates: |
+        packages/tauri-plugin
+        packages/tauri-plugin-webdriver
+
+  clippy-tauri-crates-macos-arm:
+    name: Clippy Tauri Crates [macOS-ARM]
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.run_tauri == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-rust-clippy.reusable.yml
+    secrets: inherit
+    with:
+      os: 'macos-latest'
+      crates: |
+        packages/tauri-plugin
+        packages/tauri-plugin-webdriver
+
+  # Lint the Dioxus Rust crates. Linux-only for now, matching the v1 scope of
+  # build-dioxus-crates-linux below.
+  clippy-dioxus-crates-linux:
+    name: Clippy Dioxus Crates [Linux]
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.run_dioxus == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-rust-clippy.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
+      crates: |
+        packages/dioxus-bridge
+        packages/dioxus-driver
+        packages/dioxus-embedded-driver
+
   # Build Tauri E2E app binaries - only if Tauri tests will run
   build-tauri-e2e-app-linux:
     name: Build Tauri E2E App [Linux]

--- a/packages/dioxus-bridge/src/invoke.rs
+++ b/packages/dioxus-bridge/src/invoke.rs
@@ -188,7 +188,7 @@ mod tests {
   #[test]
   fn should_forward_args_to_registered_handlers() {
     let registry = CommandRegistry::new();
-    registry.register("echo", |args| Ok(args));
+    registry.register("echo", Ok);
     let response = handle_invoke_request(&registry, &req(r#"{"command":"echo","args":{"hello":"world"}}"#));
     let body = parse_body(&response);
     assert_eq!(body["ok"], true);

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -1945,7 +1945,7 @@ fn tauri_cookie_to_webdriver(cookie: &TauriCookie<'static>) -> Cookie {
         secure: cookie.secure().unwrap_or(false),
         http_only: cookie.http_only().unwrap_or(false),
         expiry: cookie.expires().and_then(|exp| match exp {
-            Expiration::DateTime(dt) => Some(dt.unix_timestamp().cast_unsigned()),
+            Expiration::DateTime(dt) => u64::try_from(dt.unix_timestamp()).ok(),
             Expiration::Session => None,
         }),
         same_site: cookie.same_site().map(|ss| match ss {
@@ -1979,7 +1979,10 @@ fn webdriver_cookie_to_tauri(cookie: &Cookie) -> TauriCookie<'static> {
     }
 
     if let Some(expiry) = cookie.expiry {
-        if let Ok(dt) = OffsetDateTime::from_unix_timestamp(expiry.cast_signed()) {
+        if let Some(dt) = i64::try_from(expiry)
+            .ok()
+            .and_then(|expiry| OffsetDateTime::from_unix_timestamp(expiry).ok())
+        {
             builder = builder.expires(Expiration::DateTime(dt));
         }
     }

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -559,7 +559,7 @@ unsafe fn image_to_png_base64(image: &NSImage) -> Result<String, String> {
 unsafe fn describe_ns_error(error: &NSError) -> String {
     let mut out = format!(
         "{} (code {})",
-        error.localizedDescription().to_string(),
+        error.localizedDescription(),
         error.code()
     );
 

--- a/packages/tauri-plugin/src/commands.rs
+++ b/packages/tauri-plugin/src/commands.rs
@@ -115,10 +115,14 @@ pub(crate) async fn execute<R: Runtime>(
                         b'\'' if !in_double_quote && !in_backtick => in_single_quote = !in_single_quote,
                         b'"' if !in_single_quote && !in_backtick => in_double_quote = !in_double_quote,
                         b'`' if !in_single_quote && !in_double_quote => in_backtick = !in_backtick,
-                        b'=' if !in_single_quote && !in_double_quote && !in_backtick => {
-                            if i + 1 < bytes.len() && bytes[i + 1] == b'>' {
-                                return true;
-                            }
+                        b'='
+                            if !in_single_quote
+                                && !in_double_quote
+                                && !in_backtick
+                                && i + 1 < bytes.len()
+                                && bytes[i + 1] == b'>' =>
+                        {
+                            return true;
                         }
                         _ => {}
                     }
@@ -183,7 +187,7 @@ pub(crate) async fn execute<R: Runtime>(
             let mut i = 0;
             while i < bytes.len() {
                 let b = bytes[i];
-                let top_in_str = tmpl.last().map_or(false, |f| f.in_str);
+                let top_in_str = tmpl.last().is_some_and(|f| f.in_str);
 
                 // Escape: skip next byte when inside a string or template string chars.
                 if b == b'\\' && (in_single_quote || in_double_quote || top_in_str) {


### PR DESCRIPTION
## Description

Nothing in CI lints Rust today. The only Rust that gets compiled is the dioxus crates on Linux (`_ci-build-dioxus-crates.reusable.yml`) plus the fixture app builds — so `tauri-plugin-webdriver`'s `#[cfg]`-gated platform modules are each seen by exactly one runner and never under lint, and `packages/tauri-plugin` is only ever compiled transitively.

The result is that violations accumulate on `main` unnoticed. Both open Tauri contributor PRs hit them and had to work around them with `-A` flags to get a clean local clippy run (#527 used `-A clippy::incompatible-msrv`; #532 fixed one of them as a drive-by). That's friction we're pushing onto contributors for no reason.

### What this adds

`_ci-rust-clippy.reusable.yml` runs `cargo clippy --all-targets -- -D warnings` over a caller-supplied, newline-separated crate list, wired into `ci.yml` as:

| Job | OS | Crates | Gate |
|---|---|---|---|
| `clippy-tauri-crates-linux` | ubuntu | `tauri-plugin`, `tauri-plugin-webdriver` | `run_tauri` |
| `clippy-tauri-crates-windows` | windows | same | `run_tauri` |
| `clippy-tauri-crates-macos-arm` | macOS | same | `run_tauri` |
| `clippy-dioxus-crates-linux` | ubuntu | `dioxus-bridge`, `dioxus-driver`, `dioxus-embedded-driver` | `run_dioxus` |

The tauri crates run on all three OSes on purpose — a single-OS run would leave two of `macos.rs` / `windows.rs` / `linux.rs` unlinted, which is precisely how the current violations survived. Dioxus is Linux-only, matching the documented v1 scope of the existing `build-dioxus-crates-linux` job. Both are gated on the same `detect-changes` outputs as their sibling build jobs (`packages/tauri-plugin*` → `tauri`, `packages/dioxus-*` → `dioxus`, per the path classifier).

### Violations fixed

Six, across three crates:

- **`executor.rs`** — `cast_unsigned` / `cast_signed` for cookie expiry. These are stable since 1.87 against the crate's declared `rust-version = "1.77"`, so this was a genuine MSRV violation rather than lint noise. Switched to `try_from`.
- **`macos.rs`** — `.to_string()` on a `Display` type passed into `format!`.
- **`commands.rs`** (×2) — nested `if` folded into its match guard; `map_or(false, …)` → `is_some_and(…)` (stable since 1.70, matching that crate's MSRV).
- **`dioxus-bridge/invoke.rs`** — redundant `|args| Ok(args)` closure.

The `commands.rs` guard collapse is behaviour-preserving: when the added conditions fail the arm falls through to `_ => {}`, which is what the inner `if` did by falling out of the block.

### Deliberately not included

`cargo fmt --check`. 18 files in `tauri-plugin-webdriver` alone already drift from rustfmt on `main`, so wiring it up needs a repo-wide reformat first — which would conflict with both open Tauri PRs. Worth doing as its own PR once those land.

Also not included: `cargo test` for the tauri plugin crates. Those 17 unit tests currently never run in CI either, and `clippy --all-targets` already pays the compile cost, so it's a cheap follow-up — happy to fold it in here if you'd prefer.

## Type of Change

- [x] Internal/tooling change (build scripts, CI, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)

## Scope

- [x] `scope:tauri` - Tauri service and plugin

## Testing

Locally on macOS, all five crates pass the exact command CI runs:

```
packages/tauri-plugin                      PASS
packages/tauri-plugin-webdriver            PASS
packages/dioxus-bridge                     PASS
packages/dioxus-driver                     PASS
packages/dioxus-embedded-driver            PASS
```

- `cargo test` — tauri-plugin-webdriver 15 passed, dioxus-bridge 24 passed, tauri-plugin has no tests
- `actionlint .github/workflows/*.yml` — clean (the `lint` job runs this)
- Confirmed the four touched Rust files carry the same rustfmt drift before and after these edits, i.e. no new drift introduced

**Only the macOS leg is verified locally.** The Linux and Windows legs compile code paths I can't reach from here (`linux.rs`, `windows.rs`), so this PR's own CI run is the real check — don't merge until those three jobs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsgeivZCqduTQmWK55zqiT