### PR TITLE
fix(ci): stop fork PRs failing on write-scoped checks

### DIFF
--- a/.github/workflows/ci-required-status.yml
+++ b/.github/workflows/ci-required-status.yml
@@ -1,0 +1,80 @@
+name: CI Required Status
+
+# Publishes the `CI / Required` commit status for fork pull requests.
+#
+# The `ci-required` ruleset requires that status context, but the CI workflow
+# cannot post it on a fork PR: a `pull_request` run from a fork gets a read-only
+# GITHUB_TOKEN, so the publish call in ci.yml's `ci-status` job 403s. Without
+# this workflow the context is never published at all and the ruleset can never
+# be satisfied, so external contributions are permanently unmergeable.
+#
+# `workflow_run` runs in the base-repo context with a writable token and never
+# checks out PR code, so it can publish safely. The verdict is not taken from
+# the fork — it is read from the conclusion GitHub recorded for the `CI Summary`
+# job, which already encodes the curated required-job set via its `needs` list
+# (quarantined jobs are deliberately excluded there, and that stays the single
+# source of truth).
+#
+# Note: GitHub only ever runs the copy of this file on the default branch, so
+# changes to it take effect after merge, not on the PR that introduces them.
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+# Statuses are per-commit, so serialising by head SHA is exactly the scope that
+# can race. Queue rather than cancel so a re-run cannot overtake its predecessor.
+concurrency:
+  group: ci-required-status-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  statuses: write
+  actions: read
+
+jobs:
+  publish:
+    name: Publish CI / Required
+    runs-on: ubuntu-latest
+    # Fork PRs only — everything else already published the status from ci.yml.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    steps:
+      - name: Publish CI / Required commit status
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id,
+              per_page: 100,
+            });
+            const summary = jobs.find((job) => job.name === 'CI Summary');
+
+            // Never leave the context unpublished: the ruleset would sit pending forever
+            // with nothing able to resolve it. An absent or non-success summary is red.
+            let state = 'failure';
+            let description = 'One or more required CI jobs failed';
+            if (!summary) {
+              description = 'CI Summary job did not run';
+            } else if (summary.conclusion === 'success') {
+              state = 'success';
+              description = 'All required CI jobs passed';
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: run.head_sha,
+              state,
+              context: 'CI / Required',
+              description,
+              target_url: run.html_url,
+            });
+
+            core.info(`Published CI / Required=${state} to ${run.head_sha} (${description}).`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1240,7 +1240,12 @@ jobs:
         # The job already skips Dependabot pull_request runs (see the job-level `if`), so this
         # only ever runs where publishing is wanted: normal PRs, pushes, and the ci:run-
         # dispatched workflow_dispatch run. `always()` so a failure still posts a red status.
-        if: always()
+        #
+        # Skipped for fork PRs: their GITHUB_TOKEN is read-only, so this 403s and takes the
+        # whole job down with it, which is worse than not publishing — the job's own
+        # conclusion is what ci-required-status.yml reads to publish the status for them.
+        # `head.repo.fork` is null on push/workflow_dispatch, so those still publish here.
+        if: always() && github.event.pull_request.head.repo.fork != true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,9 +8,10 @@ on:
       - synchronize
       - reopened
 
+# No write scopes: fork PRs get a read-only GITHUB_TOKEN regardless of what is
+# requested here, so anything needing write would fail for external contributors.
 permissions:
   pull-requests: read
-  statuses: write
 
 jobs:
   validate-pr-title:
@@ -38,5 +39,7 @@ jobs:
           requireScope: false
           validateSingleCommit: false
           validateSingleCommitMatchesPrTitle: false
-          # Allow WIP pull requests
-          wip: true
+          # `wip: true` is deliberately not set. It exists for repos without draft
+          # PRs, and it makes the action POST a commit status — which 403s on fork
+          # PRs and fails the job before the title verdict is even reported. This
+          # repo is public, so draft PRs cover the same need.

--- a/.github/workflows/release-preview-comment.yml
+++ b/.github/workflows/release-preview-comment.yml
@@ -56,6 +56,11 @@ jobs:
           script: |
             const fs = require('fs');
             const MARKER = '<!-- releasekit-preview -->';
+            // Stamped into the comment so a run can tell whether a newer one already
+            // wrote it. `run_number` increases monotonically per workflow, so it orders
+            // runs even when they share a head SHA — which label/unlabel events do.
+            const RUN_TAG = /<!-- releasekit-preview-run: (\d+) -->/;
+            const runNumber = context.payload.workflow_run.run_number;
 
             if (!fs.existsSync('preview/preview.md')) {
               core.info('No preview artifact contents; nothing to post.');
@@ -89,7 +94,8 @@ jobs:
 
             // releasekit keys its comment off the marker so repeated runs update in
             // place. Re-add it if the preview body did not already carry one.
-            const body = raw.startsWith(MARKER) ? raw : `${MARKER}\n\n${raw}`;
+            const withMarker = raw.startsWith(MARKER) ? raw : `${MARKER}\n\n${raw}`;
+            const body = `${withMarker}\n\n<!-- releasekit-preview-run: ${runNumber} -->`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -100,6 +106,15 @@ jobs:
             const existing = comments.find((comment) => comment.body?.includes(MARKER));
 
             if (existing) {
+              // Cancelling a superseded consumer does not recall an update it already
+              // dispatched, so refuse to write over a comment a newer run produced.
+              const stamped = existing.body?.match(RUN_TAG);
+              if (stamped && Number(stamped[1]) >= runNumber) {
+                core.info(
+                  `Comment on #${prNumber} is from run ${stamped[1]} (this is ${runNumber}); leaving the newer preview in place.`,
+                );
+                return;
+              }
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/release-preview-comment.yml
+++ b/.github/workflows/release-preview-comment.yml
@@ -19,11 +19,15 @@ on:
     workflows: ['Release Preview']
     types: [completed]
 
-# Serialise per source branch so two runs for the same PR cannot interleave their
-# writes. Combined with the head-SHA check below, the newest run always wins.
+# Serialise per source branch. `cancel-in-progress: false` is deliberate: cancelling
+# a consumer does not recall an update it already dispatched, so two live consumers
+# could both read the old run stamp and race their writes. Queueing instead makes the
+# read-check-write below mutually exclusive, and the stamp then decides the winner
+# deterministically. GitHub keeps only the newest pending run per group, so a burst
+# of label events collapses to first + last rather than building a backlog.
 concurrency:
   group: release-preview-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   pull-requests: write
@@ -106,8 +110,8 @@ jobs:
             const existing = comments.find((comment) => comment.body?.includes(MARKER));
 
             if (existing) {
-              // Cancelling a superseded consumer does not recall an update it already
-              // dispatched, so refuse to write over a comment a newer run produced.
+              // Safe to read-then-write: the concurrency group above guarantees no other
+              // consumer for this branch is running, so the stamp cannot change under us.
               const stamped = existing.body?.match(RUN_TAG);
               if (stamped && Number(stamped[1]) >= runNumber) {
                 core.info(

--- a/.github/workflows/release-preview-comment.yml
+++ b/.github/workflows/release-preview-comment.yml
@@ -77,20 +77,32 @@ jobs:
               return;
             }
 
-            // Resolve the target from the triggering run's head SHA rather than from
-            // the artifact. This binds the write to the PR that actually produced the
-            // preview, and drops superseded runs for free: once the PR has moved on,
-            // no open PR still has this SHA as its head.
-            const headSha = context.payload.workflow_run.head_sha;
+            // Resolve the target from the triggering run rather than from the artifact,
+            // so the write is bound to the PR that actually produced the preview.
+            //
+            // All three of these come from GitHub, not the fork: matching the head SHA
+            // alone would also match an unrelated PR that happens to sit on the same
+            // commit, so the source repo and branch are checked too. Requiring exactly
+            // one match additionally drops superseded runs — once the PR has moved on,
+            // nothing still has this SHA as its head.
+            const run = context.payload.workflow_run;
+            const headSha = run.head_sha;
+            const headRepo = run.head_repository?.full_name;
             const associated = await github.paginate(
               github.rest.repos.listPullRequestsAssociatedWithCommit,
               { owner: context.repo.owner, repo: context.repo.repo, commit_sha: headSha },
             );
-            const targets = associated.filter((pr) => pr.state === 'open' && pr.head.sha === headSha);
+            const targets = associated.filter(
+              (pr) =>
+                pr.state === 'open' &&
+                pr.head.sha === headSha &&
+                pr.head.ref === run.head_branch &&
+                pr.head.repo?.full_name === headRepo,
+            );
 
             if (targets.length !== 1) {
               core.info(
-                `Expected exactly one open PR with head ${headSha}, found ${targets.length} — superseded or ambiguous, not posting.`,
+                `Expected exactly one open PR at ${headRepo}:${run.head_branch}@${headSha}, found ${targets.length} — superseded or ambiguous, not posting.`,
               );
               return;
             }

--- a/.github/workflows/release-preview-comment.yml
+++ b/.github/workflows/release-preview-comment.yml
@@ -1,0 +1,93 @@
+name: Release Preview Comment
+
+# Posts the artifact produced by release-preview.yml. `workflow_run` runs in the
+# base-repo context with a writable token even when the triggering run came from
+# a fork, and it never checks out PR code — so contributor PRs get a preview
+# without handing the write token to untrusted code.
+#
+# Note: GitHub only ever runs the copy of this file on the default branch, so
+# changes to it take effect after merge, not on the PR that introduces them.
+
+on:
+  workflow_run:
+    workflows: ['Release Preview']
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: Post Release Preview
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      # The preview job skips the upload when there is nothing to report, so a
+      # missing artifact is a normal outcome rather than a failure.
+      - name: Download preview artifact
+        id: download
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: release-preview
+          path: preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post or update the preview comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- releasekit-preview -->';
+
+            if (!fs.existsSync('preview/preview.md') || !fs.existsSync('preview/pr-number')) {
+              core.info('No preview artifact contents; nothing to post.');
+              return;
+            }
+
+            const raw = fs.readFileSync('preview/preview.md', 'utf8').trim();
+            if (!raw) {
+              core.info('Preview artifact was empty; nothing to post.');
+              return;
+            }
+
+            const prNumber = Number(fs.readFileSync('preview/pr-number', 'utf8').trim());
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Preview artifact carried an unusable PR number: ${prNumber}`);
+              return;
+            }
+
+            // releasekit keys its comment off the marker so repeated runs update in
+            // place. Re-add it if the preview body did not already carry one.
+            const body = raw.startsWith(MARKER) ? raw : `${MARKER}\n\n${raw}`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated release preview comment ${existing.id} on #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created release preview comment on #${prNumber}.`);
+            }

--- a/.github/workflows/release-preview-comment.yml
+++ b/.github/workflows/release-preview-comment.yml
@@ -5,6 +5,12 @@ name: Release Preview Comment
 # a fork, and it never checks out PR code — so contributor PRs get a preview
 # without handing the write token to untrusted code.
 #
+# The artifact itself is untrusted: a fork controls the workflow definition that
+# produces it. So the comment *target* is never read from it — the PR is resolved
+# from the triggering run's head SHA, which GitHub supplies and a fork cannot
+# forge. Only the body comes from the artifact, and it can only ever land on the
+# PR that produced it.
+#
 # Note: GitHub only ever runs the copy of this file on the default branch, so
 # changes to it take effect after merge, not on the PR that introduces them.
 
@@ -12,6 +18,12 @@ on:
   workflow_run:
     workflows: ['Release Preview']
     types: [completed]
+
+# Serialise per source branch so two runs for the same PR cannot interleave their
+# writes. Combined with the head-SHA check below, the newest run always wins.
+concurrency:
+  group: release-preview-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write
@@ -45,7 +57,7 @@ jobs:
             const fs = require('fs');
             const MARKER = '<!-- releasekit-preview -->';
 
-            if (!fs.existsSync('preview/preview.md') || !fs.existsSync('preview/pr-number')) {
+            if (!fs.existsSync('preview/preview.md')) {
               core.info('No preview artifact contents; nothing to post.');
               return;
             }
@@ -56,11 +68,24 @@ jobs:
               return;
             }
 
-            const prNumber = Number(fs.readFileSync('preview/pr-number', 'utf8').trim());
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.setFailed(`Preview artifact carried an unusable PR number: ${prNumber}`);
+            // Resolve the target from the triggering run's head SHA rather than from
+            // the artifact. This binds the write to the PR that actually produced the
+            // preview, and drops superseded runs for free: once the PR has moved on,
+            // no open PR still has this SHA as its head.
+            const headSha = context.payload.workflow_run.head_sha;
+            const associated = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              { owner: context.repo.owner, repo: context.repo.repo, commit_sha: headSha },
+            );
+            const targets = associated.filter((pr) => pr.state === 'open' && pr.head.sha === headSha);
+
+            if (targets.length !== 1) {
+              core.info(
+                `Expected exactly one open PR with head ${headSha}, found ${targets.length} — superseded or ambiguous, not posting.`,
+              );
               return;
             }
+            const prNumber = targets[0].number;
 
             // releasekit keys its comment off the marker so repeated runs update in
             // place. Re-add it if the preview body did not already carry one.

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -49,12 +49,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      # Only the body is staged. The consumer resolves the target PR from the
+      # triggering run's head SHA — carrying a PR number here would let a fork
+      # aim the privileged comment at someone else's PR.
       - name: Stage preview comment
         id: stage
         shell: bash
         env:
           PREVIEW_MARKDOWN: ${{ steps.preview.outputs.preview-markdown }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           if [ -z "${PREVIEW_MARKDOWN//[[:space:]]/}" ]; then
@@ -64,7 +66,6 @@ jobs:
           fi
           mkdir -p preview
           printf '%s\n' "$PREVIEW_MARKDOWN" > preview/preview.md
-          printf '%s\n' "$PR_NUMBER" > preview/pr-number
           echo "has_preview=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload preview artifact

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,5 +1,15 @@
 name: Release Preview
 
+# Computes the release preview and stores it as an artifact. It does NOT post the
+# comment — posting needs `pull-requests: write`, and a `pull_request` run from a
+# fork gets a read-only GITHUB_TOKEN no matter what is requested here, so letting
+# releasekit post directly 403s on every external contributor PR.
+#
+# release-preview-comment.yml picks the artifact up on `workflow_run` (which runs
+# in the base-repo context with a writable token) and posts it. Splitting it this
+# way keeps untrusted PR code away from the write token — the same reason this
+# workflow isn't simply switched to `pull_request_target`.
+
 on:
   pull_request:
     branches: [main]
@@ -10,7 +20,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
   contents: read
 
 env:
@@ -27,13 +36,41 @@ jobs:
           fetch-depth: 0
 
       - name: Release Preview
+        id: preview
         uses: goosewobbler/releasekit@v0.41.2
         with:
           node-version: '24'
           mode: preview
+          # Returns the markdown as an output instead of posting it.
+          preview-dry-run: true
           pr: ${{ github.event.pull_request.number }}
           repo: ${{ github.repository }}
           project-dir: .
-          verbose: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Stage preview comment
+        id: stage
+        shell: bash
+        env:
+          PREVIEW_MARKDOWN: ${{ steps.preview.outputs.preview-markdown }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PREVIEW_MARKDOWN//[[:space:]]/}" ]; then
+            echo "No preview content produced; nothing to post."
+            echo "has_preview=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mkdir -p preview
+          printf '%s\n' "$PREVIEW_MARKDOWN" > preview/preview.md
+          printf '%s\n' "$PR_NUMBER" > preview/pr-number
+          echo "has_preview=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload preview artifact
+        if: steps.stage.outputs.has_preview == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-preview
+          path: preview/
+          retention-days: 1


### PR DESCRIPTION
## Description

`Validate PR Title` and `Release Preview` fail with **`Resource not accessible by integration`** on every external contributor PR.

**Root cause:** a `pull_request` run from a forked repository gets a read-only `GITHUB_TOKEN` regardless of what the workflow's `permissions:` block requests. That's a GitHub platform rule, not a misconfiguration — so any write call 403s.

Evidence:

| PR | Fork? | Validate PR Title | Release Preview |
|---|---|---|---|
| #556 | no | pass | pass |
| #557 | no | pass | pass |
| #527 | **yes** | **fail** | **fail** |

### 1. Validate PR Title — `create-a-commit-status` 403

Traced to [the action's source](https://github.com/amannn/action-semantic-pull-request/blob/main/src/index.js): the `POST /repos/:owner/:repo/statuses/:sha` call sits inside `if (wip)`, so it only happens because we pass `wip: true`. And it runs *before* the title verdict is evaluated:

```js
if (wip) {
  await client.request('POST /repos/:owner/:repo/statuses/:sha', { … });  // 403 on forks
}
if (!isWip && validationError) {
  throw validationError;
}
```

So the check is a **100% false negative for external contributors** — #527's title (`fix(tauri): use CSS pixels for embedded window rect`) is valid conventional-commits and still failed.

The action's own comment says `wip` is for *"repositories which don't support draft pull requests"* — private repos on the free plan. This repo is public, so draft PRs already cover that. Dropping `wip: true` removes the only write the workflow made, so `statuses: write` goes with it.

### 2. Release Preview — `create-an-issue-comment` 403

This one genuinely needs `pull-requests: write`, *and* it does `actions/checkout` + runs releasekit over the tree. Switching it to `pull_request_target` would either preview the base branch (useless) or run untrusted PR code with a writable token and secrets — the classic pwn-request. So it's split into the pattern GitHub documents for exactly this:

- **`release-preview.yml`** (`pull_request`, `contents: read`) — runs releasekit with `preview-dry-run: true`, which returns the markdown via the existing `preview-markdown` output instead of posting, then uploads it as an artifact.
- **`release-preview-comment.yml`** (`workflow_run`, `pull-requests: write`) — downloads the artifact from the triggering run and posts it. Runs in the base-repo context, never checks out PR code.

No releasekit changes needed — `preview-dry-run` and `preview-markdown` already exist. The comment reuses releasekit's own `<!-- releasekit-preview -->` marker, so existing preview comments **update in place** rather than duplicating, and both fork and same-repo PRs now take one consistent path.

The consumer treats the artifact as untrusted, because a fork controls the workflow definition that produces it. The target PR is resolved from the triggering run's own metadata — head SHA **and** source repo **and** branch, all GitHub-supplied — so the body can only ever land on the PR that produced it. Consumers are serialised per branch and stamped with the producing run number, so a superseded run cannot overwrite a newer preview.

### 3. `CI / Required` — `create-a-commit-status` 403 (the blocking one)

The `ci-required` ruleset requires the `CI / Required` status context:

```
$ gh api /repos/webdriverio/desktop-mobile/rulesets/18026650 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
CI / Required
```

That context is published by `ci-status`'s final step via `gh api .../statuses/$SHA`. On a fork PR that call 403s, which fails the step, which fails the job — so the context is **never published at all**. The ruleset then sits unsatisfied with nothing capable of resolving it, which means external contributions are not merely red, they are **unmergeable**.

Same split as above:

- **`ci.yml`** — the publish step is skipped when the head repo is a fork, since it cannot succeed there. `head.repo.fork` is null on push/`workflow_dispatch`, so those keep publishing inline exactly as before.
- **`ci-required-status.yml`** (`workflow_run`, `statuses: write`) — publishes the context for fork runs from the base-repo context.

The verdict is **not** taken from anything the fork produces: it reads the conclusion GitHub recorded for the `CI Summary` job. That job's `needs` list already encodes the curated required-job set (quarantined legs like `e2e-flutter-ios-macos` are deliberately excluded there), so `ci-status.needs` remains the single source of truth and no job list is duplicated. An absent or non-success summary publishes `failure` rather than nothing, so the context is never left pending with no way to resolve it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Internal/tooling change (build scripts, CI, etc.)

## Testing

- `actionlint .github/workflows/*.yml` — clean (this is what the `lint` job runs)
- All three files parse
- Verified `actions/download-artifact@v8` supports `run-id` + `github-token` for cross-run download, and matched the action versions already used in this repo (`upload-artifact@v7`, `download-artifact@v8`, `github-script@v9`)

### Three things that can't be demonstrated on this PR

1. **`workflow_run` workflows only ever run from the copy on the default branch.** The comment half therefore does nothing until this merges — this PR's own checks can't exercise it. First real validation is the next PR opened after merge.
2. **`pull_request` workflows run from the PR's merge ref**, so already-open fork PRs (#527, #532) keep using the old `pr-title.yml` and `ci.yml` until their base is updated. Re-running after merge, or their next push, picks up the fix.
3. Same for `ci-required-status.yml` — being a `workflow_run` workflow it is inert until merged, so the first fork PR to run CI after merge is the real test of the `CI / Required` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsgeivZCqduTQmWK55zqiT
