### PR TITLE
fix(ci): bound package-test child commands so a hang fails fast

### DIFF
--- a/.github/workflows/_ci-package.reusable.yml
+++ b/.github/workflows/_ci-package.reusable.yml
@@ -54,6 +54,10 @@ jobs:
   package:
     name: Run
     runs-on: ${{ inputs.os }}
+    # Backstop for anything the per-command bound in test-package.ts can't see. The
+    # slowest of these jobs runs ~15 minutes; without a limit a wedged step inherits
+    # GitHub's 6-hour default.
+    timeout-minutes: 45
     steps:
       # Standard checkout with SSH key for private repositories
       - name: 👷 Checkout Repository

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -51,6 +51,16 @@ const __dirname = dirname(__filename);
 const rootDir = normalize(join(__dirname, '..'));
 
 /**
+ * Upper bound for any child command. pnpm has been seen printing its "Done" summary and
+ * then never exiting after the registry connection dropped mid-install; with no bound the
+ * wedged child holds the job until CI's own limit, which is hours of a paid runner for a
+ * step that normally takes seconds. No real command comes close to this — the slowest
+ * package job is ~15 minutes end to end — so tripping it means something is stuck. Raise
+ * it for a cold Rust build on a slow machine.
+ */
+const COMMAND_TIMEOUT_MS = Number(process.env.PACKAGE_TEST_COMMAND_TIMEOUT_MS) || 30 * 60_000;
+
+/**
  * Reads version overrides from the workspace's pnpm-workspace.yaml so the isolated
  * package-test install resolves the same dependency versions as the monorepo.
  * Without this, a transitive version fix pinned at the workspace level never reaches
@@ -103,17 +113,24 @@ function execCommand(command: string, cwd: string, description: string) {
   const maxAttempts = isPnpm && process.platform === 'win32' ? 2 : 1;
   let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const startedAt = Date.now();
     try {
       execSync(command, {
         cwd: normalize(cwd),
         stdio: 'inherit',
         encoding: 'utf-8',
         shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
+        timeout: COMMAND_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
       if (attempt > 1) log(`(retry ${attempt - 1} succeeded)`);
       log(`✅ ${description} completed`);
       return;
     } catch (error) {
+      // Retrying a hang just spends the budget twice, so a timeout is terminal.
+      if (Date.now() - startedAt >= COMMAND_TIMEOUT_MS) {
+        throw new Error(`${description} exceeded ${COMMAND_TIMEOUT_MS / 60_000} minutes and was killed: ${command}`);
+      }
       lastError = error;
       if (attempt < maxAttempts) {
         console.error(`⚠️  ${description} failed on attempt ${attempt}; retrying after 2s...`);
@@ -149,8 +166,18 @@ function execCommandAsync(command: string, cwd: string, description: string): Pr
       stdio: 'inherit',
       shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
     });
-    child.on('error', rejectPromise);
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      rejectPromise(
+        new Error(`${description} exceeded ${COMMAND_TIMEOUT_MS / 60_000} minutes and was killed: ${command}`),
+      );
+    }, COMMAND_TIMEOUT_MS);
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      rejectPromise(error);
+    });
     child.on('close', (code) => {
+      clearTimeout(timer);
       if (code === 0) {
         log(`✅ ${description} completed`);
         resolvePromise();


### PR DESCRIPTION
A wedged child process in `scripts/test-package.ts` had nothing to stop it. No command carried a timeout, and the package job set no `timeout-minutes`, so it inherited GitHub's 6-hour default.

That is not hypothetical — it cost ~2 hours of a macOS runner on #580 before I cancelled it manually:

```
13:11:05  Installing local packages for electron-forge-app-cjs...
13:11:17  [WARN] GET .../@esbuild/aix-ppc64... error (ENOTCONN). Will retry in 10s
13:11:22  Done in 16s using pnpm v11.20.0
15:03:43  ##[error]The operation was canceled.        <- manual, ~114 min in
```

pnpm printed its completion summary and then never exited, after the registry connection dropped mid-install (~40 `ENOTCONN` retries immediately prior). `execSync` waited on a child that was never coming back. The step normally takes seconds.

Nothing here is specific to that failure mode — any child that stops making progress produces the same outcome.

## Changes

- **Per-command bound, 30 minutes.** Applied in both `execCommand` and `execCommandAsync`, so the browser-mode path is covered too. Overridable via `PACKAGE_TEST_COMMAND_TIMEOUT_MS` for a cold Rust build on a slow machine.
- **A timeout is terminal, not retried.** The existing Windows retry exists for pnpm exiting non-zero without explanation; retrying a *hang* just spends the budget twice. Detected by elapsed time rather than by signal, so an unrelated `SIGKILL` still takes the normal retry path.
- **Job backstop, 45 minutes**, matching the convention already used across this repo (`_ci-lint` 10, `_ci-smoke-autoinstall-driver` 15, `_ci-rust-clippy` 30, the mobile builds 40–60). Catches anything the per-command bound can't see.

## Calibration

Measured across 42 `Package - *` jobs on the last three `main` runs: **slowest is 15.1 minutes** end to end (`Package - Electron [Windows] - esm`), and that whole job is many commands. No single command comes close to 30 minutes, so the bound only trips on something genuinely stuck — while cutting the worst case from 6 hours to 45 minutes.

## Verification

- Timeout path exercised directly: `execSync` with a 2s bound on `sleep 30` is killed at 2002ms and takes the timeout branch, not the retry branch.
- `node ./scripts/test-package.ts --package=electron-script-app-esm` passes end to end on this branch.
- `format:check` and `lint` clean.

Found while investigating #580, kept separate since it's unrelated to that upgrade and applies equally on `main` today.