### PR TITLE
fix(electron): resolve the installed version when the spec is a dist-tag

### DIFF
--- a/packages/electron-service/src/electronVersion.ts
+++ b/packages/electron-service/src/electronVersion.ts
@@ -7,6 +7,9 @@ import { findPnpmCatalogVersion } from './pnpm.js';
 
 const log = createLogger('electron-service', 'utils');
 
+/** Specs that point at a location — a path, repo or tarball — rather than constraining a version. */
+const LOCATION_SPEC_PATTERN = /^(file|link|portal|workspace|npm|git|git\+[a-z]+|github|gitlab|bitbucket|gist|https?):/;
+
 /**
  * Deliberately walks node_modules rather than using `require.resolve`, which also
  * consults NODE_PATH and Node's global folders — those can resolve an Electron
@@ -52,18 +55,26 @@ export async function getElectronVersion(pkg: NormalizedReadResult) {
       continue;
     }
 
-    const parsedVersion = findVersions(declaredVersion, { loose: true })[0];
-    if (parsedVersion) {
-      return parsedVersion;
-    }
-
-    // The spec carries no version to parse — a dist-tag (`latest`, `next`, `beta`), a
-    // wildcard, or a git / file spec. Chromedriver has to match the Electron that
-    // actually got installed, so read that rather than giving up on the manifest.
-    const installedVersion = await getInstalledVersion(pkgName, projectDir);
-    if (installedVersion) {
-      log.debug(`Resolved ${pkgName} v${installedVersion} from node_modules for spec "${declaredVersion}"`);
+    // A location spec is a path, not a constraint, so any version-looking substring in
+    // it is incidental — `file:/build/v1.2.3/electron` is not Electron 1.2.3. Read the
+    // install first for those, and parse the spec first for everything else. Either way
+    // the other is tried as a fallback, since a dist-tag, a partial range (`^37`) or a
+    // wildcard carries no version to parse.
+    const readInstalledFirst = LOCATION_SPEC_PATTERN.test(declaredVersion);
+    const readInstalled = async () => {
+      const installedVersion = await getInstalledVersion(pkgName, projectDir);
+      if (installedVersion) {
+        log.debug(`Resolved ${pkgName} v${installedVersion} from node_modules for spec "${declaredVersion}"`);
+      }
       return installedVersion;
+    };
+    const parseSpec = async () => findVersions(declaredVersion, { loose: true })[0];
+
+    for (const resolve of readInstalledFirst ? [readInstalled, parseSpec] : [parseSpec, readInstalled]) {
+      const version = await resolve();
+      if (version) {
+        return version;
+      }
     }
   }
 

--- a/packages/electron-service/src/electronVersion.ts
+++ b/packages/electron-service/src/electronVersion.ts
@@ -1,8 +1,38 @@
-import { dirname } from 'node:path';
-import type { NormalizedReadResult } from '@wdio/native-utils';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { createLogger, type NormalizedReadResult } from '@wdio/native-utils';
 import findVersions from 'find-versions';
 import { PKG_NAME_ELECTRON, PNPM_CATALOG_PREFIX } from './constants.js';
 import { findPnpmCatalogVersion } from './pnpm.js';
+
+const log = createLogger('electron-service', 'utils');
+
+/**
+ * Deliberately walks node_modules rather than using `require.resolve`, which also
+ * consults NODE_PATH and Node's global folders — those can resolve an Electron
+ * unrelated to the project under test.
+ */
+async function getInstalledVersion(pkgName: string, projectDir: string) {
+  let currentDir = projectDir;
+
+  while (true) {
+    const manifestPath = join(currentDir, 'node_modules', pkgName, 'package.json');
+    try {
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as { version?: string };
+      if (manifest.version) {
+        return manifest.version;
+      }
+    } catch {
+      // no install at this level, keep walking up
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+    currentDir = parentDir;
+  }
+}
 
 export async function getElectronVersion(pkg: NormalizedReadResult) {
   const projectDir = dirname(pkg.path);
@@ -16,10 +46,26 @@ export async function getElectronVersion(pkg: NormalizedReadResult) {
     return deps.startsWith(PNPM_CATALOG_PREFIX) ? await findPnpmCatalogVersion(pkgName, deps, projectDir) : deps;
   };
 
-  const pkgElectronVersion = await getElectronDependencies(PKG_NAME_ELECTRON.STABLE);
-  const pkgElectronNightlyVersion = await getElectronDependencies(PKG_NAME_ELECTRON.NIGHTLY);
+  for (const pkgName of [PKG_NAME_ELECTRON.STABLE, PKG_NAME_ELECTRON.NIGHTLY]) {
+    const declaredVersion = await getElectronDependencies(pkgName);
+    if (!declaredVersion) {
+      continue;
+    }
 
-  const electronVersion = pkgElectronVersion || pkgElectronNightlyVersion;
+    const parsedVersion = findVersions(declaredVersion, { loose: true })[0];
+    if (parsedVersion) {
+      return parsedVersion;
+    }
 
-  return electronVersion ? findVersions(electronVersion, { loose: true })[0] : undefined;
+    // The spec carries no version to parse — a dist-tag (`latest`, `next`, `beta`), a
+    // wildcard, or a git / file spec. Chromedriver has to match the Electron that
+    // actually got installed, so read that rather than giving up on the manifest.
+    const installedVersion = await getInstalledVersion(pkgName, projectDir);
+    if (installedVersion) {
+      log.debug(`Resolved ${pkgName} v${installedVersion} from node_modules for spec "${declaredVersion}"`);
+      return installedVersion;
+    }
+  }
+
+  return undefined;
 }

--- a/packages/electron-service/test/electronVersion.spec.ts
+++ b/packages/electron-service/test/electronVersion.spec.ts
@@ -24,10 +24,7 @@ function createPackageJson(depName: string, dep: { [key: string]: string }) {
 
 const projectDirs: string[] = [];
 
-/**
- * Real on-disk project so `createRequire(...).resolve()` is exercised for the
- * node_modules fallback rather than stubbed out.
- */
+/** Real on-disk project, so the node_modules walk is exercised rather than stubbed out. */
 async function createProject(deps: { [key: string]: string }, installed: { [key: string]: string } = {}) {
   const projectDir = await mkdtemp(join(tmpdir(), 'wdio-electron-version-'));
   projectDirs.push(projectDir);

--- a/packages/electron-service/test/electronVersion.spec.ts
+++ b/packages/electron-service/test/electronVersion.spec.ts
@@ -209,4 +209,34 @@ describe('getElectronVersion()', () => {
     const version = await getElectronVersion(pkg);
     expect(version).toBe('37.10.3');
   });
+
+  describe('when the declared version points at a location', () => {
+    it.each([
+      ['file:../electron', 'file'],
+      ['link:../electron', 'link'],
+      ['workspace:*', 'workspace'],
+      ['npm:my-electron-fork@latest', 'npm alias'],
+      ['github:myorg/electron-fork#my-branch', 'git'],
+      ['https://cdn.corp.net/builds/electron.tgz', 'url'],
+    ])('should use the installed version for a %s spec', async (spec) => {
+      const pkg = await createProject({ electron: spec }, { electron: '43.2.0' });
+
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('43.2.0');
+    });
+
+    it('should not mistake a version-looking path segment for the electron version', async () => {
+      const pkg = await createProject({ electron: 'file:/build/v1.2.3/electron' }, { electron: '43.2.0' });
+
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('43.2.0');
+    });
+
+    it('should fall back to parsing the spec when nothing is installed', async () => {
+      const pkg = await createProject({ electron: 'file:../vendor/electron-37.2.1.tgz' });
+
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('37.2.1');
+    });
+  });
 });

--- a/packages/electron-service/test/electronVersion.spec.ts
+++ b/packages/electron-service/test/electronVersion.spec.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { NormalizedPackageJson, NormalizedReadResult } from '@wdio/native-types';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getElectronVersion } from '../src/electronVersion.js';
 import { findPnpmCatalogVersion } from '../src/pnpm.js';
 
@@ -18,6 +21,39 @@ function createPackageJson(depName: string, dep: { [key: string]: string }) {
   pkgJson[depName] = dep;
   return pkgJson;
 }
+
+const projectDirs: string[] = [];
+
+/**
+ * Real on-disk project so `createRequire(...).resolve()` is exercised for the
+ * node_modules fallback rather than stubbed out.
+ */
+async function createProject(deps: { [key: string]: string }, installed: { [key: string]: string } = {}) {
+  const projectDir = await mkdtemp(join(tmpdir(), 'wdio-electron-version-'));
+  projectDirs.push(projectDir);
+
+  const manifestPath = join(projectDir, 'package.json');
+  await writeFile(manifestPath, JSON.stringify({ name: 'my-app', version: '1.0.0', devDependencies: deps }));
+
+  for (const [pkgName, version] of Object.entries(installed)) {
+    const installedDir = join(projectDir, 'node_modules', pkgName);
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(join(installedDir, 'package.json'), JSON.stringify({ name: pkgName, version, main: 'index.js' }));
+  }
+
+  return {
+    packageJson: createPackageJson('devDependencies', deps),
+    path: manifestPath,
+  } as NormalizedReadResult;
+}
+
+beforeEach(() => {
+  vi.mocked(findPnpmCatalogVersion).mockReset();
+});
+
+afterEach(async () => {
+  await Promise.all(projectDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+});
 describe('getElectronVersion()', () => {
   it('should return the electron version from package.json dependencies', async () => {
     const pkg = {
@@ -117,5 +153,60 @@ describe('getElectronVersion()', () => {
     } as NormalizedReadResult;
     const version = await getElectronVersion(pkg);
     expect(version).toBe('29.4.1');
+  });
+
+  describe('when the declared version is not parseable semver', () => {
+    it.each(['latest', 'next', 'beta', '*'])(
+      'should fall back to the installed electron version for "%s"',
+      async (spec) => {
+        const pkg = await createProject({ electron: spec }, { electron: '43.2.0' });
+
+        const version = await getElectronVersion(pkg);
+        expect(version).toBe('43.2.0');
+      },
+    );
+
+    it('should fall back to the installed electron version for a pnpm catalog dist-tag', async () => {
+      vi.mocked(findPnpmCatalogVersion).mockResolvedValueOnce('latest');
+
+      const pkg = await createProject({ electron: 'catalog:next' }, { electron: '43.2.0' });
+
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('43.2.0');
+    });
+
+    it('should fall back to the installed electron-nightly version', async () => {
+      const pkg = await createProject(
+        { 'electron-nightly': 'latest' },
+        { 'electron-nightly': '44.0.0-nightly.20260803' },
+      );
+
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('44.0.0-nightly.20260803');
+    });
+
+    it('should fall through to electron-nightly when electron is not installed', async () => {
+      const pkg = await createProject(
+        { electron: 'latest', 'electron-nightly': '44.0.0-nightly.20260803' },
+        { 'electron-nightly': '44.0.0-nightly.20260803' },
+      );
+
+      const version = await getElectronVersion(pkg);
+      expect(version).toBe('44.0.0-nightly.20260803');
+    });
+
+    it('should return undefined when electron is not installed either', async () => {
+      const pkg = await createProject({ electron: 'latest' });
+
+      const version = await getElectronVersion(pkg);
+      expect(version).toBeUndefined();
+    });
+  });
+
+  it('should prefer the declared version over the installed one when it is parseable', async () => {
+    const pkg = await createProject({ electron: '37.10.3' }, { electron: '43.2.0' });
+
+    const version = await getElectronVersion(pkg);
+    expect(version).toBe('37.10.3');
   });
 });


### PR DESCRIPTION
## Problem

`getElectronVersion` passes the declared dependency spec straight to `findVersions`, which returns nothing when the spec carries no semver:

```ts
return electronVersion ? findVersions(electronVersion, { loose: true })[0] : undefined;
```

`findVersions('latest')` → `[]` → `undefined`. The launcher then has no version to look up a Chromium version with, and the run dies in `onPrepare`:

```
INFO  electron-service:launcher: Found Electron v with Chromedriver vundefined
ERROR electron-service:launcher: You must install Electron locally, or provide a
      custom Chromedriver path / browserVersion value for each Electron capability
```

The message is misleading — Electron *was* installed. Only the manifest couldn't say which version.

There is a second, quieter failure in the same function: for a spec that points at a *location*, any version-looking substring is incidental, but `findVersions` extracts it anyway. `file:/build/v1.2.3/electron` resolves to Electron 1.2.3, and the mismatched Chromedriver then fails session creation.

## What actually breaks

| Spec | `findVersions` | Before | After |
|---|---|---|---|
| `latest`, `next`, `beta`, `nightly` | `[]` | fails | install |
| `*`, `x`, `""` | `[]` | fails | install |
| `^37`, `37.x`, `>=37` | `[]` | fails | install |
| `^37.0.0`, `~37.1` | `37.0.0`, `37.1.0` | ok | unchanged |
| `file:../electron`, `link:`, `portal:`, `workspace:*` | `[]` | fails | install |
| `github:myorg/electron-fork#my-branch` | `[]` | fails | install |
| `git+ssh://…/electron.git#v2-patched` | `[]` | fails | install |
| `npm:my-electron-fork@latest` | `[]` | fails | install |
| `file:/build/v1.2.3/electron` | `1.2.3` | **wrong version** | install |
| `file:../vendor/electron-37.2.1.tgz` | `37.2.1` | ok by luck | install, else parse |

Partial ranges like `^37` are worth calling out — that is an ordinary thing to write, so this is not only a dist-tag problem.

## Not a pnpm catalog bug

Catalog resolution already works — `findPnpmCatalogVersion` correctly resolved `catalog:next` to `latest` before the failure. A plain `"electron": "latest"` with no catalog anywhere fails identically; I verified that directly. Catalogs just surface it readily, since pinning a catalog to `latest` is a natural way to track releases.

It is also why only some catalogs break — `default: 37.10.3` and `minimum: ^28.0.0` parse fine, `next: latest` does not.

## Fix

Resolve from `node_modules` when the spec cannot be parsed. That is the Electron that will actually launch, so it is what Chromedriver has to match.

Order depends on what the spec *is*. A location spec (`file:`, `link:`, `portal:`, `workspace:`, `npm:` alias, git, URL) is a path rather than a constraint, so the install is read first and the string parsed only as a fallback. Everything else parses first, so a parseable range still wins and existing behaviour is unchanged.

### Why not resolve dist-tags against the registry

It answers the wrong question. The registry says what `latest` means *now*; what matters is what is installed. Those diverge whenever a release lands between install and test run — frequent for Electron — and the result is a Chromedriver mismatch on a project that was working. It would also put a network call in `onPrepare` and pull in `.npmrc`, auth and mirror handling (`ELECTRON_MIRROR`), and per the table above it only addresses the first row. Reading the install covers every row without any of that.

### Why not `require.resolve`

It consults `NODE_PATH` and Node's global folders, which can resolve an Electron unrelated to the project under test. Not hypothetical: vitest sets `NODE_PATH` to pnpm's hidden store, and during development of these tests `require.resolve` found an unrelated Electron from a fixture that had none installed. The lookup walks `node_modules` upward instead, matching the traversal `pnpm.ts` already does for `pnpm-workspace.yaml`.

### Incidental behaviour change

An unparseable `electron` spec no longer masks a parseable `electron-nightly` one — the loop falls through instead of returning `undefined`.

## Tests

Dist-tag coverage was the gap. The three existing catalog tests all mock `findPnpmCatalogVersion` returning semver (`^29.4.1`, `33.0.0-nightly.20240621`, `29.4.1`), so they exercise the plumbing but never a real-world catalog value.

Added: dist-tags and wildcard in `package.json`; dist-tag via catalog; `electron-nightly`; fall-through when `electron` is not installed; `undefined` when nothing is installed; a guard that a parseable spec still beats a differing installed version; each location-spec form; the version-looking-path case; and a location spec with nothing installed, which still parses. They build real temp projects on disk so the `node_modules` walk is genuinely exercised.

Also added a `mockReset` in `beforeEach` — a pre-existing leak (one test queues two `mockResolvedValueOnce` values and consumes one) was bleeding into the new catalog test.

## Verification

- `pnpm --filter @wdio/electron-service test` — 543 passed, `electronVersion.ts` at 100% statements / 94.44% branches
- lint + typecheck clean
- Built the package and ran `getElectronVersion` against the real project that was failing. `catalog:next` → `latest`, `^37`, `workspace:*` and `file:/build/v1.2.3/electron` all resolve to the installed `43.2.0`

Found while verifying the `next` releases in `wdio-desktop-mobile-example`, where this failed **every** Electron job — 60 of them, all three build tools across all three OSes. Those jobs pass on the `default` catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqeVQiwcnTYfuGThuN7KsY