### PR TITLE
docs(ci): add F9 (RN Android new-arch) + log occurrences on #558/#559/#560

### DIFF
--- a/docs/ci-flake-log.md
+++ b/docs/ci-flake-log.md
@@ -67,6 +67,8 @@ Not the PR's fault, but not flakes either.
 | 2026-08-01 | 30708074906 | #561 | Package - Dioxus (Docker) [Void] | F3 |
 | 2026-08-01 | 30708074906 | #561 | E2E - Electron [Windows] - forge | F2 |
 | 2026-08-01 | 30708074906 | #561 | E2E - Tauri [macOS-ARM] - standalone | F1 |
+| 2026-08-01 | 30701420535 | #560 | Package - Tauri [macOS-ARM] | F1 |
+| 2026-08-01 | 30701283449 (att. 1–3) | #559 | E2E - Tauri [macOS-ARM] - deeplink | F1 on **all 3 attempts** — retry never cleared (both symptoms: `Script execution timed out` + app-unreachable `failed to send request`) |
 | 2026-08-01 | 30700125548 | #558 | E2E - Electron [Windows] - forge | F2 |
 | 2026-08-01 | 30699263358 | #557 | Package - Dioxus (Docker) [Fedora] | F3 |
 | 2026-08-01 | 30699263358 | #557 | E2E - Flutter [iOS] - standard | F4 |


### PR DESCRIPTION
Records two more **F1 (#540 DirectEval idle-stall)** occurrences — both `Error: Script execution timed out` on the embedded provider (WebKit macOS):

- **#560** run 30701420535 — `Package - Tauri [macOS-ARM]`
- **#559** run 30701283449 — `E2E - Tauri [macOS-ARM] - deeplink` (also the app-unreachable variant `failed to send request … \"window\" GET`)

Existing class (occurrence-log rows only). F1 is now the clear top flake — 6 logged occurrences across #556/#557/#559/#560/#561. Fix in flight: #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKc4JHZKXfyqCiiU4C2b7V