### PR TITLE
docs: move dioxus-service to stable for the 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 |---|---|---|---|
 | [![@wdio/electron-service](https://img.shields.io/badge/@wdio-electron--service-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/electron-service) | [![version](https://img.shields.io/npm/v/@wdio/electron-service)](https://www.npmjs.com/package/@wdio/electron-service) | Windows / macOS / Linux | [![downloads v10+](https://img.shields.io/npm/dw/@wdio/electron-service?label=downloads%20(v10%2B))](https://www.npmjs.com/package/@wdio/electron-service)<br>[![downloads ≤v9](https://img.shields.io/npm/dw/wdio-electron-service?label=downloads%20(%E2%89%A4%20v9))](https://www.npmjs.com/package/wdio-electron-service) |
 | [![@wdio/tauri-service](https://img.shields.io/badge/@wdio-tauri--service-FFC131?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/tauri-service) | [![version](https://img.shields.io/npm/v/@wdio/tauri-service)](https://www.npmjs.com/package/@wdio/tauri-service) | Windows / macOS / Linux | [![downloads](https://img.shields.io/npm/dw/@wdio/tauri-service)](https://www.npmjs.com/package/@wdio/tauri-service) |
+| [![@wdio/dioxus-service](https://img.shields.io/badge/@wdio-dioxus--service-e96020?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/dioxus-service) | [![version](https://img.shields.io/npm/v/@wdio/dioxus-service)](https://www.npmjs.com/package/@wdio/dioxus-service) | Windows / macOS / Linux | [![downloads](https://img.shields.io/npm/dw/@wdio/dioxus-service)](https://www.npmjs.com/package/@wdio/dioxus-service) |
 
 ## Pre-release
 
@@ -44,7 +45,6 @@
 
 | Service | Version | Platforms | Downloads |
 |---|---|---|---|
-| [![@wdio/dioxus-service](https://img.shields.io/badge/@wdio-dioxus--service-e96020?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/dioxus-service) | [![version](https://img.shields.io/npm/v/@wdio/dioxus-service/next)](https://www.npmjs.com/package/@wdio/dioxus-service) | Windows / macOS / Linux | [![downloads](https://img.shields.io/npm/dw/@wdio/dioxus-service)](https://www.npmjs.com/package/@wdio/dioxus-service) |
 | [![@wdio/react-native-service](https://img.shields.io/badge/@wdio-react--native--service-61DAFB?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/react-native-service) | [![version](https://img.shields.io/npm/v/@wdio/react-native-service/next)](https://www.npmjs.com/package/@wdio/react-native-service) | Android / iOS | [![downloads](https://img.shields.io/npm/dw/@wdio/react-native-service)](https://www.npmjs.com/package/@wdio/react-native-service) |
 | [![@wdio/flutter-service](https://img.shields.io/badge/@wdio-flutter--service-055a9d?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/flutter-service) | [![version](https://img.shields.io/npm/v/@wdio/flutter-service/next)](https://www.npmjs.com/package/@wdio/flutter-service) | Android / iOS | [![downloads](https://img.shields.io/npm/dw/@wdio/flutter-service)](https://www.npmjs.com/package/@wdio/flutter-service) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,14 +16,14 @@ Published packages, grouped by release maturity. Status reflects the npm dist-ta
 **Platforms:** Windows, macOS, Linux\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/tauri-service)](https://npmjs.com/package/@wdio/tauri-service)
 
-### 🚧 Pre-release (`next`, `1.0.0-next.x`)
-
-> Feature-complete services published on the `next` dist-tag while the API and CI stabilise toward `1.0`.
-
-#### [@wdio/dioxus-service](./packages/dioxus-service) — v1.0.0-next
+#### [@wdio/dioxus-service](./packages/dioxus-service) — v1.x
 **Platforms:** Windows, macOS, Linux (`'embedded'` provider); Windows only for `'external'`\
 **Highlights:** Wry webview → CDP (shared patterns with the Tauri service); `execute`, mocking, log forwarding, browser mode, multiremote, standalone session.\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/dioxus-service)](https://npmjs.com/package/@wdio/dioxus-service)
+
+### 🚧 Pre-release (`next`, `1.0.0-next.x`)
+
+> Feature-complete services published on the `next` dist-tag while the API and CI stabilise toward `1.0`.
 
 #### [@wdio/react-native-service](./packages/react-native-service) — v1.0.0-next
 **Platforms:** Android, iOS\


### PR DESCRIPTION
`@wdio/dioxus-service@1.0.0` is now the `latest` dist-tag (`next` still points at `1.0.0-next.4`), so both documents listed it under the wrong maturity heading.

## README

Moves the row from **Pre-release** to **Supported Frameworks**, alongside electron and tauri.

Also drops `/next` from the version badge:

```diff
-  img.shields.io/npm/v/@wdio/dioxus-service/next
+  img.shields.io/npm/v/@wdio/dioxus-service
```

That one matters beyond placement — the badge was pinned to the `next` dist-tag, so it would have kept advertising `1.0.0-next.4` indefinitely while the stable table said otherwise.

## ROADMAP

Moves the entry under **✅ Stable (`latest`)** and retitles it `v1.x`, matching how `electron-service` (v10.x) and `tauri-service` (v1.x) are written. The Pre-release section keeps react-native and flutter.

## Deliberately unchanged

- The framework comparison table already marked **Dioxus** *(released)* / ✅ Implemented.
- `packages/dioxus-service/docs/development.md` lists `1.0.0-next.0`, but that column is headed **Initial version** — historical by design, not stale.

One editorial judgement I left alone: in the comparison table, Dioxus's *Driver Maturity* reads "✅ Implemented" where its now-peers say "✅ Proven" (electron, tauri) or "✅ Production-ready" (flutter). That column describes the automation driver rather than release status, so I didn't rewrite it off the back of a version bump — say the word if you'd like it levelled up.

`format:check` clean.