### PR TITLE
fix(ci): canonicalise package-test temp dir so vite 8 renderer builds pass on Windows

### DIFF
--- a/fixtures/package-tests/electron-builder-app-cjs/electron.vite.config.ts
+++ b/fixtures/package-tests/electron-builder-app-cjs/electron.vite.config.ts
@@ -32,10 +32,5 @@ export default defineConfig({
         },
       },
     },
-    // workaround for windows path issue
-    // see https://github.com/alex8088/electron-vite/issues/802
-    resolve: {
-      preserveSymlinks: true,
-    },
   },
 });

--- a/fixtures/package-tests/electron-builder-app-esm/electron.vite.config.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/electron.vite.config.ts
@@ -32,10 +32,5 @@ export default defineConfig({
         },
       },
     },
-    // workaround for windows path issue
-    // see https://github.com/alex8088/electron-vite/issues/802
-    resolve: {
-      preserveSymlinks: true,
-    },
   },
 });

--- a/fixtures/package-tests/electron-forge-app-cjs/electron.vite.config.ts
+++ b/fixtures/package-tests/electron-forge-app-cjs/electron.vite.config.ts
@@ -32,10 +32,5 @@ export default defineConfig({
         },
       },
     },
-    // workaround for windows path issue
-    // see https://github.com/alex8088/electron-vite/issues/802
-    resolve: {
-      preserveSymlinks: true,
-    },
   },
 });

--- a/fixtures/package-tests/electron-forge-app-esm/electron.vite.config.ts
+++ b/fixtures/package-tests/electron-forge-app-esm/electron.vite.config.ts
@@ -32,10 +32,5 @@ export default defineConfig({
         },
       },
     },
-    // workaround for windows path issue
-    // see https://github.com/alex8088/electron-vite/issues/802
-    resolve: {
-      preserveSymlinks: true,
-    },
   },
 });

--- a/fixtures/package-tests/electron-script-app-cjs/electron.vite.config.ts
+++ b/fixtures/package-tests/electron-script-app-cjs/electron.vite.config.ts
@@ -30,10 +30,5 @@ export default defineConfig({
         },
       },
     },
-    resolve: {
-      // workaround for windows path issue
-      // see https://github.com/alex8088/electron-vite/issues/802
-      preserveSymlinks: true,
-    },
   },
 });

--- a/fixtures/package-tests/electron-script-app-esm/electron.vite.config.ts
+++ b/fixtures/package-tests/electron-script-app-esm/electron.vite.config.ts
@@ -30,10 +30,5 @@ export default defineConfig({
         },
       },
     },
-    resolve: {
-      // workaround for windows path issue
-      // see https://github.com/alex8088/electron-vite/issues/802
-      preserveSymlinks: true,
-    },
   },
 });

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -19,7 +19,7 @@
  */
 
 import { execSync, spawn } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { dirname, extname, join, normalize } from 'node:path';
@@ -499,9 +499,14 @@ async function testExample(
     throw new Error(`Package not found: ${packagePath}`);
   }
 
-  // Create isolated test environment to avoid pnpm hoisting issues
+  // Create isolated test environment to avoid pnpm hoisting issues.
+  // On Windows os.tmpdir() is an 8.3 short-name path (C:\Users\RUNNER~1\...). vite
+  // realpath-resolves build inputs but leaves config.root un-resolved, so vite:build-html
+  // emits a `../`-laden index.html fileName that Rolldown rejects (vitejs/vite#10802).
+  // Canonicalising the base here makes config.root match vite's realpath'd ids.
   const testId = Date.now();
-  const tempDir = normalize(join(tmpdir(), `wdio-package-test-${testId}`));
+  const tempBase = process.platform === 'win32' ? realpathSync.native(tmpdir()) : tmpdir();
+  const tempDir = normalize(join(tempBase, `wdio-package-test-${testId}`));
   const packageDir = normalize(join(tempDir, packageName));
 
   // Define logs directory path for reuse throughout function


### PR DESCRIPTION
## Problem

The **Electron [Windows] package-test** build fails deterministically:

```
RolldownError: The "fileName" or "name" properties of emitted chunks and assets
must be strings that are neither absolute nor relative paths, received
"../../../../../../../../RUNNER~1/AppData/Local/Temp/.../src/renderer/index.html"
```

## Root cause — a known vite core bug, not electron-vite

[vitejs/vite#10802](https://github.com/vitejs/vite/issues/10802) (open since 2022; dup [#20420](https://github.com/vitejs/vite/issues/20420)): on Windows, vite realpath-resolves build inputs (`fs.realpathSync.native`) but leaves `config.root` un-resolved. Our package-test harness copies each fixture under `os.tmpdir()`, which on the runners is an **8.3 short-name** path — `C:\Users\RUNNER~1\AppData\Local\Temp\…`. vite realpaths the `index.html` input to the long name while `config.root` keeps the short name, so `vite:build-html`'s `path.relative(config.root, id)` produces a `../`-laden fileName that Rolldown rejects.

It's a **vite** bug, not electron-vite's — confirmed by the fact that swapping the electron-vite build tool (we tried a community fork on vite 8) changed nothing: the failing plugin is vite core's `vite:build-html`.

## Fix — canonicalise the temp base (one line, at the source)

`scripts/test-package.ts` copies fixtures into `os.tmpdir()`. Canonicalising that base on Windows makes the built fixture live at a canonical path, so `config.root` matches vite's realpath'd ids and `vite:build-html` emits a bare `index.html`:

```ts
const tempBase = process.platform === 'win32' ? realpathSync.native(tmpdir()) : tmpdir();
const tempDir = normalize(join(tempBase, `wdio-package-test-${testId}`));
```

This fixes **every** electron fixture (builder / forge / script × cjs/esm) at one point — no per-config workarounds, and **we stay on vite 8**. It's exactly the workaround vite's maintainers point to for #10802.

Also removes the dead `preserveSymlinks` #802 workaround from the six electron renderer configs — it never fixed the build, and the canonical path supersedes it.

## Why not the alternatives

- **vite 7 downgrade** — would split the workspace across two vite majors and risk knock-on breakage; rejected.
- **electron-vite fork / version swap** — can't fix a bug that lives in vite core.
- **per-config `root: realpathSync.native(...)`** — works, but 6 varied configs (script has no explicit root); the harness fix is uniform.

## Validation

Windows-only, short-name/cross-drive path bug — not reproducible on macOS. The **Electron [Windows] package** leg on this PR's CI is the proof. One marginal caveat: the canonical name (`runneradmin`) is ~3 chars longer than `RUNNER~1`, a negligible MAX_PATH nudge — CI will surface it if it ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKc4JHZKXfyqCiiU4C2b7V
