### PR TITLE
fix(ci): match the @wdio/utils tarball by pattern, drop the dead override

### DIFF
--- a/.github/workflows/actions/setup-workspace/action.yml
+++ b/.github/workflows/actions/setup-workspace/action.yml
@@ -18,11 +18,10 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        # Store cache keyed on the lockfile. Safe w.r.t. the electron-builder fixtures'
-        # @wdio/utils `file:` tarball override: pnpm honors overrides only at the workspace
-        # root (which has none), so the root lockfile never references the mutable tarball —
-        # that's confined to the isolated package-test install (test-package.ts), which this
-        # cache doesn't touch.
+        # Store cache keyed on the lockfile. Safe w.r.t. the @wdio/utils `file:` tarball
+        # override: it is applied only by test-package.ts, inside its isolated sandbox
+        # install, so the root lockfile never references the mutable tarball and this
+        # cache never sees it.
         cache: 'pnpm'
         cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/fixtures/package-tests/electron-builder-app-cjs/pnpm-workspace.sandbox.yaml
+++ b/fixtures/package-tests/electron-builder-app-cjs/pnpm-workspace.sandbox.yaml
@@ -5,5 +5,4 @@ allowBuilds:
   electron: true
   esbuild: true
 overrides:
-  '@wdio/utils': file:../../../../wdio-utils-9.23.0.tgz
   minimatch: 10.2.2

--- a/fixtures/package-tests/electron-builder-app-esm/pnpm-workspace.sandbox.yaml
+++ b/fixtures/package-tests/electron-builder-app-esm/pnpm-workspace.sandbox.yaml
@@ -5,5 +5,4 @@ allowBuilds:
   electron: true
   esbuild: true
 overrides:
-  '@wdio/utils': file:../../../../wdio-utils-9.23.0.tgz
   minimatch: 10.2.2

--- a/scripts/test-package.ts
+++ b/scripts/test-package.ts
@@ -571,9 +571,19 @@ async function testExample(
     };
     const packagesToInstall: string[] = [packages.utilsPath, packages.spyPath, packages.corePath];
 
-    // Add @wdio/utils override if the tarball exists
-    const wdioUtilsTarball = join(rootDir, 'wdio-utils-9.23.3.tgz');
-    if (existsSync(wdioUtilsTarball)) {
+    // Swap in a locally patched @wdio/utils when one has been packed to the repo root by
+    // scripts/update-packages.ts. Matched by pattern, not by pinned version: that script
+    // names the tarball after whatever version it packed, so a pinned name silently stops
+    // matching the moment upstream bumps — leaving a green run that tested nothing.
+    const wdioUtilsTarballs = readdirSync(rootDir).filter((entry) => /^wdio-utils-.+\.tgz$/.test(entry));
+    if (wdioUtilsTarballs.length > 1) {
+      throw new Error(
+        `Found ${wdioUtilsTarballs.length} @wdio/utils tarballs in ${rootDir} (${wdioUtilsTarballs.join(', ')}). ` +
+          'Leave only the one to test.',
+      );
+    }
+    if (wdioUtilsTarballs.length === 1) {
+      const wdioUtilsTarball = join(rootDir, wdioUtilsTarballs[0]);
       overrides['@wdio/utils'] = `file:${wdioUtilsTarball}`;
       packagesToInstall.push(wdioUtilsTarball);
       log(`  Adding @wdio/utils override: ${wdioUtilsTarball}`);


### PR DESCRIPTION
Three places named the `@wdio/utils` tarball and none of them agreed:

| Location | Value | From |
|---|---|---|
| `electron-builder-app-{cjs,esm}` sandbox config | `wdio-utils-9.23.0.tgz` | #94 |
| `scripts/test-package.ts` | `wdio-utils-9.23.3.tgz` | #132 |
| `scripts/update-packages.ts` — the only producer | `${packedFile}`, from `npm pack` | — |

The producer names the file after whatever version it packed; both consumers pinned a version, and pinned *different* ones. #132 bumped one and left the other. No such tarball exists in the tree, and it isn't gitignored, so it isn't an expected build artifact either.

## The fixture pin was unreachable

`test-package.ts` discards every `file:` override from the fixture config before assembling the sandbox:

```ts
for (const [key, value] of Object.entries(sourceOverrides)) {
  if (!value.startsWith('file:')) {      // file: overrides dropped
    preservedOverrides[key] = value;
  }
}
```

So that line was read and thrown away on every run since #94. Removed.

The `minimatch: 10.2.2` override sitting next to it is a plain version, not a `file:` spec, so it *is* preserved and applied — it stays.

## The pinned lookup failed silently

That one is reachable, but guarded by `existsSync`. Pack a patched `@wdio/utils` via `update-packages.ts` at any version other than exactly `9.23.3` and the guard misses, the override is skipped without a word, and the package tests go green having never exercised the build you just made. A silent no-op, which is the worse failure mode — you'd trust the result.

Now matched by pattern, so a regenerated tarball is picked up at any version. More than one candidate throws rather than picking arbitrarily.

## Verification

Exercised all three paths:

- **No tarball** (the normal case): no override applied, `electron-builder-app-cjs` package test passes end to end.
- **An arbitrary version present** (`wdio-utils-99.0.0.tgz`): matched by the new pattern — and confirmed the old `9.23.3` pin would *not* have matched it. This is precisely the bug.
- **Two tarballs present**: throws, naming both.

`format:check` and `lint` clean.

Also updates the cache-safety comment in `setup-workspace/action.yml`, whose reasoning was written around the fixture override that this PR deletes. The conclusion is unchanged — the root lockfile still never references the tarball — but it now points at `test-package.ts`, which is where the override actually comes from.