### PR TITLE
fix(mobile): sync the xcuitest matrix row with the pinned driver

### DIFF
--- a/packages/native-mobile-core/src/versionMatrix.ts
+++ b/packages/native-mobile-core/src/versionMatrix.ts
@@ -27,7 +27,7 @@ export const APPIUM_MATRIX: AppiumCompat[] = [
     appiumMajor: 3,
     drivers: {
       uiautomator2: { name: 'uiautomator2', source: 'appium-uiautomator2-driver', version: '^8.2.2' },
-      xcuitest: { name: 'xcuitest', source: 'appium-xcuitest-driver', version: '^11.17.1' },
+      xcuitest: { name: 'xcuitest', source: 'appium-xcuitest-driver', version: '^11.17.7' },
       flutter: { name: 'flutter', source: 'appium-flutter-driver', version: '^3.9.1' },
     },
   },


### PR DESCRIPTION
`@wdio/native-mobile-core`'s Appium version-matrix drift guard is red on `main`.

#576 bumped `appium-xcuitest-driver` to `^11.17.7` in `e2e/package.json`, but `APPIUM_MATRIX` still said `^11.17.1`. That's exactly the drift the guard exists to catch — the matrix is what `ensureAppiumDriver` installs from, so it would have pulled `^11.17.1` over the version the e2e suite actually pins.

One line, bringing the matrix row up to the pinned range. `uiautomator2` (`^8.2.2`) and `flutter` (`^3.9.1`) were already in sync.

## Verification

`packages/native-mobile-core`: 13 files, 112 tests, all passing — `versionMatrix.spec.ts` included, which fails on `main` today.

Found while upgrading to pnpm 11 (#580); it trips the pre-push hook, so it's split out here rather than bundled into that PR.