### PR TITLE
fix(tauri): suppress focus recovery after a raw switchToWindow

### DIFF
--- a/packages/tauri-service/src/service.ts
+++ b/packages/tauri-service/src/service.ts
@@ -17,9 +17,11 @@ import {
   clearWindowState,
   ensureActiveWindowFocus,
   getDefaultWindowLabel,
+  isInternalWindowSwitch,
   listWindowLabels,
   setCurrentWindowLabel,
   setSessionProvider,
+  suppressActiveWindowFocus,
   switchWindowByLabel,
 } from './window.js';
 
@@ -232,12 +234,35 @@ export default class TauriWorkerService {
 
     const browser = this.browser as WebdriverIO.Browser;
 
+    // Recovering focus in front of a window switch would just be undone by it.
+    if (commandName === 'switchToWindow') {
+      return;
+    }
+
     try {
       // Generic window focus detection like Electron - no app-specific knowledge
       await ensureActiveWindowFocus(browser, commandName);
     } catch (error) {
       log.warn('Failed to ensure window focus before command:', error);
     }
+  }
+
+  async afterCommand(commandName: string, _args: unknown[], _result: unknown, error?: Error): Promise<void> {
+    if (commandName !== 'switchToWindow' || !this.browser || this.browser.isMultiremote) {
+      return;
+    }
+
+    const browser = this.browser as WebdriverIO.Browser;
+
+    // A standard `browser.switchToWindow()` is just as explicit as
+    // `browser.tauri.switchWindow()`, so it has to suppress focus recovery too —
+    // otherwise the next getTitle/$/elementClick silently switches the user back.
+    // Only on success, and never for the service's own recovery switches.
+    if (error || isInternalWindowSwitch(browser)) {
+      return;
+    }
+
+    suppressActiveWindowFocus(browser);
   }
 
   async afterTest(_test: unknown, _context: unknown, _results: unknown): Promise<void> {

--- a/packages/tauri-service/src/window.ts
+++ b/packages/tauri-service/src/window.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createLogger } from '@wdio/native-utils';
 import { clearPluginAvailabilityCache } from './pluginCache.js';
 import type { DriverProvider } from './types.js';
@@ -17,6 +18,8 @@ const currentWindowLabelCache = new Map<string, string>();
 
 const userSwitchedWindowCache = new Set<string>();
 
+const internalWindowSwitchContext = new AsyncLocalStorage<string>();
+
 const sessionProviderCache = new Map<string, DriverProvider>();
 
 const DEFAULT_WINDOW_LABEL = 'main';
@@ -32,6 +35,23 @@ export function getCurrentWindowLabel(browser: WebdriverIO.Browser): string {
 export function setCurrentWindowLabel(browser: WebdriverIO.Browser, label: string): void {
   currentWindowLabelCache.set(browser.sessionId || 'default', label);
   log.debug(`Current window label set to: ${label}`);
+}
+
+/** Stop automatic focus recovery from overriding a window the user chose explicitly. */
+export function suppressActiveWindowFocus(browser: WebdriverIO.Browser): void {
+  userSwitchedWindowCache.add(browser.sessionId || 'default');
+}
+
+export function isInternalWindowSwitch(browser: WebdriverIO.Browser): boolean {
+  return internalWindowSwitchContext.getStore() === (browser.sessionId || 'default');
+}
+
+/** Mark a `switchToWindow` issued by the service itself, so it is not read as user intent. */
+export async function withInternalWindowSwitch<T>(
+  browser: WebdriverIO.Browser,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return internalWindowSwitchContext.run(browser.sessionId || 'default', operation);
 }
 
 export function setSessionProvider(browser: WebdriverIO.Browser, provider: DriverProvider): void {
@@ -93,7 +113,7 @@ export async function switchWindowByLabel(browser: WebdriverIO.Browser, label: s
 
   // Suppress auto-focus BEFORE any switching or iteration to prevent focus-change races
   // during handle discovery (ensureActiveWindowFocus checks this flag first).
-  userSwitchedWindowCache.add(sessionKey);
+  suppressActiveWindowFocus(browser);
 
   try {
     const originalHandle = await browser.getWindowHandle();
@@ -285,7 +305,10 @@ export async function ensureActiveWindowFocus(browser: WebdriverIO.Browser, comm
 
     // Switch to the active window
     log.debug(`[SERVICE] Switching to active window: ${activeWindow.title}`);
-    const switched = await switchToWindowByTitle(browser, activeWindow.title);
+    // Marked internal: this switch is the service recovering focus, not the user
+    // choosing a window. Without the marker the service's own `switchToWindow`
+    // would look like an explicit selection and permanently disable recovery.
+    const switched = await withInternalWindowSwitch(browser, () => switchToWindowByTitle(browser, activeWindow.title));
 
     if (switched) {
       log.debug(`[SERVICE] Successfully switched to active window`);

--- a/packages/tauri-service/test/service.spec.ts
+++ b/packages/tauri-service/test/service.spec.ts
@@ -36,22 +36,33 @@ vi.mock('../src/commands/execute.js', () => ({
   execute: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../src/window.js', () => ({
-  clearWindowState: vi.fn(),
-  ensureActiveWindowFocus: vi.fn().mockResolvedValue(undefined),
-  getDefaultWindowLabel: vi.fn().mockReturnValue('main'),
-  listWindowLabels: vi.fn().mockResolvedValue(['main']),
-  setCurrentWindowLabel: vi.fn(),
-  setSessionProvider: vi.fn(),
-  switchWindowByLabel: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock('../src/window.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/window.js')>();
+  return {
+    ...actual,
+    clearWindowState: vi.fn(),
+    ensureActiveWindowFocus: vi.fn().mockResolvedValue(undefined),
+    getDefaultWindowLabel: vi.fn().mockReturnValue('main'),
+    listWindowLabels: vi.fn().mockResolvedValue(['main']),
+    setCurrentWindowLabel: vi.fn(),
+    setSessionProvider: vi.fn(),
+    suppressActiveWindowFocus: vi.fn(),
+    switchWindowByLabel: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 import { waitUntilWindowAvailable } from '@wdio/native-utils';
 import { execute as executeCommand } from '../src/commands/execute.js';
 import { clearAllMocks, resetAllMocks, restoreAllMocks } from '../src/commands/mock.js';
 import mockStore from '../src/mockStore.js';
 import TauriWorkerService from '../src/service.js';
-import { clearWindowState, ensureActiveWindowFocus, setCurrentWindowLabel } from '../src/window.js';
+import {
+  clearWindowState,
+  ensureActiveWindowFocus,
+  setCurrentWindowLabel,
+  suppressActiveWindowFocus,
+  withInternalWindowSwitch,
+} from '../src/window.js';
 
 function createMockBrowser(overrides: Record<string, unknown> = {}): WebdriverIO.Browser {
   return {
@@ -913,6 +924,60 @@ describe('TauriWorkerService', () => {
       await service.beforeCommand('getTitle', []);
 
       expect(ensureActiveWindowFocus).toHaveBeenCalledWith(mockBrowser, 'getTitle');
+    });
+
+    it('should not run focus recovery in front of a window switch', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.beforeCommand('switchToWindow', ['splash']);
+
+      expect(ensureActiveWindowFocus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('afterCommand()', () => {
+    it('should suppress focus recovery after a successful switchToWindow', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.afterCommand('switchToWindow', ['splash'], undefined);
+
+      expect(suppressActiveWindowFocus).toHaveBeenCalledWith(mockBrowser);
+    });
+
+    it('should not suppress focus recovery when the switch failed', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.afterCommand('switchToWindow', ['missing'], undefined, new Error('no such window'));
+
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+    });
+
+    it('should not suppress focus recovery for the service own recovery switch', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await withInternalWindowSwitch(mockBrowser, async () => {
+        await service.afterCommand('switchToWindow', ['main'], undefined);
+      });
+
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
+    });
+
+    it('should ignore commands other than switchToWindow', async () => {
+      const mockBrowser = createMockBrowser();
+      const service = new TauriWorkerService({}, { 'wdio:tauriServiceOptions': {} });
+      (service as any).browser = mockBrowser;
+
+      await service.afterCommand('getTitle', [], 'title');
+
+      expect(suppressActiveWindowFocus).not.toHaveBeenCalled();
     });
 
     it('should return early when browser is multiremote', async () => {

--- a/packages/tauri-service/test/window.spec.ts
+++ b/packages/tauri-service/test/window.spec.ts
@@ -8,11 +8,14 @@ import {
   getCurrentWindowLabel,
   getDefaultWindowLabel,
   getLastCommand,
+  isInternalWindowSwitch,
   listWindowLabels,
   setCurrentWindowLabel,
   setSessionProvider,
+  suppressActiveWindowFocus,
   switchWindowByLabel,
   updateLastCommand,
+  withInternalWindowSwitch,
 } from '../src/window.js';
 
 describe('window management', () => {
@@ -722,6 +725,70 @@ describe('window management', () => {
       } as unknown as WebdriverIO.Browser;
 
       await expect(ensureActiveWindowFocus(mockBrowser, 'getTitle')).resolves.not.toThrow();
+    });
+  });
+
+  describe('suppressActiveWindowFocus', () => {
+    it('should stop focus recovery after an explicit switch', async () => {
+      const mockBrowser = {
+        sessionId: 'raw-switch-session',
+        tauri: { execute: vi.fn() },
+      } as unknown as WebdriverIO.Browser;
+
+      suppressActiveWindowFocus(mockBrowser);
+      await ensureActiveWindowFocus(mockBrowser, 'getTitle');
+
+      expect(mockBrowser.tauri.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('internal window switches', () => {
+    it('should report internal only while the callback runs', async () => {
+      const mockBrowser = { sessionId: 'internal-success' } as unknown as WebdriverIO.Browser;
+
+      expect(isInternalWindowSwitch(mockBrowser)).toBe(false);
+      await withInternalWindowSwitch(mockBrowser, async () => {
+        expect(isInternalWindowSwitch(mockBrowser)).toBe(true);
+      });
+      expect(isInternalWindowSwitch(mockBrowser)).toBe(false);
+    });
+
+    it('should clear the marker when the callback rejects', async () => {
+      const mockBrowser = { sessionId: 'internal-failure' } as unknown as WebdriverIO.Browser;
+
+      await expect(
+        withInternalWindowSwitch(mockBrowser, async () => {
+          throw new Error('switch failed');
+        }),
+      ).rejects.toThrow('switch failed');
+      expect(isInternalWindowSwitch(mockBrowser)).toBe(false);
+    });
+
+    it('should not leak the marker across sessions', async () => {
+      const first = { sessionId: 'session-one' } as unknown as WebdriverIO.Browser;
+      const second = { sessionId: 'session-two' } as unknown as WebdriverIO.Browser;
+
+      await withInternalWindowSwitch(first, async () => {
+        expect(isInternalWindowSwitch(first)).toBe(true);
+        expect(isInternalWindowSwitch(second)).toBe(false);
+      });
+    });
+
+    it('should leave focus recovery working once the switch completes', async () => {
+      const mockBrowser = {
+        sessionId: 'internal-focus-recovery',
+        tauri: {
+          execute: vi
+            .fn()
+            .mockResolvedValueOnce([{ label: 'main', title: 'Main Window', is_visible: true, is_focused: true }]),
+        },
+        getTitle: vi.fn().mockResolvedValue('Main Window'),
+      } as unknown as WebdriverIO.Browser;
+
+      await withInternalWindowSwitch(mockBrowser, async () => undefined);
+      await ensureActiveWindowFocus(mockBrowser, 'getTitle');
+
+      expect(mockBrowser.tauri.execute).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description

Split out of #532, with attribution to @abu0306 — that PR fixes this as part of child-webview support, but the bug is independent of the feature and present on `main` today.

### The bug

`userSwitchedWindowCache` is what tells `ensureActiveWindowFocus` to leave the user's window selection alone. On `main` it is only ever populated by `switchWindowByLabel` (`window.ts:96`) — i.e. by `browser.tauri.switchWindow(label)`.

A standard W3C `browser.switchToWindow(handle)` never sets it. So after switching windows that way, automatic focus recovery is still armed, and the next `getTitle` / `findElement` / `$` / `elementClick` can quietly switch back to whichever window the app reports as active — silently undoing an explicit selection.

### The fix

Suppress on the same terms as the Tauri-specific command, from `afterCommand` so that a *failed* switch does not count.

The subtlety is that recovery issues `browser.switchToWindow` itself (`switchToWindowByTitle`, `window.ts:13` and `:26`). Without a marker, the service's own recovery switch would look like user intent and permanently disable recovery for the session — strictly worse than the original bug. So internal switches are marked via `AsyncLocalStorage` and skipped.

`beforeCommand` also stops running focus recovery ahead of a `switchToWindow`, which was pointless work that the switch immediately undid.

### Scoped deliberately

#532's `pendingExternalWindowSwitches` map and the `setCurrentWindowLabel(handle)` commit are **not** included. Those exist to treat a WebDriver handle as a Tauri window label, which is child-webview specific and belongs with the feature.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Scope

- [x] `scope:tauri` - Tauri service and plugin

## Testing

- `vitest run test/window.spec.ts test/service.spec.ts` — **122 passed**
- New coverage: `suppressActiveWindowFocus` stops recovery; the internal-switch marker is scoped to its callback, cleared on rejection, and does not leak across sessions; recovery still works after an internal switch completes; `afterCommand` suppresses on success, not on error, not for internal switches, and ignores other commands
- `biome check` / `biome format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsgeivZCqduTQmWK55zqiT