### PR TITLE
ci: bump pnpm/action-setup to v6 in the dioxus-crates build

### DIFF
--- a/.github/workflows/_ci-build-dioxus-crates.reusable.yml
+++ b/.github/workflows/_ci-build-dioxus-crates.reusable.yml
@@ -62,7 +62,7 @@ jobs:
 
       # Build the guest-js bundle so the bridge crate's build.rs can embed it.
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
Brings the last `pnpm/action-setup` usage up to **v6**. The other two — `_release.reusable.yml` and `actions/setup-workspace/action.yml` — are already on v6; only `_ci-build-dioxus-crates.reusable.yml` was still on v4, so all three now match.

Bare `uses` (the pnpm version comes from `packageManager` in `package.json`), so no `with:` changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)