### PR TITLE
ci: scope dependabot ci:run to the frameworks a bump touches

### DIFF
--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -75,6 +75,12 @@ jobs:
         id: changes
         uses: dorny/paths-filter@v4
         with:
+          # paths-filter's base-ref handling is battle-tested for pull_request (the PR base) and push
+          # (the before-sha), but NOT for workflow_dispatch — the `ci:run` path (see dependabot-ci.yml).
+          # There, pin the base to the default branch so a scoped dispatch diffs the branch against main
+          # and runs only the affected frameworks instead of everything. Blank elsewhere keeps the
+          # battle-tested defaults; a full sweep is still available via `force_all` / `ci:run-all`.
+          base: ${{ github.event_name == 'workflow_dispatch' && github.event.repository.default_branch || '' }}
           list-files: json
           filters: |
             any:

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -2,9 +2,11 @@ name: Dependabot CI
 
 # Dependabot PRs skip CI by default (see the detect-changes gate + ci-status block in
 # ci.yml) so the weekly batch of dependency PRs doesn't drain the runners. Adding the
-# `ci:run` label dispatches the full pipeline for the PR's branch; the label is removed
-# afterwards so re-adding it re-runs CI. A human adds the label, so this run gets a normal
-# token (not Dependabot's restricted one) and can dispatch + edit the PR.
+# `ci:run` label dispatches CI scoped to the frameworks the bump actually touches (change
+# detection diffs against the default branch); `ci:run-all` forces the whole cross-platform
+# matrix — use it when a bump could affect frameworks its file diff doesn't name. The label
+# is removed afterwards so re-adding it re-runs CI. A human adds the label, so this run gets
+# a normal token (not Dependabot's restricted one) and can dispatch + edit the PR.
 #
 # The dispatched run is a `workflow_dispatch`, so GitHub never associates it with the PR —
 # it won't appear in the PR's checks list. To give immediate feedback we post a `CI / Required`
@@ -23,7 +25,7 @@ permissions:
 jobs:
   dispatch:
     if: >-
-      github.event.label.name == 'ci:run' &&
+      (github.event.label.name == 'ci:run' || github.event.label.name == 'ci:run-all') &&
       github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
@@ -33,11 +35,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
+          LABEL: ${{ github.event.label.name }}
         run: |
           # Note the current latest dispatch run (if any) so the locate step can detect the new one.
           prev=$(gh run list --repo "$REPO" --workflow=ci.yml --branch="$BRANCH" \
             --event=workflow_dispatch --limit=1 --json databaseId --jq '.[0].databaseId // empty')
-          gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH" -f force_all=true
+          # `ci:run` scopes to the frameworks the bump touches — detect-changes diffs the branch
+          # against the default branch on this workflow_dispatch run; `ci:run-all` forces everything.
+          if [ "$LABEL" = "ci:run-all" ]; then
+            gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH" -f force_all=true
+          else
+            gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH" -f force_all=false
+          fi
           echo "prev=$prev" >> "$GITHUB_OUTPUT"
           echo "runs_url=$GITHUB_SERVER_URL/$REPO/actions/workflows/ci.yml?query=branch%3A$BRANCH+event%3Aworkflow_dispatch" >> "$GITHUB_OUTPUT"
       - name: Mark CI / Required pending on the PR
@@ -92,13 +101,15 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ steps.locate.outputs.run_url }}
+          LABEL: ${{ github.event.label.name }}
         run: |
-          gh pr comment "$PR" --repo "$REPO" --body "CI dispatched via \`ci:run\` → [view run]($RUN_URL). The result posts back as the \`CI / Required\` status on this PR; the run itself won't appear in the PR checks list (\`workflow_dispatch\` runs aren't PR-associated)."
-      - name: Remove the ci:run label
+          gh pr comment "$PR" --repo "$REPO" --body "CI dispatched via \`$LABEL\` → [view run]($RUN_URL). The result posts back as the \`CI / Required\` status on this PR; the run itself won't appear in the PR checks list (\`workflow_dispatch\` runs aren't PR-associated)."
+      - name: Remove the trigger label
         # Always remove so re-adding the label re-runs CI, even if a feedback step hiccupped.
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-        run: gh pr edit "$PR" --repo "$REPO" --remove-label ci:run
+          LABEL: ${{ github.event.label.name }}
+        run: gh pr edit "$PR" --repo "$REPO" --remove-label "$LABEL"


### PR DESCRIPTION
## Problem

Adding the `ci:run` label to a Dependabot PR dispatched `ci.yml` with `force_all=true`, so the **entire cross-platform matrix** ran even when the bump touched only one or two frameworks. Example: a cargo-group bump that only changes tauri + dioxus `Cargo.lock` files still ran electron / electrobun / RN / flutter (#537).

The cause: `force_all=true` short-circuits the classifier (`scripts/detect-changes.ts`) before it ever looks at the changed paths.

## Fix

- **`dependabot-ci.yml`** — `ci:run` now dispatches `force_all=false`, so change detection scopes the run to the frameworks the bump actually touches. A new **`ci:run-all`** label keeps the `force_all=true` full sweep (for the rare bump whose effect a file diff can't name, e.g. a shared transitive dep). One job handles both; the triggering label is echoed in the status comment and removed afterward.
- **`_ci-detect-changes.reusable.yml`** — pin `paths-filter`'s `base` to the **default branch on `workflow_dispatch`** (the `ci:run` path). paths-filter's base handling is battle-tested for `pull_request`/`push` but *not* `workflow_dispatch`, where it wouldn't reliably diff against `main`. Now a dispatched run scopes exactly like a real PR event. `pull_request` / `push` runs are unchanged (base stays blank → paths-filter's defaults).

Adds the `ci:run-all` label (`#5319e7`).

## Rollout note

The dispatched run uses the **PR branch's** workflow files, so scoped `ci:run` takes effect once a Dependabot branch carries this change — new PRs automatically, existing ones after a rebase (`@dependabot rebase`). `ci:run-all` works on any branch regardless (it only needs the pre-existing `force_all` input).

## Verify after merge

Rebase an open Dependabot PR (e.g. the cargo-group one), add `ci:run`, and confirm the dispatched run only spins up the affected framework legs; add `ci:run-all` to confirm the full matrix still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
